### PR TITLE
Fix: address Copilot code review feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Both must pass. Work tasks auto-validate with these commands and will iterate up
 
 ### Database Migrations
 
-Add table creation / migration SQL in `server/db/connection.ts` inside the migration chain.
+Add table creation / migration SQL in `server/db/schema.ts` inside the `MIGRATIONS` object.
 
 ### API Endpoints
 
@@ -83,10 +83,10 @@ Add route handlers in `server/routes/` and register in `server/routes/index.ts`.
 Agents can create work tasks via `corvid_create_work_task` to propose codebase improvements:
 
 1. Agent calls `corvid_create_work_task` with a description
-2. Service creates a git branch, starts a new agent session
+2. Service creates a git worktree with a new branch, starts a new agent session
 3. Agent implements changes, commits, runs validation
 4. On validation pass, agent creates a PR
 5. On validation fail, up to 3 iteration attempts are made
-6. Original branch is restored after completion
+6. Worktree is cleaned up after completion (branch persists for PR review)
 
 Rate limited to 5 work tasks per agent per day. Protected files cannot be modified even in full-auto mode.

--- a/client/src/app/core/models/work-task.model.ts
+++ b/client/src/app/core/models/work-task.model.ts
@@ -16,6 +16,7 @@ export interface WorkTask {
     summary: string | null;
     error: string | null;
     originalBranch: string | null;
+    worktreeDir: string | null;
     iterationCount: number;
     createdAt: string;
     completedAt: string | null;

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -2,15 +2,29 @@ const host = typeof window !== 'undefined' ? window.location.host : 'localhost:3
 const protocol = typeof window !== 'undefined' ? window.location.protocol : 'http:';
 const wsProtocol = protocol === 'https:' ? 'wss:' : 'ws:';
 
-// API key can be set via ?apiKey= query param on page load, or localStorage
+// API key can be set via ?apiKey= query param on page load, or sessionStorage
 const storedKey = typeof window !== 'undefined'
-    ? new URLSearchParams(window.location.search).get('apiKey') ?? localStorage.getItem('corvid_api_key')
-    : null;
+    ? (() => {
+        const params = new URLSearchParams(window.location.search);
+        const fromUrl = params.get('apiKey');
 
-// Persist to localStorage so it survives navigation
-if (storedKey && typeof window !== 'undefined') {
-    localStorage.setItem('corvid_api_key', storedKey);
-}
+        // Strip apiKey from URL to prevent logging/sharing
+        if (fromUrl) {
+            params.delete('apiKey');
+            const newQuery = params.toString();
+            const cleanUrl = window.location.pathname
+                + (newQuery ? `?${newQuery}` : '')
+                + window.location.hash;
+            window.history.replaceState(null, '', cleanUrl);
+        }
+
+        const key = fromUrl ?? sessionStorage.getItem('corvid_api_key');
+        if (key) {
+            sessionStorage.setItem('corvid_api_key', key);
+        }
+        return key;
+    })()
+    : null;
 
 export const environment = {
     apiUrl: `${protocol}//${host}/api`,

--- a/server/index.ts
+++ b/server/index.ts
@@ -49,7 +49,9 @@ let agentMessenger: AgentMessenger | null = null;
 let agentDirectory: AgentDirectory | null = null;
 const selfTestService = new SelfTestService(db, processManager);
 const workTaskService = new WorkTaskService(db, processManager);
-workTaskService.recoverStaleTasks();
+workTaskService.recoverStaleTasks().catch((err) =>
+    log.error('Failed to recover stale work tasks', { error: err instanceof Error ? err.message : String(err) }),
+);
 
 async function initAlgoChat(): Promise<void> {
     if (!algochatConfig.enabled) {

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -685,11 +685,11 @@ export class ProcessManager {
                     const info = this.pausedSessions.get(sessionId);
                     if (!info) continue; // May have been manually resumed
 
-                    info.resumeAttempts++;
                     const backoffMs = Math.min(
                         AUTO_RESUME_BASE_MS * Math.pow(AUTO_RESUME_MULTIPLIER, info.resumeAttempts),
                         AUTO_RESUME_CAP_MS,
                     );
+                    info.resumeAttempts++;
                     info.nextResumeAt = Date.now() + backoffMs;
 
                     log.info(`Auto-resuming paused session ${sessionId}`, {


### PR DESCRIPTION
## Summary
Addresses all 7 actionable items from Copilot's review of PR #5:

- **Timing-safe API key comparison** — replaced `===` with `crypto.timingSafeEqual()` in `auth.ts` for both HTTP and WebSocket auth
- **API key URL hygiene** — strip `?apiKey=` from URL after reading via `history.replaceState`, use `sessionStorage` instead of `localStorage`
- **Unhandled async** — added `.catch()` to fire-and-forget `recoverStaleTasks()` call in `index.ts`
- **MultiEdit bypass** — `extractFilePathsFromInput` now returns ALL file paths, so protected-file checks cover every file in a MultiEdit operation
- **CLAUDE.md corrections** — fixed migration file reference (`connection.ts` → `schema.ts`), updated self-improvement docs to reflect worktree workflow
- **Auto-resume backoff off-by-one** — calculate backoff *before* incrementing `resumeAttempts` so first retry is 5min as documented
- **Client type sync** — added missing `worktreeDir` field to client `WorkTask` model

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` passes (30/30)
- [ ] Verify WS auth still works with timing-safe comparison
- [ ] Verify apiKey is stripped from browser URL bar after page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)