### PR TITLE
Add council abort endpoint and feed-style launch view

### DIFF
--- a/client/src/app/core/services/council.service.ts
+++ b/client/src/app/core/services/council.service.ts
@@ -73,6 +73,10 @@ export class CouncilService {
         return firstValueFrom(this.api.get<CouncilLaunch[]>('/council-launches'));
     }
 
+    async abortLaunch(launchId: string): Promise<{ ok: boolean }> {
+        return firstValueFrom(this.api.post<{ ok: boolean }>(`/council-launches/${launchId}/abort`));
+    }
+
     async triggerReview(launchId: string): Promise<{ launchId: string; reviewSessionIds: string[] }> {
         return firstValueFrom(
             this.api.post<{ launchId: string; reviewSessionIds: string[] }>(


### PR DESCRIPTION
## Summary
- Add `POST /api/council-launches/{id}/abort` endpoint that stops all running sessions, aggregates existing responses, and marks the launch complete with `[Council ended manually]` prefix
- Add red "End Council" button with confirm dialog, visible in any non-complete stage
- Redesign council launch view from grid cards to compact expandable feed entries with colored left borders, processing dots, and single-line preview text
- Add distinct per-stage colors to the stage bar (Responding=cyan, Discussing=amber, Reviewing=violet, Synthesizing=magenta, Complete=green)
- Remove cost display from council feed entries

## Test plan
- [ ] Launch a council and verify the "End Council" button appears during any active stage
- [ ] Click "End Council" and confirm — verify sessions stop and synthesis shows `[Council ended manually]`
- [ ] Verify member responses show as compact rows with colored left borders and expand on click
- [ ] Verify discussion messages use round badges and are expandable
- [ ] Verify peer reviews follow the same feed pattern
- [ ] Verify stage bar shows distinct colors per active stage
- [ ] Run `bun run build:client` and `bun test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)