### PR TITLE
Bind server to 127.0.0.1 by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ ALGORAND_NETWORK=testnet
 
 # --- Server (all optional, sensible defaults) ------------------------------
 # PORT=3000
+# Bind address — defaults to 127.0.0.1 (localhost only).
+# Set to 0.0.0.0 for Docker/VM deployments (put a reverse proxy with auth in front!)
+# BIND_HOST=127.0.0.1
 # LOG_LEVEL=info
 # LOG_FORMAT=text
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ CorvidAgent runs as a **local sandbox** — on your machine, in a VM, or on a pr
 
 ### What's NOT protected (by design)
 
-- **Dashboard API** (`localhost:3000`): Open on localhost. Only you have access to your machine. If deploying on a shared server, add a reverse proxy with auth.
+- **Dashboard API** (`localhost:3000`): Binds to `127.0.0.1` by default, so only local processes can reach it. If deploying on a shared server, add a reverse proxy with auth (see [Deploying on a Server](#deploying-on-a-server)).
 - **Agent sessions**: Run locally with your own AI provider credentials.
 
 ## Spending Protection
@@ -58,9 +58,12 @@ Configure via `DAILY_ALGO_LIMIT_MICRO` in `.env`.
 
 If you run CorvidAgent on a public server instead of localhost:
 
-1. Put a reverse proxy (nginx/caddy) in front with authentication
-2. Set `ALGOCHAT_OWNER_ADDRESSES` to restrict admin commands
-3. Use the allowlist to control who can message your agents
-4. The API itself has no auth — the proxy handles that
+1. **Set `BIND_HOST`**: The server binds to `127.0.0.1` (localhost only) by default. For Docker or VM deployments where you need external access, set `BIND_HOST=0.0.0.0` in your `.env` — but **always** put a reverse proxy with authentication in front.
+2. Put a reverse proxy (nginx/caddy) in front with authentication
+3. Set `ALGOCHAT_OWNER_ADDRESSES` to restrict admin commands
+4. Use the allowlist to control who can message your agents
+5. The API itself has no auth — the proxy handles that
+
+> **Why localhost-only by default?** The dashboard API has no built-in authentication. Binding to `127.0.0.1` ensures only local processes can reach it, which is the primary access-control mechanism for single-machine deployments.
 
 The `deploy/` directory has example configs for systemd, Docker, and macOS launchd.

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -13,6 +13,7 @@ COPY shared/ shared/
 COPY client/dist/ client/dist/
 
 ENV PORT=3000
+ENV BIND_HOST=0.0.0.0
 ENV LOG_LEVEL=info
 ENV NODE_ENV=production
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - db-data:/app/data
     environment:
       - PORT=3000
+      - BIND_HOST=0.0.0.0
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - ALGOCHAT_MNEMONIC=${ALGOCHAT_MNEMONIC:-}
       - ALGORAND_NETWORK=${ALGORAND_NETWORK:-testnet}

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,6 +19,7 @@ import { createLogger } from './lib/logger';
 const log = createLogger('Server');
 
 const PORT = parseInt(process.env.PORT ?? '3000', 10);
+const BIND_HOST = process.env.BIND_HOST || '127.0.0.1';
 const CLIENT_DIST = join(import.meta.dir, '..', 'client', 'dist', 'client', 'browser');
 const startTime = Date.now();
 
@@ -131,6 +132,7 @@ interface WsData {
 // Start server
 const server = Bun.serve<WsData>({
     port: PORT,
+    hostname: BIND_HOST,
 
     async fetch(req, server) {
         const url = new URL(req.url);
@@ -228,7 +230,7 @@ initAlgoChat().then(() => {
 // Start session lifecycle cleanup after server is running
 sessionLifecycle.start();
 
-log.info(`Server running at http://localhost:${PORT}`);
+log.info(`Server running at http://${BIND_HOST}:${PORT}`);
 
 // Global error handlers for 24/7 operation
 process.on('unhandledRejection', (reason) => {


### PR DESCRIPTION
## Summary

- **Bind to localhost by default**: Adds `hostname: '127.0.0.1'` to `Bun.serve()` so the unauthenticated dashboard API is no longer network-accessible on machines with public IPs or LAN interfaces
- **`BIND_HOST` env var**: Allows Docker/VM deployments to override to `0.0.0.0` when needed (`process.env.BIND_HOST || '127.0.0.1'`)
- **Docker configs updated**: Sets `BIND_HOST=0.0.0.0` in `deploy/Dockerfile` and `deploy/docker-compose.yml` since containers require all-interfaces binding for port mapping
- **Documentation updated**: `SECURITY.md` deployment guidance and `.env.example` now document the `BIND_HOST` option

This is a defense-in-depth measure — the server has no authentication, so localhost isolation is the primary access control for the dashboard API.

## Files changed

| File | Change |
|------|--------|
| `server/index.ts` | Add `BIND_HOST` const, `hostname` in `Bun.serve()`, update log message |
| `SECURITY.md` | Update deployment guidance with `BIND_HOST` docs |
| `.env.example` | Document `BIND_HOST` option |
| `deploy/Dockerfile` | Set `BIND_HOST=0.0.0.0` for container use |
| `deploy/docker-compose.yml` | Set `BIND_HOST=0.0.0.0` for container use |

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` — passes
- [x] `bun test` — all 122 tests pass
- [ ] Manual: verify server starts and binds to 127.0.0.1 (not 0.0.0.0)
- [ ] Manual: verify `BIND_HOST=0.0.0.0 bun server/index.ts` binds to all interfaces
- [ ] Manual: verify Docker build works with the updated Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)