### PR TITLE
fix: session chat scroll contained within terminal

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -37,6 +37,8 @@ import { SessionService } from './core/services/session.service';
         .app-layout__content {
             flex: 1;
             overflow-y: auto;
+            min-height: 0;
+            position: relative;
             background: var(--bg-deep);
         }
     `,

--- a/client/src/app/features/sessions/session-input.component.ts
+++ b/client/src/app/features/sessions/session-input.component.ts
@@ -29,6 +29,10 @@ import { FormsModule } from '@angular/forms';
         </div>
     `,
     styles: `
+        :host {
+            display: block;
+            flex-shrink: 0;
+        }
         .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
         .input-bar {
             display: flex;

--- a/client/src/app/features/sessions/session-output.component.ts
+++ b/client/src/app/features/sessions/session-output.component.ts
@@ -118,8 +118,16 @@ interface ParsedEvent {
         </div>
     `,
     styles: `
+        :host {
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+            min-height: 0;
+            overflow: hidden;
+        }
         .terminal {
             flex: 1;
+            min-height: 0;
             overflow-y: auto;
             padding: 0.75rem 1rem;
             background: var(--bg-deep);

--- a/client/src/app/features/sessions/session-view.component.ts
+++ b/client/src/app/features/sessions/session-view.component.ts
@@ -54,7 +54,13 @@ import type { StreamEvent, ApprovalRequestWire } from '../../core/models/ws-mess
         }
     `,
     styles: `
-        .session-view { display: flex; flex-direction: column; height: 100%; }
+        :host {
+            display: flex;
+            flex-direction: column;
+            position: absolute;
+            inset: 0;
+        }
+        .session-view { display: flex; flex-direction: column; flex: 1; min-height: 0; overflow: hidden; }
         .session-view__header {
             display: flex; align-items: center; gap: 1rem;
             padding: 0.75rem 1rem;


### PR DESCRIPTION
## Summary
- **Fix session chat page-level overscroll** — Angular standalone components render as inline elements by default. `<app-session-output>` and `<app-session-input>` had no `:host` styles, so they didn't participate in the parent's flex column layout. The `.terminal` div grew to full content height, pushing scroll to the outer `<main>` container.
- **Add `:host` display styles** to `session-output` (`display:flex; flex:1; min-height:0; overflow:hidden`) and `session-input` (`display:block; flex-shrink:0`) so the flex chain is unbroken and `overflow-y:auto` scroll stays contained within `.terminal`.
- **Add `min-height:0` and `position:relative`** to `.app-layout__content` to ensure the flex constraint chain propagates correctly from the app shell.

## Test plan
- [ ] Open a session with enough messages to overflow the viewport
- [ ] Verify only the terminal/chat area scrolls, not the entire page
- [ ] Verify the input bar stays pinned at the bottom
- [ ] Verify other pages (dashboard, agents, feed) still scroll normally
- [ ] Test on mobile viewport sizes — chat should still scroll correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)