### PR TITLE
ci: add cross-platform matrix for Linux, macOS, and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Build & Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds a matrix strategy to the CI workflow so it runs on **ubuntu-latest**, **macos-latest**, and **windows-latest** in parallel
- Sets `fail-fast: false` so all platforms report their results even if one fails
- Prepares CI for going public — macOS/Windows runners activate automatically once the repo is public

## Test plan
- [ ] Verify CI triggers on the PR and the ubuntu job passes
- [ ] Once repo is public, confirm macOS and Windows jobs also run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)