### PR TITLE
feat: council follow-up chat

### DIFF
--- a/client/src/app/core/models/council.model.ts
+++ b/client/src/app/core/models/council.model.ts
@@ -37,6 +37,7 @@ export interface CouncilLaunch {
     sessionIds: string[];
     currentDiscussionRound: number;
     totalDiscussionRounds: number;
+    chatSessionId: string | null;
     createdAt: string;
 }
 

--- a/client/src/app/core/services/council.service.ts
+++ b/client/src/app/core/services/council.service.ts
@@ -100,4 +100,13 @@ export class CouncilService {
     async getDiscussionMessages(launchId: string): Promise<CouncilDiscussionMessage[]> {
         return firstValueFrom(this.api.get<CouncilDiscussionMessage[]>(`/council-launches/${launchId}/discussion-messages`));
     }
+
+    async chatWithCouncil(launchId: string, message: string): Promise<{ sessionId: string; created: boolean }> {
+        return firstValueFrom(
+            this.api.post<{ sessionId: string; created: boolean }>(
+                `/council-launches/${launchId}/chat`,
+                { message },
+            ),
+        );
+    }
 }

--- a/server/db/councils.ts
+++ b/server/db/councils.ts
@@ -35,6 +35,7 @@ interface CouncilLaunchRow {
     synthesis: string | null;
     current_discussion_round: number;
     total_discussion_rounds: number;
+    chat_session_id: string | null;
     created_at: string;
 }
 
@@ -62,6 +63,7 @@ function rowToLaunch(row: CouncilLaunchRow, sessionIds: string[]): CouncilLaunch
         sessionIds,
         currentDiscussionRound: row.current_discussion_round ?? 0,
         totalDiscussionRounds: row.total_discussion_rounds ?? 0,
+        chatSessionId: row.chat_session_id ?? null,
         createdAt: row.created_at,
     };
 }
@@ -356,4 +358,12 @@ export function updateDiscussionMessageTxid(
     txid: string,
 ): void {
     db.query('UPDATE council_discussion_messages SET txid = ? WHERE id = ?').run(txid, messageId);
+}
+
+export function updateCouncilLaunchChatSession(
+    db: Database,
+    launchId: string,
+    chatSessionId: string,
+): void {
+    db.query('UPDATE council_launches SET chat_session_id = ? WHERE id = ?').run(chatSessionId, launchId);
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,6 +1,6 @@
 import { Database } from 'bun:sqlite';
 
-const SCHEMA_VERSION = 21;
+const SCHEMA_VERSION = 22;
 
 const MIGRATIONS: Record<number, string[]> = {
     1: [
@@ -303,6 +303,10 @@ const MIGRATIONS: Record<number, string[]> = {
     21: [
         // MCP tool permission scoping: null = default safe set, JSON array = explicit list
         `ALTER TABLE agents ADD COLUMN mcp_tool_permissions TEXT DEFAULT NULL`,
+    ],
+    22: [
+        // Follow-up chat session for completed council launches
+        `ALTER TABLE council_launches ADD COLUMN chat_session_id TEXT DEFAULT NULL`,
     ],
 };
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -192,6 +192,7 @@ export interface CouncilLaunch {
     sessionIds: string[];
     currentDiscussionRound: number;
     totalDiscussionRounds: number;
+    chatSessionId: string | null;
     createdAt: string;
 }
 


### PR DESCRIPTION
## Summary
- Adds ability to chat with a completed council launch, using the synthesis and discussion as context
- Creates a new session with the chairman agent (or first council member as fallback)
- Supports multi-turn conversation — first message creates the session, subsequent messages resume it
- New `POST /api/council-launches/:id/chat` endpoint with `{ message }` body
- Migration 22 adds `chat_session_id` column to `council_launches`
- Chat UI appears below the synthesis in the council launch view with live streaming

## Test plan
- [ ] Run a council to completion, verify "Chat with Council" section appears below the decision
- [ ] Send a follow-up question, verify a session is created and streams a response
- [ ] Send a second message, verify it resumes the same session (not creating a new one)
- [ ] Refresh the page, verify the chat history persists and loads correctly
- [ ] Verify councils without synthesis (manually ended with no responses) don't show the chat section
- [ ] `bun x tsc --noEmit --skipLibCheck` passes
- [ ] `bun test` — 122 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)