### PR TITLE
fix: make PSK state network-aware

### DIFF
--- a/server/algochat/bridge.ts
+++ b/server/algochat/bridge.ts
@@ -732,7 +732,7 @@ export class AlgoChatBridge {
     private setupPSKManager(): void {
         if (!this.config.pskContact) return;
 
-        this.pskManager = new PSKManager(this.db, this.service, this.config.pskContact);
+        this.pskManager = new PSKManager(this.db, this.service, this.config.pskContact, this.config.network);
 
         this.pskManager.onMessage((msg) => {
             this.handleIncomingMessage(msg.sender, msg.content, msg.confirmedRound).catch((err) => {


### PR DESCRIPTION
## Summary
- Adds `network` column to `algochat_psk_state` table with `(address, network)` composite primary key
- PSKManager now accepts and uses network parameter in all DB queries
- Bridge passes `config.network` when constructing PSKManager
- Migration 23 recreates the table and preserves existing rows as `testnet`

## Problem
PSK counters (`sendCounter`, `peerLastCounter`, `seenCounters`) and `lastRound` were stored globally by address. When switching between testnet and mainnet in the web UI, the shared state caused counter desync and missed messages because round numbers differ between networks.

## Test plan
- [ ] Verify build passes (`bun run build`)
- [ ] Switch between testnet and mainnet — each should maintain independent PSK state
- [ ] Confirm existing testnet PSK conversations continue working after migration
- [ ] Verify new mainnet PSK state is initialized fresh on first use

🤖 Generated with [Claude Code](https://claude.com/claude-code)