### PR TITLE
feat: restrict AlgoChat to owner addresses only

### DIFF
--- a/server/algochat/bridge.ts
+++ b/server/algochat/bridge.ts
@@ -279,11 +279,11 @@ export class AlgoChatBridge {
     /** Check if a participant is authorized to run privileged commands. Fail-closed: returns false when no owners configured. */
     private isOwner(participant: string): boolean {
         if (this.config.ownerAddresses.size === 0) {
-            log.warn('Privileged command rejected — no owner addresses configured', { participant: participant.slice(0, 8) });
+            log.warn('Owner check failed — no owner addresses configured', { participant: participant.slice(0, 8) });
             return false;
         }
         if (!this.config.ownerAddresses.has(participant)) {
-            log.warn('Privileged command rejected — sender not in owner list', { participant: participant.slice(0, 8) });
+            log.debug('Non-owner address', { participant: participant.slice(0, 8) });
             return false;
         }
         return true;
@@ -848,6 +848,12 @@ export class AlgoChatBridge {
                 log.info('Agent-to-agent message — handled by AgentMessenger', { senderAgentId });
                 return;
             }
+        }
+
+        // Owner-only mode: only respond to wallets in ALGOCHAT_OWNER_ADDRESSES
+        if (!this.isOwner(participant)) {
+            log.info('Ignoring message from non-owner address', { address: participant.slice(0, 8) + '...' });
+            return;
         }
 
         // Allowlist filtering — if allowlist has entries, only listed addresses get through


### PR DESCRIPTION
## Summary
- Adds an owner-only gate in `handleIncomingMessage()` — messages from wallets not in `ALGOCHAT_OWNER_ADDRESSES` are silently dropped before any processing
- Updates `isOwner()` log messages to be generic (no longer says "privileged command rejected") and downgrades non-owner log to `debug` level
- Agent-to-agent messages still flow normally (check happens after that filter)

## Test plan
- [ ] Verify messages from owner wallets are processed normally
- [ ] Verify messages from non-owner wallets are silently dropped (no response sent)
- [ ] Verify agent-to-agent communication still works
- [ ] Confirm all 153 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)