### PR TITLE
security: validate Algorand address checksums in parseOwnerAddresses

### DIFF
--- a/server/__tests__/algochat-config.test.ts
+++ b/server/__tests__/algochat-config.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { parseOwnerAddresses } from '../algochat/config';
+
+// A valid Algorand address (the zero address, which always passes checksum validation)
+const VALID_ADDRESS = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ';
+
+// A 58-character base32 string that passes format checks but has an invalid checksum.
+// This is the zero address with the last character changed, breaking the checksum.
+const BAD_CHECKSUM_ADDRESS = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKA';
+
+describe('parseOwnerAddresses', () => {
+    let originalEnv: string | undefined;
+
+    beforeEach(() => {
+        originalEnv = process.env.ALGOCHAT_OWNER_ADDRESSES;
+    });
+
+    afterEach(() => {
+        if (originalEnv === undefined) {
+            delete process.env.ALGOCHAT_OWNER_ADDRESSES;
+        } else {
+            process.env.ALGOCHAT_OWNER_ADDRESSES = originalEnv;
+        }
+    });
+
+    it('accepts a valid Algorand address', () => {
+        process.env.ALGOCHAT_OWNER_ADDRESSES = VALID_ADDRESS;
+        const result = parseOwnerAddresses('testnet');
+        expect(result.size).toBe(1);
+        expect(result.has(VALID_ADDRESS)).toBe(true);
+    });
+
+    it('rejects an address with valid format but invalid checksum', () => {
+        // Verify the bad address matches the old regex pattern (58-char base32)
+        expect(/^[A-Z2-7]{58}$/.test(BAD_CHECKSUM_ADDRESS)).toBe(true);
+
+        process.env.ALGOCHAT_OWNER_ADDRESSES = BAD_CHECKSUM_ADDRESS;
+        const result = parseOwnerAddresses('testnet');
+        expect(result.size).toBe(0);
+    });
+
+    it('rejects non-base32 strings', () => {
+        process.env.ALGOCHAT_OWNER_ADDRESSES = 'not-an-algorand-address';
+        const result = parseOwnerAddresses('testnet');
+        expect(result.size).toBe(0);
+    });
+
+    it('accepts multiple valid addresses separated by commas', () => {
+        // Use the same valid address twice — Set deduplicates, so size is 1
+        process.env.ALGOCHAT_OWNER_ADDRESSES = `${VALID_ADDRESS},${VALID_ADDRESS}`;
+        const result = parseOwnerAddresses('testnet');
+        expect(result.size).toBe(1);
+    });
+
+    it('skips invalid addresses while keeping valid ones', () => {
+        process.env.ALGOCHAT_OWNER_ADDRESSES = `${VALID_ADDRESS},${BAD_CHECKSUM_ADDRESS}`;
+        const result = parseOwnerAddresses('testnet');
+        expect(result.size).toBe(1);
+        expect(result.has(VALID_ADDRESS)).toBe(true);
+    });
+
+    it('returns empty set when env var is not set', () => {
+        delete process.env.ALGOCHAT_OWNER_ADDRESSES;
+        const result = parseOwnerAddresses('testnet');
+        expect(result.size).toBe(0);
+    });
+
+    it('returns empty set for empty string', () => {
+        process.env.ALGOCHAT_OWNER_ADDRESSES = '';
+        const result = parseOwnerAddresses('testnet');
+        expect(result.size).toBe(0);
+    });
+
+    it('normalizes lowercase addresses to uppercase', () => {
+        process.env.ALGOCHAT_OWNER_ADDRESSES = VALID_ADDRESS.toLowerCase();
+        const result = parseOwnerAddresses('testnet');
+        expect(result.size).toBe(1);
+        expect(result.has(VALID_ADDRESS)).toBe(true);
+    });
+
+    it('trims whitespace around addresses', () => {
+        process.env.ALGOCHAT_OWNER_ADDRESSES = `  ${VALID_ADDRESS}  `;
+        const result = parseOwnerAddresses('testnet');
+        expect(result.size).toBe(1);
+        expect(result.has(VALID_ADDRESS)).toBe(true);
+    });
+});

--- a/server/algochat/config.ts
+++ b/server/algochat/config.ts
@@ -1,4 +1,5 @@
 import type { AlgoChatNetwork } from '../../shared/types';
+import { isValidAddress } from 'algosdk';
 import { createLogger } from '../lib/logger';
 
 const log = createLogger('AlgoChatConfig');
@@ -52,16 +53,8 @@ export function loadAlgoChatConfig(): AlgoChatConfig {
     };
 }
 
-/**
- * Synchronous format check for Algorand addresses.
- * Algorand addresses are 58-character base32 strings (A-Z, 2-7).
- * This does NOT verify the checksum — only that the string is plausibly an address.
- */
-export function isPlausibleAlgorandAddress(addr: string): boolean {
-    return /^[A-Z2-7]{58}$/.test(addr);
-}
-
-function parseOwnerAddresses(network: AlgoChatNetwork): Set<string> {
+/** Exported for testing. */
+export function parseOwnerAddresses(network: AlgoChatNetwork): Set<string> {
     const raw = process.env.ALGOCHAT_OWNER_ADDRESSES ?? '';
     const addresses = new Set<string>();
     for (const addr of raw.split(',')) {
@@ -71,8 +64,8 @@ function parseOwnerAddresses(network: AlgoChatNetwork): Set<string> {
         // Normalize to uppercase for case-insensitive matching
         const normalized = trimmed.toUpperCase();
 
-        if (!isPlausibleAlgorandAddress(normalized)) {
-            log.error(`Invalid owner address skipped (not a 58-char base32 Algorand address): ${trimmed}`);
+        if (!isValidAddress(normalized)) {
+            log.error(`Invalid owner address skipped (failed Algorand address checksum validation): "${trimmed}"`);
             continue;
         }
         addresses.add(normalized);


### PR DESCRIPTION
## Summary
- **Replaced `isPlausibleAlgorandAddress()` (regex-only format check) with `algosdk.isValidAddress()`** in `parseOwnerAddresses()` to perform full Algorand address checksum verification
- **Removed the unused `isPlausibleAlgorandAddress()` function** — it was only referenced within `config.ts` and is now superseded by the SDK validation
- **Added 9 unit tests** covering valid addresses, bad checksums, non-base32 strings, mixed valid/invalid input, empty values, case normalization, and whitespace trimming

### Why this matters
A typo in `ALGOCHAT_OWNER_ADDRESSES` could previously pass the regex format check (`/^[A-Z2-7]{58}$/`) but have an invalid checksum, silently creating an owner entry that never matches any real sender. This fix ensures only cryptographically valid Algorand addresses are accepted, consistent with the validation already used in `routes/allowlist.ts`.

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — 131 tests pass (0 failures), including 9 new tests for `parseOwnerAddresses()`
- [ ] Verify on testnet that valid owner addresses still work for privileged commands
- [ ] Verify that mainnet still exits if no valid owner addresses are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)