### PR TITLE
refactor: decompose bridge.ts into four focused modules

### DIFF
--- a/server/algochat/command-handler.ts
+++ b/server/algochat/command-handler.ts
@@ -1,0 +1,428 @@
+/**
+ * CommandHandler — Processes slash commands from AlgoChat messages.
+ *
+ * Owns the mapping from incoming `/command` strings to handler functions,
+ * parameter validation, authorization checks, and response formatting.
+ *
+ * Extracted from bridge.ts to isolate command dispatch concerns from
+ * message routing and subscription management.
+ */
+import type { Database } from 'bun:sqlite';
+import type { AlgoChatConfig } from './config';
+import type { ProcessManager } from '../process/manager';
+import type { AgentMessenger } from './agent-messenger';
+import type { WorkTaskService } from '../work/service';
+import type { ResponseFormatter } from './response-formatter';
+import {
+    listConversations,
+} from '../db/sessions';
+import { getAlgochatEnabledAgents } from '../db/agents';
+import {
+    getBalance,
+    getCreditConfig,
+    getTransactionHistory,
+} from '../db/credits';
+import { listCouncils, createCouncil, getCouncilLaunch } from '../db/councils';
+import { launchCouncil, onCouncilStageChange } from '../routes/councils';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('CommandHandler');
+
+/** Commands that require owner authorization. */
+const PRIVILEGED_COMMANDS = new Set(['/stop', '/approve', '/deny', '/mode', '/work', '/agent', '/council']);
+
+/**
+ * Context required by the CommandHandler for resolving agents and projects.
+ * Keeps the handler decoupled from bridge internals.
+ */
+export interface CommandHandlerContext {
+    /** Find the default agent for new conversations. */
+    findAgentForNewConversation(): string | null;
+    /** Get or create the default project ID. */
+    getDefaultProjectId(): string;
+}
+
+/**
+ * Handles slash-command parsing, authorization, and dispatch for AlgoChat.
+ *
+ * All commands return a response via the injected ResponseFormatter.
+ * The handler is stateless aside from its injected dependencies.
+ */
+export class CommandHandler {
+    private db: Database;
+    private config: AlgoChatConfig;
+    private processManager: ProcessManager;
+    private responseFormatter: ResponseFormatter;
+    private context: CommandHandlerContext;
+    private workTaskService: WorkTaskService | null = null;
+    private agentMessengerRef: AgentMessenger | null = null;
+
+    constructor(
+        db: Database,
+        config: AlgoChatConfig,
+        processManager: ProcessManager,
+        responseFormatter: ResponseFormatter,
+        context: CommandHandlerContext,
+    ) {
+        this.db = db;
+        this.config = config;
+        this.processManager = processManager;
+        this.responseFormatter = responseFormatter;
+        this.context = context;
+    }
+
+    /** Inject the optional work task service. */
+    setWorkTaskService(service: WorkTaskService): void {
+        this.workTaskService = service;
+    }
+
+    /** Inject the optional agent messenger reference (for councils). */
+    setAgentMessenger(messenger: AgentMessenger): void {
+        this.agentMessengerRef = messenger;
+    }
+
+    /**
+     * Check if a participant is authorized to run privileged commands.
+     * Fail-closed: returns false when no owners configured.
+     */
+    isOwner(participant: string): boolean {
+        if (this.config.ownerAddresses.size === 0) {
+            log.warn('Owner check failed — no owner addresses configured', { participant: participant.slice(0, 8) });
+            return false;
+        }
+        if (!this.config.ownerAddresses.has(participant)) {
+            log.debug('Non-owner address', { participant: participant.slice(0, 8) });
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Handle commands from AlgoChat messages.
+     * Returns true if the message was handled as a command.
+     */
+    handleCommand(participant: string, content: string): boolean {
+        const trimmed = content.trim();
+        if (!trimmed.startsWith('/')) return false;
+
+        const parts = trimmed.split(/\s+/);
+        const command = parts[0].toLowerCase();
+
+        // Privileged commands require owner authorization
+        if (PRIVILEGED_COMMANDS.has(command) && !this.isOwner(participant)) {
+            log.warn('Unauthorized command attempt', { participant: participant.slice(0, 8), command });
+            this.responseFormatter.sendResponse(participant, `Unauthorized: ${command} requires owner access`);
+            return true;
+        }
+
+        switch (command) {
+            case '/status': {
+                const activeCount = this.processManager.getActiveSessionIds().length;
+                const conversations = listConversations(this.db);
+                this.responseFormatter.sendResponse(participant, `Active sessions: ${activeCount}, conversations: ${conversations.length}`);
+                return true;
+            }
+
+            case '/stop': {
+                const sessionId = parts[1];
+                if (!sessionId) {
+                    this.responseFormatter.sendResponse(participant, 'Usage: /stop <session-id>');
+                    return true;
+                }
+                if (this.processManager.isRunning(sessionId)) {
+                    this.processManager.stopProcess(sessionId);
+                    this.responseFormatter.sendResponse(participant, `Stopped session ${sessionId}`);
+                } else {
+                    this.responseFormatter.sendResponse(participant, `Session ${sessionId} is not running`);
+                }
+                return true;
+            }
+
+            case '/agent': {
+                const agentName = parts.slice(1).join(' ');
+                if (!agentName) {
+                    const agents = getAlgochatEnabledAgents(this.db);
+                    const names = agents.map((a) => a.name).join(', ');
+                    this.responseFormatter.sendResponse(participant, `Available agents: ${names || 'none'}`);
+                    return true;
+                }
+                // Route subsequent messages to the specified agent
+                const agents = getAlgochatEnabledAgents(this.db);
+                const matched = agents.find((a) => a.name.toLowerCase() === agentName.toLowerCase());
+                if (matched) {
+                    this.config.defaultAgentId = matched.id;
+                    this.responseFormatter.sendResponse(participant, `Routing to agent: ${matched.name}`);
+                } else {
+                    this.responseFormatter.sendResponse(participant, `Agent "${agentName}" not found`);
+                }
+                return true;
+            }
+
+            case '/queue': {
+                const queued = this.processManager.approvalManager.getQueuedRequests();
+                if (queued.length === 0) {
+                    this.responseFormatter.sendResponse(participant, 'No pending escalation requests');
+                } else {
+                    const lines = queued.map((q) => `#${q.id}: [${q.toolName}] session=${q.sessionId.slice(0, 8)} (${q.createdAt})`);
+                    this.responseFormatter.sendResponse(participant, `Pending escalations:\n${lines.join('\n')}`);
+                }
+                return true;
+            }
+
+            case '/approve': {
+                const queueId = parseInt(parts[1], 10);
+                if (isNaN(queueId)) {
+                    this.responseFormatter.sendResponse(participant, 'Usage: /approve <queue-id>');
+                    return true;
+                }
+                const resolved = this.processManager.approvalManager.resolveQueuedRequest(queueId, true);
+                this.responseFormatter.sendResponse(participant, resolved
+                    ? `Escalation #${queueId} approved`
+                    : `Escalation #${queueId} not found or already resolved`);
+                return true;
+            }
+
+            case '/deny': {
+                const queueId = parseInt(parts[1], 10);
+                if (isNaN(queueId)) {
+                    this.responseFormatter.sendResponse(participant, 'Usage: /deny <queue-id>');
+                    return true;
+                }
+                const resolved = this.processManager.approvalManager.resolveQueuedRequest(queueId, false);
+                this.responseFormatter.sendResponse(participant, resolved
+                    ? `Escalation #${queueId} denied`
+                    : `Escalation #${queueId} not found or already resolved`);
+                return true;
+            }
+
+            case '/mode': {
+                const newMode = parts[1]?.toLowerCase();
+                if (!newMode) {
+                    this.responseFormatter.sendResponse(participant, `Current mode: ${this.processManager.approvalManager.operationalMode}`);
+                    return true;
+                }
+                const validModes = ['normal', 'queued', 'paused'];
+                if (!validModes.includes(newMode)) {
+                    this.responseFormatter.sendResponse(participant, `Invalid mode. Use: ${validModes.join(', ')}`);
+                    return true;
+                }
+                this.processManager.approvalManager.operationalMode = newMode as 'normal' | 'queued' | 'paused';
+                this.responseFormatter.sendResponse(participant, `Mode set to: ${newMode}`);
+                return true;
+            }
+
+            case '/credits': {
+                const balance = getBalance(this.db, participant);
+                const config = getCreditConfig(this.db);
+                const lines = [
+                    `💰 Credit Balance:`,
+                    `  Available: ${balance.available} credits`,
+                    `  Reserved: ${balance.reserved} credits`,
+                    `  Total: ${balance.credits} credits`,
+                    `  Purchased: ${balance.totalPurchased} | Used: ${balance.totalConsumed}`,
+                    ``,
+                    `📊 Rates:`,
+                    `  1 ALGO = ${config.creditsPerAlgo} credits`,
+                    `  1 turn = ${config.creditsPerTurn} credit(s)`,
+                    `  1 agent message = ${config.creditsPerAgentMessage} credit(s)`,
+                    ``,
+                    `Send ALGO to this address to purchase credits.`,
+                ];
+                this.responseFormatter.sendResponse(participant, lines.join('\n'));
+                return true;
+            }
+
+            case '/history': {
+                const limit = parseInt(parts[1], 10) || 10;
+                const transactions = getTransactionHistory(this.db, participant, Math.min(limit, 20));
+                if (transactions.length === 0) {
+                    this.responseFormatter.sendResponse(participant, 'No credit transactions yet.');
+                    return true;
+                }
+                const lines = transactions.map((t) =>
+                    `${t.type === 'purchase' || t.type === 'grant' ? '+' : '-'}${t.amount} [${t.type}] → bal:${t.balanceAfter} (${t.createdAt})`
+                );
+                this.responseFormatter.sendResponse(participant, `📜 Recent Transactions:\n${lines.join('\n')}`);
+                return true;
+            }
+
+            case '/work': {
+                const description = parts.slice(1).join(' ');
+                if (!description) {
+                    this.responseFormatter.sendResponse(participant, 'Usage: /work <task description>');
+                    return true;
+                }
+
+                if (!this.workTaskService) {
+                    this.responseFormatter.sendResponse(participant, 'Work task service not available');
+                    return true;
+                }
+
+                const agentId = this.context.findAgentForNewConversation();
+                if (!agentId) {
+                    this.responseFormatter.sendResponse(participant, 'No agent available for work tasks');
+                    return true;
+                }
+
+                this.workTaskService.create({
+                    agentId,
+                    description,
+                    source: 'algochat',
+                    requesterInfo: { participant },
+                }).then((task) => {
+                    this.responseFormatter.sendResponse(participant, `Work task started: ${task.id}\nBranch: ${task.branchName ?? 'creating...'}\nStatus: ${task.status}`);
+
+                    this.workTaskService?.onComplete(task.id, (completed) => {
+                        if (completed.status === 'completed' && completed.prUrl) {
+                            this.responseFormatter.sendResponse(participant, `Work task completed!\nPR: ${completed.prUrl}`);
+                        } else {
+                            this.responseFormatter.sendResponse(participant, `Work task failed: ${completed.error ?? 'Unknown error'}`);
+                        }
+                    });
+                }).catch((err) => {
+                    this.responseFormatter.sendResponse(participant, `Work task error: ${err instanceof Error ? err.message : String(err)}`);
+                });
+                return true;
+            }
+
+            case '/council': {
+                this.handleCouncilCommand(participant, parts).catch((err) => {
+                    this.responseFormatter.sendResponse(participant, `Council error: ${err instanceof Error ? err.message : String(err)}`);
+                });
+                return true;
+            }
+
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Handle the `/council` command from AlgoChat.
+     *
+     * Usage:
+     *   /council <prompt>                       — auto-create council with all enabled agents
+     *   /council MyCouncilName -- <prompt>      — use existing council by name
+     */
+    private async handleCouncilCommand(participant: string, parts: string[]): Promise<void> {
+        const rest = parts.slice(1).join(' ').trim();
+        if (!rest) {
+            this.responseFormatter.sendResponse(participant, 'Usage:\n  /council <prompt>\n  /council <CouncilName> -- <prompt>');
+            return;
+        }
+
+        // Parse: "/council CouncilName -- prompt" or "/council prompt"
+        const doubleDashIdx = rest.indexOf('--');
+        let councilName: string | null = null;
+        let prompt: string;
+
+        if (doubleDashIdx >= 0) {
+            councilName = rest.slice(0, doubleDashIdx).trim();
+            prompt = rest.slice(doubleDashIdx + 2).trim();
+        } else {
+            prompt = rest;
+        }
+
+        if (!prompt) {
+            this.responseFormatter.sendResponse(participant, 'Please provide a prompt for the council.');
+            return;
+        }
+
+        // Resolve or auto-create the council
+        let councilId: string;
+        let councilLabel: string;
+
+        if (councilName) {
+            // Find existing council by name
+            const councils = listCouncils(this.db);
+            const match = councils.find((c) => c.name.toLowerCase() === councilName!.toLowerCase());
+            if (!match) {
+                const available = councils.map((c) => c.name).join(', ');
+                this.responseFormatter.sendResponse(participant, `Council "${councilName}" not found.\nAvailable: ${available || 'none'}`);
+                return;
+            }
+            councilId = match.id;
+            councilLabel = match.name;
+        } else {
+            // Auto-create council with all algochat-enabled agents
+            const agents = getAlgochatEnabledAgents(this.db);
+            if (agents.length === 0) {
+                this.responseFormatter.sendResponse(participant, 'No AlgoChat-enabled agents available for council.');
+                return;
+            }
+            const agentIds = agents.map((a) => a.id);
+            const chairmanId = agents[0].id; // First agent becomes chairman
+            const council = createCouncil(this.db, {
+                name: `AlgoChat Council ${new Date().toISOString().slice(0, 16)}`,
+                description: 'Auto-created from AlgoChat /council command',
+                agentIds,
+                chairmanAgentId: chairmanId,
+                discussionRounds: 2,
+            });
+            councilId = council.id;
+            councilLabel = council.name;
+        }
+
+        // Resolve project ID (reuse existing helper)
+        const projectId = this.context.getDefaultProjectId();
+
+        // Launch the council
+        this.responseFormatter.sendResponse(participant, `Launching council "${councilLabel}"...\nPrompt: ${prompt.slice(0, 200)}`);
+
+        try {
+            const result = launchCouncil(
+                this.db,
+                this.processManager,
+                councilId,
+                projectId,
+                prompt,
+                this.agentMessengerRef,
+            );
+
+            this.responseFormatter.sendResponse(participant, `Council launched! (${result.sessionIds.length} agents responding)\nLaunch ID: ${result.launchId.slice(0, 8)}...`);
+
+            // Monitor stage changes and relay progress + final synthesis on-chain.
+            // Safety timeout prevents the listener from leaking if the council
+            // pipeline crashes before reaching the 'complete' stage.
+            const COUNCIL_LISTENER_TIMEOUT_MS = 45 * 60 * 1000; // 45 minutes
+
+            const cleanup = () => {
+                clearTimeout(safetyTimer);
+                unsubscribe();
+            };
+
+            const safetyTimer = setTimeout(() => {
+                log.warn('Council stage listener timed out, cleaning up', { launchId: result.launchId });
+                unsubscribe();
+            }, COUNCIL_LISTENER_TIMEOUT_MS);
+
+            const unsubscribe = onCouncilStageChange((launchId, stage) => {
+                if (launchId !== result.launchId) return;
+
+                if (stage === 'discussing') {
+                    this.responseFormatter.sendResponse(participant, `[Council] Agents are now discussing...`);
+                } else if (stage === 'reviewing') {
+                    this.responseFormatter.sendResponse(participant, `[Council] Peer review stage started.`);
+                } else if (stage === 'synthesizing') {
+                    this.responseFormatter.sendResponse(participant, `[Council] Chairman is synthesizing final answer...`);
+                } else if (stage === 'complete') {
+                    cleanup();
+                    // Fetch the synthesis and send it back
+                    const launch = getCouncilLaunch(this.db, result.launchId);
+                    if (launch?.synthesis) {
+                        const MAX_SYNTHESIS_LENGTH = 3000;
+                        const synthesis = launch.synthesis.length > MAX_SYNTHESIS_LENGTH
+                            ? launch.synthesis.slice(0, MAX_SYNTHESIS_LENGTH) + '\n\n[Truncated — view full synthesis on dashboard]'
+                            : launch.synthesis;
+                        this.responseFormatter.sendResponse(participant, `[Council Complete]\n\n${synthesis}`);
+                    } else {
+                        this.responseFormatter.sendResponse(participant, `[Council Complete] No synthesis produced.`);
+                    }
+                }
+            });
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            this.responseFormatter.sendResponse(participant, `Council launch failed: ${msg}`);
+        }
+    }
+}

--- a/server/algochat/discovery-service.ts
+++ b/server/algochat/discovery-service.ts
@@ -1,0 +1,244 @@
+/**
+ * DiscoveryService — Handles agent/sender discovery and conversation seeding
+ * for the AlgoChat bridge.
+ *
+ * Responsibilities:
+ * - Seed the SyncManager with known conversation participants from the DB
+ * - Periodically discover new senders via the Algorand indexer
+ * - Fast-poll for approval responses when approvals are pending
+ * - Cache and refresh agent wallet addresses
+ *
+ * Extracted from bridge.ts to isolate discovery/polling concerns from
+ * message handling and subscription management.
+ */
+import type { Database } from 'bun:sqlite';
+import type { AlgoChatConfig } from './config';
+import type { AlgoChatService } from './service';
+import type { ApprovalManager } from '../process/approval-manager';
+import {
+    listConversations,
+} from '../db/sessions';
+import { listAgents, getAlgochatEnabledAgents } from '../db/agents';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('DiscoveryService');
+
+/**
+ * Authorization check function — injected by the bridge so this module
+ * doesn't need direct access to config.ownerAddresses.
+ */
+export type IsOwnerFn = (participant: string) => boolean;
+
+/**
+ * Manages agent discovery, conversation seeding, and polling for the
+ * AlgoChat system.
+ *
+ * This service is responsible for:
+ * - Populating the SyncManager with existing DB conversations on startup
+ * - Discovering new senders by querying the Algorand indexer
+ * - Fast-polling for approval responses (5s interval)
+ * - Caching agent wallet addresses to filter outbound messages
+ */
+export class DiscoveryService {
+    private db: Database;
+    private config: AlgoChatConfig;
+    private service: AlgoChatService;
+    private isOwnerFn: IsOwnerFn;
+    private approvalManager: ApprovalManager | null = null;
+
+    /** Timer for fast-polling during pending approvals. */
+    private fastPollTimer: ReturnType<typeof setInterval> | null = null;
+    /** Timer for periodic sender discovery. */
+    private discoveryTimer: ReturnType<typeof setInterval> | null = null;
+    /** Cached agent wallet addresses (refreshed every 60s). */
+    private cachedAgentWallets: Set<string> | null = null;
+    private cachedAgentWalletsAt = 0;
+
+    constructor(
+        db: Database,
+        config: AlgoChatConfig,
+        service: AlgoChatService,
+        isOwnerFn: IsOwnerFn,
+    ) {
+        this.db = db;
+        this.config = config;
+        this.service = service;
+        this.isOwnerFn = isOwnerFn;
+    }
+
+    /** Inject the optional approval manager for fast-polling checks. */
+    setApprovalManager(manager: ApprovalManager): void {
+        this.approvalManager = manager;
+    }
+
+    /**
+     * Seed the SyncManager with known conversation participants from the DB
+     * so that fetchAllConversations has something to iterate over.
+     */
+    seedConversations(): void {
+        const conversations = listConversations(this.db);
+        for (const conv of conversations) {
+            const syncConv = this.service.syncManager.getOrCreateConversation(conv.participantAddr);
+            if (conv.lastRound > 0) {
+                // Use lastRound + 1 because minRound is inclusive and we already
+                // processed the message at lastRound in a previous run
+                syncConv.setLastFetchedRound(conv.lastRound + 1);
+            }
+        }
+        if (conversations.length > 0) {
+            log.info(`Seeded ${conversations.length} conversation(s) from DB`);
+        }
+    }
+
+    /**
+     * Start periodic discovery polling for new senders.
+     * Runs immediately, then on the configured sync interval.
+     */
+    startDiscoveryPolling(): void {
+        if (this.discoveryTimer) return;
+
+        // Run immediately then on the sync interval
+        this.discoverNewSenders().catch((err) => {
+            log.warn('Discovery error', { error: err instanceof Error ? err.message : String(err) });
+        });
+
+        this.discoveryTimer = setInterval(() => {
+            this.discoverNewSenders().catch((err) => {
+                log.warn('Discovery error', { error: err instanceof Error ? err.message : String(err) });
+            });
+        }, this.config.syncInterval);
+    }
+
+    /** Stop the discovery polling timer. */
+    stopDiscoveryPolling(): void {
+        if (this.discoveryTimer) {
+            clearInterval(this.discoveryTimer);
+            this.discoveryTimer = null;
+        }
+    }
+
+    /**
+     * Discover new senders by querying the indexer for incoming transactions
+     * from addresses not yet in the SyncManager.
+     */
+    async discoverNewSenders(): Promise<void> {
+        if (!this.service.indexerClient) return;
+
+        const myAddr = this.service.chatAccount.address;
+        const response = await this.service.indexerClient
+            .searchForTransactions()
+            .address(myAddr)
+            .addressRole('receiver')
+            .limit(50)
+            .do();
+
+        const knownParticipants = new Set(
+            this.service.syncManager.getConversations().map((c) => c.participant),
+        );
+
+        const newSenders = new Set<string>();
+        for (const tx of (response as { transactions?: Array<{ sender: string; note?: string }> }).transactions ?? []) {
+            if (tx.sender !== myAddr && tx.note && !knownParticipants.has(tx.sender)) {
+                if (!this.isOwnerFn(tx.sender)) continue;
+                newSenders.add(tx.sender);
+            }
+        }
+
+        for (const sender of newSenders) {
+            log.info(`Discovered new sender`, { address: sender });
+            this.service.syncManager.getOrCreateConversation(sender);
+        }
+    }
+
+    /**
+     * Start fast-polling (5s interval) while approval requests are pending.
+     * Triggers manual syncs so the user's reply is picked up quickly.
+     */
+    startFastPolling(): void {
+        if (this.fastPollTimer) return;
+
+        const FAST_POLL_MS = 5000;
+        this.fastPollTimer = setInterval(() => {
+            // If no more pending approvals, stop fast polling
+            if (!this.approvalManager?.hasPendingRequests()) {
+                this.stopFastPolling();
+                return;
+            }
+
+            // Trigger a manual sync
+            this.service.syncManager.sync().catch((err) => {
+                log.warn('Fast-poll sync error', { error: err instanceof Error ? err.message : String(err) });
+            });
+        }, FAST_POLL_MS);
+
+        log.debug('Started fast-polling for approval responses');
+    }
+
+    /** Stop fast-polling. */
+    stopFastPolling(): void {
+        if (this.fastPollTimer) {
+            clearInterval(this.fastPollTimer);
+            this.fastPollTimer = null;
+            log.debug('Stopped fast-polling');
+        }
+    }
+
+    /**
+     * Get the set of agent wallet addresses (cached, refreshed every 60s).
+     * Used to filter outbound messages that the sync sees as 'received'.
+     */
+    getAgentWalletAddresses(): Set<string> {
+        const now = Date.now();
+        // Refresh cache every 60s
+        if (this.cachedAgentWallets && now - this.cachedAgentWalletsAt < 60_000) {
+            return this.cachedAgentWallets;
+        }
+        const agents = listAgents(this.db);
+        const addrs = new Set<string>();
+        for (const a of agents) {
+            if (a.walletAddress) addrs.add(a.walletAddress);
+        }
+        // Also include the main chat account address
+        addrs.add(this.service.chatAccount.address);
+        this.cachedAgentWallets = addrs;
+        this.cachedAgentWalletsAt = now;
+        return addrs;
+    }
+
+    /**
+     * Find the default agent for new conversations.
+     * Prefers the configured default, then auto-enabled agents, then the first available.
+     */
+    findAgentForNewConversation(): string | null {
+        if (this.config.defaultAgentId) {
+            return this.config.defaultAgentId;
+        }
+
+        const agents = getAlgochatEnabledAgents(this.db);
+        const autoAgent = agents.find((a) => a.algochatAuto);
+        return autoAgent?.id ?? agents[0]?.id ?? null;
+    }
+
+    /**
+     * Get or create the default project ID for new sessions.
+     */
+    getDefaultProjectId(): string {
+        const { listProjects, createProject } = require('../db/projects');
+        const projects = listProjects(this.db);
+        if (projects.length > 0) return projects[0].id;
+
+        const project = createProject(this.db, {
+            name: 'AlgoChat Default',
+            workingDir: process.cwd(),
+        });
+        return project.id;
+    }
+
+    /**
+     * Clean up all timers. Called during bridge shutdown.
+     */
+    cleanup(): void {
+        this.stopFastPolling();
+        this.stopDiscoveryPolling();
+    }
+}

--- a/server/algochat/response-formatter.ts
+++ b/server/algochat/response-formatter.ts
@@ -1,0 +1,304 @@
+/**
+ * ResponseFormatter — Handles on-chain and PSK response sending,
+ * ALGO spending tracking, and event emission for AlgoChat messages.
+ *
+ * Extracted from bridge.ts to isolate message serialization, delivery,
+ * and event persistence concerns.
+ */
+import type { Database } from 'bun:sqlite';
+import type { AlgoChatConfig } from './config';
+import type { AlgoChatService } from './service';
+import type { AgentWalletService } from './agent-wallet';
+import type { PSKManager } from './psk';
+import {
+    getConversationByParticipant,
+} from '../db/sessions';
+import { checkAlgoLimit, recordAlgoSpend } from '../db/spending';
+import { updateSessionAlgoSpent } from '../db/sessions';
+import { saveAlgoChatMessage } from '../db/algochat-messages';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('ResponseFormatter');
+
+/** TTL for cached public keys. */
+const PUBLIC_KEY_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Callback signature for AlgoChat feed events (UI, WS, etc.).
+ */
+export type AlgoChatEventCallback = (
+    participant: string,
+    content: string,
+    direction: 'inbound' | 'outbound' | 'status',
+    fee?: number,
+) => void;
+
+interface CachedPublicKey {
+    key: Uint8Array;
+    cachedAt: number;
+}
+
+/**
+ * Manages response serialization, on-chain delivery, and event emission.
+ *
+ * Responsibilities:
+ * - Sending messages on-chain (group txns, single txn fallback, PSK)
+ * - Splitting oversized PSK payloads into sequential chunks
+ * - Tracking ALGO spending and per-session costs
+ * - Persisting messages to DB and emitting feed events
+ * - Caching recipient public keys
+ */
+export class ResponseFormatter {
+    private db: Database;
+    private service: AlgoChatService;
+    private agentWalletService: AgentWalletService | null = null;
+    private pskManager: PSKManager | null = null;
+    private eventCallbacks: Set<AlgoChatEventCallback> = new Set();
+    private publicKeyCache: Map<string, CachedPublicKey> = new Map();
+
+    constructor(
+        db: Database,
+        _config: AlgoChatConfig,
+        service: AlgoChatService,
+    ) {
+        this.db = db;
+        this.service = service;
+    }
+
+    /** Inject the optional agent wallet service for per-agent sending. */
+    setAgentWalletService(service: AgentWalletService): void {
+        this.agentWalletService = service;
+    }
+
+    /** Inject the optional PSK manager for pre-shared-key messaging. */
+    setPskManager(manager: PSKManager | null): void {
+        this.pskManager = manager;
+    }
+
+    /** Register a callback for AlgoChat feed events. */
+    onEvent(callback: AlgoChatEventCallback): void {
+        this.eventCallbacks.add(callback);
+    }
+
+    /** Unregister a feed event callback. */
+    offEvent(callback: AlgoChatEventCallback): void {
+        this.eventCallbacks.delete(callback);
+    }
+
+    /**
+     * Send a response message to a participant on-chain.
+     *
+     * Routing order:
+     * 1. PSK contacts → PSKManager (chunked if needed)
+     * 2. Per-agent wallet → group transaction
+     * 3. Main account → group transaction
+     * 4. Fallback → single transaction (truncated)
+     */
+    async sendResponse(participant: string, content: string): Promise<void> {
+        // Check daily ALGO spending limit (estimate min fee of 1000 microAlgos per txn)
+        try {
+            checkAlgoLimit(this.db, 1000);
+        } catch (err) {
+            const conversation = getConversationByParticipant(this.db, participant);
+            log.warn(`On-chain response blocked by spending limit — dead letter`, {
+                participant,
+                conversationId: conversation?.id ?? null,
+                sessionId: conversation?.sessionId ?? null,
+                contentLength: content.length,
+                contentPreview: content.slice(0, 200),
+                error: err instanceof Error ? err.message : String(err),
+            });
+            return;
+        }
+
+        try {
+            // Route PSK contacts through the PSK manager
+            if (this.pskManager && participant === this.pskManager.contactAddress) {
+                // PSK has an 878-byte payload limit per transaction.
+                // Split oversized messages into sequential sends with a delay
+                // between each so they land in different blocks (preserving order).
+                const PSK_MAX_BYTES = 800;
+                const PSK_INTER_CHUNK_DELAY_MS = 4500;
+                const chunks = this.splitPskContent(content, PSK_MAX_BYTES);
+                for (let i = 0; i < chunks.length; i++) {
+                    if (i > 0) {
+                        await new Promise((r) => setTimeout(r, PSK_INTER_CHUNK_DELAY_MS));
+                    }
+                    await this.pskManager.sendMessage(chunks[i]);
+                }
+                log.info(`Sent PSK response to ${participant}`, {
+                    content: content.slice(0, 100),
+                    chunks: chunks.length,
+                });
+                this.emitEvent(participant, content, 'outbound');
+                return;
+            }
+
+            // Try to use per-agent wallet if available
+            let senderAccount = this.service.chatAccount;
+            if (this.agentWalletService) {
+                const conversation = getConversationByParticipant(this.db, participant);
+                if (conversation?.agentId) {
+                    const agentAccount = await this.agentWalletService.getAgentChatAccount(conversation.agentId);
+                    if (agentAccount) {
+                        senderAccount = agentAccount.account;
+                        log.debug(`Using agent wallet ${agentAccount.address} for response`);
+                    }
+                }
+            }
+
+            const pubKey = await this.getPublicKey(participant);
+
+            // Use group transactions for all recipients. External AlgoChat
+            // clients that support [GRP:] reassembly will show the full message;
+            // for short messages that fit in a single txn, sendGroupMessage
+            // automatically falls back to a standard single send.
+            try {
+                const { sendGroupMessage } = await import('./group-sender');
+                const groupResult = await sendGroupMessage(
+                    this.service,
+                    senderAccount,
+                    participant,
+                    pubKey,
+                    content,
+                );
+
+                log.info(`Sent response to ${participant}`, { content: content.slice(0, 100), fee: groupResult.fee, txids: groupResult.txids.length });
+                if (groupResult.fee) {
+                    recordAlgoSpend(this.db, groupResult.fee);
+                    const conv = getConversationByParticipant(this.db, participant);
+                    if (conv?.sessionId) updateSessionAlgoSpent(this.db, conv.sessionId, groupResult.fee);
+                }
+                this.emitEvent(participant, content, 'outbound', groupResult.fee);
+                return;
+            } catch (groupErr) {
+                log.warn('Group send failed, falling back to single txn', {
+                    error: groupErr instanceof Error ? groupErr.message : String(groupErr),
+                });
+            }
+
+            // Fallback: single transaction (truncates if needed)
+            let sendContent = content;
+            const encoded = new TextEncoder().encode(content);
+            if (encoded.byteLength > 850) {
+                sendContent = new TextDecoder().decode(encoded.slice(0, 840)) + '...';
+            }
+
+            const result = await this.service.algorandService.sendMessage(
+                senderAccount,
+                participant,
+                pubKey,
+                sendContent,
+            );
+
+            const fee = (result as unknown as { fee?: number }).fee;
+            log.info(`Sent response to ${participant}`, { content: content.slice(0, 100), fee });
+            if (fee) {
+                recordAlgoSpend(this.db, fee);
+                const conv = getConversationByParticipant(this.db, participant);
+                if (conv?.sessionId) updateSessionAlgoSpent(this.db, conv.sessionId, fee);
+            }
+            this.emitEvent(participant, content, 'outbound', fee);
+        } catch (err) {
+            // Dead-letter logging: capture full context for failed message sends
+            // so they can be investigated and potentially retried.
+            const conversation = getConversationByParticipant(this.db, participant);
+            log.error('Failed to send response — dead letter', {
+                participant,
+                conversationId: conversation?.id ?? null,
+                sessionId: conversation?.sessionId ?? null,
+                agentId: conversation?.agentId ?? null,
+                contentLength: content.length,
+                contentPreview: content.slice(0, 200),
+                error: err instanceof Error ? err.message : String(err),
+                stack: err instanceof Error ? err.stack : undefined,
+            });
+        }
+    }
+
+    /**
+     * Emit a feed event: persists to DB and notifies all registered callbacks.
+     */
+    emitEvent(
+        participant: string,
+        content: string,
+        direction: 'inbound' | 'outbound' | 'status',
+        fee?: number,
+    ): void {
+        // Persist to DB so messages survive page refresh
+        try {
+            saveAlgoChatMessage(this.db, { participant, content, direction, fee });
+        } catch (err) {
+            log.warn('Failed to persist algochat message', { error: err instanceof Error ? err.message : String(err) });
+        }
+
+        for (const cb of this.eventCallbacks) {
+            try {
+                cb(participant, content, direction, fee);
+            } catch (err) {
+                log.error('Event callback threw', { error: err instanceof Error ? err.message : String(err) });
+            }
+        }
+    }
+
+    /**
+     * Split content into byte-limited chunks for PSK sends,
+     * breaking at newlines when possible for readability.
+     */
+    splitPskContent(content: string, maxBytes: number): string[] {
+        const encoder = new TextEncoder();
+        if (encoder.encode(content).byteLength <= maxBytes) {
+            return [content];
+        }
+
+        const chunks: string[] = [];
+        let remaining = content;
+
+        while (remaining.length > 0) {
+            if (encoder.encode(remaining).byteLength <= maxBytes) {
+                chunks.push(remaining);
+                break;
+            }
+
+            // Binary search for the max character count that fits in maxBytes
+            let low = 0;
+            let high = remaining.length;
+            while (low < high) {
+                const mid = Math.floor((low + high + 1) / 2);
+                if (encoder.encode(remaining.slice(0, mid)).byteLength <= maxBytes) {
+                    low = mid;
+                } else {
+                    high = mid - 1;
+                }
+            }
+
+            // Try to break at a newline within the last 20% for readability
+            let cut = low;
+            const searchStart = Math.floor(low * 0.8);
+            const lastNewline = remaining.lastIndexOf('\n', low);
+            if (lastNewline >= searchStart) {
+                cut = lastNewline + 1;
+            }
+
+            chunks.push(remaining.slice(0, cut));
+            remaining = remaining.slice(cut);
+        }
+
+        return chunks;
+    }
+
+    /**
+     * Get (or cache) a recipient's public key for on-chain encryption.
+     * Keys are cached for 1 hour.
+     */
+    async getPublicKey(address: string): Promise<Uint8Array> {
+        const cached = this.publicKeyCache.get(address);
+        if (cached && (Date.now() - cached.cachedAt) < PUBLIC_KEY_CACHE_TTL_MS) {
+            return cached.key;
+        }
+
+        const pubKey = await this.service.algorandService.discoverPublicKey(address);
+        this.publicKeyCache.set(address, { key: pubKey, cachedAt: Date.now() });
+        return pubKey;
+    }
+}

--- a/server/algochat/subscription-manager.ts
+++ b/server/algochat/subscription-manager.ts
@@ -1,0 +1,647 @@
+/**
+ * SubscriptionManager — Manages session event subscriptions and response
+ * lifecycle for both on-chain and local (browser dashboard) conversations.
+ *
+ * This is the highest-complexity extraction from bridge.ts. It owns:
+ * - On-chain response subscriptions with progress tracking
+ * - Local (WebSocket) response subscriptions with streaming
+ * - Subscription timeout management with activity-based resets
+ * - Acknowledgment delay logic (skip ack if response arrives quickly)
+ * - Periodic progress updates sent on-chain
+ *
+ * The module uses a callback-based event pattern (matching ProcessManager's
+ * subscribe/unsubscribe API) rather than observables to stay consistent with
+ * existing codebase conventions.
+ */
+import type { ProcessManager } from '../process/manager';
+import type { ClaudeStreamEvent } from '../process/types';
+import { extractContentText } from '../process/types';
+import type { ResponseFormatter } from './response-formatter';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('SubscriptionManager');
+
+/** Timeout before a subscription is considered stale and cleaned up. */
+const SUBSCRIPTION_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes (activity resets timer)
+
+/**
+ * Callback for sending local chat messages back to the browser.
+ */
+export type LocalChatSendFn = (
+    participant: string,
+    content: string,
+    direction: 'inbound' | 'outbound',
+) => void;
+
+/**
+ * Structured events for local chat streaming (tool use, thinking, etc.).
+ */
+export type LocalChatEvent =
+    | { type: 'message'; content: string; direction: 'inbound' | 'outbound' }
+    | { type: 'stream'; chunk: string; done: boolean }
+    | { type: 'tool_use'; toolName: string; input: string }
+    | { type: 'thinking'; active: boolean }
+    | { type: 'session_info'; sessionId: string };
+
+/**
+ * Callback for structured local chat events.
+ */
+export type LocalChatEventFn = (event: LocalChatEvent) => void;
+
+/** Internal progress action for tracking what the agent is doing. */
+interface ProgressAction {
+    type: 'tool_use' | 'agent_query' | 'text_block' | 'milestone';
+    action: string;
+    timestamp: number;
+    details?: string;
+}
+
+/**
+ * Manages subscriptions to ProcessManager session events for both
+ * on-chain (AlgoChat) and local (browser dashboard) response delivery.
+ *
+ * Each subscription tracks the session lifecycle from first assistant
+ * event through session exit, buffering text and sending the final
+ * response via the appropriate channel.
+ */
+export class SubscriptionManager {
+    private processManager: ProcessManager;
+    private responseFormatter: ResponseFormatter;
+
+    /** Active on-chain subscriptions (sessionId set). */
+    private chainSubscriptions: Set<string> = new Set();
+    /** Local subscription callbacks keyed by sessionId. */
+    private localSubscriptions: Map<string, (sid: string, event: ClaudeStreamEvent) => void> = new Map();
+    /** Local send functions keyed by sessionId (updatable for WS reconnects). */
+    private localSendFns: Map<string, LocalChatSendFn> = new Map();
+    /** Local event functions keyed by sessionId. */
+    private localEventFns: Map<string, LocalChatEventFn> = new Map();
+    /** Subscription timeout timers keyed by sessionId. */
+    private subscriptionTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+
+    constructor(
+        processManager: ProcessManager,
+        responseFormatter: ResponseFormatter,
+    ) {
+        this.processManager = processManager;
+        this.responseFormatter = responseFormatter;
+    }
+
+    /**
+     * Check whether a local subscription already exists for a session.
+     */
+    hasLocalSubscription(sessionId: string): boolean {
+        return this.localSubscriptions.has(sessionId);
+    }
+
+    /**
+     * Update the send function for a local session (e.g. on WS reconnect).
+     */
+    updateLocalSendFn(sessionId: string, sendFn: LocalChatSendFn): void {
+        this.localSendFns.set(sessionId, sendFn);
+    }
+
+    /**
+     * Update the event function for a local session.
+     */
+    updateLocalEventFn(sessionId: string, eventFn: LocalChatEventFn): void {
+        this.localEventFns.set(sessionId, eventFn);
+    }
+
+    /**
+     * Clean up all local subscription state for a session.
+     */
+    cleanupLocalSession(sessionId: string): void {
+        this.localSubscriptions.delete(sessionId);
+        this.localSendFns.delete(sessionId);
+        this.localEventFns.delete(sessionId);
+    }
+
+    /**
+     * Subscribe for an on-chain response to a session.
+     *
+     * Tracks the full session lifecycle:
+     * - Buffers streamed text blocks, keeping only the last one
+     * - Sends periodic progress updates on-chain for long-running sessions
+     * - Delays the initial acknowledgment (skips if response arrives quickly)
+     * - Sends the final response on-chain when the session exits
+     * - Cleans up timers and subscriptions on completion or timeout
+     *
+     * @param sessionId - The session to subscribe to
+     * @param participant - The on-chain participant address to send responses to
+     */
+    subscribeForResponse(sessionId: string, participant: string): void {
+        // Avoid duplicate subscriptions when multiple messages arrive for the same session
+        if (this.chainSubscriptions.has(sessionId)) return;
+        this.chainSubscriptions.add(sessionId);
+
+        // We only send the LAST text block from the last turn. Earlier text
+        // blocks are intermediate explanations (tool call reasoning, etc.)
+        // and would clutter the on-chain response.
+        let lastTextBlock = '';
+        let lastAssistantText = '';
+        let lastTurnResponse = '';
+        let sent = false;
+        const startedAt = Date.now();
+
+        const sendOnce = () => {
+            if (sent) return;
+            sent = true;
+
+            // Track completion milestone
+            const totalElapsed = Date.now() - startedAt;
+            trackProgress({
+                type: 'milestone',
+                action: 'response_completed',
+                timestamp: Date.now(),
+                details: `Total time: ${Math.round(totalElapsed / 1000)}s, tools: ${toolsUsed.size}, agents: ${agentsQueried.size}`
+            });
+
+            stopProgressTimer();
+            this.processManager.unsubscribe(sessionId, callback);
+            this.chainSubscriptions.delete(sessionId);
+            this.clearSubscriptionTimer(sessionId);
+
+            // Prefer streamed text block > last turn response > full assistant text
+            const finalText = (lastTextBlock.trim() || lastTurnResponse.trim() || lastAssistantText.trim());
+            if (finalText) {
+                this.responseFormatter.sendResponse(participant, finalText);
+            }
+        };
+
+        const resetTimer = () => {
+            this.setSubscriptionTimer(sessionId, () => {
+                log.warn(`Subscription timeout for session ${sessionId}`);
+                sendOnce();
+            });
+        };
+
+        let statusEmitted = false;
+        let ackSent = false;
+        let agentQueryCount = 0;
+        let currentTextBlock = '';
+        let inTextBlock = false;
+
+        // Enhanced progress tracking
+        const MAX_PROGRESS_HISTORY = 100;
+        const progressHistory: ProgressAction[] = [];
+        const trackProgress = (action: ProgressAction) => {
+            progressHistory.push(action);
+            // Sliding window to prevent unbounded memory growth in long sessions
+            if (progressHistory.length > MAX_PROGRESS_HISTORY) {
+                progressHistory.splice(0, progressHistory.length - MAX_PROGRESS_HISTORY);
+            }
+        };
+        let lastProgressUpdate = startedAt;
+        let toolsUsed: Set<string> = new Set();
+        let agentsQueried: Set<string> = new Set();
+        let progressTimer: ReturnType<typeof setInterval> | null = null;
+        let ackDelayTimer: ReturnType<typeof setTimeout> | null = null;
+
+        // How long to wait before sending the on-chain ack. If the response
+        // arrives within this window we skip the ack entirely.
+        const ACK_DELAY_MS = 10_000; // 10 seconds
+        const PROGRESS_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
+
+        const cancelAckDelay = () => {
+            if (ackDelayTimer) {
+                clearTimeout(ackDelayTimer);
+                ackDelayTimer = null;
+            }
+        };
+
+        // Generate progress summary from recent actions
+        const generateProgressSummary = (): string => {
+            const now = Date.now();
+            const elapsed = Math.round((now - startedAt) / 1000);
+            const recentActions = progressHistory.filter(a => a.timestamp > lastProgressUpdate);
+
+            let summary = `Still working (${elapsed}s elapsed)`;
+
+            // Add what we've been doing
+            const recentSummary: string[] = [];
+
+            if (recentActions.length > 0) {
+                const toolActions = recentActions.filter(a => a.type === 'tool_use');
+                const agentActions = recentActions.filter(a => a.type === 'agent_query');
+                const textActions = recentActions.filter(a => a.type === 'text_block');
+
+                if (toolActions.length > 0) {
+                    const uniqueTools = [...new Set(toolActions.map(a => a.action))];
+                    recentSummary.push(`used ${uniqueTools.join(', ')}`);
+                }
+
+                if (agentActions.length > 0) {
+                    const uniqueAgents = [...new Set(agentActions.map(a => a.action))];
+                    recentSummary.push(`queried ${uniqueAgents.join(', ')}`);
+                }
+
+                if (textActions.length > 0) {
+                    const lastText = textActions[textActions.length - 1];
+                    if (lastText.details && lastText.details.length > 0) {
+                        const preview = lastText.details.length > 60
+                            ? lastText.details.slice(0, 60) + '...'
+                            : lastText.details;
+                        recentSummary.push(`working on: ${preview}`);
+                    }
+                }
+            }
+
+            // Overall progress
+            if (toolsUsed.size > 0 || agentsQueried.size > 0) {
+                const progress: string[] = [];
+                if (toolsUsed.size > 0) {
+                    progress.push(`${toolsUsed.size} tool${toolsUsed.size > 1 ? 's' : ''}`);
+                }
+                if (agentsQueried.size > 0) {
+                    progress.push(`${agentsQueried.size} agent${agentsQueried.size > 1 ? 's' : ''}`);
+                }
+                summary += ` — used ${progress.join(' and ')}`;
+            }
+
+            if (recentSummary.length > 0) {
+                summary += ` — recently ${recentSummary.join(', ')}`;
+            }
+
+            lastProgressUpdate = now;
+            return summary;
+        };
+
+        // Send periodic on-chain progress updates so the user's AlgoChat
+        // client knows the agent is still working
+        const startProgressTimer = () => {
+            if (progressTimer) return;
+            progressTimer = setInterval(() => {
+                if (sent) { stopProgressTimer(); return; }
+                const msg = generateProgressSummary();
+                this.responseFormatter.sendResponse(participant, `[Status] ${msg}`).catch((err) => {
+                    log.warn('Failed to send progress update', {
+                        participant,
+                        sessionId,
+                        error: err instanceof Error ? err.message : String(err),
+                    });
+                });
+                this.responseFormatter.emitEvent(participant, msg, 'status');
+            }, PROGRESS_INTERVAL_MS);
+        };
+
+        const stopProgressTimer = () => {
+            if (progressTimer) {
+                clearInterval(progressTimer);
+                progressTimer = null;
+            }
+        };
+
+        // Actually send the on-chain ack and start progress timer
+        const sendAckNow = () => {
+            if (ackSent || sent) return;
+            ackSent = true;
+
+            // Track acknowledgment milestone
+            trackProgress({
+                type: 'milestone',
+                action: 'request_acknowledged',
+                timestamp: Date.now(),
+                details: 'Processing request'
+            });
+
+            this.responseFormatter.sendResponse(participant, '[Status] Received your message — working on it now.').catch((err) => {
+                log.warn('Failed to send acknowledgment', {
+                    participant,
+                    sessionId,
+                    error: err instanceof Error ? err.message : String(err),
+                });
+            });
+            startProgressTimer();
+        };
+
+        const flushTextBlock = () => {
+            const text = currentTextBlock.trim();
+            if (text.length > 0) {
+                // Keep track of the latest text block — this overwrites
+                // previous ones so we only send the final one on-chain.
+                lastTextBlock = text;
+
+                // Track meaningful text for progress summaries
+                if (text.length > 50) { // Only track substantial text blocks
+                    trackProgress({
+                        type: 'text_block',
+                        action: 'reasoning',
+                        timestamp: Date.now(),
+                        details: text
+                    });
+                }
+
+                // Show the agent's intermediate text as a status update
+                // Truncate long blocks to a reasonable preview
+                const preview = text.length > 300
+                    ? text.slice(0, 300) + '...'
+                    : text;
+                this.responseFormatter.emitEvent(participant, preview, 'status');
+            }
+            currentTextBlock = '';
+            inTextBlock = false;
+        };
+
+        const callback = (sid: string, event: ClaudeStreamEvent) => {
+            if (sid !== sessionId) return;
+
+            // On first assistant event, show a local status and schedule
+            // the on-chain ack after a delay (skip if we finish quickly)
+            if (event.type === 'assistant' && !statusEmitted) {
+                statusEmitted = true;
+
+                // Track processing milestone
+                trackProgress({
+                    type: 'milestone',
+                    action: 'processing_started',
+                    timestamp: Date.now(),
+                    details: 'Agent began processing'
+                });
+
+                this.responseFormatter.emitEvent(participant, 'Agent is processing your message...', 'status');
+
+                if (!ackSent && !ackDelayTimer) {
+                    ackDelayTimer = setTimeout(sendAckNow, ACK_DELAY_MS);
+                }
+            }
+
+            // Forward named status events from tool handlers (e.g. "Querying CorvidLabs...")
+            if ((event as { type: string }).type === 'tool_status') {
+                const message = (event as unknown as { message: string }).message;
+                if (message) {
+                    this.responseFormatter.emitEvent(participant, message, 'status');
+
+                    // Track status action for progress summaries
+                    trackProgress({
+                        type: 'milestone',
+                        action: 'status_update',
+                        timestamp: Date.now(),
+                        details: message
+                    });
+
+                    // Agent is calling other agents — this will take a while,
+                    // send the ack immediately
+                    if (!ackSent) {
+                        cancelAckDelay();
+                        sendAckNow();
+                    }
+                    resetTimer();
+                }
+                return;
+            }
+
+            // Track text content blocks — stream agent's intermediate text to the feed
+            if (event.type === 'content_block_start') {
+                const block = event.content_block;
+                if (block?.type === 'text') {
+                    inTextBlock = true;
+                    currentTextBlock = '';
+                } else if (block?.type === 'tool_use') {
+                    // Flush any pending text before tool use starts
+                    if (inTextBlock) flushTextBlock();
+                    const toolName = (block as unknown as { name?: string }).name;
+
+                    if (toolName) {
+                        // Track tool usage for progress summaries
+                        toolsUsed.add(toolName);
+                        trackProgress({
+                            type: 'tool_use',
+                            action: toolName,
+                            timestamp: Date.now()
+                        });
+
+                        if (toolName === 'corvid_send_message') {
+                            agentQueryCount++;
+                            // Try to extract agent name from tool input
+                            const toolInput = (block as unknown as { input?: { to_agent?: string } }).input;
+                            if (toolInput?.to_agent) {
+                                agentsQueried.add(toolInput.to_agent);
+                                trackProgress({
+                                    type: 'agent_query',
+                                    action: toolInput.to_agent,
+                                    timestamp: Date.now()
+                                });
+                            }
+                            // Agent-to-agent call means longer processing — send ack now
+                            if (!ackSent) {
+                                cancelAckDelay();
+                                sendAckNow();
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Accumulate streaming text deltas
+            if (event.type === 'content_block_delta' && event.delta?.text && inTextBlock) {
+                currentTextBlock += event.delta.text;
+                resetTimer();
+            }
+
+            // Text block finished — flush it as a status update
+            if (event.type === 'content_block_stop' && inTextBlock) {
+                flushTextBlock();
+            }
+
+            // Capture assistant message content as fallback in case content_block
+            // streaming events don't fire (e.g. non-streaming SDK responses)
+            if (event.type === 'assistant' && event.message?.content) {
+                const text = extractContentText(event.message.content);
+                if (text.trim()) {
+                    lastAssistantText = text;
+                }
+                resetTimer();
+            } else if (event.type === 'assistant') {
+                resetTimer();
+            }
+
+            // Each 'result' marks end of a turn — save last text block and reset
+            if (event.type === 'result') {
+                if (inTextBlock) flushTextBlock();
+
+                // Track turn completion milestone
+                trackProgress({
+                    type: 'milestone',
+                    action: 'turn_completed',
+                    timestamp: Date.now(),
+                    details: `Completed turn with ${agentQueryCount} agent queries`
+                });
+
+                // Only show synthesizing status if we've been working long enough
+                const elapsed = Date.now() - startedAt;
+                if (agentQueryCount > 0 && elapsed > ACK_DELAY_MS) {
+                    const synthesizingMsg = `Synthesizing response from ${agentQueryCount} agent${agentQueryCount > 1 ? 's' : ''}...`;
+
+                    // Track synthesis milestone
+                    trackProgress({
+                        type: 'milestone',
+                        action: 'synthesis_started',
+                        timestamp: Date.now(),
+                        details: synthesizingMsg
+                    });
+
+                    this.responseFormatter.emitEvent(participant, synthesizingMsg, 'status');
+                }
+                // Prefer the last streamed text block; fall back to full assistant text
+                if (lastTextBlock.trim()) {
+                    lastTurnResponse = lastTextBlock;
+                } else if (lastAssistantText.trim()) {
+                    lastTurnResponse = lastAssistantText;
+                }
+                lastTextBlock = '';
+                lastAssistantText = '';
+                resetTimer(); // Turn completed — reset timeout
+            }
+
+            // Send only the last turn's response when the session fully exits
+            if (event.type === 'session_exited') {
+                if (inTextBlock) flushTextBlock();
+                cancelAckDelay();
+                stopProgressTimer();
+                sendOnce();
+            }
+        };
+
+        this.processManager.subscribe(sessionId, callback);
+        resetTimer();
+    }
+
+    /**
+     * Subscribe for local (browser dashboard) responses to a session.
+     *
+     * Streams events (text deltas, tool use, thinking state) to the
+     * browser via the provided sendFn and eventFn callbacks. Buffers
+     * assistant text and sends it on turn completion.
+     *
+     * @param sessionId - The session to subscribe to
+     * @param sendFn - Callback for sending chat messages to the browser
+     */
+    subscribeForLocalResponse(sessionId: string, sendFn: LocalChatSendFn): void {
+        // Store the sendFn so it can be updated if the WS connection changes
+        this.localSendFns.set(sessionId, sendFn);
+
+        // Check if already subscribed (avoid duplicate subscriptions on subsequent messages)
+        if (this.localSubscriptions.has(sessionId)) return;
+
+        let responseBuffer = '';
+        let isThinking = false;
+
+        const callback = (sid: string, event: ClaudeStreamEvent) => {
+            if (sid !== sessionId) return;
+
+            // Always use the latest sendFn and eventFn
+            const currentSendFn = this.localSendFns.get(sessionId);
+            if (!currentSendFn) return;
+            const currentEventFn = this.localEventFns.get(sessionId);
+
+            log.debug(`Local response event`, { sessionId, type: event.type, subtype: event.subtype });
+
+            // Emit thinking events
+            if (event.type === 'assistant' && !isThinking) {
+                isThinking = true;
+                currentEventFn?.({ type: 'thinking', active: true });
+            }
+
+            // Emit streaming chunks for content_block_delta
+            if (event.type === 'content_block_delta' && event.delta?.text) {
+                currentEventFn?.({ type: 'stream', chunk: event.delta.text, done: false });
+            }
+
+            // Emit tool_use events
+            if (event.type === 'content_block_start' && event.content_block?.type === 'tool_use') {
+                const toolName = (event.content_block as unknown as { name?: string }).name ?? 'unknown';
+                const input = JSON.stringify((event.content_block as unknown as { input?: unknown }).input ?? {});
+                currentEventFn?.({ type: 'tool_use', toolName, input });
+            }
+
+            if (event.type === 'assistant' && event.message?.content) {
+                const text = extractContentText(event.message.content);
+                log.debug(`Assistant content chunk`, { text: text.slice(0, 80) });
+                responseBuffer += text;
+            }
+
+            // Turn completed — send accumulated response and reset buffer for next turn
+            if (event.type === 'result') {
+                log.debug(`Turn completed`, { bufferLength: responseBuffer.length });
+                isThinking = false;
+                currentEventFn?.({ type: 'thinking', active: false });
+                currentEventFn?.({ type: 'stream', chunk: '', done: true });
+
+                if (responseBuffer.trim()) {
+                    log.debug(`Sending outbound response`, { text: responseBuffer.trim().slice(0, 80) });
+                    currentSendFn('local', responseBuffer.trim(), 'outbound');
+                    currentEventFn?.({ type: 'message', content: responseBuffer.trim(), direction: 'outbound' });
+                }
+                responseBuffer = '';
+            }
+
+            // Session exited — clean up subscription
+            if (event.type === 'session_exited') {
+                log.debug('Session exited, cleaning up subscription');
+                this.processManager.unsubscribe(sessionId, callback);
+                this.localSubscriptions.delete(sessionId);
+                this.localSendFns.delete(sessionId);
+                this.localEventFns.delete(sessionId);
+                this.clearSubscriptionTimer(sessionId);
+
+                isThinking = false;
+                currentEventFn?.({ type: 'thinking', active: false });
+
+                // Send any remaining buffered text
+                if (responseBuffer.trim()) {
+                    currentSendFn('local', responseBuffer.trim(), 'outbound');
+                    currentEventFn?.({ type: 'message', content: responseBuffer.trim(), direction: 'outbound' });
+                }
+            }
+        };
+
+        this.localSubscriptions.set(sessionId, callback);
+        this.processManager.subscribe(sessionId, callback);
+        this.setSubscriptionTimer(sessionId, () => {
+            log.warn(`Local subscription timeout for session ${sessionId}`);
+            this.processManager.unsubscribe(sessionId, callback);
+            this.localSubscriptions.delete(sessionId);
+            const currentSendFn = this.localSendFns.get(sessionId);
+            this.localSendFns.delete(sessionId);
+            this.localEventFns.delete(sessionId);
+            if (responseBuffer.trim() && currentSendFn) {
+                currentSendFn('local', responseBuffer.trim(), 'outbound');
+            }
+        });
+    }
+
+    /**
+     * Set (or reset) the subscription timeout for a session.
+     * Each activity event resets the timer.
+     */
+    setSubscriptionTimer(sessionId: string, onTimeout: () => void): void {
+        // Clear any existing timer for this session
+        this.clearSubscriptionTimer(sessionId);
+        const timer = setTimeout(onTimeout, SUBSCRIPTION_TIMEOUT_MS);
+        this.subscriptionTimers.set(sessionId, timer);
+    }
+
+    /**
+     * Clear the subscription timeout timer for a session.
+     */
+    clearSubscriptionTimer(sessionId: string): void {
+        const timer = this.subscriptionTimers.get(sessionId);
+        if (timer) {
+            clearTimeout(timer);
+            this.subscriptionTimers.delete(sessionId);
+        }
+    }
+
+    /**
+     * Clean up all subscription timers and chain subscriptions.
+     * Called during bridge shutdown.
+     */
+    cleanup(): void {
+        for (const timer of this.subscriptionTimers.values()) {
+            clearTimeout(timer);
+        }
+        this.subscriptionTimers.clear();
+        this.chainSubscriptions.clear();
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the monolithic `bridge.ts` (~1856 lines) into four focused, independently testable modules with clear responsibility boundaries:

- **ResponseFormatter** (304 lines) — On-chain message sending, PSK chunking, ALGO spend tracking, event emission, and public key caching
- **CommandHandler** (428 lines) — Slash command parsing (`/status`, `/stop`, `/agent`, `/credits`, `/work`, `/council`, etc.), authorization checks, and dispatch
- **SubscriptionManager** (647 lines) — Session event subscriptions for both on-chain and local (browser) responses, progress tracking with periodic updates, ack delays, and timeout management
- **DiscoveryService** (244 lines) — Sender discovery via Algorand indexer, conversation seeding from DB, agent wallet caching, fast-polling for approval responses, and default agent/project resolution

`bridge.ts` becomes a thin orchestration layer (694 lines, **63% reduction**) that composes these services and handles incoming message routing.

### Key architectural decisions:
- All public API surface preserved via re-exports — **callers require zero changes**
- Follows existing codebase patterns for service injection (constructor + setter methods)
- JSDoc on all public interfaces
- Lambda-based dependency injection avoids circular reference issues between services

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` — compiles clean
- [x] `bun test` — all 122 tests pass (0 failures)
- [x] Public API surface unchanged: `AlgoChatBridge` class, `AlgoChatEventCallback`, `LocalChatSendFn`, `LocalChatEvent`, `LocalChatEventFn` types all re-exported from bridge.ts
- [ ] End-to-end MCP tool invocations work after decomposition (manual verification)
- [ ] On-chain message send/receive cycle works (manual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)