### PR TITLE
fix: multi-stage Docker build for Angular client

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -52,4 +52,4 @@ AppState/
 run.sh
 playwright.config.js
 bunfig.toml
-tsconfig.json
+/tsconfig.json

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,16 +1,29 @@
-FROM oven/bun:1 AS base
+# ── Stage 1: Build Angular client ────────────────────────────────
+FROM oven/bun:1 AS client-build
+WORKDIR /app/client
+
+# Install client dependencies
+COPY client/package.json client/bun.lock* ./
+RUN bun install --frozen-lockfile
+
+# Copy client source & build
+COPY client/ .
+RUN bun run build
+
+# ── Stage 2: Production image ───────────────────────────────────
+FROM oven/bun:1 AS production
 WORKDIR /app
 
-# Install dependencies
+# Install server dependencies only
 COPY package.json bun.lock* ./
 RUN bun install --frozen-lockfile --production
 
-# Copy source
+# Copy server source
 COPY server/ server/
 COPY shared/ shared/
 
-# Copy pre-built client (if available)
-COPY client/dist/ client/dist/
+# Copy built client from stage 1
+COPY --from=client-build /app/client/dist/ client/dist/
 
 ENV PORT=3000
 # WARNING: 0.0.0.0 binds to all interfaces. In production, use a reverse


### PR DESCRIPTION
## Summary
- **Root cause**: Dockerfile had `COPY client/dist/ client/dist/` but `client/dist/` doesn't exist in the repo — it's a build artifact excluded by `.dockerignore`
- **Fix**: Added a `client-build` stage that installs Angular deps and runs `bun run build` before copying output to the production image
- **Also fixed**: `.dockerignore` excluded `tsconfig.json` at all levels, blocking `client/tsconfig.json` needed for the Angular build — scoped to root only with `/tsconfig.json`

## What failed
Both workflows triggered by the v0.2.0 tag:
- `Docker Publish / Build & Push Docker Image` — ❌ `"/client/dist": not found`
- `Release / Docker / Build & Push Docker Image` — ❌ same error

## Test plan
- [ ] CI passes (existing 162 tests unaffected)
- [ ] Re-run Docker Publish workflow after merge to verify image builds
- [ ] Verify image runs: `docker run ghcr.io/corvidlabs/corvid-agent:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)