### PR TITLE
docs: add reverse proxy configs and update deploy README

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,22 +1,66 @@
-# Deployment Configs (Optional)
+# Deployment Configs
 
-These are **optional** deployment configs for running CorvidAgent as a background service. Most users just run `bun server/index.ts` or `bun run dev` directly.
+Optional configs for running CorvidAgent as a production service. For local development, just use `bun run dev`.
 
 ## Files
 
 | File | Purpose |
 |------|---------|
-| `Dockerfile` | Docker container for isolated deployment |
-| `docker-compose.yml` | Docker Compose orchestration |
-| `corvid-agent.service` | systemd unit file (Linux) |
-| `daemon.sh` | Generic daemon launcher script |
+| `Dockerfile` | Multi-stage Docker build (Angular client + Bun server) |
+| `docker-compose.yml` | Docker Compose orchestration with health checks |
+| `daemon.sh` | Cross-platform daemon installer (auto-detects launchd/systemd) |
+| `corvid-agent.service` | systemd unit file (Linux) with security hardening |
 | `com.corvidlabs.corvid-agent.plist` | macOS launchd plist |
 | `corvid-agent.newsyslog.conf` | macOS log rotation |
+| `caddy/Caddyfile` | Caddy reverse proxy with auto-TLS |
+| `nginx/corvid-agent.conf` | nginx reverse proxy with rate limiting |
 
-## When to use these
+## Quick Start
 
-- Running CorvidAgent on a server that stays on 24/7
-- Running as a background daemon on your dev machine
-- Deploying in a Docker container for isolation
+### Docker (simplest)
 
-For local development, just use `bun run dev`.
+```bash
+cp .env.example .env   # add your API keys
+cd deploy
+docker compose up -d
+```
+
+### Daemon (bare metal)
+
+```bash
+# Auto-detects macOS (launchd) or Linux (systemd)
+./deploy/daemon.sh install
+./deploy/daemon.sh status
+./deploy/daemon.sh logs
+```
+
+### Reverse Proxy (production TLS)
+
+For production, bind the server to localhost and terminate TLS at the proxy:
+
+1. Set `BIND_HOST=127.0.0.1` in your `.env` or docker-compose override
+2. Choose your proxy:
+
+**Caddy** (auto-TLS via Let's Encrypt):
+```bash
+# Edit deploy/caddy/Caddyfile — replace "yourdomain.com" with your domain
+sudo cp deploy/caddy/Caddyfile /etc/caddy/Caddyfile
+sudo systemctl restart caddy
+```
+
+**nginx** (manual TLS via certbot):
+```bash
+# Edit deploy/nginx/corvid-agent.conf — replace "yourdomain.com"
+sudo cp deploy/nginx/corvid-agent.conf /etc/nginx/sites-available/
+sudo ln -s /etc/nginx/sites-available/corvid-agent.conf /etc/nginx/sites-enabled/
+sudo certbot --nginx -d yourdomain.com
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+## Security Notes
+
+- The systemd unit runs with `NoNewPrivileges`, `ProtectSystem=strict`, and `PrivateTmp`
+- Secrets go in `/etc/corvid-agent/env` (mode 600, root-owned) on Linux
+- Docker runs as non-root user `corvid` inside the container
+- nginx config includes rate limiting (30 req/s, burst 50) with health check exemption
+- Both proxy configs add `X-Content-Type-Options`, `X-Frame-Options`, and `Referrer-Policy` headers

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -1,0 +1,38 @@
+# CorvidAgent reverse proxy — Caddy
+#
+# Caddy automatically provisions and renews TLS certificates via Let's Encrypt.
+# Replace "yourdomain.com" with your actual domain.
+#
+# Usage:
+#   1. Install Caddy: https://caddyserver.com/docs/install
+#   2. Copy this file to /etc/caddy/Caddyfile (or use `caddy run --config Caddyfile`)
+#   3. Ensure DNS A/AAAA records point to your server
+#   4. Set BIND_HOST=127.0.0.1 in your .env or docker-compose override
+#   5. Start Caddy: `sudo systemctl start caddy`
+
+yourdomain.com {
+    reverse_proxy localhost:3000
+
+    # WebSocket support (automatic in Caddy, but explicit for clarity)
+    @websocket {
+        header Connection *Upgrade*
+        header Upgrade websocket
+    }
+    reverse_proxy @websocket localhost:3000
+
+    # Security headers
+    header {
+        X-Content-Type-Options nosniff
+        X-Frame-Options DENY
+        Referrer-Policy strict-origin-when-cross-origin
+        -Server
+    }
+
+    # Request logging
+    log {
+        output file /var/log/caddy/corvid-agent.log {
+            roll_size 50MiB
+            roll_keep 3
+        }
+    }
+}

--- a/deploy/nginx/corvid-agent.conf
+++ b/deploy/nginx/corvid-agent.conf
@@ -1,0 +1,63 @@
+# CorvidAgent reverse proxy — nginx
+#
+# Prerequisites:
+#   1. Install nginx and certbot (for TLS)
+#   2. Copy this file to /etc/nginx/sites-available/corvid-agent.conf
+#   3. Symlink: ln -s /etc/nginx/sites-available/corvid-agent.conf /etc/nginx/sites-enabled/
+#   4. Replace "yourdomain.com" with your actual domain
+#   5. Run: sudo certbot --nginx -d yourdomain.com
+#   6. Set BIND_HOST=127.0.0.1 in your .env or docker-compose override
+#   7. Reload: sudo nginx -t && sudo systemctl reload nginx
+
+# Rate limiting zone (adjust as needed)
+limit_req_zone $binary_remote_addr zone=corvid:10m rate=30r/s;
+
+server {
+    listen 80;
+    server_name yourdomain.com;
+
+    # Certbot will add the HTTPS redirect here
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name yourdomain.com;
+
+    # Certbot will populate these:
+    # ssl_certificate /etc/letsencrypt/live/yourdomain.com/fullchain.pem;
+    # ssl_certificate_key /etc/letsencrypt/live/yourdomain.com/privkey.pem;
+
+    # Security headers
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options DENY always;
+    add_header Referrer-Policy strict-origin-when-cross-origin always;
+
+    # Proxy settings
+    location / {
+        limit_req zone=corvid burst=50 nodelay;
+
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket support
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+    }
+
+    # Health check (allow without rate limit)
+    location = /api/health {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+
+    access_log /var/log/nginx/corvid-agent.access.log;
+    error_log /var/log/nginx/corvid-agent.error.log;
+}


### PR DESCRIPTION
## Summary

- Add Caddy reverse proxy config (`deploy/caddy/Caddyfile`) with auto-TLS, WebSocket support, and security headers
- Add nginx reverse proxy config (`deploy/nginx/corvid-agent.conf`) with rate limiting (30r/s), WebSocket upgrade, and health check exemption
- Expand `deploy/README.md` with quick start guides for Docker, daemon, and reverse proxy setups, plus security notes

## Files Changed

| File | Change |
|------|--------|
| `deploy/caddy/Caddyfile` | **New** — Caddy reverse proxy config |
| `deploy/nginx/corvid-agent.conf` | **New** — nginx reverse proxy config |
| `deploy/README.md` | **Updated** — comprehensive deployment guide |

## Context

These configs were already present locally but never committed. The README previously only documented Docker, systemd, and launchd configs — now it covers the full deployment story including TLS termination.

## Test Plan

- [x] Reviewed Caddyfile syntax and WebSocket matcher
- [x] Reviewed nginx config for proper proxy headers, rate limiting, and TLS setup
- [x] Verified README quick start instructions match actual file paths and commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)