### PR TITLE
docs: update README, SECURITY, and env config for recent changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ BIND_HOST=127.0.0.1
 # (e.g. shared mounts or CI workspaces).
 # ALLOWED_BROWSE_ROOTS=/opt/projects,/mnt/shared
 
+# --- Wallet Security -------------------------------------------------------
+# AES-256 encryption key for agent sub-wallets at rest.
+# Defaults to a key derived from ALGOCHAT_MNEMONIC on localnet.
+# WALLET_ENCRYPTION_KEY=
+
 # --- Spending Limits (protects your wallet from runaway agents) ------------
 # Daily ALGO spending cap in microALGOs (default: 10000000 = 10 ALGO)
 # DAILY_ALGO_LIMIT_MICRO=10000000
@@ -48,6 +53,12 @@ BIND_HOST=127.0.0.1
 # --- Agent Sessions --------------------------------------------------------
 # Agent session timeout in ms (default: 1800000 = 30 min)
 # AGENT_TIMEOUT_MS=1800000
+
+# --- Work Tasks (self-improvement workflow) --------------------------------
+# Base directory for git worktrees (default: sibling .corvid-worktrees dir)
+# WORKTREE_BASE_DIR=
+# Max validation iterations before marking a task as failed (default: 3)
+# WORK_MAX_ITERATIONS=3
 
 # --- GitHub (for work tasks) -----------------------------------------------
 # GH_TOKEN=ghp_...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,11 @@ Write clear, concise commit messages:
 
 1. Create a feature branch from `main`
 2. Make your changes with clear, focused commits
-3. Ensure `bun test` passes
+3. Verify before pushing:
+   ```bash
+   bunx tsc --noEmit --skipLibCheck   # type-check
+   bun test                           # unit tests
+   ```
 4. Open a PR with:
    - A short title describing the change
    - A summary of what and why

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ AI agent orchestration platform with on-chain messaging via Algorand.
 ## Features
 
 - **Agent orchestration** -- spawn, manage, and monitor Claude-powered agents
-- **Council discussions** -- multi-agent deliberation with structured voting
-- **AlgoChat** -- on-chain messaging and group transactions via Algorand
+- **Council discussions** -- multi-agent deliberation with structured voting and follow-up chat
+- **AlgoChat** -- on-chain encrypted messaging via Algorand (PSK / X25519)
+- **Self-improvement** -- agents create work tasks, branch, validate, and open PRs autonomously
 - **Mobile chat client** -- responsive Angular UI with real-time WebSocket updates
 - **MCP tools** -- extensible tool system using the Model Context Protocol
-- **Work tasks** -- persistent task tracking with SQLite
 
 ## Tech Stack
 
@@ -62,11 +62,16 @@ e2e/             Playwright end-to-end tests
 | `ALGOCHAT_SYNC_INTERVAL` | Polling interval for on-chain messages (ms) | `30000` |
 | `ALGOCHAT_DEFAULT_AGENT_ID` | Default agent ID for AlgoChat | -- |
 | `ALGOCHAT_OWNER_ADDRESSES` | Comma-separated Algorand addresses authorized for admin commands | -- (open) |
+| `ALGOCHAT_PSK_URI` | Pre-shared key URI for encrypted AlgoChat channels | -- |
+| `AGENT_NETWORK` | Network for agent sub-wallets | `localnet` |
 | `ANTHROPIC_API_KEY` | Anthropic API key for Claude agents | -- |
 | `PORT` | HTTP server port | `3000` |
 | `BIND_HOST` | Bind address (`127.0.0.1` for localhost, `0.0.0.0` for Docker/VM) | `127.0.0.1` |
 | `API_KEY` | Bearer token for HTTP/WS auth (required when `BIND_HOST` is non-localhost) | -- |
 | `ALLOWED_ORIGINS` | Comma-separated CORS origins | `*` |
+| `WALLET_ENCRYPTION_KEY` | AES-256 key for wallet encryption at rest | derived from mnemonic |
+| `LOG_LEVEL` | Logging level (`debug`, `info`, `warn`, `error`) | `info` |
+| `GH_TOKEN` | GitHub token for work task PR creation | -- |
 
 Copy `.env.example` to `.env` and fill in your values. Bun loads `.env` automatically.
 
@@ -84,7 +89,8 @@ See the `deploy/` directory for production configurations:
 - `Dockerfile` + `docker-compose.yml` -- containerized deployment
 - `corvid-agent.service` -- systemd unit for Linux
 - `com.corvidlabs.corvid-agent.plist` -- macOS LaunchAgent
-- `daemon.sh` -- helper script
+- `daemon.sh` -- cross-platform daemon installer
+- `nginx/` + `caddy/` -- reverse proxy configs with TLS termination
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,9 @@ CorvidAgent runs as a **local sandbox** — on your machine, in a VM, or on a pr
 
 - **Localhost mode** (default): `BIND_HOST=127.0.0.1` -- no API key required. Only local processes can reach the API.
 - **Network mode**: Set `API_KEY` in `.env`. All HTTP routes require `Authorization: Bearer <key>` and WebSocket upgrades require `?key=<key>` or a Bearer header. The server **refuses to start** if `BIND_HOST` is non-localhost and no `API_KEY` is set.
+- **WebSocket auth**: WebSocket upgrades require a valid API key (query param or Bearer header) before the connection is established. Unauthenticated upgrades are rejected with 401.
 - **CORS**: Configure `ALLOWED_ORIGINS` (comma-separated) to restrict browser access. Defaults to `*` on localhost.
+- **Directory browsing**: The `/api/browse-dirs` endpoint is sandboxed to the user's home directory, registered project working directories, and any paths in `ALLOWED_BROWSE_ROOTS`. Path traversal attempts are blocked.
 - **Health endpoint**: `/api/health` is always public for monitoring probes.
 - **Timing-safe comparison**: API key validation uses constant-time comparison to prevent timing attacks.
 - **Agent sessions**: Run locally with your own AI provider credentials.
@@ -48,7 +50,7 @@ The agent has real ALGO in its wallet. These safeguards prevent runaway spending
 |-----------|-------|---------|
 | Daily ALGO cap | `server/db/spending.ts` | 10 ALGO/day |
 | Per-message cost check | AlgoChat bridge | Checks before send |
-| Credit system | `server/db/credits.ts` | Tracks per-wallet usage |
+| Credit system | `server/db/credits.ts` | Guest-only; owners bypass credits |
 
 Configure via `DAILY_ALGO_LIMIT_MICRO` in `.env`.
 


### PR DESCRIPTION
## Summary

- **README.md**: Add council follow-up chat, self-improvement workflow, and PSK encryption to features list. Add missing env vars (`WALLET_ENCRYPTION_KEY`, `GH_TOKEN`, `LOG_LEVEL`, `AGENT_NETWORK`, `ALGOCHAT_PSK_URI`). Mention nginx/caddy reverse proxy configs in deployment section.
- **SECURITY.md**: Document WebSocket authentication (PR #58) and directory browsing sandbox (PR #55). Update credit system to reflect guest-only scope (PR #62).
- **CONTRIBUTING.md**: Add `bunx tsc --noEmit --skipLibCheck` to pre-push verification checklist.
- **.env.example**: Add wallet security, work task, and worktree configuration sections.

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` passes (230 tests)
- [x] Documentation-only changes, no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)