### PR TITLE
feat: wallet viewer + docs cleanup + AlgoChat optional

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -78,6 +78,11 @@ export const routes: Routes = [
             import('./features/allowlist/allowlist.component').then((m) => m.AllowlistComponent),
     },
     {
+        path: 'wallets',
+        loadComponent: () =>
+            import('./features/wallets/wallet-viewer.component').then((m) => m.WalletViewerComponent),
+    },
+    {
         path: 'feed',
         loadComponent: () =>
             import('./features/feed/live-feed.component').then((m) => m.LiveFeedComponent),

--- a/client/src/app/features/wallets/wallet-viewer.component.ts
+++ b/client/src/app/features/wallets/wallet-viewer.component.ts
@@ -1,0 +1,417 @@
+import {
+    Component,
+    ChangeDetectionStrategy,
+    inject,
+    OnInit,
+    OnDestroy,
+    signal,
+    computed,
+} from '@angular/core';
+import { ApiService } from '../../core/services/api.service';
+import { AllowlistService } from '../../core/services/allowlist.service';
+import { WebSocketService } from '../../core/services/websocket.service';
+import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
+import { firstValueFrom } from 'rxjs';
+
+interface WalletSummary {
+    address: string;
+    label: string;
+    messageCount: number;
+    inboundCount: number;
+    outboundCount: number;
+    lastActive: string;
+    onAllowlist: boolean;
+    credits: number;
+    totalPurchased: number;
+}
+
+interface WalletMessage {
+    id: number;
+    participant: string;
+    content: string;
+    direction: 'inbound' | 'outbound' | 'status';
+    fee: number;
+    createdAt: string;
+}
+
+@Component({
+    selector: 'app-wallet-viewer',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [RelativeTimePipe],
+    template: `
+        <div class="page">
+            <div class="page__header">
+                <h2>
+                    Wallets
+                    @if (wallets().length > 0) {
+                        <span class="count">({{ wallets().length }})</span>
+                    }
+                </h2>
+            </div>
+
+            <div class="search-bar">
+                <input
+                    class="input"
+                    type="text"
+                    placeholder="Search by address or label..."
+                    [value]="searchQuery()"
+                    (input)="onSearch(toInputValue($event))" />
+            </div>
+
+            @if (loading()) {
+                <p class="loading">Loading wallets...</p>
+            } @else if (filteredWallets().length === 0) {
+                <p class="empty">No external wallets have interacted via AlgoChat yet.</p>
+            } @else {
+                <div class="wallet-list">
+                    @for (wallet of filteredWallets(); track wallet.address) {
+                        <div class="wallet-card" [class.wallet-card--expanded]="expandedWallet() === wallet.address">
+                            <div class="wallet-card__header" (click)="toggleExpand(wallet.address)">
+                                <div class="wallet-card__info">
+                                    <div class="wallet-card__address">
+                                        {{ truncateAddress(wallet.address) }}
+                                        @if (wallet.label) {
+                                            <span class="wallet-card__label">{{ wallet.label }}</span>
+                                        }
+                                    </div>
+                                    <div class="wallet-card__stats">
+                                        <span class="stat">
+                                            <span class="stat__icon stat__icon--in">&#x2B07;</span>
+                                            {{ wallet.inboundCount }}
+                                        </span>
+                                        <span class="stat">
+                                            <span class="stat__icon stat__icon--out">&#x2B06;</span>
+                                            {{ wallet.outboundCount }}
+                                        </span>
+                                        <span class="stat">
+                                            <span class="stat__icon stat__icon--credits">&#x26A1;</span>
+                                            {{ wallet.credits }}
+                                        </span>
+                                        <span class="stat stat--time">
+                                            {{ wallet.lastActive | relativeTime }}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="wallet-card__actions">
+                                    @if (wallet.onAllowlist) {
+                                        <span class="badge badge--allowed">Allowed</span>
+                                        <button
+                                            class="btn btn--small btn--danger"
+                                            (click)="removeFromAllowlist($event, wallet.address)">
+                                            Remove
+                                        </button>
+                                    } @else {
+                                        <button
+                                            class="btn btn--small btn--primary"
+                                            (click)="addToAllowlist($event, wallet.address)">
+                                            Allow
+                                        </button>
+                                    }
+                                    <span class="expand-icon">{{ expandedWallet() === wallet.address ? '&#x25B2;' : '&#x25BC;' }}</span>
+                                </div>
+                            </div>
+
+                            @if (expandedWallet() === wallet.address) {
+                                <div class="wallet-card__messages">
+                                    @if (messagesLoading()) {
+                                        <p class="loading">Loading messages...</p>
+                                    } @else if (messages().length === 0) {
+                                        <p class="empty">No messages found.</p>
+                                    } @else {
+                                        <div class="full-address">
+                                            <code>{{ wallet.address }}</code>
+                                        </div>
+                                        <div class="message-list">
+                                            @for (msg of messages(); track msg.id) {
+                                                <div class="message" [class.message--in]="msg.direction === 'inbound'" [class.message--out]="msg.direction === 'outbound'" [class.message--status]="msg.direction === 'status'">
+                                                    <div class="message__header">
+                                                        <span class="message__dir">
+                                                            @if (msg.direction === 'inbound') {
+                                                                <span class="accent-cyan">IN</span>
+                                                            } @else if (msg.direction === 'outbound') {
+                                                                <span class="accent-magenta">OUT</span>
+                                                            } @else {
+                                                                <span class="accent-amber">SYS</span>
+                                                            }
+                                                        </span>
+                                                        <span class="message__time">{{ msg.createdAt | relativeTime }}</span>
+                                                        @if (msg.fee > 0) {
+                                                            <span class="message__fee">{{ (msg.fee / 1000000).toFixed(4) }} ALGO</span>
+                                                        }
+                                                    </div>
+                                                    <div class="message__content">{{ msg.content }}</div>
+                                                </div>
+                                            }
+                                        </div>
+                                        @if (messageTotal() > messages().length) {
+                                            <button class="btn btn--small btn--ghost load-more" (click)="loadMoreMessages(wallet.address)">
+                                                Load more ({{ messageTotal() - messages().length }} remaining)
+                                            </button>
+                                        }
+                                    }
+                                </div>
+                            }
+                        </div>
+                    }
+                </div>
+            }
+        </div>
+    `,
+    styles: `
+        .page { padding: 1.5rem; }
+        .page__header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1.5rem; }
+        .page__header h2 { margin: 0; color: var(--text-primary); }
+        .count { color: var(--text-tertiary); font-weight: 400; font-size: 0.85rem; }
+
+        .search-bar { margin-bottom: 1.5rem; }
+        .input {
+            width: 100%; padding: 0.5rem 0.75rem; background: var(--bg-surface); border: 1px solid var(--border);
+            border-radius: var(--radius); color: var(--text-primary); font-family: inherit; font-size: 0.85rem;
+        }
+        .input::placeholder { color: var(--text-tertiary); }
+
+        .loading { color: var(--text-secondary); }
+        .empty { color: var(--text-tertiary); }
+
+        .wallet-list { display: flex; flex-direction: column; gap: 0.5rem; }
+
+        .wallet-card {
+            background: var(--bg-surface); border: 1px solid var(--border);
+            border-radius: var(--radius-lg); overflow: hidden;
+            transition: border-color 0.15s;
+        }
+        .wallet-card:hover { border-color: var(--border-bright); }
+        .wallet-card--expanded { border-color: var(--accent-cyan); }
+
+        .wallet-card__header {
+            display: flex; align-items: center; justify-content: space-between;
+            padding: 1rem; cursor: pointer; gap: 1rem;
+        }
+        .wallet-card__header:hover { background: var(--bg-hover); }
+
+        .wallet-card__info { flex: 1; min-width: 0; }
+        .wallet-card__address {
+            font-family: monospace; font-size: 0.85rem; color: var(--text-primary);
+            display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
+        }
+        .wallet-card__label {
+            font-size: 0.75rem; color: var(--accent-cyan); font-family: inherit;
+            background: rgba(0, 229, 255, 0.08); padding: 0.1rem 0.4rem; border-radius: 3px;
+        }
+
+        .wallet-card__stats {
+            display: flex; gap: 1rem; margin-top: 0.4rem; font-size: 0.75rem;
+            color: var(--text-secondary); flex-wrap: wrap;
+        }
+        .stat { display: flex; align-items: center; gap: 0.25rem; }
+        .stat__icon { font-size: 0.7rem; }
+        .stat__icon--in { color: var(--accent-cyan); }
+        .stat__icon--out { color: var(--accent-magenta); }
+        .stat__icon--credits { color: var(--accent-green); }
+        .stat--time { color: var(--text-tertiary); }
+
+        .wallet-card__actions {
+            display: flex; align-items: center; gap: 0.5rem; flex-shrink: 0;
+        }
+
+        .badge {
+            font-size: 0.65rem; padding: 0.15rem 0.4rem; border-radius: 3px;
+            font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em;
+        }
+        .badge--allowed {
+            color: var(--accent-green); background: rgba(0, 255, 136, 0.1);
+            border: 1px solid rgba(0, 255, 136, 0.2);
+        }
+
+        .expand-icon { color: var(--text-tertiary); font-size: 0.7rem; }
+
+        .btn {
+            padding: 0.5rem 1rem; border-radius: var(--radius); font-size: 0.8rem; font-weight: 600;
+            cursor: pointer; border: 1px solid; font-family: inherit; text-transform: uppercase; letter-spacing: 0.05em;
+            transition: background 0.15s, box-shadow 0.15s; background: transparent;
+        }
+        .btn:disabled { opacity: 0.4; cursor: default; }
+        .btn--primary { color: var(--accent-cyan); border-color: var(--accent-cyan); }
+        .btn--primary:hover:not(:disabled) { background: rgba(0, 229, 255, 0.1); box-shadow: 0 0 8px rgba(0, 229, 255, 0.2); }
+        .btn--danger { color: var(--accent-red, #f44); border-color: var(--accent-red, #f44); }
+        .btn--danger:hover { background: rgba(255, 68, 68, 0.1); }
+        .btn--small { padding: 0.25rem 0.5rem; font-size: 0.7rem; }
+        .btn--ghost { border-color: var(--border); color: var(--text-secondary); }
+        .btn--ghost:hover { background: var(--bg-hover); }
+
+        .wallet-card__messages {
+            border-top: 1px solid var(--border); padding: 1rem;
+            background: var(--bg-deep);
+        }
+
+        .full-address {
+            font-size: 0.7rem; color: var(--text-tertiary); margin-bottom: 0.75rem;
+            word-break: break-all;
+        }
+        .full-address code { font-family: monospace; color: var(--text-secondary); }
+
+        .message-list { display: flex; flex-direction: column; gap: 0.5rem; max-height: 400px; overflow-y: auto; }
+
+        .message {
+            padding: 0.6rem 0.75rem; border-radius: var(--radius);
+            border: 1px solid var(--border);
+        }
+        .message--in { border-left: 3px solid var(--accent-cyan); background: rgba(0, 229, 255, 0.03); }
+        .message--out { border-left: 3px solid var(--accent-magenta); background: rgba(255, 0, 170, 0.03); }
+        .message--status { border-left: 3px solid var(--accent-amber, #ffaa00); background: rgba(255, 170, 0, 0.03); }
+
+        .message__header {
+            display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.3rem;
+            font-size: 0.7rem;
+        }
+        .message__dir { font-weight: 700; font-size: 0.65rem; }
+        .message__time { color: var(--text-tertiary); }
+        .message__fee { color: var(--accent-green); }
+        .accent-cyan { color: var(--accent-cyan); }
+        .accent-magenta { color: var(--accent-magenta); }
+        .accent-amber { color: var(--accent-amber, #ffaa00); }
+
+        .message__content {
+            font-size: 0.8rem; color: var(--text-primary); line-height: 1.6;
+            white-space: pre-wrap; word-break: break-word;
+        }
+
+        .load-more { margin-top: 0.5rem; width: 100%; }
+
+        @media (max-width: 600px) {
+            .wallet-card__header { flex-direction: column; align-items: flex-start; }
+            .wallet-card__actions { margin-top: 0.5rem; }
+            .wallet-card__stats { gap: 0.5rem; }
+        }
+    `,
+})
+export class WalletViewerComponent implements OnInit, OnDestroy {
+    private readonly api = inject(ApiService);
+    private readonly allowlistService = inject(AllowlistService);
+    private readonly ws = inject(WebSocketService);
+
+    readonly wallets = signal<WalletSummary[]>([]);
+    readonly loading = signal(false);
+    readonly searchQuery = signal('');
+    readonly expandedWallet = signal<string | null>(null);
+    readonly messages = signal<WalletMessage[]>([]);
+    readonly messagesLoading = signal(false);
+    readonly messageTotal = signal(0);
+
+    readonly filteredWallets = computed(() => {
+        const query = this.searchQuery().toLowerCase();
+        if (!query) return this.wallets();
+        return this.wallets().filter(
+            (w) =>
+                w.address.toLowerCase().includes(query) ||
+                w.label.toLowerCase().includes(query),
+        );
+    });
+
+    private wsUnsub: (() => void) | null = null;
+
+    ngOnInit(): void {
+        this.loadWallets();
+
+        // Listen for real-time AlgoChat messages to update counts
+        this.wsUnsub = this.ws.onMessage((msg) => {
+            if (msg.type === 'algochat_message') {
+                // Refresh wallet list when a new message arrives
+                this.loadWallets();
+            }
+        });
+    }
+
+    ngOnDestroy(): void {
+        this.wsUnsub?.();
+    }
+
+    toInputValue(event: Event): string {
+        return (event.target as HTMLInputElement).value;
+    }
+
+    onSearch(query: string): void {
+        this.searchQuery.set(query);
+    }
+
+    truncateAddress(address: string): string {
+        if (address.length <= 16) return address;
+        return `${address.slice(0, 6)}...${address.slice(-6)}`;
+    }
+
+    async loadWallets(): Promise<void> {
+        this.loading.set(true);
+        try {
+            const result = await firstValueFrom(
+                this.api.get<{ wallets: WalletSummary[] }>('/wallets/summary'),
+            );
+            this.wallets.set(result.wallets);
+        } finally {
+            this.loading.set(false);
+        }
+    }
+
+    async toggleExpand(address: string): Promise<void> {
+        if (this.expandedWallet() === address) {
+            this.expandedWallet.set(null);
+            this.messages.set([]);
+            return;
+        }
+
+        this.expandedWallet.set(address);
+        this.messagesLoading.set(true);
+        this.messages.set([]);
+
+        try {
+            const result = await firstValueFrom(
+                this.api.get<{ messages: WalletMessage[]; total: number }>(
+                    `/wallets/${encodeURIComponent(address)}/messages?limit=50`,
+                ),
+            );
+            this.messages.set(result.messages);
+            this.messageTotal.set(result.total);
+        } finally {
+            this.messagesLoading.set(false);
+        }
+    }
+
+    async loadMoreMessages(address: string): Promise<void> {
+        const currentCount = this.messages().length;
+        const result = await firstValueFrom(
+            this.api.get<{ messages: WalletMessage[]; total: number }>(
+                `/wallets/${encodeURIComponent(address)}/messages?limit=50&offset=${currentCount}`,
+            ),
+        );
+        this.messages.update((msgs) => [...msgs, ...result.messages]);
+        this.messageTotal.set(result.total);
+    }
+
+    async addToAllowlist(event: Event, address: string): Promise<void> {
+        event.stopPropagation();
+        try {
+            await this.allowlistService.addEntry(address);
+            this.wallets.update((wallets) =>
+                wallets.map((w) =>
+                    w.address === address ? { ...w, onAllowlist: true } : w,
+                ),
+            );
+        } catch {
+            // Silently fail — allowlist service handles errors
+        }
+    }
+
+    async removeFromAllowlist(event: Event, address: string): Promise<void> {
+        event.stopPropagation();
+        if (!confirm(`Remove ${address.slice(0, 8)}... from the allowlist?`)) return;
+        try {
+            await this.allowlistService.removeEntry(address);
+            this.wallets.update((wallets) =>
+                wallets.map((w) =>
+                    w.address === address ? { ...w, onAllowlist: false } : w,
+                ),
+            );
+        } catch {
+            // Silently fail
+        }
+    }
+}

--- a/client/src/app/shared/components/sidebar.component.ts
+++ b/client/src/app/shared/components/sidebar.component.ts
@@ -67,6 +67,14 @@ import { filter, Subscription } from 'rxjs';
                 <li>
                     <a
                         class="sidebar__link"
+                        routerLink="/wallets"
+                        routerLinkActive="sidebar__link--active">
+                        Wallets
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="sidebar__link"
                         routerLink="/feed"
                         routerLinkActive="sidebar__link--active">
                         Feed

--- a/docs/algochat.html
+++ b/docs/algochat.html
@@ -42,8 +42,23 @@
     <div class="hero__scanline"></div>
   </header>
 
+  <!-- ═══════════════════ OPTIONAL CALLOUT ═══════════════════ -->
+  <section class="section" id="optional">
+    <div class="container">
+      <div class="callout callout--cyan">
+        <h3 class="callout__title accent-cyan">AlgoChat is Optional</h3>
+        <p>CorvidAgent works fully without AlgoChat. Without an <code class="accent-cyan">ALGOCHAT_MNEMONIC</code>, the on-chain bridge stays disabled. All features &mdash; sessions, councils, work tasks, the web UI &mdash; work via HTTP/WebSocket + SQLite. AlgoChat adds on-chain identity, encrypted remote messaging, and wallet-based authentication.</p>
+      </div>
+
+      <div class="callout callout--green">
+        <h3 class="callout__title accent-green">Localnet: Zero-Cost Development</h3>
+        <p>Agents default to <code class="accent-green">AGENT_NETWORK=localnet</code>. Localnet auto-generates test wallets and funds them with 10 ALGO &mdash; zero real crypto needed. Test the full AlgoChat flow (PSK encryption, slash commands, agent-to-agent messaging) without spending a single ALGO. The server and agents can even run on different networks (e.g., mainnet for the server, localnet for agents).</p>
+      </div>
+    </div>
+  </section>
+
   <!-- ═══════════════════ WHAT IS ALGOCHAT ═══════════════════ -->
-  <section class="section" id="what">
+  <section class="section section--alt" id="what">
     <div class="container">
       <h2 class="section__title">What is AlgoChat?</h2>
       <div class="grid grid--3">
@@ -67,7 +82,7 @@
   </section>
 
   <!-- ═══════════════════ HOW IT WORKS ═══════════════════ -->
-  <section class="section section--alt" id="how">
+  <section class="section" id="how">
     <div class="container">
       <h2 class="section__title">How It Works</h2>
 
@@ -116,7 +131,7 @@
   </section>
 
   <!-- ═══════════════════ ARCHITECTURE ═══════════════════ -->
-  <section class="section" id="components">
+  <section class="section section--alt" id="components">
     <div class="container">
       <h2 class="section__title">Components</h2>
       <div class="terminal">
@@ -142,7 +157,7 @@
   </section>
 
   <!-- ═══════════════════ PSK ENCRYPTION ═══════════════════ -->
-  <section class="section section--alt" id="encryption">
+  <section class="section" id="encryption">
     <div class="container">
       <h2 class="section__title">PSK Encryption</h2>
 
@@ -183,7 +198,7 @@ algochat-psk://v1?addr=<span class="accent-magenta">ALGO_ADDR</span>&amp;psk=<sp
   </section>
 
   <!-- ═══════════════════ SLASH COMMANDS ═══════════════════ -->
-  <section class="section" id="commands">
+  <section class="section section--alt" id="commands">
     <div class="container">
       <h2 class="section__title">Slash Commands</h2>
       <p class="section__subtitle">Send these commands via AlgoChat to control your agent remotely. Requires <code class="accent-magenta">ALGOCHAT_OWNER_ADDRESSES</code> authorization.</p>
@@ -245,7 +260,7 @@ algochat-psk://v1?addr=<span class="accent-magenta">ALGO_ADDR</span>&amp;psk=<sp
   </section>
 
   <!-- ═══════════════════ AGENT MESSAGING ═══════════════════ -->
-  <section class="section section--alt" id="agent-messaging">
+  <section class="section" id="agent-messaging">
     <div class="container">
       <h2 class="section__title">Agent-to-Agent Messaging</h2>
 
@@ -290,13 +305,13 @@ corvid_send_message({
   </section>
 
   <!-- ═══════════════════ CONFIGURATION ═══════════════════ -->
-  <section class="section" id="config">
+  <section class="section section--alt" id="config">
     <div class="container">
       <h2 class="section__title">Configuration</h2>
 
       <div class="grid grid--2">
         <div class="card card--green">
-          <h3 class="card__title">Required for AlgoChat</h3>
+          <h3 class="card__title">Required <span style="font-size: 7px; opacity: 0.7;">(only if using AlgoChat)</span></h3>
           <div class="config-table">
             <div class="config-row">
               <span class="config-key accent-green">ALGOCHAT_MNEMONIC</span>
@@ -338,7 +353,7 @@ corvid_send_message({
   </section>
 
   <!-- ═══════════════════ NEXT ═══════════════════ -->
-  <section class="section section--alt" id="next">
+  <section class="section" id="next">
     <div class="container">
       <h2 class="section__title">Related Docs</h2>
       <div class="grid grid--3">

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -60,7 +60,7 @@
         <div class="card card--green">
           <div class="card__icon">&#x26D3;</div>
           <h3 class="card__title">AlgoKit (optional)</h3>
-          <p>Required only for AlgoChat messaging. Install via <code class="accent-green">pipx install algokit</code>.</p>
+          <p>Only needed for on-chain AlgoChat messaging. Without it, everything still works &mdash; chat via the web UI, agents run sessions, councils deliberate. Install via <code class="accent-green">pipx install algokit</code> if you want Localnet or Testnet messaging.</p>
         </div>
       </div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -74,8 +74,8 @@
 
         <div class="card card--magenta">
           <div class="card__icon">&#x1F4AC;</div>
-          <h3 class="card__title">AlgoChat Messaging</h3>
-          <p>On-chain encrypted messaging via Algorand. Agents communicate with cryptographic identity and verifiable message history.</p>
+          <h3 class="card__title">AlgoChat Messaging <span class="accent-magenta" style="font-size: 7px; opacity: 0.7;">(optional)</span></h3>
+          <p>On-chain encrypted messaging via Algorand. Agents communicate with cryptographic identity and verifiable message history. Works fully without it &mdash; chat via the web UI + SQLite persistence.</p>
         </div>
 
         <div class="card card--green">

--- a/docs/style.css
+++ b/docs/style.css
@@ -240,6 +240,7 @@ a {
 .grid {
   display: grid;
   gap: 20px;
+  align-items: stretch;
 }
 
 .grid--3 {
@@ -257,6 +258,8 @@ a {
   border-radius: 6px;
   padding: 28px 24px;
   transition: all 0.2s ease;
+  display: flex;
+  flex-direction: column;
 }
 
 .card:hover {
@@ -503,6 +506,7 @@ a {
   font-family: 'Dogica Pixel', monospace;
   letter-spacing: 0.5px;
   flex-shrink: 0;
+  word-break: break-all;
 }
 
 .config-val {
@@ -526,7 +530,7 @@ a {
   text-align: center;
   font-size: 9px;
   color: var(--text-secondary);
-  margin-top: -32px;
+  margin-top: -16px;
   margin-bottom: 40px;
   line-height: 2;
 }
@@ -625,6 +629,12 @@ a {
   background: transparent;
   color: var(--text-tertiary);
   border-color: var(--border);
+}
+
+/* ─── Terminals inside steps/cards fill parent ─── */
+.step__content .terminal,
+.card .terminal {
+  max-width: none;
 }
 
 /* ═══════════════════ COMPACT TERMINAL ═══════════════════ */
@@ -774,7 +784,7 @@ a {
   }
 
   .api-desc {
-    margin-left: 52px;
+    margin-left: 0;
     flex-basis: 100%;
   }
 
@@ -827,6 +837,36 @@ a {
   .nav__links {
     gap: 8px;
   }
+}
+
+/* ═══════════════════ CALLOUT BOX ═══════════════════ */
+.callout {
+  background: var(--bg-raised);
+  border: 1px solid var(--border-bright);
+  border-radius: 6px;
+  padding: 20px 24px;
+  margin-bottom: 32px;
+  line-height: 2;
+}
+
+.callout--cyan {
+  border-left: 3px solid var(--cyan);
+}
+
+.callout--green {
+  border-left: 3px solid var(--green);
+}
+
+.callout__title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  margin-bottom: 8px;
+}
+
+.callout p {
+  font-size: 9px;
+  color: var(--text-secondary);
 }
 
 /* ─── Subtle animation ─── */

--- a/server/db/algochat-messages.ts
+++ b/server/db/algochat-messages.ts
@@ -94,3 +94,98 @@ export function searchAlgoChatMessages(
 
     return { messages: rows.map(rowToMessage), total: countRow.cnt };
 }
+
+// ─── Wallet Summaries ────────────────────────────────────────────────────
+
+export interface WalletSummary {
+    address: string;
+    label: string;
+    messageCount: number;
+    inboundCount: number;
+    outboundCount: number;
+    lastActive: string;
+    onAllowlist: boolean;
+    credits: number;
+    totalPurchased: number;
+}
+
+interface WalletSummaryRow {
+    participant: string;
+    message_count: number;
+    inbound_count: number;
+    outbound_count: number;
+    last_active: string;
+}
+
+/**
+ * Get a summary of all external wallets that have interacted via AlgoChat.
+ * Joins with allowlist for labels and credit_ledger for balances.
+ */
+export function getWalletSummaries(
+    db: Database,
+    options?: { search?: string },
+): WalletSummary[] {
+    let where = '';
+    const params: string[] = [];
+
+    if (options?.search) {
+        where = 'WHERE m.participant LIKE ? OR COALESCE(a.label, \'\') LIKE ?';
+        params.push(`%${options.search}%`, `%${options.search}%`);
+    }
+
+    const rows = db.query(`
+        SELECT
+            m.participant,
+            COUNT(*) as message_count,
+            SUM(CASE WHEN m.direction = 'inbound' THEN 1 ELSE 0 END) as inbound_count,
+            SUM(CASE WHEN m.direction = 'outbound' THEN 1 ELSE 0 END) as outbound_count,
+            MAX(m.created_at) as last_active
+        FROM algochat_messages m
+        LEFT JOIN algochat_allowlist a ON m.participant = a.address
+        ${where}
+        GROUP BY m.participant
+        ORDER BY last_active DESC
+    `).all(...params) as WalletSummaryRow[];
+
+    return rows.map((row) => {
+        const allowlistRow = db.query(
+            'SELECT label FROM algochat_allowlist WHERE address = ?'
+        ).get(row.participant) as { label: string } | null;
+
+        const creditRow = db.query(
+            'SELECT credits, total_purchased FROM credit_ledger WHERE wallet_address = ?'
+        ).get(row.participant) as { credits: number; total_purchased: number } | null;
+
+        return {
+            address: row.participant,
+            label: allowlistRow?.label ?? '',
+            messageCount: row.message_count,
+            inboundCount: row.inbound_count,
+            outboundCount: row.outbound_count,
+            lastActive: row.last_active,
+            onAllowlist: allowlistRow !== null,
+            credits: creditRow?.credits ?? 0,
+            totalPurchased: creditRow?.total_purchased ?? 0,
+        };
+    });
+}
+
+/**
+ * Get messages for a specific wallet address, chronologically.
+ */
+export function getWalletMessages(
+    db: Database,
+    address: string,
+    limit: number = 50,
+    offset: number = 0,
+): { messages: AlgoChatMessage[]; total: number } {
+    const countRow = db.query(
+        'SELECT COUNT(*) as cnt FROM algochat_messages WHERE participant = ?'
+    ).get(address) as { cnt: number };
+
+    const rows = db.query(
+        `SELECT * FROM algochat_messages WHERE participant = ? ORDER BY created_at ASC LIMIT ? OFFSET ?`,
+    ).all(address, limit, offset) as AlgoChatMessageRow[];
+
+    return { messages: rows.map(rowToMessage), total: countRow.cnt };
+}


### PR DESCRIPTION
## Summary

- **Wallet Viewer** — New `/wallets` page to monitor and moderate external AlgoChat wallets. Shows per-wallet message counts, credit balances, allowlist status, and expandable conversation history with real-time WebSocket updates
- **Docs CSS Fixes** — Fixed mobile API row alignment, section subtitle spacing, config key overflow, grid card equal heights, and terminals inside steps filling parent width
- **AlgoChat = Optional** — Added prominent callouts on the AlgoChat page explaining it's fully optional, highlighted Localnet zero-cost development, updated index and getting-started pages

## Files Changed (9 files, ~600 lines)

| File | Change |
|---|---|
| `server/db/algochat-messages.ts` | +95 lines: `getWalletSummaries()` and `getWalletMessages()` queries |
| `server/routes/index.ts` | +19 lines: `GET /api/wallets/summary` and `GET /api/wallets/:address/messages` |
| `client/.../wallets/wallet-viewer.component.ts` | **New** (~420 lines): Full wallet viewer with search, expand, moderation |
| `client/.../app.routes.ts` | +5 lines: `/wallets` route |
| `client/.../sidebar.component.ts` | +8 lines: "Wallets" nav link |
| `docs/style.css` | +44 lines: CSS fixes + callout styles |
| `docs/algochat.html` | +33 lines: Optional callout + Localnet section |
| `docs/index.html` | Updated AlgoChat feature card |
| `docs/getting-started.html` | Updated AlgoKit prerequisite |

## Test plan
- [x] Server TypeScript compiles clean (`bun tsc --noEmit`)
- [x] All 230 existing tests pass (`bun test`)
- [x] Angular client TypeScript compiles (only pre-existing test-setup.ts error)
- [ ] Manual: Visit `/wallets` in the Angular UI
- [ ] Manual: Verify docs site CSS alignment on mobile
- [ ] Manual: Check AlgoChat page callout renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)