### PR TITLE
chore: bump version to v0.3.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
   <!-- ═══════════════════ HERO ═══════════════════ -->
   <header class="hero">
     <div class="container">
-      <div class="hero__badge">v0.2.0</div>
+      <div class="hero__badge">v0.3.0</div>
       <h1 class="hero__title">
         <span class="glow-cyan">Corvid</span><span class="glow-magenta">Agent</span>
       </h1>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version from `0.2.0` → `0.3.0` across `package.json`, `client/package.json`, and `docs/index.html`

## What's in v0.3.0 (since v0.2.0)

### Features
- `/extend` AlgoChat command + skip credit deduction for owners (#66)
- Wallet viewer + docs cleanup (#65)
- GitHub Pages landing site with cyberpunk pixel aesthetic (#53)

### Fixes
- Prevent silent session death from subscription timeout (#64)
- Credit purchases not detected from ALGO payments (#62)
- Multi-stage Docker build for Angular client (#52)

### Security
- Sandbox `/api/browse-dirs` to allowlisted directories (#55)
- WebSocket authentication before upgrade (#58)

### Refactoring
- Extract SessionEventBus from ProcessManager (#59)

### Docs
- Comprehensive API/architecture rewrite with ~40 missing endpoints (#63)
- Getting Started, API, and AlgoChat pages (#61)
- Mobile-friendly responsive site (#67)
- Reverse proxy configs and deploy README (#56)

### Tests & CI
- WorkTaskService unit tests (#57)
- E2E approval dialog critical path tests (#46)
- Bump actions/checkout 4→6, @anthropic-ai/sdk 0.39→0.74 (#50, #51)

## After merge
Tag `v0.3.0` on the merge commit and create a GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)