### PR TITLE
feat: add command autocomplete and /help to dashboard chat

### DIFF
--- a/client/src/app/features/dashboard/dashboard.component.ts
+++ b/client/src/app/features/dashboard/dashboard.component.ts
@@ -11,6 +11,7 @@ import { TerminalChatComponent, type TerminalMessage, type ToolEvent } from '../
 import { ApiService } from '../../core/services/api.service';
 import type { ServerWsMessage } from '../../core/models/ws-message.model';
 import type { Agent } from '../../core/models/agent.model';
+import { COMMAND_DEFS, type CommandDef } from '../../../../../shared/command-defs';
 import { firstValueFrom } from 'rxjs';
 
 interface AgentSummary {
@@ -173,6 +174,8 @@ interface AgentSummary {
                             [thinking]="thinking()"
                             [toolEvents]="toolEvents()"
                             [inputDisabled]="!selectedAgentId()"
+                            [commandDefs]="commandDefs"
+                            [agentNames]="chatAgentNames()"
                             (messageSent)="onChatMessage($event)"
                             (rewardSent)="tipAgent()"
                         />
@@ -482,6 +485,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
     protected readonly chatSessionId = signal<string | null>(null);
     protected readonly selfTestRunning = signal(false);
     protected readonly agentSummaries = signal<AgentSummary[]>([]);
+    protected readonly commandDefs: CommandDef[] = COMMAND_DEFS;
+    protected readonly chatAgentNames = computed(() =>
+        this.agentService.agents().map((a) => a.name),
+    );
 
     private unsubscribeWs: (() => void) | null = null;
 

--- a/client/src/app/shared/components/terminal-chat.component.ts
+++ b/client/src/app/shared/components/terminal-chat.component.ts
@@ -8,7 +8,9 @@ import {
     ElementRef,
     ViewChild,
     AfterViewChecked,
+    effect,
 } from '@angular/core';
+import type { CommandDef } from '../../../../../shared/command-defs';
 
 export interface TerminalMessage {
     content: string;
@@ -20,6 +22,15 @@ export interface ToolEvent {
     toolName: string;
     input: string;
     timestamp: Date;
+}
+
+/** Item shown in the autocomplete dropdown. */
+interface AutocompleteItem {
+    label: string;
+    description: string;
+    /** The text to insert when selected. */
+    insertText: string;
+    kind: 'command' | 'agent';
 }
 
 @Component({
@@ -59,22 +70,49 @@ export interface ToolEvent {
                     </div>
                 }
                 @if (messages().length === 0 && !thinking() && streamBuffer().length === 0) {
-                    <p class="terminal__empty">No messages yet. Select an agent and send a message.</p>
+                    <p class="terminal__empty">No messages yet. Type <code>/help</code> for commands or send a message.</p>
                 }
             </div>
             <div class="terminal__input-area">
                 <span class="terminal__input-prompt">> </span>
-                <textarea
-                    class="terminal__input"
-                    [placeholder]="inputDisabled() ? 'Select an agent...' : 'Type a message...'"
-                    [disabled]="inputDisabled()"
-                    [value]="inputValue()"
-                    (input)="onInput($event)"
-                    (keydown)="onKeydown($event)"
-                    [rows]="inputRows()"
-                    aria-label="Chat message input"
-                    #inputEl
-                ></textarea>
+                <div class="terminal__input-wrapper">
+                    @if (showAutocomplete() && autocompleteItems().length > 0) {
+                        <div class="autocomplete" role="listbox" aria-label="Autocomplete suggestions">
+                            @for (item of autocompleteItems(); track item.label; let i = $index) {
+                                <div
+                                    class="autocomplete__item"
+                                    [class.autocomplete__item--active]="i === autocompleteIndex()"
+                                    [attr.data-kind]="item.kind"
+                                    role="option"
+                                    [attr.aria-selected]="i === autocompleteIndex()"
+                                    (mousedown)="selectAutocomplete(item, $event)"
+                                    (mouseenter)="autocompleteIndex.set(i)"
+                                >
+                                    <span class="autocomplete__label">{{ item.label }}</span>
+                                    <span class="autocomplete__desc">{{ item.description }}</span>
+                                </div>
+                            }
+                        </div>
+                    }
+                    <textarea
+                        class="terminal__input"
+                        [placeholder]="inputDisabled() ? 'Select an agent...' : 'Type / for commands, @ for agents...'"
+                        [disabled]="inputDisabled()"
+                        [value]="inputValue()"
+                        (input)="onInput($event)"
+                        (keydown)="onKeydown($event)"
+                        (blur)="onBlur()"
+                        [rows]="inputRows()"
+                        aria-label="Chat message input"
+                        #inputEl
+                    ></textarea>
+                </div>
+                <button
+                    class="terminal__help-btn"
+                    (click)="toggleHelp()"
+                    aria-label="Show command help"
+                    title="Show available commands"
+                >?</button>
             </div>
         </div>
     `,
@@ -216,6 +254,13 @@ export interface ToolEvent {
             margin: 0;
             font-style: italic;
         }
+        .terminal__empty :global(code) {
+            background: #161b22;
+            padding: 1px 4px;
+            border-radius: 3px;
+            font-size: 0.78rem;
+            color: #f0883e;
+        }
         .terminal__input-area {
             display: flex;
             align-items: flex-start;
@@ -229,8 +274,12 @@ export interface ToolEvent {
             padding-top: 2px;
             user-select: none;
         }
-        .terminal__input {
+        .terminal__input-wrapper {
             flex: 1;
+            position: relative;
+        }
+        .terminal__input {
+            width: 100%;
             background: transparent;
             border: none;
             color: #c9d1d9;
@@ -244,6 +293,81 @@ export interface ToolEvent {
         }
         .terminal__input::placeholder { color: #484f58; }
         .terminal__input:disabled { opacity: 0.3; }
+        .terminal__help-btn {
+            background: transparent;
+            border: 1px solid #30363d;
+            color: #484f58;
+            font-family: inherit;
+            font-size: 0.75rem;
+            font-weight: 700;
+            width: 22px;
+            height: 22px;
+            border-radius: 50%;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-left: 0.5rem;
+            margin-top: 1px;
+            transition: color 0.15s, border-color 0.15s;
+            flex-shrink: 0;
+        }
+        .terminal__help-btn:hover {
+            color: var(--accent-cyan);
+            border-color: var(--accent-cyan);
+        }
+
+        /* Autocomplete overlay */
+        .autocomplete {
+            position: absolute;
+            bottom: 100%;
+            left: 0;
+            right: 0;
+            max-height: 220px;
+            overflow-y: auto;
+            background: #161b22;
+            border: 1px solid #30363d;
+            border-radius: var(--radius, 6px);
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+            z-index: 10;
+            margin-bottom: 4px;
+            scrollbar-width: thin;
+            scrollbar-color: #30363d transparent;
+        }
+        .autocomplete__item {
+            display: flex;
+            align-items: baseline;
+            gap: 0.75rem;
+            padding: 0.4rem 0.75rem;
+            cursor: pointer;
+            transition: background 0.1s;
+        }
+        .autocomplete__item:hover,
+        .autocomplete__item--active {
+            background: #1c2128;
+        }
+        .autocomplete__item--active {
+            border-left: 2px solid var(--accent-cyan, #00e5ff);
+        }
+        .autocomplete__label {
+            color: #f0f6fc;
+            font-weight: 600;
+            font-size: 0.78rem;
+            white-space: nowrap;
+        }
+        .autocomplete__item[data-kind="command"] .autocomplete__label {
+            color: var(--accent-cyan, #00e5ff);
+        }
+        .autocomplete__item[data-kind="agent"] .autocomplete__label {
+            color: var(--accent-magenta, #ff00aa);
+        }
+        .autocomplete__desc {
+            color: #8b949e;
+            font-size: 0.7rem;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
     `,
 })
 export class TerminalChatComponent implements AfterViewChecked {
@@ -253,6 +377,11 @@ export class TerminalChatComponent implements AfterViewChecked {
     readonly thinking = input(false);
     readonly toolEvents = input<ToolEvent[]>([]);
     readonly inputDisabled = input(false);
+
+    /** Command definitions for autocomplete (passed from parent). */
+    readonly commandDefs = input<CommandDef[]>([]);
+    /** Agent names for @mention autocomplete (passed from parent). */
+    readonly agentNames = input<string[]>([]);
 
     readonly messageSent = output<string>();
     readonly rewardSent = output<number>();
@@ -266,7 +395,22 @@ export class TerminalChatComponent implements AfterViewChecked {
         return Math.min(Math.max(lines, 1), 6);
     });
 
+    // Autocomplete state
+    protected readonly showAutocomplete = signal(false);
+    protected readonly autocompleteIndex = signal(0);
+    protected readonly autocompleteItems = signal<AutocompleteItem[]>([]);
+
     private shouldScroll = true;
+    /** Track the autocomplete trigger: 'command' for /, 'agent' for @ */
+    private autocompleteTrigger: 'command' | 'agent' | null = null;
+
+    constructor() {
+        // React to input changes for autocomplete
+        effect(() => {
+            const value = this.inputValue();
+            this.updateAutocomplete(value);
+        });
+    }
 
     ngAfterViewChecked(): void {
         if (this.shouldScroll && this.outputEl) {
@@ -282,9 +426,62 @@ export class TerminalChatComponent implements AfterViewChecked {
     }
 
     protected onKeydown(event: KeyboardEvent): void {
+        // Handle autocomplete navigation
+        if (this.showAutocomplete() && this.autocompleteItems().length > 0) {
+            const items = this.autocompleteItems();
+            const idx = this.autocompleteIndex();
+
+            if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                this.autocompleteIndex.set((idx + 1) % items.length);
+                return;
+            }
+            if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                this.autocompleteIndex.set((idx - 1 + items.length) % items.length);
+                return;
+            }
+            if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
+                event.preventDefault();
+                this.applyAutocomplete(items[idx]);
+                return;
+            }
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                this.dismissAutocomplete();
+                return;
+            }
+        }
+
+        // Normal send
         if (event.key === 'Enter' && !event.shiftKey) {
             event.preventDefault();
             this.send();
+        }
+    }
+
+    protected onBlur(): void {
+        // Delay dismiss so mousedown on autocomplete items can fire first
+        setTimeout(() => this.dismissAutocomplete(), 150);
+    }
+
+    protected selectAutocomplete(item: AutocompleteItem, event: MouseEvent): void {
+        event.preventDefault();
+        this.applyAutocomplete(item);
+        // Re-focus input after selection
+        this.inputEl?.nativeElement.focus();
+    }
+
+    protected toggleHelp(): void {
+        if (this.showAutocomplete()) {
+            this.dismissAutocomplete();
+        } else {
+            // Show all commands
+            const items = this.buildCommandItems('');
+            this.autocompleteItems.set(items);
+            this.autocompleteIndex.set(0);
+            this.showAutocomplete.set(items.length > 0);
+            this.autocompleteTrigger = 'command';
         }
     }
 
@@ -296,6 +493,98 @@ export class TerminalChatComponent implements AfterViewChecked {
         return renderLightMarkdown(text);
     }
 
+    // ── Autocomplete logic ──────────────────────────────────────────────
+
+    private updateAutocomplete(value: string): void {
+        // Command autocomplete: triggered when input starts with /
+        if (value.startsWith('/')) {
+            const search = value.split(/\s/)[0].toLowerCase(); // first word (the command)
+            // Only show autocomplete while typing the command name (no space yet)
+            if (!value.includes(' ')) {
+                const items = this.buildCommandItems(search);
+                this.autocompleteItems.set(items);
+                this.autocompleteIndex.set(0);
+                this.showAutocomplete.set(items.length > 0);
+                this.autocompleteTrigger = 'command';
+                return;
+            }
+        }
+
+        // Agent mention autocomplete: triggered by @ in /council context or standalone @
+        const atMatch = value.match(/@(\w*)$/);
+        if (atMatch) {
+            const search = atMatch[1].toLowerCase();
+            const items = this.buildAgentItems(search);
+            this.autocompleteItems.set(items);
+            this.autocompleteIndex.set(0);
+            this.showAutocomplete.set(items.length > 0);
+            this.autocompleteTrigger = 'agent';
+            return;
+        }
+
+        // No trigger — dismiss
+        this.dismissAutocomplete();
+    }
+
+    private buildCommandItems(search: string): AutocompleteItem[] {
+        const defs = this.commandDefs();
+        return defs
+            .filter((d) => d.name.toLowerCase().startsWith(search || '/'))
+            .map((d) => ({
+                label: d.name,
+                description: d.description,
+                insertText: d.name + ' ',
+                kind: 'command' as const,
+            }));
+    }
+
+    private buildAgentItems(search: string): AutocompleteItem[] {
+        const names = this.agentNames();
+        return names
+            .filter((n) => n.toLowerCase().startsWith(search))
+            .map((n) => ({
+                label: `@${n}`,
+                description: 'Agent',
+                insertText: `@${n} `,
+                kind: 'agent' as const,
+            }));
+    }
+
+    private applyAutocomplete(item: AutocompleteItem): void {
+        const value = this.inputValue();
+
+        if (this.autocompleteTrigger === 'command') {
+            // Replace the typed command with the selected one
+            const rest = value.includes(' ') ? value.slice(value.indexOf(' ')) : '';
+            const newValue = item.insertText + rest.trimStart();
+            this.setInput(newValue);
+        } else if (this.autocompleteTrigger === 'agent') {
+            // Replace the @partial at the end with the full @name
+            const atIdx = value.lastIndexOf('@');
+            const newValue = value.slice(0, atIdx) + item.insertText;
+            this.setInput(newValue);
+        }
+
+        this.dismissAutocomplete();
+    }
+
+    private dismissAutocomplete(): void {
+        this.showAutocomplete.set(false);
+        this.autocompleteItems.set([]);
+        this.autocompleteIndex.set(0);
+        this.autocompleteTrigger = null;
+    }
+
+    private setInput(value: string): void {
+        this.inputValue.set(value);
+        if (this.inputEl) {
+            this.inputEl.nativeElement.value = value;
+            // Move cursor to end
+            const len = value.length;
+            this.inputEl.nativeElement.setSelectionRange(len, len);
+        }
+    }
+
     private send(): void {
         const content = this.inputValue().trim();
         if (!content) return;
@@ -304,6 +593,7 @@ export class TerminalChatComponent implements AfterViewChecked {
         if (this.inputEl) {
             this.inputEl.nativeElement.value = '';
         }
+        this.dismissAutocomplete();
         this.shouldScroll = true;
         this.messageSent.emit(content);
     }

--- a/shared/command-defs.ts
+++ b/shared/command-defs.ts
@@ -1,0 +1,171 @@
+/**
+ * Shared command definitions used by both client autocomplete and server validation.
+ *
+ * Each command definition describes the syntax, purpose, and argument structure
+ * so the dashboard can provide intelligent autocomplete and inline help.
+ */
+
+export interface CommandParam {
+    name: string;
+    description: string;
+    required: boolean;
+    /** If true, the rest of the input is consumed as this param (e.g., prompt text). */
+    rest?: boolean;
+    /** If true, show agent mention autocomplete (@AgentName). */
+    agentMention?: boolean;
+}
+
+export interface CommandDef {
+    name: string;
+    description: string;
+    usage: string;
+    params: CommandParam[];
+    /** Commands requiring owner authorization. */
+    privileged: boolean;
+    /** Short example(s) shown in the autocomplete dropdown. */
+    examples: string[];
+}
+
+export const COMMAND_DEFS: CommandDef[] = [
+    {
+        name: '/status',
+        description: 'Show active sessions and conversation count',
+        usage: '/status',
+        params: [],
+        privileged: false,
+        examples: ['/status'],
+    },
+    {
+        name: '/credits',
+        description: 'Show your credit balance and rates',
+        usage: '/credits',
+        params: [],
+        privileged: false,
+        examples: ['/credits'],
+    },
+    {
+        name: '/history',
+        description: 'Show recent credit transactions',
+        usage: '/history [limit]',
+        params: [
+            { name: 'limit', description: 'Number of transactions (default 10, max 20)', required: false },
+        ],
+        privileged: false,
+        examples: ['/history', '/history 20'],
+    },
+    {
+        name: '/queue',
+        description: 'Show pending escalation/approval requests',
+        usage: '/queue',
+        params: [],
+        privileged: false,
+        examples: ['/queue'],
+    },
+    {
+        name: '/agent',
+        description: 'List available agents or switch default agent',
+        usage: '/agent [name]',
+        params: [
+            { name: 'name', description: 'Agent name to switch to', required: false, rest: true },
+        ],
+        privileged: true,
+        examples: ['/agent', '/agent CorvidAgent'],
+    },
+    {
+        name: '/stop',
+        description: 'Stop a running session',
+        usage: '/stop <session-id>',
+        params: [
+            { name: 'session-id', description: 'Session ID to stop', required: true },
+        ],
+        privileged: true,
+        examples: ['/stop abc123'],
+    },
+    {
+        name: '/approve',
+        description: 'Approve a pending escalation request',
+        usage: '/approve <queue-id>',
+        params: [
+            { name: 'queue-id', description: 'Escalation queue ID', required: true },
+        ],
+        privileged: true,
+        examples: ['/approve 1'],
+    },
+    {
+        name: '/deny',
+        description: 'Deny a pending escalation request',
+        usage: '/deny <queue-id>',
+        params: [
+            { name: 'queue-id', description: 'Escalation queue ID', required: true },
+        ],
+        privileged: true,
+        examples: ['/deny 1'],
+    },
+    {
+        name: '/mode',
+        description: 'View or set operational mode (normal, queued, paused)',
+        usage: '/mode [normal|queued|paused]',
+        params: [
+            { name: 'mode', description: 'New operational mode', required: false },
+        ],
+        privileged: true,
+        examples: ['/mode', '/mode queued'],
+    },
+    {
+        name: '/work',
+        description: 'Create a work task (branch + PR)',
+        usage: '/work <description>',
+        params: [
+            { name: 'description', description: 'Task description', required: true, rest: true },
+        ],
+        privileged: true,
+        examples: ['/work fix the login bug', '/work add unit tests for auth module'],
+    },
+    {
+        name: '/council',
+        description: 'Launch a multi-agent council discussion',
+        usage: '/council <prompt> | /council @Agent1 @Agent2 -- <prompt> | /council CouncilName -- <prompt>',
+        params: [
+            { name: 'agents-or-name', description: '@mentions or council name (optional)', required: false, agentMention: true },
+            { name: 'prompt', description: 'The prompt/question for the council', required: true, rest: true },
+        ],
+        privileged: true,
+        examples: [
+            '/council review the auth system',
+            '/council @CorvidAgent @ReviewBot -- review the auth system',
+            '/council SecurityCouncil -- audit the API endpoints',
+        ],
+    },
+    {
+        name: '/extend',
+        description: 'Extend a running session timeout',
+        usage: '/extend [minutes] [session-id]',
+        params: [
+            { name: 'minutes', description: 'Minutes to extend (default 30, max 120)', required: false },
+            { name: 'session-id', description: 'Session ID (default: current session)', required: false },
+        ],
+        privileged: true,
+        examples: ['/extend', '/extend 60'],
+    },
+    {
+        name: '/help',
+        description: 'Show available commands and usage',
+        usage: '/help [command]',
+        params: [
+            { name: 'command', description: 'Specific command to get help for', required: false },
+        ],
+        privileged: false,
+        examples: ['/help', '/help council'],
+    },
+];
+
+/** Get a command definition by name (with or without leading /). */
+export function getCommandDef(name: string): CommandDef | undefined {
+    const normalized = name.startsWith('/') ? name : `/${name}`;
+    return COMMAND_DEFS.find((c) => c.name === normalized.toLowerCase());
+}
+
+/** Get all command names for autocomplete matching. */
+export function getCommandNames(): string[] {
+    return COMMAND_DEFS.map((c) => c.name);
+}


### PR DESCRIPTION
## Summary

- **Shared command definitions** (`shared/command-defs.ts`) — typed `CommandDef` objects for all 13 slash commands, reusable by both server and client
- **`/help` command** — shows all available commands or detailed help for a specific command (`/help council`)
- **Slash commands from dashboard** — commands like `/status`, `/help`, `/council` now work directly in the dashboard local chat (routed through `CommandHandler` before creating sessions)
- **Autocomplete overlay** in `TerminalChatComponent`:
  - Type `/` → command palette dropdown with descriptions
  - Type `@` → agent name autocomplete (for `/council @Agent1 @Agent2 -- prompt`)
  - Arrow keys + Tab to navigate/select, Escape to dismiss, mouse click supported
  - `?` help button next to input to show all commands at a glance
- **Dashboard wiring** — passes `COMMAND_DEFS` and agent names to the terminal chat component

## Files Changed

| File | Change |
|------|--------|
| `shared/command-defs.ts` | **NEW** — shared command definitions |
| `server/algochat/command-handler.ts` | Add `/help`, `responseFn` callback, use `respond()` helper |
| `server/algochat/bridge.ts` | Route slash commands from local chat through CommandHandler |
| `client/.../terminal-chat.component.ts` | Autocomplete overlay, `?` button, new inputs |
| `client/.../dashboard.component.ts` | Wire `commandDefs` and `agentNames` to terminal chat |

## Test plan

- [x] All 230 server tests pass
- [x] Angular production build succeeds
- [ ] Manual test: type `/` in dashboard chat → command palette appears
- [ ] Manual test: type `@` in dashboard chat → agent names appear
- [ ] Manual test: `/help` shows all commands, `/help council` shows council details
- [ ] Manual test: `/status` from dashboard returns session count (no agent session created)
- [ ] Manual test: Arrow keys, Tab, Escape, and mouse all work for autocomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)