### PR TITLE
Fix broken Unicode box diagrams on docs site

### DIFF
--- a/docs/algochat.html
+++ b/docs/algochat.html
@@ -94,20 +94,66 @@
           <span class="terminal__dot terminal__dot--green"></span>
           <span class="terminal__label">message flow</span>
         </div>
-        <pre class="terminal__body"><code>
-<span class="accent-cyan">  Human</span>                    <span class="accent-magenta">AlgoChat Bridge</span>              <span class="accent-green">Agent</span>
-    │                           │                          │
-    │  <span class="t-comment">Algorand Txn (hex)</span>      │                          │
-    │──────────────────────────▶│                          │
-    │                           │  <span class="t-comment">Parse &amp; decrypt</span>        │
-    │                           │─────────────────────────▶│
-    │                           │                          │
-    │                           │  <span class="t-comment">Agent response</span>         │
-    │                           │◀─────────────────────────│
-    │  <span class="t-comment">Algorand Txn (PSK)</span>      │                          │
-    │◀──────────────────────────│                          │
-    │                           │                          │
-</code></pre>
+        <div class="flow-diagram">
+          <!-- Column headers -->
+          <div class="flow-header">
+            <span class="flow-header__col accent-cyan">Human</span>
+            <span class="flow-header__col accent-magenta">AlgoChat Bridge</span>
+            <span class="flow-header__col accent-green">Agent</span>
+          </div>
+
+          <!-- Step 1: Human → Bridge -->
+          <div class="flow-step">
+            <div class="flow-step__dot"></div>
+            <div class="flow-step__spacer">
+              <div class="flow-step__arrow flow-step__arrow--right" style="position: relative;">
+                <span class="flow-step__label">Algorand Txn (hex)</span>
+              </div>
+            </div>
+            <div class="flow-step__dot"></div>
+            <div class="flow-step__spacer"></div>
+            <div class="flow-step__dot"></div>
+          </div>
+
+          <!-- Step 2: Bridge → Agent -->
+          <div class="flow-step">
+            <div class="flow-step__dot"></div>
+            <div class="flow-step__spacer"></div>
+            <div class="flow-step__dot"></div>
+            <div class="flow-step__spacer">
+              <div class="flow-step__arrow flow-step__arrow--right" style="position: relative;">
+                <span class="flow-step__label">Parse &amp; decrypt</span>
+              </div>
+            </div>
+            <div class="flow-step__dot"></div>
+          </div>
+
+          <!-- Step 3: Agent → Bridge -->
+          <div class="flow-step">
+            <div class="flow-step__dot"></div>
+            <div class="flow-step__spacer"></div>
+            <div class="flow-step__dot"></div>
+            <div class="flow-step__spacer">
+              <div class="flow-step__arrow flow-step__arrow--left" style="position: relative;">
+                <span class="flow-step__label">Agent response</span>
+              </div>
+            </div>
+            <div class="flow-step__dot"></div>
+          </div>
+
+          <!-- Step 4: Bridge → Human -->
+          <div class="flow-step">
+            <div class="flow-step__dot"></div>
+            <div class="flow-step__spacer">
+              <div class="flow-step__arrow flow-step__arrow--left" style="position: relative;">
+                <span class="flow-step__label">Algorand Txn (PSK)</span>
+              </div>
+            </div>
+            <div class="flow-step__dot"></div>
+            <div class="flow-step__spacer"></div>
+            <div class="flow-step__dot"></div>
+          </div>
+        </div>
       </div>
 
       <div class="grid grid--2">

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -54,19 +54,57 @@
           <span class="terminal__dot terminal__dot--green"></span>
           <span class="terminal__label">architecture</span>
         </div>
-        <pre class="terminal__body"><code>
-<span class="t-comment">  ┌─────────────┐     ┌──────────────┐     ┌──────────────┐</span>
-<span class="t-comment">  │</span> <span class="accent-cyan">Angular UI</span>  <span class="t-comment">│────▶│</span> <span class="accent-magenta">Bun Server</span>   <span class="t-comment">│────▶│</span> <span class="accent-green">Claude SDK</span>   <span class="t-comment">│</span>
-<span class="t-comment">  │</span>  Port 4200  <span class="t-comment">│     │</span>  Port 3000  <span class="t-comment">│     │</span>  Subprocess <span class="t-comment">│</span>
-<span class="t-comment">  └─────────────┘     └──────┬───────┘     └──────────────┘</span>
-<span class="t-comment">                             │</span>
-<span class="t-comment">        ┌────────────────────┼────────────────────┐</span>
-<span class="t-comment">        ▼                    ▼                    ▼</span>
-<span class="t-comment">  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐</span>
-<span class="t-comment">  │</span> <span class="accent-cyan">SQLite DB</span>    <span class="t-comment">│  │</span> <span class="accent-magenta">MCP Server</span>   <span class="t-comment">│  │</span> <span class="accent-green">AlgoChat</span>     <span class="t-comment">│</span>
-<span class="t-comment">  │</span>  Persistence <span class="t-comment">│  │</span>  9 Tools     <span class="t-comment">│  │</span>  (optional) <span class="t-comment">│</span>
-<span class="t-comment">  └──────────────┘  └──────────────┘  └──────────────┘</span>
-</code></pre>
+        <div class="arch-diagram">
+          <!-- Top row: Angular UI → Bun Server → Claude SDK -->
+          <div class="arch-row">
+            <div class="arch-box arch-box--cyan">
+              <div class="arch-box__label accent-cyan">Angular UI</div>
+              <div class="arch-box__sub">Port 4200</div>
+            </div>
+            <span class="arch-arrow"></span>
+            <div class="arch-box arch-box--magenta">
+              <div class="arch-box__label accent-magenta">Bun Server</div>
+              <div class="arch-box__sub">Port 3000</div>
+            </div>
+            <span class="arch-arrow"></span>
+            <div class="arch-box arch-box--green">
+              <div class="arch-box__label accent-green">Claude SDK</div>
+              <div class="arch-box__sub">Subprocess</div>
+            </div>
+          </div>
+
+          <!-- Connector: vertical line from Bun Server down -->
+          <div class="arch-arrow--down"></div>
+
+          <!-- Branching connectors -->
+          <div class="arch-connector">
+            <div class="arch-connector__line"></div>
+            <div class="arch-connector__junction">
+              <div class="arch-connector__vert"></div>
+            </div>
+            <div class="arch-connector__line"></div>
+            <div class="arch-connector__junction">
+              <div class="arch-connector__vert"></div>
+            </div>
+            <div class="arch-connector__line"></div>
+          </div>
+
+          <!-- Bottom row: SQLite, MCP Server, AlgoChat -->
+          <div class="arch-row">
+            <div class="arch-box arch-box--cyan">
+              <div class="arch-box__label accent-cyan">SQLite DB</div>
+              <div class="arch-box__sub">Persistence</div>
+            </div>
+            <div class="arch-box arch-box--magenta">
+              <div class="arch-box__label accent-magenta">MCP Server</div>
+              <div class="arch-box__sub">9 Tools</div>
+            </div>
+            <div class="arch-box arch-box--green">
+              <div class="arch-box__label accent-green">AlgoChat</div>
+              <div class="arch-box__sub">(optional)</div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </section>
@@ -682,17 +720,62 @@
           <span class="terminal__dot terminal__dot--green"></span>
           <span class="terminal__label">lifecycle</span>
         </div>
-        <pre class="terminal__body"><code>
-<span class="accent-cyan">  Created</span> ──▶ <span class="accent-green">Running</span> ──▶ <span class="accent-magenta">Paused</span> ──▶ <span class="accent-green">Resumed</span>
-                 │                          │
-                 │    <span class="t-comment">context reset</span>          │
-                 │    <span class="t-comment">(every 8 turns)</span>        │
-                 ▼                          ▼
-              <span class="accent-cyan">Timeout</span> ──▶ <span class="accent-magenta">Stopped</span>     <span class="accent-green">Running</span>
+        <div class="arch-diagram" style="padding: 20px 12px;">
+          <!-- Main flow: Created → Running → Paused → Resumed -->
+          <div class="arch-row">
+            <div class="arch-box arch-box--cyan">
+              <div class="arch-box__label accent-cyan">Created</div>
+            </div>
+            <span class="arch-arrow"></span>
+            <div class="arch-box arch-box--green">
+              <div class="arch-box__label accent-green">Running</div>
+            </div>
+            <span class="arch-arrow"></span>
+            <div class="arch-box arch-box--magenta">
+              <div class="arch-box__label accent-magenta">Paused</div>
+            </div>
+            <span class="arch-arrow"></span>
+            <div class="arch-box arch-box--green">
+              <div class="arch-box__label accent-green">Resumed</div>
+            </div>
+          </div>
 
-  <span class="t-comment">Auto-resume backoff: 5m → 15m → 45m → 60m cap</span>
-  <span class="t-comment">Default timeout: 30 minutes (configurable)</span>
-</code></pre>
+          <!-- Branches down -->
+          <div style="display: flex; justify-content: space-around; width: 100%; padding: 0 40px;">
+            <div style="text-align: center; flex: 1;">
+              <div class="arch-arrow--down"></div>
+              <div style="font-size: 7px; color: var(--text-tertiary); padding: 2px 0;">context reset</div>
+              <div style="font-size: 7px; color: var(--text-tertiary); padding: 0 0 4px;">(every 8 turns)</div>
+              <div class="arch-arrow--down arch-arrow--down-tip"></div>
+            </div>
+            <div style="text-align: center; flex: 1;">
+              <div class="arch-arrow--down"></div>
+              <div style="padding: 16px 0 4px;"></div>
+              <div class="arch-arrow--down arch-arrow--down-tip"></div>
+            </div>
+          </div>
+
+          <div class="arch-row" style="gap: 40px;">
+            <div style="display: flex; align-items: center; gap: 12px;">
+              <div class="arch-box arch-box--cyan">
+                <div class="arch-box__label accent-cyan">Timeout</div>
+              </div>
+              <span class="arch-arrow"></span>
+              <div class="arch-box arch-box--magenta">
+                <div class="arch-box__label accent-magenta">Stopped</div>
+              </div>
+            </div>
+            <div class="arch-box arch-box--green">
+              <div class="arch-box__label accent-green">Running</div>
+            </div>
+          </div>
+
+          <!-- Notes -->
+          <div style="margin-top: 20px; text-align: center;">
+            <div style="font-size: 8px; color: var(--text-tertiary); line-height: 2.2;">Auto-resume backoff: 5m &rarr; 15m &rarr; 45m &rarr; 60m cap</div>
+            <div style="font-size: 8px; color: var(--text-tertiary); line-height: 2.2;">Default timeout: 30 minutes (configurable)</div>
+          </div>
+        </div>
       </div>
 
       <div class="grid grid--3" style="margin-top: 40px;">

--- a/docs/index.html
+++ b/docs/index.html
@@ -166,7 +166,7 @@
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-file">agent.ts</span>     <span class="t-comment"># Claude Agent SDK integration</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-file">council.ts</span>   <span class="t-comment"># Multi-agent deliberation</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x2514;&#x2500;&#x2500;</span> <span class="t-dir">tools/</span>       <span class="t-comment"># MCP tool implementations</span>
-<span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">client/</span>          <span class="t-comment"># Angular 20 UI</span>
+<span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">client/</span>          <span class="t-comment"># Angular 21 UI</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x2514;&#x2500;&#x2500;</span> <span class="t-dir">src/app/</span>     <span class="t-comment"># Components &amp; services</span>
 <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">mcp-server/</span>      <span class="t-comment"># MCP tool server</span>
 <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">deploy/</span>          <span class="t-comment"># Docker &amp; CI/CD</span>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1204,3 +1204,272 @@ a {
 .hero__badge {
   animation: pulse-glow 3s ease-in-out infinite;
 }
+
+/* ═══════════════════ ARCHITECTURE DIAGRAM ═══════════════════ */
+.arch-diagram {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+  padding: 24px 12px;
+}
+
+.arch-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  flex-wrap: nowrap;
+}
+
+.arch-box {
+  border: 1px solid var(--border-bright);
+  border-radius: 4px;
+  padding: 12px 16px;
+  text-align: center;
+  min-width: 120px;
+  background: var(--bg-raised);
+  transition: all 0.2s ease;
+}
+
+.arch-box:hover {
+  transform: translateY(-2px);
+}
+
+.arch-box--cyan    { border-color: rgba(0, 229, 255, 0.3); }
+.arch-box--magenta { border-color: rgba(255, 0, 170, 0.3); }
+.arch-box--green   { border-color: rgba(0, 255, 136, 0.3); }
+
+.arch-box--cyan:hover    { border-color: var(--cyan);    box-shadow: var(--glow-cyan); }
+.arch-box--magenta:hover { border-color: var(--magenta); box-shadow: var(--glow-magenta); }
+.arch-box--green:hover   { border-color: var(--green);   box-shadow: var(--glow-green); }
+
+.arch-box__label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  margin-bottom: 4px;
+}
+
+.arch-box__sub {
+  font-size: 7px;
+  color: var(--text-tertiary);
+  letter-spacing: 0.5px;
+}
+
+.arch-arrow {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  flex-shrink: 0;
+  height: 1px;
+  width: 32px;
+  background: var(--border-bright);
+  position: relative;
+}
+
+.arch-arrow::after {
+  content: '';
+  position: absolute;
+  right: -1px;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 6px solid var(--text-tertiary);
+}
+
+.arch-arrow--down {
+  display: block;
+  height: 16px;
+  width: 1px;
+  margin: 0 auto;
+  background: var(--border-bright);
+  position: relative;
+}
+
+.arch-arrow--down-tip::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: -3px;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 6px solid var(--text-tertiary);
+}
+
+.arch-connector {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 0;
+  gap: 0;
+  width: 100%;
+}
+
+.arch-connector__line {
+  height: 1px;
+  flex: 1;
+  max-width: 120px;
+  background: var(--border-bright);
+}
+
+.arch-connector__vert {
+  width: 1px;
+  height: 20px;
+  background: var(--border-bright);
+}
+
+.arch-connector__junction {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* ═══════════════════ FLOW DIAGRAM ═══════════════════ */
+.flow-diagram {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 24px 12px;
+}
+
+.flow-header {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 12px;
+}
+
+.flow-header__col {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-align: center;
+  flex: 1;
+}
+
+.flow-step {
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+}
+
+.flow-step__spacer {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.flow-step__arrow {
+  height: 1px;
+  flex: 1;
+  position: relative;
+  margin: 0 8px;
+}
+
+.flow-step__arrow--right {
+  background: linear-gradient(to right, var(--border-bright), var(--cyan));
+}
+
+.flow-step__arrow--right::after {
+  content: '';
+  position: absolute;
+  right: -1px;
+  top: -3px;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 6px solid var(--cyan);
+}
+
+.flow-step__arrow--left {
+  background: linear-gradient(to left, var(--border-bright), var(--magenta));
+}
+
+.flow-step__arrow--left::before {
+  content: '';
+  position: absolute;
+  left: -1px;
+  top: -3px;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-right: 6px solid var(--magenta);
+}
+
+.flow-step__label {
+  font-size: 8px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  position: absolute;
+  top: -14px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.flow-step__dot {
+  width: 1px;
+  height: 28px;
+  background: var(--border-bright);
+  flex-shrink: 0;
+}
+
+/* ═══════════════════ DIAGRAM RESPONSIVE ═══════════════════ */
+@media (max-width: 768px) {
+  .arch-row {
+    gap: 10px;
+  }
+
+  .arch-box {
+    min-width: 90px;
+    padding: 10px 10px;
+  }
+
+  .arch-box__label {
+    font-size: 8px;
+  }
+
+  .arch-box__sub {
+    font-size: 6px;
+  }
+
+  .arch-arrow {
+    font-size: 10px;
+  }
+
+  .flow-header__col {
+    font-size: 8px;
+  }
+
+  .flow-step__label {
+    font-size: 7px;
+  }
+}
+
+@media (max-width: 480px) {
+  .arch-row {
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+  }
+
+  .arch-box {
+    min-width: 80px;
+    padding: 8px;
+  }
+
+  .arch-box__label {
+    font-size: 7px;
+  }
+
+  .arch-arrow {
+    font-size: 8px;
+  }
+
+  .flow-header {
+    gap: 4px;
+  }
+
+  .flow-header__col {
+    font-size: 7px;
+  }
+}


### PR DESCRIPTION
## Summary
- Replaced all Unicode box-drawing character diagrams (┌─┐│└┘) with pure CSS/HTML components across docs pages
- Added ~270 lines of CSS for `.arch-diagram`, `.arch-box`, `.arch-arrow`, `.flow-diagram`, `.flow-step` components
- All arrows now use CSS border triangles instead of Unicode characters
- Fully responsive with breakpoints at 768px and 480px
- Fixed "Angular 20" → "Angular 21" in index.html

## Why
The `Dogica Pixel` font doesn't have consistent monospace widths for Unicode box-drawing characters, causing all ASCII art diagrams to render with broken alignment.

## Files changed
- `docs/style.css` — New CSS component styles for diagrams
- `docs/architecture.html` — System overview + session lifecycle diagrams
- `docs/algochat.html` — Message flow sequence diagram
- `docs/index.html` — Angular version fix

## Test plan
- [ ] Verify diagrams render correctly on GitHub Pages
- [ ] Check responsive behavior at mobile breakpoints
- [ ] Confirm hover glow effects work on diagram boxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)