### PR TITLE
feat: add Analytics, Settings, Work Tasks, and Logs pages

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -103,6 +103,26 @@ export const routes: Routes = [
             import('./features/sessions/session-view.component').then((m) => m.SessionViewComponent),
     },
     {
+        path: 'work-tasks',
+        loadComponent: () =>
+            import('./features/work-tasks/work-task-list.component').then((m) => m.WorkTaskListComponent),
+    },
+    {
+        path: 'analytics',
+        loadComponent: () =>
+            import('./features/analytics/analytics.component').then((m) => m.AnalyticsComponent),
+    },
+    {
+        path: 'logs',
+        loadComponent: () =>
+            import('./features/logs/system-logs.component').then((m) => m.SystemLogsComponent),
+    },
+    {
+        path: 'settings',
+        loadComponent: () =>
+            import('./features/settings/settings.component').then((m) => m.SettingsComponent),
+    },
+    {
         path: 'nft/review',
         loadComponent: () =>
             import('./features/nft/nft-initial-review.component').then((m) => m.NFTInitialReviewComponent),

--- a/client/src/app/features/agents/agent-detail.component.ts
+++ b/client/src/app/features/agents/agent-detail.component.ts
@@ -230,7 +230,7 @@ import type { ServerWsMessage } from '../../core/models/ws-message.model';
             font-size: 0.85rem; font-family: inherit; background: var(--bg-input); color: var(--text-primary);
         }
         .invoke-select:focus, .invoke-textarea:focus { border-color: var(--accent-cyan); box-shadow: var(--glow-cyan); outline: none; }
-        .invoke-textarea { resize: vertical; min-height: 60px; }
+        .invoke-textarea { resize: vertical; min-height: 5em; line-height: 1.5; }
         .btn--primary {
             padding: 0.5rem 1rem; border-radius: var(--radius); font-size: 0.8rem; font-weight: 600;
             cursor: pointer; border: 1px solid var(--accent-cyan); background: var(--accent-cyan-dim);

--- a/client/src/app/features/agents/agent-form.component.ts
+++ b/client/src/app/features/agents/agent-form.component.ts
@@ -23,7 +23,7 @@ import type { Project } from '../../core/models/project.model';
                 <div class="form__field">
                     <label for="description" class="form__label">Description</label>
                     <textarea id="description" formControlName="description" class="form__input form__textarea"
-                              rows="2"></textarea>
+                              rows="3"></textarea>
                 </div>
 
                 <div class="form__field">
@@ -49,13 +49,13 @@ import type { Project } from '../../core/models/project.model';
                 <div class="form__field">
                     <label for="systemPrompt" class="form__label">System Prompt</label>
                     <textarea id="systemPrompt" formControlName="systemPrompt" class="form__input form__textarea"
-                              rows="4" placeholder="Custom system instructions..."></textarea>
+                              rows="8" placeholder="Custom system instructions..."></textarea>
                 </div>
 
                 <div class="form__field">
                     <label for="appendPrompt" class="form__label">Append Prompt</label>
                     <textarea id="appendPrompt" formControlName="appendPrompt" class="form__input form__textarea"
-                              rows="3" placeholder="Appended to the system prompt..."></textarea>
+                              rows="6" placeholder="Appended to the system prompt..."></textarea>
                 </div>
 
                 <div class="form__field">
@@ -117,7 +117,7 @@ import type { Project } from '../../core/models/project.model';
             font-size: 0.85rem; font-family: inherit; background: var(--bg-input); color: var(--text-primary);
         }
         .form__input:focus { outline: none; border-color: var(--accent-cyan); box-shadow: var(--glow-cyan); }
-        .form__textarea { resize: vertical; }
+        .form__textarea { resize: vertical; min-height: 5em; line-height: 1.5; }
         .form__fieldset { border: 1px solid var(--border-bright); border-radius: var(--radius); padding: 1rem; margin: 0; background: var(--bg-surface); }
         .form__legend { font-weight: 600; font-size: 0.8rem; color: var(--accent-magenta); padding: 0 0.25rem; letter-spacing: 0.05em; }
         .form__checkbox { display: flex; align-items: center; gap: 0.5rem; font-size: 0.85rem; margin-top: 0.5rem; cursor: pointer; color: var(--text-primary); }

--- a/client/src/app/features/analytics/analytics.component.ts
+++ b/client/src/app/features/analytics/analytics.component.ts
@@ -1,0 +1,458 @@
+import { Component, ChangeDetectionStrategy, inject, OnInit, signal, computed } from '@angular/core';
+import { DecimalPipe } from '@angular/common';
+import { ApiService } from '../../core/services/api.service';
+import { firstValueFrom } from 'rxjs';
+
+interface OverviewData {
+    totalSessions: number;
+    totalCostUsd: number;
+    totalAlgoSpent: number;
+    totalTurns: number;
+    totalCreditsConsumed: number;
+    activeSessions: number;
+    totalAgents: number;
+    totalProjects: number;
+    workTasks: Record<string, number>;
+    agentMessages: number;
+    algochatMessages: number;
+    todaySpending: { algoMicro: number; apiCostUsd: number };
+}
+
+interface SpendingDay {
+    date: string;
+    algo_micro: number;
+    api_cost_usd: number;
+}
+
+interface SessionCostDay {
+    date: string;
+    session_count: number;
+    cost_usd: number;
+    turns: number;
+}
+
+interface SpendingData {
+    spending: SpendingDay[];
+    sessionCosts: SessionCostDay[];
+    days: number;
+}
+
+interface AgentSessionStat {
+    agent_id: string;
+    agent_name: string;
+    session_count: number;
+    total_cost: number;
+    total_turns: number;
+}
+
+interface SessionStats {
+    byAgent: AgentSessionStat[];
+    bySource: { source: string; count: number }[];
+    byStatus: { status: string; count: number }[];
+}
+
+@Component({
+    selector: 'app-analytics',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [DecimalPipe],
+    template: `
+        <div class="analytics">
+            <h2>Analytics</h2>
+
+            @if (loading()) {
+                <p class="loading">Loading analytics data...</p>
+            } @else if (overview()) {
+                <!-- Overview Cards -->
+                <div class="analytics__cards">
+                    <div class="stat-card">
+                        <span class="stat-card__label">Total Sessions</span>
+                        <span class="stat-card__value">{{ overview()!.totalSessions }}</span>
+                    </div>
+                    <div class="stat-card">
+                        <span class="stat-card__label">API Cost (USD)</span>
+                        <span class="stat-card__value stat-card__value--usd">\${{ overview()!.totalCostUsd | number:'1.2-4' }}</span>
+                    </div>
+                    <div class="stat-card">
+                        <span class="stat-card__label">ALGO Spent</span>
+                        <span class="stat-card__value stat-card__value--algo">{{ (overview()!.totalAlgoSpent / 1000000) | number:'1.4-4' }}</span>
+                    </div>
+                    <div class="stat-card">
+                        <span class="stat-card__label">Total Turns</span>
+                        <span class="stat-card__value">{{ overview()!.totalTurns }}</span>
+                    </div>
+                    <div class="stat-card">
+                        <span class="stat-card__label">Active Now</span>
+                        <span class="stat-card__value stat-card__value--active">{{ overview()!.activeSessions }}</span>
+                    </div>
+                    <div class="stat-card">
+                        <span class="stat-card__label">Messages</span>
+                        <span class="stat-card__value">{{ overview()!.agentMessages + overview()!.algochatMessages }}</span>
+                    </div>
+                    <div class="stat-card">
+                        <span class="stat-card__label">Credits Used</span>
+                        <span class="stat-card__value">{{ overview()!.totalCreditsConsumed }}</span>
+                    </div>
+                    <div class="stat-card stat-card--today">
+                        <span class="stat-card__label">Today's Spend</span>
+                        <span class="stat-card__value stat-card__value--usd">\${{ overview()!.todaySpending.apiCostUsd | number:'1.2-4' }}</span>
+                    </div>
+                </div>
+
+                <!-- Work Tasks Summary -->
+                @if (workTaskTotal() > 0) {
+                    <div class="analytics__section">
+                        <h3>Work Tasks</h3>
+                        <div class="work-task-bar">
+                            @for (entry of workTaskEntries(); track entry.status) {
+                                <div
+                                    class="work-task-segment"
+                                    [attr.data-status]="entry.status"
+                                    [style.flex]="entry.count"
+                                    [title]="entry.status + ': ' + entry.count"
+                                >
+                                    <span class="work-task-segment__label">{{ entry.status }} ({{ entry.count }})</span>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                }
+
+                <!-- Spending Over Time (ASCII chart) -->
+                @if (spending()) {
+                    <div class="analytics__section">
+                        <h3>Daily API Cost (Last {{ spendingDays() }} Days)</h3>
+                        <div class="chart-controls">
+                            <button class="chart-btn" [class.chart-btn--active]="spendingDays() === 7" (click)="loadSpending(7)">7d</button>
+                            <button class="chart-btn" [class.chart-btn--active]="spendingDays() === 14" (click)="loadSpending(14)">14d</button>
+                            <button class="chart-btn" [class.chart-btn--active]="spendingDays() === 30" (click)="loadSpending(30)">30d</button>
+                            <button class="chart-btn" [class.chart-btn--active]="spendingDays() === 90" (click)="loadSpending(90)">90d</button>
+                        </div>
+                        <div class="ascii-chart">
+                            @for (bar of spendingBars(); track bar.date) {
+                                <div class="chart-row" [title]="bar.date + ': $' + bar.value.toFixed(4)">
+                                    <span class="chart-row__label">{{ bar.dateShort }}</span>
+                                    <div class="chart-row__bar-wrapper">
+                                        <div class="chart-row__bar" [style.width.%]="bar.pct"></div>
+                                    </div>
+                                    <span class="chart-row__value">\${{ bar.value.toFixed(4) }}</span>
+                                </div>
+                            }
+                            @if (spendingBars().length === 0) {
+                                <p class="empty-state">No spending data for this period</p>
+                            }
+                        </div>
+                    </div>
+                }
+
+                <!-- Agent Breakdown -->
+                @if (sessionStats()) {
+                    <div class="analytics__section">
+                        <h3>Usage by Agent</h3>
+                        <div class="agent-table">
+                            <div class="agent-table__header">
+                                <span>Agent</span>
+                                <span>Sessions</span>
+                                <span>Turns</span>
+                                <span>Cost (USD)</span>
+                            </div>
+                            @for (agent of sessionStats()!.byAgent; track agent.agent_id) {
+                                <div class="agent-table__row">
+                                    <span class="agent-name">{{ agent.agent_name || 'Unknown' }}</span>
+                                    <span>{{ agent.session_count }}</span>
+                                    <span>{{ agent.total_turns }}</span>
+                                    <span class="cost-cell">\${{ agent.total_cost | number:'1.2-4' }}</span>
+                                </div>
+                            }
+                            @if (sessionStats()!.byAgent.length === 0) {
+                                <p class="empty-state">No agent session data</p>
+                            }
+                        </div>
+                    </div>
+
+                    <!-- Session Sources & Status -->
+                    <div class="analytics__grid-2">
+                        <div class="analytics__section">
+                            <h3>Sessions by Source</h3>
+                            @for (entry of sessionStats()!.bySource; track entry.source) {
+                                <div class="kv-row">
+                                    <span class="kv-key">{{ entry.source }}</span>
+                                    <span class="kv-val">{{ entry.count }}</span>
+                                </div>
+                            }
+                        </div>
+                        <div class="analytics__section">
+                            <h3>Sessions by Status</h3>
+                            @for (entry of sessionStats()!.byStatus; track entry.status) {
+                                <div class="kv-row">
+                                    <span class="kv-key" [attr.data-status]="entry.status">{{ entry.status }}</span>
+                                    <span class="kv-val">{{ entry.count }}</span>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                }
+            }
+        </div>
+    `,
+    styles: `
+        .analytics { padding: 1.5rem; }
+        .analytics h2 { margin: 0 0 1.5rem; color: var(--text-primary); }
+        .analytics h3 { margin: 0 0 0.75rem; color: var(--text-primary); font-size: 0.85rem; }
+        .loading { color: var(--text-secondary); }
+
+        .analytics__cards {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+            gap: 0.75rem;
+            margin-bottom: 2rem;
+        }
+
+        .stat-card {
+            background: var(--bg-surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 1rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+        }
+        .stat-card--today {
+            border-color: var(--accent-amber);
+            border-style: dashed;
+        }
+        .stat-card__label {
+            font-size: 0.65rem;
+            color: var(--text-tertiary);
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+        .stat-card__value {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: var(--accent-cyan);
+            text-shadow: 0 0 10px rgba(0, 229, 255, 0.15);
+        }
+        .stat-card__value--usd { color: var(--accent-green); text-shadow: 0 0 10px rgba(0, 255, 136, 0.15); }
+        .stat-card__value--algo { color: var(--accent-magenta); text-shadow: 0 0 10px rgba(255, 0, 170, 0.15); }
+        .stat-card__value--active { color: var(--accent-amber); text-shadow: 0 0 10px rgba(255, 170, 0, 0.15); }
+
+        .analytics__section {
+            background: var(--bg-surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 1.25rem;
+            margin-bottom: 1.25rem;
+        }
+
+        .analytics__grid-2 {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 1.25rem;
+            margin-bottom: 1.25rem;
+        }
+        @media (max-width: 767px) {
+            .analytics__grid-2 { grid-template-columns: 1fr; }
+        }
+
+        /* Work task bar */
+        .work-task-bar {
+            display: flex;
+            height: 28px;
+            border-radius: var(--radius);
+            overflow: hidden;
+            border: 1px solid var(--border);
+        }
+        .work-task-segment {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 40px;
+            transition: flex 0.3s;
+        }
+        .work-task-segment__label {
+            font-size: 0.6rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+            white-space: nowrap;
+        }
+        .work-task-segment[data-status="completed"] { background: var(--accent-green-dim); color: var(--accent-green); }
+        .work-task-segment[data-status="pending"] { background: var(--accent-amber-dim); color: var(--accent-amber); }
+        .work-task-segment[data-status="running"], .work-task-segment[data-status="branching"], .work-task-segment[data-status="validating"] { background: var(--accent-cyan-dim); color: var(--accent-cyan); }
+        .work-task-segment[data-status="failed"] { background: var(--accent-red-dim); color: var(--accent-red); }
+
+        /* Chart controls */
+        .chart-controls {
+            display: flex;
+            gap: 0.35rem;
+            margin-bottom: 0.75rem;
+        }
+        .chart-btn {
+            padding: 0.3rem 0.65rem;
+            background: var(--bg-raised);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            color: var(--text-secondary);
+            font-size: 0.7rem;
+            font-family: inherit;
+            cursor: pointer;
+            transition: border-color 0.15s, color 0.15s;
+        }
+        .chart-btn:hover { border-color: var(--border-bright); color: var(--text-primary); }
+        .chart-btn--active { border-color: var(--accent-cyan); color: var(--accent-cyan); background: var(--accent-cyan-dim); }
+
+        /* ASCII bar chart */
+        .ascii-chart { display: flex; flex-direction: column; gap: 3px; }
+        .chart-row {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        .chart-row__label {
+            width: 48px;
+            flex-shrink: 0;
+            font-size: 0.6rem;
+            color: var(--text-tertiary);
+            text-align: right;
+        }
+        .chart-row__bar-wrapper {
+            flex: 1;
+            height: 14px;
+            background: var(--bg-raised);
+            border-radius: 2px;
+            overflow: hidden;
+        }
+        .chart-row__bar {
+            height: 100%;
+            background: linear-gradient(90deg, var(--accent-cyan-dim), var(--accent-cyan));
+            border-radius: 2px;
+            min-width: 1px;
+            transition: width 0.3s;
+        }
+        .chart-row__value {
+            width: 64px;
+            flex-shrink: 0;
+            font-size: 0.6rem;
+            color: var(--accent-green);
+            text-align: right;
+        }
+
+        /* Agent table */
+        .agent-table { display: flex; flex-direction: column; }
+        .agent-table__header, .agent-table__row {
+            display: grid;
+            grid-template-columns: 2fr 1fr 1fr 1fr;
+            gap: 0.5rem;
+            padding: 0.4rem 0;
+            font-size: 0.7rem;
+        }
+        .agent-table__header {
+            color: var(--text-tertiary);
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            border-bottom: 1px solid var(--border);
+            font-weight: 700;
+        }
+        .agent-table__row {
+            color: var(--text-secondary);
+            border-bottom: 1px solid var(--border);
+        }
+        .agent-table__row:last-child { border-bottom: none; }
+        .agent-name { color: var(--accent-cyan); font-weight: 600; }
+        .cost-cell { color: var(--accent-green); }
+
+        /* Key-value rows */
+        .kv-row {
+            display: flex;
+            justify-content: space-between;
+            padding: 0.35rem 0;
+            border-bottom: 1px solid var(--border);
+            font-size: 0.75rem;
+        }
+        .kv-row:last-child { border-bottom: none; }
+        .kv-key { color: var(--text-secondary); text-transform: capitalize; }
+        .kv-key[data-status="running"] { color: var(--accent-cyan); }
+        .kv-key[data-status="stopped"] { color: var(--text-tertiary); }
+        .kv-key[data-status="error"] { color: var(--accent-red); }
+        .kv-val { color: var(--text-primary); font-weight: 600; }
+
+        .empty-state { color: var(--text-tertiary); font-size: 0.75rem; text-align: center; padding: 1rem; }
+    `,
+})
+export class AnalyticsComponent implements OnInit {
+    private readonly api = inject(ApiService);
+
+    readonly loading = signal(true);
+    readonly overview = signal<OverviewData | null>(null);
+    readonly spending = signal<SpendingData | null>(null);
+    readonly sessionStats = signal<SessionStats | null>(null);
+    readonly spendingDays = signal(30);
+
+    readonly workTaskTotal = computed(() => {
+        const tasks = this.overview()?.workTasks;
+        if (!tasks) return 0;
+        return Object.values(tasks).reduce((sum, count) => sum + count, 0);
+    });
+
+    readonly workTaskEntries = computed(() => {
+        const tasks = this.overview()?.workTasks;
+        if (!tasks) return [];
+        return Object.entries(tasks).map(([status, count]) => ({ status, count }));
+    });
+
+    readonly spendingBars = computed(() => {
+        const data = this.spending();
+        if (!data) return [];
+
+        // Merge daily_spending and session costs by date
+        const dateMap = new Map<string, number>();
+        for (const d of data.spending) {
+            dateMap.set(d.date, (dateMap.get(d.date) ?? 0) + d.api_cost_usd);
+        }
+        for (const d of data.sessionCosts) {
+            dateMap.set(d.date, (dateMap.get(d.date) ?? 0) + d.cost_usd);
+        }
+
+        const entries = Array.from(dateMap.entries())
+            .map(([date, value]) => ({ date, value }))
+            .sort((a, b) => a.date.localeCompare(b.date));
+
+        const max = Math.max(...entries.map((e) => e.value), 0.001);
+
+        return entries.map((e) => ({
+            date: e.date,
+            dateShort: e.date.slice(5), // MM-DD
+            value: e.value,
+            pct: (e.value / max) * 100,
+        }));
+    });
+
+    ngOnInit(): void {
+        this.loadAll();
+    }
+
+    protected loadSpending(days: number): void {
+        this.spendingDays.set(days);
+        firstValueFrom(this.api.get<SpendingData>(`/analytics/spending?days=${days}`))
+            .then((data) => this.spending.set(data))
+            .catch(() => {});
+    }
+
+    private async loadAll(): Promise<void> {
+        this.loading.set(true);
+        try {
+            const [overview, spending, sessions] = await Promise.all([
+                firstValueFrom(this.api.get<OverviewData>('/analytics/overview')),
+                firstValueFrom(this.api.get<SpendingData>(`/analytics/spending?days=${this.spendingDays()}`)),
+                firstValueFrom(this.api.get<SessionStats>('/analytics/sessions')),
+            ]);
+            this.overview.set(overview);
+            this.spending.set(spending);
+            this.sessionStats.set(sessions);
+        } catch {
+            // Analytics is non-critical
+        } finally {
+            this.loading.set(false);
+        }
+    }
+}

--- a/client/src/app/features/dashboard/dashboard.component.ts
+++ b/client/src/app/features/dashboard/dashboard.component.ts
@@ -288,8 +288,22 @@ interface AgentSummary {
             background: rgba(80, 227, 194, 0.1);
             border-color: rgba(80, 227, 194, 0.4);
         }
-        .dashboard__local-chat { margin-top: 1.5rem; }
-        .dashboard__local-chat h3 { margin: 0 0 0.75rem; }
+        .dashboard__local-chat {
+            margin-top: 1.5rem;
+            display: flex;
+            flex-direction: column;
+            min-height: 500px;
+            height: calc(100vh - 200px);
+            max-height: 800px;
+        }
+        .dashboard__local-chat h3 { margin: 0 0 0.75rem; flex-shrink: 0; }
+        .dashboard__local-chat .chat-controls { flex-shrink: 0; }
+        .dashboard__local-chat app-terminal-chat {
+            flex: 1;
+            min-height: 0;
+            display: flex;
+            flex-direction: column;
+        }
         .chat-controls {
             margin-bottom: 0.75rem;
             display: flex;

--- a/client/src/app/features/logs/system-logs.component.ts
+++ b/client/src/app/features/logs/system-logs.component.ts
@@ -1,0 +1,378 @@
+import { Component, ChangeDetectionStrategy, inject, OnInit, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ApiService } from '../../core/services/api.service';
+import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
+import { firstValueFrom } from 'rxjs';
+
+interface LogEntry {
+    type: string;
+    id: string | number;
+    message: string;
+    detail: string | null;
+    level: string;
+    timestamp: string;
+}
+
+interface CreditTransaction {
+    id: number;
+    wallet_address: string;
+    type: string;
+    amount: number;
+    balance_after: number;
+    reference: string | null;
+    txid: string | null;
+    session_id: string | null;
+    created_at: string;
+}
+
+@Component({
+    selector: 'app-system-logs',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [RouterLink, RelativeTimePipe],
+    template: `
+        <div class="logs">
+            <h2>System Logs</h2>
+
+            <!-- Tab bar -->
+            <div class="tabs">
+                <button
+                    class="tab-btn"
+                    [class.tab-btn--active]="activeTab() === 'logs'"
+                    (click)="switchTab('logs')"
+                >Event Logs</button>
+                <button
+                    class="tab-btn"
+                    [class.tab-btn--active]="activeTab() === 'credits'"
+                    (click)="switchTab('credits')"
+                >Credit Transactions</button>
+            </div>
+
+            @if (activeTab() === 'logs') {
+                <!-- Log type filters -->
+                <div class="log-filters">
+                    @for (type of logTypes; track type) {
+                        <button
+                            class="filter-chip"
+                            [class.filter-chip--active]="logTypeFilter() === type"
+                            (click)="setLogType(type)"
+                        >{{ type }}</button>
+                    }
+                </div>
+
+                @if (loadingLogs()) {
+                    <p class="loading">Loading logs...</p>
+                } @else if (logs().length === 0) {
+                    <div class="empty">No system logs found.</div>
+                } @else {
+                    <div class="log-list">
+                        @for (log of logs(); track log.id + '-' + log.type) {
+                            <div class="log-entry" [attr.data-level]="log.level">
+                                <div class="log-entry__header">
+                                    <span class="log-type" [attr.data-type]="log.type">{{ log.type }}</span>
+                                    <span class="log-level" [attr.data-level]="log.level">{{ log.level }}</span>
+                                    <span class="log-time">{{ log.timestamp | relativeTime }}</span>
+                                </div>
+                                <p class="log-message">{{ log.message }}</p>
+                                @if (log.detail) {
+                                    <p class="log-detail">{{ log.detail }}</p>
+                                }
+                            </div>
+                        }
+                    </div>
+                    @if (logs().length >= 100) {
+                        <button class="load-more" (click)="loadMoreLogs()">Load more</button>
+                    }
+                }
+            }
+
+            @if (activeTab() === 'credits') {
+                @if (loadingCredits()) {
+                    <p class="loading">Loading credit transactions...</p>
+                } @else if (creditTxns().length === 0) {
+                    <div class="empty">No credit transactions found.</div>
+                } @else {
+                    <div class="credit-table">
+                        <div class="credit-header">
+                            <span>Type</span>
+                            <span>Amount</span>
+                            <span>Balance</span>
+                            <span>Wallet</span>
+                            <span>Time</span>
+                        </div>
+                        @for (txn of creditTxns(); track txn.id) {
+                            <div class="credit-row">
+                                <span class="credit-type" [attr.data-type]="txn.type">{{ txn.type }}</span>
+                                <span class="credit-amount" [class.credit-amount--positive]="txn.amount > 0" [class.credit-amount--negative]="txn.amount < 0">
+                                    {{ txn.amount > 0 ? '+' : '' }}{{ txn.amount }}
+                                </span>
+                                <span class="credit-balance">{{ txn.balance_after }}</span>
+                                <span class="credit-wallet">
+                                    <code>{{ txn.wallet_address.slice(0, 8) }}...</code>
+                                </span>
+                                <span class="credit-time">{{ txn.created_at | relativeTime }}</span>
+                            </div>
+                        }
+                    </div>
+                    @if (creditTxns().length >= 50) {
+                        <button class="load-more" (click)="loadMoreCredits()">Load more</button>
+                    }
+                }
+            }
+        </div>
+    `,
+    styles: `
+        .logs { padding: 1.5rem; }
+        .logs h2 { margin: 0 0 1rem; color: var(--text-primary); }
+        .loading { color: var(--text-secondary); }
+        .empty { text-align: center; padding: 3rem; color: var(--text-tertiary); }
+
+        /* Tabs */
+        .tabs {
+            display: flex;
+            gap: 0.35rem;
+            margin-bottom: 1rem;
+        }
+        .tab-btn {
+            padding: 0.45rem 1rem;
+            background: var(--bg-raised);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            color: var(--text-secondary);
+            font-size: 0.75rem;
+            font-family: inherit;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.15s;
+        }
+        .tab-btn:hover { border-color: var(--border-bright); color: var(--text-primary); }
+        .tab-btn--active { border-color: var(--accent-cyan); color: var(--accent-cyan); background: var(--accent-cyan-dim); }
+
+        /* Log filters */
+        .log-filters {
+            display: flex;
+            gap: 0.35rem;
+            margin-bottom: 1rem;
+        }
+        .filter-chip {
+            padding: 0.25rem 0.55rem;
+            background: var(--bg-surface);
+            border: 1px solid var(--border);
+            border-radius: 20px;
+            color: var(--text-tertiary);
+            font-size: 0.65rem;
+            font-family: inherit;
+            cursor: pointer;
+            text-transform: capitalize;
+            transition: all 0.15s;
+        }
+        .filter-chip:hover { border-color: var(--border-bright); color: var(--text-secondary); }
+        .filter-chip--active { border-color: var(--accent-magenta); color: var(--accent-magenta); background: var(--accent-magenta-dim); }
+
+        /* Log entries */
+        .log-list {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+        .log-entry {
+            background: var(--bg-surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            padding: 0.75rem;
+            transition: border-color 0.15s;
+        }
+        .log-entry:hover { border-color: var(--border-bright); }
+        .log-entry[data-level="error"] { border-left: 3px solid var(--accent-red); }
+        .log-entry[data-level="warn"] { border-left: 3px solid var(--accent-amber); }
+        .log-entry[data-level="info"] { border-left: 3px solid var(--accent-cyan); }
+
+        .log-entry__header {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            margin-bottom: 0.35rem;
+        }
+
+        .log-type {
+            font-size: 0.6rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            padding: 1px 6px;
+            border-radius: var(--radius-sm);
+        }
+        .log-type[data-type="council"] { color: var(--accent-cyan); background: var(--accent-cyan-dim); }
+        .log-type[data-type="escalation"] { color: var(--accent-amber); background: var(--accent-amber-dim); }
+        .log-type[data-type="work-task"] { color: var(--accent-magenta); background: var(--accent-magenta-dim); }
+
+        .log-level {
+            font-size: 0.55rem;
+            text-transform: uppercase;
+            font-weight: 600;
+        }
+        .log-level[data-level="error"] { color: var(--accent-red); }
+        .log-level[data-level="warn"] { color: var(--accent-amber); }
+        .log-level[data-level="info"] { color: var(--text-tertiary); }
+
+        .log-time {
+            font-size: 0.6rem;
+            color: var(--text-tertiary);
+            margin-left: auto;
+        }
+
+        .log-message {
+            margin: 0;
+            font-size: 0.75rem;
+            color: var(--text-secondary);
+            line-height: 1.4;
+        }
+
+        .log-detail {
+            margin: 0.25rem 0 0;
+            font-size: 0.65rem;
+            color: var(--text-tertiary);
+            font-family: monospace;
+        }
+
+        /* Credit table */
+        .credit-table {
+            display: flex;
+            flex-direction: column;
+        }
+        .credit-header, .credit-row {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr 1.5fr 1fr;
+            gap: 0.5rem;
+            padding: 0.45rem 0.5rem;
+            font-size: 0.7rem;
+        }
+        .credit-header {
+            color: var(--text-tertiary);
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            font-weight: 700;
+            border-bottom: 1px solid var(--border);
+        }
+        .credit-row {
+            color: var(--text-secondary);
+            border-bottom: 1px solid var(--border);
+        }
+        .credit-row:last-child { border-bottom: none; }
+
+        .credit-type {
+            text-transform: capitalize;
+            font-weight: 600;
+        }
+        .credit-type[data-type="purchase"] { color: var(--accent-green); }
+        .credit-type[data-type="consume"] { color: var(--accent-amber); }
+        .credit-type[data-type="reserve"] { color: var(--accent-magenta); }
+
+        .credit-amount--positive { color: var(--accent-green); }
+        .credit-amount--negative { color: var(--accent-red); }
+        .credit-balance { color: var(--text-primary); font-weight: 600; }
+        .credit-wallet code {
+            font-size: 0.6rem;
+            background: var(--bg-raised);
+            padding: 1px 4px;
+            border-radius: var(--radius-sm);
+            color: var(--text-tertiary);
+        }
+        .credit-time { color: var(--text-tertiary); }
+
+        /* Load more */
+        .load-more {
+            display: block;
+            margin: 1rem auto;
+            padding: 0.5rem 1.5rem;
+            background: var(--bg-raised);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            color: var(--text-secondary);
+            font-size: 0.75rem;
+            font-family: inherit;
+            cursor: pointer;
+            transition: all 0.15s;
+        }
+        .load-more:hover { border-color: var(--accent-cyan); color: var(--accent-cyan); }
+    `,
+})
+export class SystemLogsComponent implements OnInit {
+    private readonly api = inject(ApiService);
+
+    readonly activeTab = signal<'logs' | 'credits'>('logs');
+    readonly logTypeFilter = signal('all');
+    readonly loadingLogs = signal(true);
+    readonly loadingCredits = signal(true);
+    readonly logs = signal<LogEntry[]>([]);
+    readonly creditTxns = signal<CreditTransaction[]>([]);
+
+    private logOffset = 0;
+    private creditOffset = 0;
+
+    readonly logTypes = ['all', 'council', 'escalation', 'work-task'];
+
+    ngOnInit(): void {
+        this.loadLogs();
+    }
+
+    protected switchTab(tab: 'logs' | 'credits'): void {
+        this.activeTab.set(tab);
+        if (tab === 'credits' && this.creditTxns().length === 0) {
+            this.loadCredits();
+        }
+    }
+
+    protected setLogType(type: string): void {
+        this.logTypeFilter.set(type);
+        this.logOffset = 0;
+        this.logs.set([]);
+        this.loadLogs();
+    }
+
+    protected loadMoreLogs(): void {
+        this.logOffset += 100;
+        this.loadLogs(true);
+    }
+
+    protected loadMoreCredits(): void {
+        this.creditOffset += 50;
+        this.loadCredits(true);
+    }
+
+    private async loadLogs(append = false): Promise<void> {
+        this.loadingLogs.set(true);
+        try {
+            const type = this.logTypeFilter();
+            const result = await firstValueFrom(
+                this.api.get<{ logs: LogEntry[] }>(`/system-logs?type=${type}&limit=100&offset=${this.logOffset}`),
+            );
+            if (append) {
+                this.logs.update((current) => [...current, ...result.logs]);
+            } else {
+                this.logs.set(result.logs);
+            }
+        } catch {
+            // Non-critical
+        } finally {
+            this.loadingLogs.set(false);
+        }
+    }
+
+    private async loadCredits(append = false): Promise<void> {
+        this.loadingCredits.set(true);
+        try {
+            const result = await firstValueFrom(
+                this.api.get<{ transactions: CreditTransaction[] }>(`/system-logs/credit-transactions?limit=50&offset=${this.creditOffset}`),
+            );
+            if (append) {
+                this.creditTxns.update((current) => [...current, ...result.transactions]);
+            } else {
+                this.creditTxns.set(result.transactions);
+            }
+        } catch {
+            // Non-critical
+        } finally {
+            this.loadingCredits.set(false);
+        }
+    }
+}

--- a/client/src/app/features/settings/settings.component.ts
+++ b/client/src/app/features/settings/settings.component.ts
@@ -1,0 +1,395 @@
+import { Component, ChangeDetectionStrategy, inject, OnInit, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ApiService } from '../../core/services/api.service';
+import { NotificationService } from '../../core/services/notification.service';
+import { SessionService } from '../../core/services/session.service';
+import { firstValueFrom } from 'rxjs';
+
+interface SettingsData {
+    creditConfig: Record<string, string>;
+    system: {
+        schemaVersion: number;
+        agentCount: number;
+        projectCount: number;
+        sessionCount: number;
+    };
+}
+
+interface OperationalMode {
+    mode: string;
+}
+
+@Component({
+    selector: 'app-settings',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [FormsModule],
+    template: `
+        <div class="settings">
+            <h2>Settings</h2>
+
+            @if (loading()) {
+                <p class="loading">Loading settings...</p>
+            } @else {
+                <!-- System Info -->
+                <div class="settings__section">
+                    <h3>System Info</h3>
+                    <div class="info-grid">
+                        <div class="info-item">
+                            <span class="info-label">Schema Version</span>
+                            <span class="info-value">{{ settings()?.system?.schemaVersion }}</span>
+                        </div>
+                        <div class="info-item">
+                            <span class="info-label">Agents</span>
+                            <span class="info-value">{{ settings()?.system?.agentCount }}</span>
+                        </div>
+                        <div class="info-item">
+                            <span class="info-label">Projects</span>
+                            <span class="info-value">{{ settings()?.system?.projectCount }}</span>
+                        </div>
+                        <div class="info-item">
+                            <span class="info-label">Sessions</span>
+                            <span class="info-value">{{ settings()?.system?.sessionCount }}</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- AlgoChat Status -->
+                <div class="settings__section">
+                    <h3>AlgoChat</h3>
+                    @if (algochatStatus(); as status) {
+                        <div class="info-grid">
+                            <div class="info-item">
+                                <span class="info-label">Status</span>
+                                <span class="info-value" [class.info-value--active]="status.enabled" [class.info-value--inactive]="!status.enabled">
+                                    {{ status.enabled ? 'Connected' : 'Disconnected' }}
+                                </span>
+                            </div>
+                            @if (status.address && status.address !== 'local') {
+                                <div class="info-item">
+                                    <span class="info-label">Address</span>
+                                    <code class="info-code">{{ status.address }}</code>
+                                </div>
+                            }
+                            <div class="info-item">
+                                <span class="info-label">Network</span>
+                                <span class="info-value network-badge" [attr.data-network]="status.network">{{ status.network }}</span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label">Active Chats</span>
+                                <span class="info-value">{{ status.activeConversations }}</span>
+                            </div>
+                        </div>
+                    } @else {
+                        <p class="muted">AlgoChat not configured</p>
+                    }
+                </div>
+
+                <!-- Operational Mode -->
+                <div class="settings__section">
+                    <h3>Operational Mode</h3>
+                    <div class="mode-selector">
+                        @for (mode of modes; track mode) {
+                            <button
+                                class="mode-btn"
+                                [class.mode-btn--active]="operationalMode() === mode"
+                                (click)="setMode(mode)"
+                            >{{ mode }}</button>
+                        }
+                    </div>
+                    <p class="mode-desc">
+                        @switch (operationalMode()) {
+                            @case ('normal') { Agents execute tools immediately without approval. }
+                            @case ('queued') { Tool calls are queued for manual approval before execution. }
+                            @case ('paused') { All sessions are paused. No tool execution. }
+                        }
+                    </p>
+                </div>
+
+                <!-- Credit Configuration -->
+                <div class="settings__section">
+                    <h3>Credit Configuration</h3>
+                    <div class="credit-grid">
+                        @for (field of creditFields; track field.key) {
+                            <div class="credit-field">
+                                <label class="credit-label" [for]="'credit_' + field.key">{{ field.label }}</label>
+                                <input
+                                    class="credit-input"
+                                    type="number"
+                                    [id]="'credit_' + field.key"
+                                    [ngModel]="getCreditValue(field.key)"
+                                    (ngModelChange)="setCreditValue(field.key, $event)"
+                                />
+                                <span class="credit-desc">{{ field.description }}</span>
+                            </div>
+                        }
+                    </div>
+                    <button
+                        class="save-btn"
+                        [disabled]="saving()"
+                        (click)="saveCreditConfig()"
+                    >{{ saving() ? 'Saving...' : 'Save Credit Config' }}</button>
+                </div>
+
+                <!-- Database Backup -->
+                <div class="settings__section">
+                    <h3>Database</h3>
+                    <button
+                        class="backup-btn"
+                        [disabled]="backingUp()"
+                        (click)="runBackup()"
+                    >{{ backingUp() ? 'Backing up...' : 'Create Backup' }}</button>
+                    @if (backupResult()) {
+                        <p class="backup-result">{{ backupResult() }}</p>
+                    }
+                </div>
+            }
+        </div>
+    `,
+    styles: `
+        .settings { padding: 1.5rem; max-width: 900px; }
+        .settings h2 { margin: 0 0 1.5rem; color: var(--text-primary); }
+        .settings h3 { margin: 0 0 0.75rem; color: var(--text-primary); font-size: 0.85rem; }
+        .loading, .muted { color: var(--text-secondary); font-size: 0.8rem; }
+
+        .settings__section {
+            background: var(--bg-surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 1.25rem;
+            margin-bottom: 1.25rem;
+        }
+
+        .info-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+            gap: 0.75rem;
+        }
+        .info-item {
+            display: flex;
+            flex-direction: column;
+            gap: 0.2rem;
+        }
+        .info-label {
+            font-size: 0.6rem;
+            color: var(--text-tertiary);
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+        }
+        .info-value {
+            font-size: 1rem;
+            font-weight: 700;
+            color: var(--text-primary);
+        }
+        .info-value--active { color: var(--accent-green); }
+        .info-value--inactive { color: var(--accent-red); }
+        .info-code {
+            background: var(--bg-raised);
+            color: var(--accent-magenta);
+            padding: 2px 6px;
+            border-radius: var(--radius-sm);
+            font-size: 0.7rem;
+            border: 1px solid var(--border);
+            word-break: break-all;
+        }
+        .network-badge {
+            text-transform: uppercase;
+            font-size: 0.75rem;
+        }
+        .network-badge[data-network="testnet"] { color: #4a90d9; }
+        .network-badge[data-network="mainnet"] { color: #50e3c2; }
+        .network-badge[data-network="localnet"] { color: #f5a623; }
+
+        /* Operational mode */
+        .mode-selector {
+            display: flex;
+            gap: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+        .mode-btn {
+            padding: 0.45rem 0.85rem;
+            background: var(--bg-raised);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            color: var(--text-secondary);
+            font-size: 0.75rem;
+            font-family: inherit;
+            font-weight: 600;
+            cursor: pointer;
+            text-transform: capitalize;
+            transition: border-color 0.15s, color 0.15s, background 0.15s;
+        }
+        .mode-btn:hover { border-color: var(--border-bright); color: var(--text-primary); }
+        .mode-btn--active {
+            border-color: var(--accent-cyan);
+            color: var(--accent-cyan);
+            background: var(--accent-cyan-dim);
+        }
+        .mode-desc {
+            font-size: 0.7rem;
+            color: var(--text-tertiary);
+            margin: 0;
+        }
+
+        /* Credit fields */
+        .credit-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+            gap: 1rem;
+            margin-bottom: 1rem;
+        }
+        .credit-field {
+            display: flex;
+            flex-direction: column;
+            gap: 0.2rem;
+        }
+        .credit-label {
+            font-size: 0.7rem;
+            color: var(--text-secondary);
+            font-weight: 600;
+        }
+        .credit-input {
+            padding: 0.45rem;
+            background: var(--bg-input);
+            border: 1px solid var(--border-bright);
+            border-radius: var(--radius);
+            color: var(--text-primary);
+            font-size: 0.85rem;
+            font-family: inherit;
+            width: 100%;
+        }
+        .credit-input:focus { border-color: var(--accent-cyan); box-shadow: var(--glow-cyan); outline: none; }
+        .credit-desc {
+            font-size: 0.6rem;
+            color: var(--text-tertiary);
+        }
+
+        /* Buttons */
+        .save-btn, .backup-btn {
+            padding: 0.5rem 1.25rem;
+            border-radius: var(--radius);
+            font-size: 0.75rem;
+            font-weight: 600;
+            cursor: pointer;
+            font-family: inherit;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            transition: background 0.15s;
+        }
+        .save-btn {
+            background: var(--accent-cyan-dim);
+            color: var(--accent-cyan);
+            border: 1px solid var(--accent-cyan);
+        }
+        .save-btn:hover:not(:disabled) { background: rgba(0, 229, 255, 0.2); }
+        .save-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .backup-btn {
+            background: var(--accent-magenta-dim);
+            color: var(--accent-magenta);
+            border: 1px solid var(--accent-magenta);
+        }
+        .backup-btn:hover:not(:disabled) { background: rgba(255, 0, 170, 0.2); }
+        .backup-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .backup-result {
+            font-size: 0.7rem;
+            color: var(--accent-green);
+            margin-top: 0.5rem;
+        }
+    `,
+})
+export class SettingsComponent implements OnInit {
+    private readonly api = inject(ApiService);
+    private readonly notifications = inject(NotificationService);
+    private readonly sessionService = inject(SessionService);
+
+    readonly loading = signal(true);
+    readonly saving = signal(false);
+    readonly backingUp = signal(false);
+    readonly settings = signal<SettingsData | null>(null);
+    readonly operationalMode = signal('normal');
+    readonly backupResult = signal<string | null>(null);
+    readonly algochatStatus = this.sessionService.algochatStatus;
+
+    // Mutable copy for credit config editing
+    private creditValues: Record<string, string> = {};
+
+    readonly modes = ['normal', 'queued', 'paused'];
+
+    readonly creditFields = [
+        { key: 'credits_per_algo', label: 'Credits per ALGO', description: 'How many credits 1 ALGO buys' },
+        { key: 'credits_per_turn', label: 'Credits per Turn', description: 'Credits consumed per agent turn' },
+        { key: 'credits_per_agent_message', label: 'Credits per Agent Message', description: 'Credits for agent-to-agent messages' },
+        { key: 'low_credit_threshold', label: 'Low Credit Warning', description: 'Threshold for low-balance warnings' },
+        { key: 'free_credits_on_first_message', label: 'Free Credits (First Message)', description: 'Credits given on first contact' },
+        { key: 'reserve_per_group_message', label: 'Reserve per Group Message', description: 'Credits reserved for group chats' },
+    ];
+
+    ngOnInit(): void {
+        this.loadAll();
+    }
+
+    getCreditValue(key: string): string {
+        return this.creditValues[key] ?? this.settings()?.creditConfig?.[key] ?? '';
+    }
+
+    setCreditValue(key: string, value: string): void {
+        this.creditValues[key] = value;
+    }
+
+    async setMode(mode: string): Promise<void> {
+        try {
+            await firstValueFrom(this.api.post<{ ok: boolean }>('/operational-mode', { mode }));
+            this.operationalMode.set(mode);
+            this.notifications.success(`Operational mode set to ${mode}`);
+        } catch {
+            this.notifications.error('Failed to update operational mode');
+        }
+    }
+
+    async saveCreditConfig(): Promise<void> {
+        if (Object.keys(this.creditValues).length === 0) {
+            this.notifications.error('No changes to save');
+            return;
+        }
+        this.saving.set(true);
+        try {
+            await firstValueFrom(this.api.put<{ ok: boolean }>('/settings/credits', this.creditValues));
+            this.notifications.success('Credit configuration saved');
+            this.creditValues = {};
+        } catch {
+            this.notifications.error('Failed to save credit configuration');
+        } finally {
+            this.saving.set(false);
+        }
+    }
+
+    async runBackup(): Promise<void> {
+        this.backingUp.set(true);
+        this.backupResult.set(null);
+        try {
+            const result = await firstValueFrom(this.api.post<{ path: string }>('/backup'));
+            this.backupResult.set(`Backup created: ${result.path}`);
+            this.notifications.success('Database backup created');
+        } catch {
+            this.notifications.error('Backup failed');
+        } finally {
+            this.backingUp.set(false);
+        }
+    }
+
+    private async loadAll(): Promise<void> {
+        this.loading.set(true);
+        try {
+            const [settings, mode] = await Promise.all([
+                firstValueFrom(this.api.get<SettingsData>('/settings')),
+                firstValueFrom(this.api.get<OperationalMode>('/operational-mode')),
+            ]);
+            this.settings.set(settings);
+            this.operationalMode.set(mode.mode);
+            this.sessionService.loadAlgoChatStatus();
+        } catch {
+            // Non-critical
+        } finally {
+            this.loading.set(false);
+        }
+    }
+}

--- a/client/src/app/features/work-tasks/work-task-list.component.ts
+++ b/client/src/app/features/work-tasks/work-task-list.component.ts
@@ -1,0 +1,287 @@
+import { Component, ChangeDetectionStrategy, inject, OnInit, OnDestroy, signal, computed } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { WorkTaskService } from '../../core/services/work-task.service';
+import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
+import type { WorkTask } from '../../core/models/work-task.model';
+
+@Component({
+    selector: 'app-work-task-list',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [RouterLink, RelativeTimePipe],
+    template: `
+        <div class="tasks">
+            <div class="tasks__header">
+                <h2>Work Tasks</h2>
+                <div class="tasks__filters">
+                    <button
+                        class="filter-btn"
+                        [class.filter-btn--active]="activeFilter() === 'all'"
+                        (click)="setFilter('all')"
+                    >All ({{ allTasks().length }})</button>
+                    <button
+                        class="filter-btn"
+                        [class.filter-btn--active]="activeFilter() === 'active'"
+                        (click)="setFilter('active')"
+                    >Active ({{ activeTasks().length }})</button>
+                    <button
+                        class="filter-btn"
+                        [class.filter-btn--active]="activeFilter() === 'completed'"
+                        (click)="setFilter('completed')"
+                    >Completed ({{ completedTasks().length }})</button>
+                    <button
+                        class="filter-btn"
+                        [class.filter-btn--active]="activeFilter() === 'failed'"
+                        (click)="setFilter('failed')"
+                    >Failed ({{ failedTasks().length }})</button>
+                </div>
+            </div>
+
+            @if (taskService.loading()) {
+                <p class="loading">Loading work tasks...</p>
+            } @else if (filteredTasks().length === 0) {
+                <div class="empty">
+                    <p>No {{ activeFilter() === 'all' ? '' : activeFilter() + ' ' }}work tasks found.</p>
+                </div>
+            } @else {
+                <div class="task-list">
+                    @for (task of filteredTasks(); track task.id) {
+                        <div class="task-card" [attr.data-status]="task.status">
+                            <div class="task-card__header">
+                                <span class="task-status" [attr.data-status]="task.status">{{ task.status }}</span>
+                                <span class="task-time">{{ task.createdAt | relativeTime }}</span>
+                            </div>
+                            <p class="task-desc">{{ task.description }}</p>
+                            <div class="task-meta">
+                                @if (task.branchName) {
+                                    <span class="task-branch">{{ task.branchName }}</span>
+                                }
+                                @if (task.prUrl) {
+                                    <a class="task-pr" [href]="task.prUrl" target="_blank" rel="noopener">View PR</a>
+                                }
+                                @if (task.sessionId) {
+                                    <a class="task-session" [routerLink]="['/sessions', task.sessionId]">Session</a>
+                                }
+                                @if (task.iterationCount > 0) {
+                                    <span class="task-iterations">{{ task.iterationCount }} iteration{{ task.iterationCount > 1 ? 's' : '' }}</span>
+                                }
+                            </div>
+                            @if (task.error) {
+                                <div class="task-error">{{ task.error }}</div>
+                            }
+                            @if (task.summary) {
+                                <div class="task-summary">{{ task.summary }}</div>
+                            }
+                        </div>
+                    }
+                </div>
+            }
+        </div>
+    `,
+    styles: `
+        .tasks { padding: 1.5rem; }
+        .tasks__header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            margin-bottom: 1.5rem;
+        }
+        .tasks__header h2 { margin: 0; color: var(--text-primary); }
+        .loading { color: var(--text-secondary); }
+
+        .tasks__filters {
+            display: flex;
+            gap: 0.35rem;
+        }
+        .filter-btn {
+            padding: 0.35rem 0.65rem;
+            background: var(--bg-raised);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            color: var(--text-secondary);
+            font-size: 0.7rem;
+            font-family: inherit;
+            cursor: pointer;
+            transition: border-color 0.15s, color 0.15s;
+        }
+        .filter-btn:hover { border-color: var(--border-bright); color: var(--text-primary); }
+        .filter-btn--active { border-color: var(--accent-cyan); color: var(--accent-cyan); background: var(--accent-cyan-dim); }
+
+        .empty {
+            text-align: center;
+            padding: 3rem;
+            color: var(--text-tertiary);
+        }
+
+        .task-list {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .task-card {
+            background: var(--bg-surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 1rem;
+            transition: border-color 0.2s;
+        }
+        .task-card:hover { border-color: var(--border-bright); }
+        .task-card[data-status="running"],
+        .task-card[data-status="branching"],
+        .task-card[data-status="validating"] {
+            border-left: 3px solid var(--accent-cyan);
+        }
+        .task-card[data-status="completed"] {
+            border-left: 3px solid var(--accent-green);
+        }
+        .task-card[data-status="failed"] {
+            border-left: 3px solid var(--accent-red);
+        }
+        .task-card[data-status="pending"] {
+            border-left: 3px solid var(--accent-amber);
+        }
+
+        .task-card__header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 0.5rem;
+        }
+
+        .task-status {
+            font-size: 0.65rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            padding: 2px 8px;
+            border-radius: var(--radius-sm);
+            border: 1px solid;
+        }
+        .task-status[data-status="pending"] { color: var(--accent-amber); background: var(--accent-amber-dim); border-color: var(--accent-amber); }
+        .task-status[data-status="branching"],
+        .task-status[data-status="running"],
+        .task-status[data-status="validating"] { color: var(--accent-cyan); background: var(--accent-cyan-dim); border-color: var(--accent-cyan); }
+        .task-status[data-status="completed"] { color: var(--accent-green); background: var(--accent-green-dim); border-color: var(--accent-green); }
+        .task-status[data-status="failed"] { color: var(--accent-red); background: var(--accent-red-dim); border-color: var(--accent-red); }
+
+        .task-time {
+            font-size: 0.65rem;
+            color: var(--text-tertiary);
+        }
+
+        .task-desc {
+            margin: 0 0 0.5rem;
+            font-size: 0.8rem;
+            color: var(--text-secondary);
+            line-height: 1.5;
+        }
+
+        .task-meta {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+        .task-branch {
+            font-size: 0.65rem;
+            color: var(--accent-magenta);
+            background: var(--accent-magenta-dim);
+            padding: 2px 6px;
+            border-radius: var(--radius-sm);
+            font-family: monospace;
+        }
+        .task-pr {
+            font-size: 0.65rem;
+            color: var(--accent-green);
+            text-decoration: none;
+            border: 1px solid var(--accent-green);
+            padding: 2px 6px;
+            border-radius: var(--radius-sm);
+        }
+        .task-pr:hover { background: var(--accent-green-dim); }
+        .task-session {
+            font-size: 0.65rem;
+            color: var(--accent-cyan);
+            text-decoration: none;
+            border: 1px solid var(--accent-cyan);
+            padding: 2px 6px;
+            border-radius: var(--radius-sm);
+        }
+        .task-session:hover { background: var(--accent-cyan-dim); }
+        .task-iterations {
+            font-size: 0.6rem;
+            color: var(--text-tertiary);
+        }
+
+        .task-error {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background: var(--accent-red-dim);
+            border: 1px solid var(--accent-red);
+            border-radius: var(--radius);
+            color: var(--accent-red);
+            font-size: 0.7rem;
+            font-family: monospace;
+            white-space: pre-wrap;
+            max-height: 100px;
+            overflow-y: auto;
+        }
+
+        .task-summary {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background: var(--bg-raised);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            color: var(--text-secondary);
+            font-size: 0.7rem;
+            line-height: 1.5;
+            max-height: 120px;
+            overflow-y: auto;
+        }
+    `,
+})
+export class WorkTaskListComponent implements OnInit, OnDestroy {
+    protected readonly taskService = inject(WorkTaskService);
+    readonly activeFilter = signal<'all' | 'active' | 'completed' | 'failed'>('all');
+
+    readonly allTasks = computed(() => this.taskService.tasks());
+
+    readonly activeTasks = computed(() =>
+        this.taskService.tasks().filter((t) =>
+            ['pending', 'branching', 'running', 'validating'].includes(t.status),
+        ),
+    );
+
+    readonly completedTasks = computed(() =>
+        this.taskService.tasks().filter((t) => t.status === 'completed'),
+    );
+
+    readonly failedTasks = computed(() =>
+        this.taskService.tasks().filter((t) => t.status === 'failed'),
+    );
+
+    readonly filteredTasks = computed(() => {
+        switch (this.activeFilter()) {
+            case 'active': return this.activeTasks();
+            case 'completed': return this.completedTasks();
+            case 'failed': return this.failedTasks();
+            default: return this.allTasks();
+        }
+    });
+
+    ngOnInit(): void {
+        this.taskService.loadTasks();
+        this.taskService.startListening();
+    }
+
+    ngOnDestroy(): void {
+        this.taskService.stopListening();
+    }
+
+    protected setFilter(filter: 'all' | 'active' | 'completed' | 'failed'): void {
+        this.activeFilter.set(filter);
+    }
+}

--- a/client/src/app/shared/components/sidebar.component.ts
+++ b/client/src/app/shared/components/sidebar.component.ts
@@ -91,6 +91,41 @@ import { filter, Subscription } from 'rxjs';
                 <li>
                     <a
                         class="sidebar__link"
+                        routerLink="/work-tasks"
+                        routerLinkActive="sidebar__link--active">
+                        Work Tasks
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="sidebar__link"
+                        routerLink="/analytics"
+                        routerLinkActive="sidebar__link--active">
+                        Analytics
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="sidebar__link"
+                        routerLink="/logs"
+                        routerLinkActive="sidebar__link--active">
+                        Logs
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="sidebar__link"
+                        routerLink="/settings"
+                        routerLinkActive="sidebar__link--active">
+                        Settings
+                    </a>
+                </li>
+
+                <li class="sidebar__divider" aria-hidden="true"></li>
+
+                <li>
+                    <a
+                        class="sidebar__link"
                         routerLink="/nft/review"
                         routerLinkActive="sidebar__link--active">
                         NFT Review
@@ -146,6 +181,12 @@ import { filter, Subscription } from 'rxjs';
             background: var(--bg-raised);
             border-left: 3px solid var(--accent-cyan);
             text-shadow: 0 0 8px rgba(0, 229, 255, 0.3);
+        }
+        .sidebar__divider {
+            height: 1px;
+            background: var(--border);
+            margin: 0.5rem 1.5rem;
+            list-style: none;
         }
 
         /* ── Mobile (<768px): slide-out overlay ── */

--- a/client/src/app/shared/components/terminal-chat.component.ts
+++ b/client/src/app/shared/components/terminal-chat.component.ts
@@ -117,6 +117,12 @@ interface AutocompleteItem {
         </div>
     `,
     styles: `
+        :host {
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+            min-height: 0;
+        }
         .terminal {
             display: flex;
             flex-direction: column;
@@ -127,7 +133,8 @@ interface AutocompleteItem {
             font-size: 0.8rem;
             line-height: 1.6;
             overflow: hidden;
-            height: 100%;
+            flex: 1;
+            min-height: 0;
         }
         .terminal__output {
             flex: 1;

--- a/server/routes/analytics.ts
+++ b/server/routes/analytics.ts
@@ -1,0 +1,216 @@
+/**
+ * Analytics API routes — provides spending, session, and agent usage data
+ * for the Analytics Dashboard page.
+ */
+
+import type { Database } from 'bun:sqlite';
+
+function json(data: unknown, status: number = 200): Response {
+    return new Response(JSON.stringify(data), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+interface DailySpendingRow {
+    date: string;
+    algo_micro: number;
+    api_cost_usd: number;
+}
+
+interface SessionRow {
+    id: string;
+    agent_id: string | null;
+    status: string;
+    source: string;
+    total_cost_usd: number;
+    total_algo_spent: number;
+    total_turns: number;
+    credits_consumed: number;
+    created_at: string;
+}
+
+interface WorkTaskRow {
+    status: string;
+    count: number;
+}
+
+interface SessionByAgentRow {
+    agent_id: string;
+    session_count: number;
+    total_cost: number;
+    total_turns: number;
+}
+
+interface MessageCountRow {
+    count: number;
+}
+
+export function handleAnalyticsRoutes(req: Request, url: URL, db: Database): Response | null {
+    // GET /api/analytics/overview — summary stats
+    if (url.pathname === '/api/analytics/overview' && req.method === 'GET') {
+        return handleOverview(db);
+    }
+
+    // GET /api/analytics/spending — daily spending over time
+    if (url.pathname === '/api/analytics/spending' && req.method === 'GET') {
+        const days = Number(url.searchParams.get('days') ?? '30');
+        return handleSpending(db, days);
+    }
+
+    // GET /api/analytics/sessions — session stats
+    if (url.pathname === '/api/analytics/sessions' && req.method === 'GET') {
+        return handleSessionStats(db);
+    }
+
+    return null;
+}
+
+function handleOverview(db: Database): Response {
+    // Total sessions & costs
+    const sessionStats = db.query(`
+        SELECT
+            COUNT(*) as total_sessions,
+            SUM(total_cost_usd) as total_cost_usd,
+            SUM(total_algo_spent) as total_algo_spent,
+            SUM(total_turns) as total_turns,
+            SUM(credits_consumed) as total_credits
+        FROM sessions
+    `).get() as Record<string, number | null>;
+
+    // Active sessions
+    const activeCount = db.query(`
+        SELECT COUNT(*) as count FROM sessions WHERE status = 'running'
+    `).get() as MessageCountRow;
+
+    // Total agents
+    const agentCount = db.query(`
+        SELECT COUNT(*) as count FROM agents
+    `).get() as MessageCountRow;
+
+    // Total projects
+    const projectCount = db.query(`
+        SELECT COUNT(*) as count FROM projects
+    `).get() as MessageCountRow;
+
+    // Work task breakdown
+    const workTasks = db.query(`
+        SELECT status, COUNT(*) as count FROM work_tasks GROUP BY status
+    `).all() as WorkTaskRow[];
+
+    const workTaskMap: Record<string, number> = {};
+    for (const row of workTasks) {
+        workTaskMap[row.status] = row.count;
+    }
+
+    // Agent messages total
+    const agentMsgCount = db.query(`
+        SELECT COUNT(*) as count FROM agent_messages
+    `).get() as MessageCountRow;
+
+    // AlgoChat messages total
+    const algochatMsgCount = db.query(`
+        SELECT COUNT(*) as count FROM algochat_messages
+    `).get() as MessageCountRow;
+
+    // Today's spending
+    const today = new Date().toISOString().slice(0, 10);
+    const todaySpending = db.query(`
+        SELECT algo_micro, api_cost_usd FROM daily_spending WHERE date = ?
+    `).get(today) as DailySpendingRow | null;
+
+    return json({
+        totalSessions: sessionStats.total_sessions ?? 0,
+        totalCostUsd: sessionStats.total_cost_usd ?? 0,
+        totalAlgoSpent: sessionStats.total_algo_spent ?? 0,
+        totalTurns: sessionStats.total_turns ?? 0,
+        totalCreditsConsumed: sessionStats.total_credits ?? 0,
+        activeSessions: activeCount.count,
+        totalAgents: agentCount.count,
+        totalProjects: projectCount.count,
+        workTasks: workTaskMap,
+        agentMessages: agentMsgCount.count,
+        algochatMessages: algochatMsgCount.count,
+        todaySpending: {
+            algoMicro: todaySpending?.algo_micro ?? 0,
+            apiCostUsd: todaySpending?.api_cost_usd ?? 0,
+        },
+    });
+}
+
+function handleSpending(db: Database, days: number): Response {
+    const clampedDays = Math.min(Math.max(days, 1), 365);
+
+    // Get daily spending data
+    const spending = db.query(`
+        SELECT date, algo_micro, api_cost_usd
+        FROM daily_spending
+        WHERE date >= date('now', '-' || ? || ' days')
+        ORDER BY date ASC
+    `).all(clampedDays) as DailySpendingRow[];
+
+    // Get session costs by day
+    const sessionCosts = db.query(`
+        SELECT
+            date(created_at) as date,
+            COUNT(*) as session_count,
+            SUM(total_cost_usd) as cost_usd,
+            SUM(total_turns) as turns
+        FROM sessions
+        WHERE created_at >= datetime('now', '-' || ? || ' days')
+        GROUP BY date(created_at)
+        ORDER BY date ASC
+    `).all(clampedDays) as { date: string; session_count: number; cost_usd: number; turns: number }[];
+
+    return json({
+        spending,
+        sessionCosts,
+        days: clampedDays,
+    });
+}
+
+function handleSessionStats(db: Database): Response {
+    // Sessions by agent
+    const byAgent = db.query(`
+        SELECT
+            s.agent_id,
+            a.name as agent_name,
+            COUNT(*) as session_count,
+            SUM(s.total_cost_usd) as total_cost,
+            SUM(s.total_turns) as total_turns
+        FROM sessions s
+        LEFT JOIN agents a ON s.agent_id = a.id
+        WHERE s.agent_id IS NOT NULL
+        GROUP BY s.agent_id
+        ORDER BY session_count DESC
+    `).all() as (SessionByAgentRow & { agent_name: string })[];
+
+    // Sessions by source
+    const bySource = db.query(`
+        SELECT source, COUNT(*) as count
+        FROM sessions
+        GROUP BY source
+    `).all() as { source: string; count: number }[];
+
+    // Sessions by status
+    const byStatus = db.query(`
+        SELECT status, COUNT(*) as count
+        FROM sessions
+        GROUP BY status
+    `).all() as { status: string; count: number }[];
+
+    // Recent sessions (last 20)
+    const recent = db.query(`
+        SELECT id, agent_id, status, source, total_cost_usd, total_turns, created_at
+        FROM sessions
+        ORDER BY created_at DESC
+        LIMIT 20
+    `).all() as SessionRow[];
+
+    return json({
+        byAgent,
+        bySource,
+        byStatus,
+        recent,
+    });
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -6,6 +6,9 @@ import { handleCouncilRoutes } from './councils';
 import { handleWorkTaskRoutes } from './work-tasks';
 import { handleMcpApiRoutes } from './mcp-api';
 import { handleAllowlistRoutes } from './allowlist';
+import { handleAnalyticsRoutes } from './analytics';
+import { handleSystemLogRoutes } from './system-logs';
+import { handleSettingsRoutes } from './settings';
 import type { ProcessManager } from '../process/manager';
 import type { AlgoChatBridge } from '../algochat/bridge';
 import type { AgentWalletService } from '../algochat/agent-wallet';
@@ -123,6 +126,15 @@ async function handleRoutes(
 
     const allowlistResponse = handleAllowlistRoutes(req, url, db);
     if (allowlistResponse) return allowlistResponse;
+
+    const analyticsResponse = handleAnalyticsRoutes(req, url, db);
+    if (analyticsResponse) return analyticsResponse;
+
+    const systemLogResponse = handleSystemLogRoutes(req, url, db);
+    if (systemLogResponse) return systemLogResponse;
+
+    const settingsResponse = await handleSettingsRoutes(req, url, db);
+    if (settingsResponse) return settingsResponse;
 
     const sessionResponse = await handleSessionRoutes(req, url, db, processManager);
     if (sessionResponse) return sessionResponse;

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -1,0 +1,94 @@
+/**
+ * Settings API routes — provides read/write access to system configuration
+ * including credit config, operational mode info, and AlgoChat status.
+ */
+
+import type { Database } from 'bun:sqlite';
+
+function json(data: unknown, status: number = 200): Response {
+    return new Response(JSON.stringify(data), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+export function handleSettingsRoutes(req: Request, url: URL, db: Database): Response | Promise<Response> | null {
+    // GET /api/settings — all settings
+    if (url.pathname === '/api/settings' && req.method === 'GET') {
+        return handleGetSettings(db);
+    }
+
+    // PUT /api/settings/credits — update credit config
+    if (url.pathname === '/api/settings/credits' && req.method === 'PUT') {
+        return handleUpdateCreditConfig(req, db);
+    }
+
+    return null;
+}
+
+function handleGetSettings(db: Database): Response {
+    // Credit configuration
+    const creditRows = db.query(`SELECT key, value FROM credit_config`).all() as { key: string; value: string }[];
+    const creditConfig: Record<string, string> = {};
+    for (const row of creditRows) {
+        creditConfig[row.key] = row.value;
+    }
+
+    // System stats
+    const agentCount = (db.query(`SELECT COUNT(*) as c FROM agents`).get() as { c: number }).c;
+    const projectCount = (db.query(`SELECT COUNT(*) as c FROM projects`).get() as { c: number }).c;
+    const sessionCount = (db.query(`SELECT COUNT(*) as c FROM sessions`).get() as { c: number }).c;
+    const schemaVersion = (db.query(`SELECT version FROM schema_version LIMIT 1`).get() as { version: number } | null)?.version ?? 0;
+
+    return json({
+        creditConfig,
+        system: {
+            schemaVersion,
+            agentCount,
+            projectCount,
+            sessionCount,
+        },
+    });
+}
+
+async function handleUpdateCreditConfig(req: Request, db: Database): Promise<Response> {
+    let body: Record<string, string>;
+    try {
+        body = await req.json() as Record<string, string>;
+    } catch {
+        return json({ error: 'Invalid JSON body' }, 400);
+    }
+
+    const allowedKeys = [
+        'credits_per_algo',
+        'low_credit_threshold',
+        'reserve_per_group_message',
+        'credits_per_turn',
+        'credits_per_agent_message',
+        'free_credits_on_first_message',
+    ];
+
+    const updates: { key: string; value: string }[] = [];
+    for (const [key, value] of Object.entries(body)) {
+        if (!allowedKeys.includes(key)) {
+            return json({ error: `Unknown config key: ${key}` }, 400);
+        }
+        if (typeof value !== 'string' && typeof value !== 'number') {
+            return json({ error: `Invalid value for ${key}` }, 400);
+        }
+        updates.push({ key, value: String(value) });
+    }
+
+    if (updates.length === 0) {
+        return json({ error: 'No valid config keys provided' }, 400);
+    }
+
+    const stmt = db.prepare(`INSERT OR REPLACE INTO credit_config (key, value, updated_at) VALUES (?, ?, datetime('now'))`);
+    db.transaction(() => {
+        for (const { key, value } of updates) {
+            stmt.run(key, value);
+        }
+    })();
+
+    return json({ ok: true, updated: updates.length });
+}

--- a/server/routes/system-logs.ts
+++ b/server/routes/system-logs.ts
@@ -1,0 +1,159 @@
+/**
+ * System Logs API routes — provides escalation queue history,
+ * council launch logs, credit transactions, and work task logs.
+ */
+
+import type { Database } from 'bun:sqlite';
+
+function json(data: unknown, status: number = 200): Response {
+    return new Response(JSON.stringify(data), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+export function handleSystemLogRoutes(req: Request, url: URL, db: Database): Response | null {
+    // GET /api/system-logs — aggregated system logs
+    if (url.pathname === '/api/system-logs' && req.method === 'GET') {
+        const limit = Number(url.searchParams.get('limit') ?? '100');
+        const offset = Number(url.searchParams.get('offset') ?? '0');
+        const type = url.searchParams.get('type') ?? 'all';
+        return handleLogs(db, limit, offset, type);
+    }
+
+    // GET /api/system-logs/credit-transactions — credit ledger
+    if (url.pathname === '/api/system-logs/credit-transactions' && req.method === 'GET') {
+        const limit = Number(url.searchParams.get('limit') ?? '50');
+        const offset = Number(url.searchParams.get('offset') ?? '0');
+        return handleCreditTransactions(db, limit, offset);
+    }
+
+    return null;
+}
+
+interface LogEntry {
+    type: string;
+    id: string | number;
+    message: string;
+    detail: string | null;
+    level: string;
+    timestamp: string;
+}
+
+function handleLogs(db: Database, limit: number, offset: number, type: string): Response {
+    const clampedLimit = Math.min(Math.max(limit, 1), 500);
+    const logs: LogEntry[] = [];
+
+    // Council launch logs
+    if (type === 'all' || type === 'council') {
+        const councilLogs = db.query(`
+            SELECT
+                cll.id, cll.level, cll.message, cll.detail, cll.created_at,
+                cl.council_id
+            FROM council_launch_logs cll
+            JOIN council_launches cl ON cll.launch_id = cl.id
+            ORDER BY cll.created_at DESC
+            LIMIT ? OFFSET ?
+        `).all(clampedLimit, offset) as {
+            id: number; level: string; message: string; detail: string | null;
+            created_at: string; council_id: string;
+        }[];
+
+        for (const log of councilLogs) {
+            logs.push({
+                type: 'council',
+                id: log.id,
+                message: log.message,
+                detail: log.detail,
+                level: log.level,
+                timestamp: log.created_at,
+            });
+        }
+    }
+
+    // Escalation queue events
+    if (type === 'all' || type === 'escalation') {
+        const escalations = db.query(`
+            SELECT id, session_id, tool_name, status, created_at, resolved_at
+            FROM escalation_queue
+            ORDER BY created_at DESC
+            LIMIT ? OFFSET ?
+        `).all(clampedLimit, offset) as {
+            id: number; session_id: string; tool_name: string;
+            status: string; created_at: string; resolved_at: string | null;
+        }[];
+
+        for (const esc of escalations) {
+            logs.push({
+                type: 'escalation',
+                id: esc.id,
+                message: `Tool "${esc.tool_name}" escalation — ${esc.status}`,
+                detail: `Session: ${esc.session_id}${esc.resolved_at ? ` | Resolved: ${esc.resolved_at}` : ''}`,
+                level: esc.status === 'pending' ? 'warn' : 'info',
+                timestamp: esc.created_at,
+            });
+        }
+    }
+
+    // Work task events
+    if (type === 'all' || type === 'work-task') {
+        const tasks = db.query(`
+            SELECT wt.id, wt.description, wt.status, wt.branch_name, wt.pr_url,
+                   wt.error, wt.created_at, wt.completed_at, a.name as agent_name
+            FROM work_tasks wt
+            LEFT JOIN agents a ON wt.agent_id = a.id
+            ORDER BY wt.created_at DESC
+            LIMIT ? OFFSET ?
+        `).all(clampedLimit, offset) as {
+            id: string; description: string; status: string; branch_name: string | null;
+            pr_url: string | null; error: string | null; created_at: string;
+            completed_at: string | null; agent_name: string | null;
+        }[];
+
+        for (const task of tasks) {
+            const level = task.status === 'failed' ? 'error'
+                : task.status === 'completed' ? 'info'
+                    : 'warn';
+            logs.push({
+                type: 'work-task',
+                id: task.id,
+                message: `[${task.agent_name ?? 'unknown'}] ${task.description.slice(0, 100)}`,
+                detail: task.error ?? task.pr_url ?? task.branch_name ?? null,
+                level,
+                timestamp: task.created_at,
+            });
+        }
+    }
+
+    // Sort all logs by timestamp descending
+    logs.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+    // Apply limit after merging
+    const paged = logs.slice(0, clampedLimit);
+
+    return json({ logs: paged, total: logs.length });
+}
+
+function handleCreditTransactions(db: Database, limit: number, offset: number): Response {
+    const clampedLimit = Math.min(Math.max(limit, 1), 200);
+
+    const transactions = db.query(`
+        SELECT id, wallet_address, type, amount, balance_after, reference, txid, session_id, created_at
+        FROM credit_transactions
+        ORDER BY created_at DESC
+        LIMIT ? OFFSET ?
+    `).all(clampedLimit, offset) as {
+        id: number; wallet_address: string; type: string; amount: number;
+        balance_after: number; reference: string | null; txid: string | null;
+        session_id: string | null; created_at: string;
+    }[];
+
+    const countRow = db.query(`SELECT COUNT(*) as count FROM credit_transactions`).get() as { count: number };
+
+    return json({
+        transactions,
+        total: countRow.count,
+        limit: clampedLimit,
+        offset,
+    });
+}


### PR DESCRIPTION
## Summary
- **Analytics page** — overview stats (total sessions, API cost, ALGO spent, turns, credits), daily spending bar chart with 7d/14d/30d/90d controls, usage breakdown by agent, session source/status distribution, work task summary bar
- **Settings page** — system info display, AlgoChat status, operational mode selector (normal/queued/paused), credit configuration editor with save, database backup button
- **Work Tasks page** — dedicated filterable list with All/Active/Completed/Failed filters, status badges, PR links, session links, error display, iteration counts
- **System Logs page** — tabbed event log viewer (council, escalation, work-task) with level indicators, credit transaction viewer tab with wallet/amount/balance columns, load-more pagination
- **Sidebar navigation** — reorganized with new pages (Work Tasks, Analytics, Logs, Settings) and a divider before NFT section
- **Backend** — 3 new API route files (`analytics.ts`, `settings.ts`, `system-logs.ts`) with 6 new endpoints
- **Minor UI fixes** — chat layout flex improvements, textarea sizing

## New API Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/analytics/overview` | Aggregate stats |
| GET | `/api/analytics/spending?days=N` | Daily spending data |
| GET | `/api/analytics/sessions` | Session stats by agent/source/status |
| GET | `/api/settings` | Credit config + system info |
| PUT | `/api/settings/credits` | Update credit configuration |
| GET | `/api/system-logs?type=X` | Aggregated event logs |
| GET | `/api/system-logs/credit-transactions` | Credit transaction ledger |

## Test plan
- [x] TypeScript compiles clean (`bun tsc --noEmit`)
- [x] All 285 tests pass (`bun test`)
- [ ] Navigate to each new page in browser
- [ ] Verify analytics loads data from existing sessions
- [ ] Verify settings page can change operational mode
- [ ] Verify work tasks page shows filtered views
- [ ] Verify system logs pagination works

🤖 Generated with [Claude Code](https://claude.com/claude-code)