### PR TITLE
feat: add wallet address identity to WebSocket connections

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -152,6 +152,7 @@ const wsHandler = createWebSocketHandler(processManager, () => algochatBridge, (
 
 interface WsData {
     subscriptions: Map<string, unknown>;
+    walletAddress?: string;
 }
 
 // Start server
@@ -170,8 +171,14 @@ const server = Bun.serve<WsData>({
                     headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer' },
                 });
             }
+            // Extract wallet address if provided (from chat client)
+            const walletAddress = url.searchParams.get('wallet') || undefined;
+            if (walletAddress) {
+                log.info('WebSocket connection with wallet identity', { wallet: walletAddress.slice(0, 8) + '...' });
+            }
+
             const upgraded = server.upgrade(req, {
-                data: { subscriptions: new Map() },
+                data: { subscriptions: new Map(), walletAddress },
             });
             if (upgraded) return undefined as unknown as Response;
             return new Response('WebSocket upgrade failed', { status: 400 });

--- a/server/ws/handler.ts
+++ b/server/ws/handler.ts
@@ -11,6 +11,7 @@ const log = createLogger('WebSocket');
 
 interface WsData {
     subscriptions: Map<string, EventCallback>;
+    walletAddress?: string;
 }
 
 export function createWebSocketHandler(
@@ -127,7 +128,8 @@ function handleClientMessage(
         }
 
         case 'chat_send': {
-            log.debug(`chat_send received`, { agentId: msg.agentId, content: msg.content.slice(0, 50) });
+            const walletCtx = ws.data?.walletAddress;
+            log.debug(`chat_send received`, { agentId: msg.agentId, content: msg.content.slice(0, 50), wallet: walletCtx?.slice(0, 8) });
             const bridge = getBridge();
             if (!bridge) {
                 log.debug('chat_send: bridge is null, AlgoChat not available');


### PR DESCRIPTION
## Summary
- Extracts `?wallet=ADDRESS` query parameter from WebSocket upgrade requests
- Stores wallet address in `WsData` for each connection
- Logs wallet identity on connection and with chat messages
- Enables the chat client (corvid-agent-chat) to pass Algorand wallet addresses for identity tracking

## Context
The [corvid-agent-chat](https://corvid-agent.github.io/corvid-agent-chat/) client now supports wallet management (generate/import mnemonic, encrypted storage). This server-side change accepts the wallet address passed by the client and logs it for identity tracking. Deeper integration (challenge/response auth, credit tracking by wallet) will follow.

## Test plan
- [x] All 285 tests pass
- [ ] Verify WS connection with `?wallet=ADDRESS` logs truncated address
- [ ] Verify WS connection without `?wallet` works as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>