### PR TITLE
fix: copy patches dir in Dockerfile before bun install

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 
 # Install server dependencies only
 COPY package.json bun.lock* ./
+COPY patches/ patches/
 RUN bun install --frozen-lockfile --production
 
 # Copy server source


### PR DESCRIPTION
## Summary

- Adds `COPY patches/ patches/` to the Dockerfile before `bun install`, fixing the Docker build failure on version releases
- The `patchedDependencies` in `package.json` references `patches/@corvidlabs%2Fts-algochat@0.3.0.patch` but the patches directory was never copied into the Docker build context before install

This fixes the failing Docker publish CI for v0.2.0 and v0.3.0 releases.

## Test plan

- [ ] Re-trigger Docker publish workflow after merge — should now succeed
- [ ] Verify `bun install --frozen-lockfile --production` succeeds with patches available

🤖 Generated with [Claude Code](https://claude.com/claude-code)