### PR TITLE
chore: v0.4.0 release — bump version and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ AI agent orchestration platform with on-chain messaging via Algorand.
 
 ## Features
 
-- **Agent orchestration** -- spawn, manage, and monitor Claude-powered agents
-- **Council discussions** -- multi-agent deliberation with structured voting and follow-up chat
+- **Agent orchestration** -- spawn, manage, and monitor AI agents (Claude + Ollama)
+- **Council discussions** -- multi-agent deliberation with structured voting, discussion rounds, and follow-up chat
+- **Scheduler** -- cron/interval-based autonomous agent tasks with approval policies
+- **Ollama support** -- run local models (Qwen, LLama, etc.) with weight-based concurrency and tok/s metrics
 - **AlgoChat** -- on-chain encrypted messaging via Algorand (PSK / X25519)
 - **Self-improvement** -- agents create work tasks, branch, validate, and open PRs autonomously
-- **Mobile chat client** -- responsive Angular UI with real-time WebSocket updates
+- **Mobile connect** -- QR code PSK exchange for mobile wallet pairing
+- **Dashboard** -- Angular UI with analytics, settings, work tasks, system logs, and real-time streaming
 - **MCP tools** -- extensible tool system using the Model Context Protocol
 
 ## Tech Stack
@@ -18,6 +21,7 @@ AI agent orchestration platform with on-chain messaging via Algorand.
 - [SQLite](https://bun.sh/docs/api/sqlite) -- persistence via `bun:sqlite`
 - [Algorand](https://algorand.co) (`algosdk`) -- on-chain messaging
 - [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) -- agent orchestration
+- [Ollama](https://ollama.com) -- local model inference (optional)
 - [MCP SDK](https://github.com/modelcontextprotocol/sdk) -- tool protocol
 
 ## Quick Start
@@ -40,10 +44,12 @@ server/          Bun HTTP + WebSocket server, agent process management
   algochat/      AlgoChat on-chain messaging layer
   db/            SQLite schema and queries
   lib/           Shared utilities (logger, crypto, validation)
-  mcp/           MCP tool server
+  mcp/           MCP tool server and coding tools for Ollama agents
   middleware/    HTTP/WS auth, CORS, startup security checks
-  process/       Agent lifecycle management
-  routes/        REST API routes
+  process/       Agent lifecycle (SDK + direct Ollama execution)
+  providers/     LLM provider registry (Anthropic, Ollama)
+  routes/        REST API routes (agents, sessions, schedules, councils)
+  scheduler/     Cron/interval schedule execution engine
   selftest/      Self-test service
   work/          Task/work item management
   ws/            WebSocket handlers
@@ -72,6 +78,10 @@ e2e/             Playwright end-to-end tests
 | `WALLET_ENCRYPTION_KEY` | AES-256 key for wallet encryption at rest | derived from mnemonic |
 | `LOG_LEVEL` | Logging level (`debug`, `info`, `warn`, `error`) | `info` |
 | `GH_TOKEN` | GitHub token for work task PR creation | -- |
+| `OLLAMA_URL` | Ollama API base URL | `http://localhost:11434` |
+| `OLLAMA_MAX_PARALLEL` | Max concurrency weight budget for Ollama | `3` |
+| `SCHEDULER_ENABLED` | Enable the autonomous scheduler | `true` |
+| `SCHEDULER_MAX_CONCURRENT` | Max concurrent schedule executions | `2` |
 
 Copy `.env.example` to `.env` and fill in your values. Bun loads `.env` automatically.
 

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -55,7 +55,7 @@
           <span class="terminal__label">architecture</span>
         </div>
         <div class="arch-diagram">
-          <!-- Top row: Angular UI → Bun Server → Claude SDK -->
+          <!-- Top row: Angular UI → Bun Server → LLM Providers -->
           <div class="arch-row">
             <div class="arch-box arch-box--cyan">
               <div class="arch-box__label accent-cyan">Angular UI</div>
@@ -68,8 +68,8 @@
             </div>
             <span class="arch-arrow"></span>
             <div class="arch-box arch-box--green">
-              <div class="arch-box__label accent-green">Claude SDK</div>
-              <div class="arch-box__sub">Subprocess</div>
+              <div class="arch-box__label accent-green">LLM Providers</div>
+              <div class="arch-box__sub">Claude + Ollama</div>
             </div>
           </div>
 
@@ -89,15 +89,15 @@
             <div class="arch-connector__line"></div>
           </div>
 
-          <!-- Bottom row: SQLite, MCP Server, AlgoChat -->
+          <!-- Bottom row: SQLite, Scheduler, AlgoChat -->
           <div class="arch-row">
             <div class="arch-box arch-box--cyan">
               <div class="arch-box__label accent-cyan">SQLite DB</div>
               <div class="arch-box__sub">Persistence</div>
             </div>
             <div class="arch-box arch-box--magenta">
-              <div class="arch-box__label accent-magenta">MCP Server</div>
-              <div class="arch-box__sub">9 Tools</div>
+              <div class="arch-box__label accent-magenta">Scheduler</div>
+              <div class="arch-box__sub">Cron / Interval</div>
             </div>
             <div class="arch-box arch-box--green">
               <div class="arch-box__label accent-green">AlgoChat</div>
@@ -125,10 +125,12 @@
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">algochat/</span>        <span class="t-comment"># On-chain messaging layer</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">db/</span>              <span class="t-comment"># SQLite schema &amp; queries</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">lib/</span>             <span class="t-comment"># Logger, crypto, validation</span>
-<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">mcp/</span>             <span class="t-comment"># MCP tool server &amp; handlers</span>
-<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">middleware/</span>       <span class="t-comment"># Auth, CORS</span>
-<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">process/</span>         <span class="t-comment"># Agent lifecycle &amp; SDK integration</span>
+<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">mcp/</span>             <span class="t-comment"># MCP tool server &amp; coding tools</span>
+<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">middleware/</span>       <span class="t-comment"># Auth, CORS, rate limiting</span>
+<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">process/</span>         <span class="t-comment"># Agent lifecycle (SDK + Ollama)</span>
+<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">providers/</span>       <span class="t-comment"># LLM registry (Anthropic, Ollama)</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">routes/</span>          <span class="t-comment"># REST API endpoints</span>
+<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">scheduler/</span>       <span class="t-comment"># Cron/interval execution engine</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">work/</span>            <span class="t-comment"># Git worktree &amp; work tasks</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">ws/</span>              <span class="t-comment"># WebSocket handler</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x2514;&#x2500;&#x2500;</span> <span class="t-file">index.ts</span>         <span class="t-comment"># Entry point</span>
@@ -362,6 +364,58 @@
             <span class="api-method api-method--post">POST</span>
             <code class="api-path">/api/council-launches/:id/chat</code>
             <span class="api-desc">Follow-up chat on completed council</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Schedules -->
+      <div class="api-group">
+        <h3 class="api-group__title accent-green">Schedules</h3>
+        <div class="api-table">
+          <div class="api-row">
+            <span class="api-method api-method--get">GET</span>
+            <code class="api-path">/api/schedules</code>
+            <span class="api-desc">List schedules (?agentId filter)</span>
+          </div>
+          <div class="api-row">
+            <span class="api-method api-method--post">POST</span>
+            <code class="api-path">/api/schedules</code>
+            <span class="api-desc">Create schedule (cron or interval)</span>
+          </div>
+          <div class="api-row">
+            <span class="api-method api-method--get">GET</span>
+            <code class="api-path">/api/schedules/:id</code>
+            <span class="api-desc">Get schedule details</span>
+          </div>
+          <div class="api-row">
+            <span class="api-method api-method--put">PUT</span>
+            <code class="api-path">/api/schedules/:id</code>
+            <span class="api-desc">Update schedule</span>
+          </div>
+          <div class="api-row">
+            <span class="api-method api-method--delete">DEL</span>
+            <code class="api-path">/api/schedules/:id</code>
+            <span class="api-desc">Delete schedule</span>
+          </div>
+          <div class="api-row">
+            <span class="api-method api-method--get">GET</span>
+            <code class="api-path">/api/schedules/:id/executions</code>
+            <span class="api-desc">List executions for schedule</span>
+          </div>
+          <div class="api-row">
+            <span class="api-method api-method--get">GET</span>
+            <code class="api-path">/api/schedule-executions</code>
+            <span class="api-desc">List all executions</span>
+          </div>
+          <div class="api-row">
+            <span class="api-method api-method--post">POST</span>
+            <code class="api-path">/api/schedule-executions/:id/resolve</code>
+            <span class="api-desc">Approve or deny execution</span>
+          </div>
+          <div class="api-row">
+            <span class="api-method api-method--get">GET</span>
+            <code class="api-path">/api/scheduler/health</code>
+            <span class="api-desc">Scheduler health &amp; stats</span>
           </div>
         </div>
       </div>
@@ -799,7 +853,7 @@
   <section class="section" id="database">
     <div class="container">
       <h2 class="section__title">Database Schema</h2>
-      <p class="section__subtitle">SQLite via <code class="accent-cyan">bun:sqlite</code>. Schema version 23. Auto-migrates on startup.</p>
+      <p class="section__subtitle">SQLite via <code class="accent-cyan">bun:sqlite</code>. Schema version 24. Auto-migrates on startup.</p>
 
       <div class="grid grid--3">
         <div class="card card--cyan">
@@ -832,6 +886,8 @@
             <div class="schema-item"><code>council_launches</code> <span class="t-comment">&mdash; stage</span></div>
             <div class="schema-item"><code>council_launch_logs</code></div>
             <div class="schema-item"><code>council_discussion_messages</code></div>
+            <div class="schema-item"><code>schedules</code> <span class="t-comment">&mdash; cron, interval, actions</span></div>
+            <div class="schema-item"><code>schedule_executions</code> <span class="t-comment">&mdash; status, result</span></div>
             <div class="schema-item"><code>credit_ledger</code> <span class="t-comment">&mdash; wallet, balance</span></div>
             <div class="schema-item"><code>credit_transactions</code></div>
             <div class="schema-item"><code>credit_config</code></div>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -56,12 +56,12 @@
         <div class="card card--magenta">
           <div class="card__icon">&#x1F916;</div>
           <h3 class="card__title">Anthropic API Key</h3>
-          <p>Required for the Claude Agent SDK. Get one at <a href="https://console.anthropic.com" class="accent-magenta">console.anthropic.com</a>.</p>
+          <p>Required for Claude agents. Get one at <a href="https://console.anthropic.com" class="accent-magenta">console.anthropic.com</a>. Not needed if using Ollama only.</p>
         </div>
         <div class="card card--green">
-          <div class="card__icon">&#x26D3;</div>
-          <h3 class="card__title">AlgoKit (optional)</h3>
-          <p>Only needed for on-chain AlgoChat messaging. Without it, everything still works &mdash; chat via the web UI, agents run sessions, councils deliberate. Install via <code class="accent-green">pipx install algokit</code> if you want Localnet or Testnet messaging.</p>
+          <div class="card__icon">&#x1F9CA;</div>
+          <h3 class="card__title">Ollama (optional)</h3>
+          <p>Run local models (Qwen, LLama, Mistral). Install from <a href="https://ollama.com" class="accent-green">ollama.com</a>. Agents can use any pulled model. Weight-based concurrency prevents memory thrashing.</p>
         </div>
       </div>
     </div>
@@ -105,6 +105,9 @@
 
 <span class="t-comment"># Required</span>
 ANTHROPIC_API_KEY=sk-ant-...
+
+<span class="t-comment"># Optional &mdash; for Ollama local models</span>
+OLLAMA_URL=http://localhost:11434
 
 <span class="t-comment"># Optional &mdash; for AlgoChat messaging</span>
 ALGOCHAT_MNEMONIC=your twenty five word mnemonic ...
@@ -262,19 +265,23 @@ GH_TOKEN=ghp_...</code></pre>
         </div>
 
         <div class="card card--green">
-          <h3 class="card__title">Limits</h3>
+          <h3 class="card__title">Ollama &amp; Scheduler</h3>
           <div class="config-table">
             <div class="config-row">
-              <span class="config-key accent-green">AGENT_TIMEOUT_MS</span>
-              <span class="config-val">1800000 (30 min)</span>
+              <span class="config-key accent-green">OLLAMA_URL</span>
+              <span class="config-val">http://localhost:11434</span>
             </div>
             <div class="config-row">
-              <span class="config-key accent-green">DAILY_ALGO_LIMIT_MICRO</span>
-              <span class="config-val">10000000 (10 ALGO)</span>
+              <span class="config-key accent-green">OLLAMA_MAX_PARALLEL</span>
+              <span class="config-val">3 (weight budget)</span>
             </div>
             <div class="config-row">
-              <span class="config-key accent-green">WORK_MAX_ITERATIONS</span>
-              <span class="config-val">3</span>
+              <span class="config-key accent-green">SCHEDULER_ENABLED</span>
+              <span class="config-val">true</span>
+            </div>
+            <div class="config-row">
+              <span class="config-key accent-green">SCHEDULER_MAX_CONCURRENT</span>
+              <span class="config-val">2</span>
             </div>
           </div>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
   <!-- ═══════════════════ HERO ═══════════════════ -->
   <header class="hero">
     <div class="container">
-      <div class="hero__badge">v0.3.0</div>
+      <div class="hero__badge">v0.4.0</div>
       <h1 class="hero__title">
         <span class="glow-cyan">Corvid</span><span class="glow-magenta">Agent</span>
       </h1>
@@ -70,7 +70,7 @@
         <div class="card card--cyan">
           <div class="card__icon">&#x1F9E0;</div>
           <h3 class="card__title">Agent Orchestration</h3>
-          <p>Multi-agent council system with configurable personas. Agents deliberate, vote, and reach consensus on complex decisions.</p>
+          <p>Multi-agent council system with configurable personas. Agents deliberate, vote, and reach consensus. Supports both Claude and local Ollama models.</p>
         </div>
 
         <div class="card card--magenta">
@@ -80,15 +80,15 @@
         </div>
 
         <div class="card card--green">
-          <div class="card__icon">&#x1F4F1;</div>
-          <h3 class="card__title">Cyberpunk UI</h3>
-          <p>Angular client with pixel-art aesthetic, real-time streaming, and mobile-responsive design. Dark mode by default.</p>
+          <div class="card__icon">&#x23F0;</div>
+          <h3 class="card__title">Scheduler</h3>
+          <p>Cron and interval-based autonomous task execution. Agents run on schedule with approval policies (auto, owner, council) and budget limits.</p>
         </div>
 
         <div class="card card--cyan">
-          <div class="card__icon">&#x1F527;</div>
-          <h3 class="card__title">MCP Tools</h3>
-          <p>Built-in Model Context Protocol tools for memory, agent messaging, credit checking, and work task creation.</p>
+          <div class="card__icon">&#x1F9CA;</div>
+          <h3 class="card__title">Ollama / Local Models</h3>
+          <p>Run Qwen, LLama, Mistral, and other local models. Weight-based concurrency prevents memory thrashing. Real-time tok/s metrics.</p>
         </div>
 
         <div class="card card--magenta">
@@ -98,9 +98,9 @@
         </div>
 
         <div class="card card--green">
-          <div class="card__icon">&#x1F512;</div>
-          <h3 class="card__title">On-Chain Identity</h3>
-          <p>Algorand wallet-based authentication. Every agent has a verifiable on-chain identity with encrypted memory storage.</p>
+          <div class="card__icon">&#x1F4F1;</div>
+          <h3 class="card__title">Dashboard &amp; Mobile</h3>
+          <p>Angular UI with analytics, system logs, work tasks, settings, and QR-based mobile connect. Dark cyberpunk aesthetic.</p>
         </div>
 
       </div>
@@ -117,7 +117,7 @@
         <div class="chip chip--green">SQLite</div>
         <div class="chip chip--cyan">Algorand</div>
         <div class="chip chip--magenta">Claude SDK</div>
-        <div class="chip chip--green">MCP</div>
+        <div class="chip chip--green">Ollama</div>
       </div>
     </div>
   </section>
@@ -162,15 +162,15 @@
         </div>
         <pre class="terminal__body"><code><span class="t-dir">corvid-agent/</span>
 <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">server/</span>          <span class="t-comment"># Bun HTTP + WebSocket server</span>
-<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-file">index.ts</span>     <span class="t-comment"># Entry point &amp; routing</span>
-<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-file">agent.ts</span>     <span class="t-comment"># Claude Agent SDK integration</span>
-<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-file">council.ts</span>   <span class="t-comment"># Multi-agent deliberation</span>
-<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x2514;&#x2500;&#x2500;</span> <span class="t-dir">tools/</span>       <span class="t-comment"># MCP tool implementations</span>
+<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">process/</span>     <span class="t-comment"># Agent lifecycle (SDK + Ollama)</span>
+<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">providers/</span>   <span class="t-comment"># LLM registry (Anthropic, Ollama)</span>
+<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">scheduler/</span>   <span class="t-comment"># Cron/interval task engine</span>
+<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x2514;&#x2500;&#x2500;</span> <span class="t-dir">mcp/</span>         <span class="t-comment"># MCP + coding tools</span>
 <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">client/</span>          <span class="t-comment"># Angular 21 UI</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x2514;&#x2500;&#x2500;</span> <span class="t-dir">src/app/</span>     <span class="t-comment"># Components &amp; services</span>
-<span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">mcp-server/</span>      <span class="t-comment"># MCP tool server</span>
-<span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">deploy/</span>          <span class="t-comment"># Docker &amp; CI/CD</span>
-<span class="t-branch">&#x2514;&#x2500;&#x2500;</span> <span class="t-dir">tests/</span>           <span class="t-comment"># Bun test suite</span></code></pre>
+<span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">shared/</span>          <span class="t-comment"># Shared types &amp; WS protocol</span>
+<span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">deploy/</span>          <span class="t-comment"># Docker, systemd, Caddy, nginx</span>
+<span class="t-branch">&#x2514;&#x2500;&#x2500;</span> <span class="t-dir">e2e/</span>             <span class="t-comment"># Playwright + Bun tests</span></code></pre>
       </div>
     </div>
   </section>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump `package.json` version to `0.4.0`
- Update README with new features (scheduler, Ollama, mobile connect, dashboard pages)
- Update GitHub Pages docs site:
  - **index.html**: v0.4.0 badge, new feature cards (Scheduler, Ollama), updated architecture tree
  - **architecture.html**: LLM Providers diagram, Schedules API endpoints, updated project structure, schema v24
  - **getting-started.html**: Ollama prerequisite, OLLAMA_URL config, scheduler env vars

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [ ] CI passes
- [ ] GitHub Pages renders correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)