### PR TITLE
fix: RelativeTimePipe showing "just now" for future dates

### DIFF
--- a/client/src/app/shared/pipes/relative-time.pipe.ts
+++ b/client/src/app/shared/pipes/relative-time.pipe.ts
@@ -10,6 +10,22 @@ export class RelativeTimePipe implements PipeTransform {
         const date = new Date(normalized);
         const now = new Date();
         const diffMs = now.getTime() - date.getTime();
+
+        // Future dates (negative diff) — show "in X"
+        if (diffMs < 0) {
+            const futureSec = Math.floor(-diffMs / 1000);
+            const futureMin = Math.floor(futureSec / 60);
+            const futureHour = Math.floor(futureMin / 60);
+            const futureDay = Math.floor(futureHour / 24);
+
+            if (futureSec < 60) return 'in <1m';
+            if (futureMin < 60) return `in ${futureMin}m`;
+            if (futureHour < 24) return `in ${futureHour}h`;
+            if (futureDay < 30) return `in ${futureDay}d`;
+            return date.toLocaleDateString();
+        }
+
+        // Past dates
         const diffSec = Math.floor(diffMs / 1000);
         const diffMin = Math.floor(diffSec / 60);
         const diffHour = Math.floor(diffMin / 60);


### PR DESCRIPTION
## Summary

- **RelativeTimePipe** only handled past dates — when `next_run_at` is in the future, `diffMs` is negative, so `diffSec < 60` was always true, causing all schedule next-run times to display as "just now"
- Now detects future dates and displays "in Xm", "in Xh", "in Xd" format

## Test plan

- [ ] `bunx tsc --noEmit --skipLibCheck` passes
- [ ] Schedule page shows correct future times (e.g. "in 47m", "in 3h")
- [ ] Past dates still display correctly ("5m ago", "2h ago")

🤖 Generated with [Claude Code](https://claude.com/claude-code)