### PR TITLE
fix: AlgoChat replies not sent on-chain for existing sessions

### DIFF
--- a/server/algochat/bridge.ts
+++ b/server/algochat/bridge.ts
@@ -691,12 +691,14 @@ export class AlgoChatBridge {
             }
         } else {
             if (conversation.sessionId) {
+                // Always subscribe so the reply gets sent back on-chain
+                this.subscriptionManager.subscribeForResponse(conversation.sessionId, participant);
+
                 const sent = this.processManager.sendMessage(conversation.sessionId, content);
                 if (!sent) {
                     const { getSession } = await import('../db/sessions');
                     const session = getSession(this.db, conversation.sessionId);
                     if (session) {
-                        this.subscriptionManager.subscribeForResponse(session.id, participant);
                         this.processManager.resumeProcess(session, content);
                     }
                 }


### PR DESCRIPTION
## Summary

- When an AlgoChat message arrived for an agent with a running session, `sendMessage()` succeeded but `subscribeForResponse()` was never called
- The agent processed the message and produced a response, but nobody was listening to send the reply back on-chain
- Status messages flowed correctly (progress updates), but the final outbound reply was silently dropped
- Fix: register the subscription **before** the sendMessage/resume branch so it's always in place

## Test plan

- [ ] `bunx tsc --noEmit --skipLibCheck` passes
- [ ] `bun test` passes (317 tests)
- [ ] Manual: send AlgoChat message to agent with existing session — reply arrives on-chain
- [ ] Manual: send AlgoChat message to agent with no session — reply arrives on-chain (existing path, regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)