### PR TITLE
ci: add CodeQL static security analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 6am UTC
+    - cron: "0 6 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Adds CodeQL workflow for deep static security analysis (XSS, SQL injection, command injection, etc.)
- Runs on push/PR to main + weekly schedule (Monday 6am UTC)
- Uses `security-extended,security-and-quality` query suites for thorough coverage
- Complements existing gitleaks secret scanning (which catches leaked credentials but not code-level vulnerabilities)

## Test plan
- [ ] Verify workflow triggers on this PR
- [ ] Check CodeQL analysis completes without errors
- [ ] Review any findings in the Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)