### PR TITLE
fix: Docker build fails — missing shared/ types

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -6,6 +6,9 @@ WORKDIR /app/client
 COPY client/package.json client/bun.lock* ./
 RUN bun install --frozen-lockfile
 
+# Copy shared types (client imports from ../shared/)
+COPY shared/ /app/shared/
+
 # Copy client source & build
 COPY client/ .
 RUN bun run build


### PR DESCRIPTION
## Summary
- The Angular client imports `shared/command-defs` via relative paths (`../../../../../shared/`)
- The Dockerfile's client-build stage only copied `client/` — `shared/` was missing from the container
- This caused **all three releases** (v0.2.0, v0.3.0, v0.4.0) to fail with `TS2307: Cannot find module '../../../../../shared/command-defs'`
- Fix: copy `shared/` into the client-build stage at `/app/shared/` so the relative imports resolve correctly

## Test plan
- [ ] CI passes (the `bun run build` in the Docker build should now succeed)
- [ ] After merge, re-tag v0.4.0 or release v0.4.1 to verify the full release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)