### PR TITLE
feat: add web search and deep research MCP tools

### DIFF
--- a/server/__tests__/web-search.test.ts
+++ b/server/__tests__/web-search.test.ts
@@ -1,0 +1,332 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { braveWebSearch, braveMultiSearch } from '../lib/web-search';
+import { handleWebSearch, handleDeepResearch, type McpToolContext } from '../mcp/tool-handlers';
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/** Build a minimal McpToolContext for testing (only fields used by web search handlers). */
+function makeCtx(overrides?: Partial<McpToolContext>): McpToolContext {
+    return {
+        agentId: 'test-agent',
+        db: {} as McpToolContext['db'],
+        agentMessenger: {} as McpToolContext['agentMessenger'],
+        agentDirectory: {} as McpToolContext['agentDirectory'],
+        agentWalletService: {} as McpToolContext['agentWalletService'],
+        emitStatus: () => {},
+        ...overrides,
+    };
+}
+
+/** Create a mock Brave API success response. */
+function braveResponse(results: Array<{ title: string; url: string; description: string; age?: string }>) {
+    return new Response(JSON.stringify({ web: { results } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+function mockFetch(fn: (input: string | URL | Request) => Promise<Response>) {
+    globalThis.fetch = fn as typeof fetch;
+}
+
+/** Extract text from a CallToolResult content array. */
+function getText(result: { content: Array<{ type: string; text?: string }> }): string {
+    const first = result.content[0];
+    return (first as { type: 'text'; text: string }).text;
+}
+
+// ── braveWebSearch ───────────────────────────────────────────────────────
+
+describe('braveWebSearch', () => {
+    const originalFetch = globalThis.fetch;
+    const originalEnv = process.env.BRAVE_SEARCH_API_KEY;
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+        if (originalEnv !== undefined) {
+            process.env.BRAVE_SEARCH_API_KEY = originalEnv;
+        } else {
+            delete process.env.BRAVE_SEARCH_API_KEY;
+        }
+    });
+
+    test('returns empty array when API key is missing', async () => {
+        delete process.env.BRAVE_SEARCH_API_KEY;
+        const results = await braveWebSearch('test query');
+        expect(results).toEqual([]);
+    });
+
+    test('returns parsed results on success', async () => {
+        process.env.BRAVE_SEARCH_API_KEY = 'test-key';
+        mockFetch(async (input) => {
+            const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+            expect(url).toContain('api.search.brave.com');
+            expect(url).toContain('q=bun+runtime');
+            return braveResponse([
+                { title: 'Bun', url: 'https://bun.sh', description: 'Fast JS runtime' },
+                { title: 'Bun Docs', url: 'https://bun.sh/docs', description: 'Documentation', age: '2 days ago' },
+            ]);
+        });
+
+        const results = await braveWebSearch('bun runtime');
+        expect(results).toHaveLength(2);
+        expect(results[0].title).toBe('Bun');
+        expect(results[0].url).toBe('https://bun.sh');
+        expect(results[1].age).toBe('2 days ago');
+    });
+
+    test('passes count and freshness params', async () => {
+        process.env.BRAVE_SEARCH_API_KEY = 'test-key';
+        mockFetch(async (input) => {
+            const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+            expect(url).toContain('count=10');
+            expect(url).toContain('freshness=pw');
+            return braveResponse([]);
+        });
+
+        await braveWebSearch('test', { count: 10, freshness: 'pw' });
+    });
+
+    test('clamps count to max 20', async () => {
+        process.env.BRAVE_SEARCH_API_KEY = 'test-key';
+        mockFetch(async (input) => {
+            const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+            expect(url).toContain('count=20');
+            return braveResponse([]);
+        });
+
+        await braveWebSearch('test', { count: 50 });
+    });
+
+    test('throws on API error', async () => {
+        process.env.BRAVE_SEARCH_API_KEY = 'test-key';
+        mockFetch(async () => new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' }));
+
+        await expect(braveWebSearch('test')).rejects.toThrow('Brave Search API error: 401');
+    });
+});
+
+// ── braveMultiSearch ─────────────────────────────────────────────────────
+
+describe('braveMultiSearch', () => {
+    const originalFetch = globalThis.fetch;
+    const originalEnv = process.env.BRAVE_SEARCH_API_KEY;
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+        if (originalEnv !== undefined) {
+            process.env.BRAVE_SEARCH_API_KEY = originalEnv;
+        } else {
+            delete process.env.BRAVE_SEARCH_API_KEY;
+        }
+    });
+
+    test('deduplicates results by URL across queries', async () => {
+        process.env.BRAVE_SEARCH_API_KEY = 'test-key';
+        mockFetch(async (input) => {
+            const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+            if (url.includes('q=query+one')) {
+                return braveResponse([
+                    { title: 'Shared', url: 'https://shared.com', description: 'Shared result' },
+                    { title: 'Unique A', url: 'https://a.com', description: 'Only in query one' },
+                ]);
+            }
+            return braveResponse([
+                { title: 'Shared Dup', url: 'https://shared.com', description: 'Duplicate' },
+                { title: 'Unique B', url: 'https://b.com', description: 'Only in query two' },
+            ]);
+        });
+
+        const grouped = await braveMultiSearch(['query one', 'query two']);
+        expect(grouped).toHaveLength(2);
+
+        // First query keeps both
+        expect(grouped[0].results).toHaveLength(2);
+        // Second query: shared.com is deduped, only b.com remains
+        expect(grouped[1].results).toHaveLength(1);
+        expect(grouped[1].results[0].url).toBe('https://b.com');
+    });
+
+    test('handles partial failures gracefully', async () => {
+        process.env.BRAVE_SEARCH_API_KEY = 'test-key';
+        let callCount = 0;
+        mockFetch(async () => {
+            callCount++;
+            if (callCount === 1) {
+                return braveResponse([{ title: 'OK', url: 'https://ok.com', description: 'Success' }]);
+            }
+            return new Response('Server Error', { status: 500, statusText: 'Internal Server Error' });
+        });
+
+        const grouped = await braveMultiSearch(['good', 'bad']);
+        // Only the successful query should appear
+        expect(grouped).toHaveLength(1);
+        expect(grouped[0].query).toBe('good');
+    });
+});
+
+// ── handleWebSearch ──────────────────────────────────────────────────────
+
+describe('handleWebSearch', () => {
+    const originalFetch = globalThis.fetch;
+    const originalEnv = process.env.BRAVE_SEARCH_API_KEY;
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+        if (originalEnv !== undefined) {
+            process.env.BRAVE_SEARCH_API_KEY = originalEnv;
+        } else {
+            delete process.env.BRAVE_SEARCH_API_KEY;
+        }
+    });
+
+    test('returns error for empty query', async () => {
+        const ctx = makeCtx();
+        const result = await handleWebSearch(ctx, { query: '' });
+        expect(result.isError).toBe(true);
+        expect(getText(result)).toContain('query is required');
+    });
+
+    test('formats results as numbered markdown', async () => {
+        process.env.BRAVE_SEARCH_API_KEY = 'test-key';
+        mockFetch(async () =>
+            braveResponse([
+                { title: 'Result One', url: 'https://one.com', description: 'First result' },
+                { title: 'Result Two', url: 'https://two.com', description: 'Second result', age: '1 day ago' },
+            ]),
+        );
+
+        const ctx = makeCtx();
+        const result = await handleWebSearch(ctx, { query: 'test' });
+        expect(result.isError).toBeUndefined();
+
+        const text = getText(result);
+        expect(text).toContain('1. **Result One**');
+        expect(text).toContain('https://one.com');
+        expect(text).toContain('2. **Result Two**');
+        expect(text).toContain('(1 day ago)');
+    });
+
+    test('emits status messages', async () => {
+        process.env.BRAVE_SEARCH_API_KEY = 'test-key';
+        mockFetch(async () => braveResponse([{ title: 'R', url: 'https://r.com', description: 'D' }]));
+
+        const statuses: string[] = [];
+        const ctx = makeCtx({ emitStatus: (msg) => statuses.push(msg) });
+        await handleWebSearch(ctx, { query: 'test' });
+
+        expect(statuses.length).toBeGreaterThanOrEqual(1);
+        expect(statuses[0]).toContain('Searching');
+    });
+
+    test('returns no-results message when API key is missing', async () => {
+        delete process.env.BRAVE_SEARCH_API_KEY;
+        const ctx = makeCtx();
+        const result = await handleWebSearch(ctx, { query: 'test' });
+        expect(result.isError).toBeUndefined();
+        expect(getText(result)).toContain('No results found');
+    });
+});
+
+// ── handleDeepResearch ───────────────────────────────────────────────────
+
+describe('handleDeepResearch', () => {
+    const originalFetch = globalThis.fetch;
+    const originalEnv = process.env.BRAVE_SEARCH_API_KEY;
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+        if (originalEnv !== undefined) {
+            process.env.BRAVE_SEARCH_API_KEY = originalEnv;
+        } else {
+            delete process.env.BRAVE_SEARCH_API_KEY;
+        }
+    });
+
+    test('returns error for empty topic', async () => {
+        const ctx = makeCtx();
+        const result = await handleDeepResearch(ctx, { topic: '' });
+        expect(result.isError).toBe(true);
+        expect(getText(result)).toContain('topic is required');
+    });
+
+    test('generates sub-queries automatically', async () => {
+        process.env.BRAVE_SEARCH_API_KEY = 'test-key';
+        const queries: string[] = [];
+        mockFetch(async (input) => {
+            const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+            const parsed = new URL(url);
+            queries.push(parsed.searchParams.get('q') ?? '');
+            return braveResponse([{ title: 'R', url: `https://r${queries.length}.com`, description: 'Desc' }]);
+        });
+
+        const ctx = makeCtx();
+        await handleDeepResearch(ctx, { topic: 'TypeScript' });
+
+        // Should have main topic + 4 auto-generated angles = 5 total
+        expect(queries).toHaveLength(5);
+        expect(queries[0]).toBe('TypeScript');
+        expect(queries).toContainEqual('TypeScript benefits');
+        expect(queries).toContainEqual('TypeScript challenges');
+    });
+
+    test('uses custom sub_questions when provided', async () => {
+        process.env.BRAVE_SEARCH_API_KEY = 'test-key';
+        const queries: string[] = [];
+        mockFetch(async (input) => {
+            const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+            const parsed = new URL(url);
+            queries.push(parsed.searchParams.get('q') ?? '');
+            return braveResponse([{ title: 'R', url: `https://r${queries.length}.com`, description: 'Desc' }]);
+        });
+
+        const ctx = makeCtx();
+        await handleDeepResearch(ctx, {
+            topic: 'Bun runtime',
+            sub_questions: ['Bun vs Node', 'Bun performance'],
+        });
+
+        expect(queries).toHaveLength(3);
+        expect(queries[0]).toBe('Bun runtime');
+        expect(queries[1]).toBe('Bun vs Node');
+        expect(queries[2]).toBe('Bun performance');
+    });
+
+    test('limits to 5 queries total', async () => {
+        process.env.BRAVE_SEARCH_API_KEY = 'test-key';
+        const queries: string[] = [];
+        mockFetch(async (input) => {
+            const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+            const parsed = new URL(url);
+            queries.push(parsed.searchParams.get('q') ?? '');
+            return braveResponse([{ title: 'R', url: `https://r${queries.length}.com`, description: 'Desc' }]);
+        });
+
+        const ctx = makeCtx();
+        await handleDeepResearch(ctx, {
+            topic: 'topic',
+            sub_questions: ['q1', 'q2', 'q3', 'q4', 'q5', 'q6'],
+        });
+
+        // topic + 4 sub_questions = 5 (capped)
+        expect(queries).toHaveLength(5);
+    });
+
+    test('returns organized sections with headers', async () => {
+        process.env.BRAVE_SEARCH_API_KEY = 'test-key';
+        mockFetch(async (input) => {
+            const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+            return braveResponse([
+                { title: 'Result', url: `https://r-${encodeURIComponent(new URL(url).searchParams.get('q') ?? '')}.com`, description: 'Desc' },
+            ]);
+        });
+
+        const ctx = makeCtx();
+        const result = await handleDeepResearch(ctx, { topic: 'AI agents' });
+
+        const text = getText(result);
+        expect(text).toContain('# Deep Research: AI agents');
+        expect(text).toContain('### AI agents');
+        expect(text).toContain('deduplicated');
+    });
+});

--- a/server/lib/web-search.ts
+++ b/server/lib/web-search.ts
@@ -1,0 +1,112 @@
+import { createLogger } from './logger';
+
+const log = createLogger('WebSearch');
+
+export interface WebSearchResult {
+    title: string;
+    url: string;
+    description: string;
+    age?: string;
+}
+
+export interface WebSearchOptions {
+    /** Number of results to return (default 5, max 20). */
+    count?: number;
+    /** Freshness filter: pd (past day), pw (past week), pm (past month), py (past year). */
+    freshness?: 'pd' | 'pw' | 'pm' | 'py';
+}
+
+interface BraveSearchResponse {
+    web?: {
+        results?: Array<{
+            title: string;
+            url: string;
+            description: string;
+            age?: string;
+        }>;
+    };
+    query?: { original: string };
+}
+
+/**
+ * Search the web using Brave Search API.
+ * Returns an empty array with a logged warning if BRAVE_SEARCH_API_KEY is not set.
+ */
+export async function braveWebSearch(
+    query: string,
+    options?: WebSearchOptions,
+): Promise<WebSearchResult[]> {
+    const apiKey = process.env.BRAVE_SEARCH_API_KEY;
+    if (!apiKey) {
+        log.warn('BRAVE_SEARCH_API_KEY not set — web search unavailable');
+        return [];
+    }
+
+    const count = Math.min(Math.max(options?.count ?? 5, 1), 20);
+    const params = new URLSearchParams({
+        q: query,
+        count: String(count),
+    });
+    if (options?.freshness) {
+        params.set('freshness', options.freshness);
+    }
+
+    const url = `https://api.search.brave.com/res/v1/web/search?${params}`;
+
+    log.info('Brave search request', { query, count, freshness: options?.freshness });
+
+    const response = await fetch(url, {
+        headers: {
+            Accept: 'application/json',
+            'Accept-Encoding': 'gzip',
+            'X-Subscription-Token': apiKey,
+        },
+    });
+
+    if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        log.error('Brave search API error', { status: response.status, body: body.slice(0, 200) });
+        throw new Error(`Brave Search API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as BraveSearchResponse;
+    const results: WebSearchResult[] = (data.web?.results ?? []).map((r) => ({
+        title: r.title,
+        url: r.url,
+        description: r.description,
+        age: r.age,
+    }));
+
+    log.info('Brave search completed', { query, resultCount: results.length });
+    return results;
+}
+
+/**
+ * Run multiple searches concurrently and deduplicate results by URL.
+ */
+export async function braveMultiSearch(
+    queries: string[],
+    options?: WebSearchOptions,
+): Promise<{ query: string; results: WebSearchResult[] }[]> {
+    const settled = await Promise.allSettled(
+        queries.map((q) => braveWebSearch(q, options).then((results) => ({ query: q, results }))),
+    );
+
+    const seenUrls = new Set<string>();
+    const output: { query: string; results: WebSearchResult[] }[] = [];
+
+    for (const entry of settled) {
+        if (entry.status === 'fulfilled') {
+            const deduped = entry.value.results.filter((r) => {
+                if (seenUrls.has(r.url)) return false;
+                seenUrls.add(r.url);
+                return true;
+            });
+            output.push({ query: entry.value.query, results: deduped });
+        } else {
+            log.warn('Multi-search query failed', { reason: String(entry.reason) });
+        }
+    }
+
+    return output;
+}

--- a/server/mcp/tool-handlers.ts
+++ b/server/mcp/tool-handlers.ts
@@ -16,6 +16,7 @@ import {
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { encryptMemoryContent } from '../lib/crypto';
 import { createLogger } from '../lib/logger';
+import { braveWebSearch, braveMultiSearch } from '../lib/web-search';
 
 const log = createLogger('McpToolHandlers');
 
@@ -516,5 +517,96 @@ export async function handleCreateWorkTask(
         const message = err instanceof Error ? err.message : String(err);
         log.error('MCP create_work_task failed', { error: message });
         return errorResult(`Failed to create work task: ${message}`);
+    }
+}
+
+// ─── Web search handlers ─────────────────────────────────────────────────
+
+export async function handleWebSearch(
+    ctx: McpToolContext,
+    args: { query: string; count?: number; freshness?: string },
+): Promise<CallToolResult> {
+    if (!args.query?.trim()) {
+        return errorResult('A search query is required.');
+    }
+
+    try {
+        ctx.emitStatus?.(`Searching the web for "${args.query}"...`);
+
+        const results = await braveWebSearch(args.query, {
+            count: args.count,
+            freshness: args.freshness as 'pd' | 'pw' | 'pm' | 'py' | undefined,
+        });
+
+        if (results.length === 0) {
+            return textResult(
+                'No results found. This may mean BRAVE_SEARCH_API_KEY is not configured, or the query returned no matches.',
+            );
+        }
+
+        const lines = results.map(
+            (r, i) => `${i + 1}. **${r.title}**\n   ${r.url}\n   ${r.description}${r.age ? ` (${r.age})` : ''}`,
+        );
+
+        ctx.emitStatus?.(`Found ${results.length} results`);
+        return textResult(`Web search results for "${args.query}":\n\n${lines.join('\n\n')}`);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.error('MCP web_search failed', { error: message });
+        return errorResult(`Web search failed: ${message}`);
+    }
+}
+
+/** Default sub-query suffixes appended to the topic for deep research. */
+const DEEP_RESEARCH_ANGLES = ['benefits', 'challenges', 'examples', 'latest news'];
+
+export async function handleDeepResearch(
+    ctx: McpToolContext,
+    args: { topic: string; sub_questions?: string[] },
+): Promise<CallToolResult> {
+    if (!args.topic?.trim()) {
+        return errorResult('A research topic is required.');
+    }
+
+    try {
+        // Build query list: main topic + sub-questions (up to 5 total)
+        const subQuestions = args.sub_questions?.length
+            ? args.sub_questions
+            : DEEP_RESEARCH_ANGLES.map((angle) => `${args.topic} ${angle}`);
+
+        const queries = [args.topic, ...subQuestions].slice(0, 5);
+
+        ctx.emitStatus?.(`Researching "${args.topic}" with ${queries.length} queries...`);
+
+        const grouped = await braveMultiSearch(queries, { count: 5 });
+
+        if (grouped.length === 0 || grouped.every((g) => g.results.length === 0)) {
+            return textResult(
+                'No results found. This may mean BRAVE_SEARCH_API_KEY is not configured, or the queries returned no matches.',
+            );
+        }
+
+        const sections: string[] = [];
+        let totalResults = 0;
+
+        for (const group of grouped) {
+            if (group.results.length === 0) continue;
+            totalResults += group.results.length;
+            const items = group.results.map(
+                (r, i) => `  ${i + 1}. **${r.title}**\n     ${r.url}\n     ${r.description}${r.age ? ` (${r.age})` : ''}`,
+            );
+            sections.push(`### ${group.query}\n\n${items.join('\n\n')}`);
+        }
+
+        ctx.emitStatus?.(`Research complete — ${totalResults} results across ${grouped.length} queries`);
+        return textResult(
+            `# Deep Research: ${args.topic}\n\n` +
+            `*${totalResults} results from ${queries.length} queries (deduplicated)*\n\n` +
+            sections.join('\n\n---\n\n'),
+        );
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.error('MCP deep_research failed', { error: message });
+        return errorResult(`Deep research failed: ${message}`);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `corvid_web_search` and `corvid_deep_research` MCP tools using the Brave Search API (free tier: 2k queries/month)
- `corvid_web_search` performs single searches with configurable result count (1-20) and freshness filters (past day/week/month/year)
- `corvid_deep_research` runs up to 5 concurrent searches from different angles, deduplicates by URL, and returns organized results by query
- Both tools gracefully handle missing `BRAVE_SEARCH_API_KEY` (returns informative no-results message)

Closes #100

## Changes

| File | Description |
|------|-------------|
| `server/lib/web-search.ts` | New Brave Search API client (`braveWebSearch`, `braveMultiSearch` with URL dedup) |
| `server/mcp/tool-handlers.ts` | `handleWebSearch` and `handleDeepResearch` handlers with validation and status emissions |
| `server/mcp/sdk-tools.ts` | Tool registrations with Zod schemas, added to `DEFAULT_ALLOWED_TOOLS` |
| `server/mcp/direct-tools.ts` | Tool registrations with JSON Schema, added to `DEFAULT_ALLOWED_TOOLS` |
| `server/__tests__/web-search.test.ts` | 16 tests covering search, dedup, formatting, sub-query generation, error handling |

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test server/__tests__/web-search.test.ts` — 16/16 pass
- [x] `bun test` — 388/388 pass (no regressions)
- [ ] Manual: set `BRAVE_SEARCH_API_KEY` and test `corvid_web_search` via agent session
- [ ] Manual: test `corvid_deep_research` with custom sub-questions
- [ ] Manual: verify tools appear for both SDK and direct/Ollama sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)