### PR TITLE
fix: Dockerfile user creation and healthcheck

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -36,14 +36,14 @@ ENV BIND_HOST=0.0.0.0
 ENV LOG_LEVEL=info
 ENV NODE_ENV=production
 
-# Run as non-root user
-RUN addgroup --system corvid && adduser --system --ingroup corvid corvid
+# Run as non-root user (oven/bun:1 is Debian-slim — use native commands)
+RUN groupadd --system corvid && useradd --system --gid corvid corvid
 RUN chown -R corvid:corvid /app
 USER corvid
 
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:3000/api/health || exit 1
+    CMD bun -e "const r = await fetch('http://localhost:3000/api/health'); process.exit(r.ok ? 0 : 1)"
 
 CMD ["bun", "server/index.ts"]


### PR DESCRIPTION
## Summary
- `addgroup`/`adduser` don't exist in `oven/bun:1` (Debian-slim) — use `groupadd`/`useradd` instead
- `curl` isn't installed either — replace healthcheck with `bun -e fetch()`
- This is the second fix needed for the Docker build (first was missing `shared/` in #106)

## Test plan
- [ ] Docker build completes successfully in CI
- [ ] After merge, re-tag v0.5.0 to trigger a working release

🤖 Generated with [Claude Code](https://claude.com/claude-code)