### PR TITLE
fix: restore Schedules tab in sidebar navigation

### DIFF
--- a/client/src/app/shared/components/sidebar.component.ts
+++ b/client/src/app/shared/components/sidebar.component.ts
@@ -77,6 +77,16 @@ import { filter, Subscription } from 'rxjs';
                 <li>
                     <a
                         class="sidebar__link"
+                        routerLink="/schedules"
+                        routerLinkActive="sidebar__link--active"
+                        title="Schedules">
+                        <span class="sidebar__label">Schedules</span>
+                        <span class="sidebar__abbr">Sc</span>
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="sidebar__link"
                         routerLink="/feed"
                         routerLinkActive="sidebar__link--active"
                         title="Feed">


### PR DESCRIPTION
## Summary
- The sidebar consolidation commit removed Schedules from the nav
- Restores it between Councils and Feed

Sidebar: Dashboard, Agents, Conversations, Councils, **Schedules**, Feed, Settings

## Test plan
- [ ] Schedules tab visible in sidebar
- [ ] Route `/schedules` loads schedule list component

🤖 Generated with [Claude Code](https://claude.com/claude-code)