### PR TITLE
feat: click-to-expand schedule cards and execution rows

### DIFF
--- a/client/src/app/core/services/schedule.service.ts
+++ b/client/src/app/core/services/schedule.service.ts
@@ -103,6 +103,10 @@ export class ScheduleService {
         this.schedules.update((list) => list.filter((s) => s.id !== id));
     }
 
+    async getScheduleExecutions(scheduleId: string, limit: number = 20): Promise<ScheduleExecution[]> {
+        return firstValueFrom(this.api.get<ScheduleExecution[]>(`/schedules/${scheduleId}/executions?limit=${limit}`));
+    }
+
     async loadExecutions(scheduleId?: string, limit: number = 50): Promise<void> {
         const path = scheduleId
             ? `/schedules/${scheduleId}/executions?limit=${limit}`


### PR DESCRIPTION
## Summary
- Schedule cards are now clickable — expanding inline to show that schedule's execution history
- Execution rows (both per-schedule and global) expand on click to show full result text
- Added `getScheduleExecutions()` to schedule service for per-schedule fetching
- Action buttons (Pause/Resume/Delete) use stopPropagation to avoid triggering card expand

## Test plan
- [ ] Click a schedule card → should expand showing execution history
- [ ] Click again → should collapse
- [ ] Click an execution row → should show full result text below
- [ ] Click Session link → should navigate without toggling expand
- [ ] Pause/Resume/Delete buttons still work without expanding

🤖 Generated with [Claude Code](https://claude.com/claude-code)