### PR TITLE
fix: prevent duplicate poll sessions for the same GitHub issue

### DIFF
--- a/server/polling/service.ts
+++ b/server/polling/service.ts
@@ -192,19 +192,27 @@ export class MentionPollingService {
 
             log.info('Found new mentions', { configId: config.id, repo: config.repo, count: newMentions.length });
 
-            // Process each new mention — only track IDs that were actually handled
-            const processedNewIds: string[] = [];
-            for (const mention of newMentions) {
-                const handled = await this.processMention(config, mention);
-                if (handled) {
-                    processedNewIds.push(mention.id);
+            // Deduplicate: collapse multiple mentions for the same issue number
+            // (e.g. comment-123, issue-8, assigned-8 all for #8) into one.
+            // We keep the first (newest, since mentions are sorted desc).
+            const seenNumbers = new Set<number>();
+            const dedupedMentions: DetectedMention[] = [];
+            for (const m of newMentions) {
+                if (!seenNumbers.has(m.number)) {
+                    seenNumbers.add(m.number);
+                    dedupedMentions.push(m);
                 }
             }
 
-            // Only persist IDs of mentions that were actually processed
-            if (processedNewIds.length > 0) {
-                const updatedIds = [...config.processedIds, ...processedNewIds];
-                updateProcessedIds(this.db, config.id, updatedIds);
+            // Process each deduplicated mention and persist IDs immediately
+            // to narrow the race window with concurrent poll cycles.
+            for (const mention of dedupedMentions) {
+                await this.processMention(config, mention);
+                // Collect ALL mention IDs for this issue number (comment-X, issue-N, assigned-N)
+                // so duplicates from other search paths don't reappear.
+                const relatedIds = newMentions.filter(m => m.number === mention.number).map(m => m.id);
+                config.processedIds = [...config.processedIds, ...relatedIds];
+                updateProcessedIds(this.db, config.id, config.processedIds);
             }
 
             // Also update lastSeenId to the newest for backward compat
@@ -504,6 +512,16 @@ export class MentionPollingService {
         const projectId = config.projectId || agent.defaultProjectId;
         if (!projectId) {
             log.error('No project for polling config and agent has no default', { configId: config.id, agentId: config.agentId });
+            return false;
+        }
+
+        // Guard: skip if there's already an active session for this issue
+        const sessionPrefix = `Poll: ${config.repo.split('/')[1]} #${mention.number}:`;
+        const existing = this.db.query(
+            `SELECT id FROM sessions WHERE name LIKE ? AND status IN ('running', 'idle') AND created_at > datetime('now', '-1 hour')`
+        ).get(sessionPrefix + '%') as { id: string } | null;
+        if (existing) {
+            log.debug('Active session already exists for issue', { number: mention.number, existingId: existing.id });
             return false;
         }
 


### PR DESCRIPTION
## Summary

- **Deduplicate mentions by issue number** — The three search paths (comments, new issues, assignments) can return the same issue with different IDs (`comment-123`, `issue-8`, `assigned-8`). After filtering, mentions are now collapsed by issue number, keeping only the newest.
- **Persist `processedIds` immediately** — Instead of batching all ID updates at the end, IDs are written to the DB after each mention is processed, narrowing the race window when concurrent poll cycles overlap.
- **Active-session guard** — Before creating a session, queries for an existing `running`/`idle` session for the same issue (within the last hour) to prevent true duplicates.

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — all 675 tests pass
- [ ] Trigger a poll for a repo with an issue that has both an @mention and an assignment — verify only 1 session created
- [ ] Check `sqlite3 corvid-agent.db "SELECT name, status FROM sessions WHERE name LIKE 'Poll:%' ORDER BY created_at DESC LIMIT 10;"` — no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)