### PR TITLE
fix: add missing network param in recreateWallet

### DIFF
--- a/server/algochat/agent-wallet.ts
+++ b/server/algochat/agent-wallet.ts
@@ -216,7 +216,7 @@ export class AgentWalletService {
 
         const algochat = await import('@corvidlabs/ts-algochat');
         const generated = algochat.createRandomChatAccount();
-        const encrypted = await encryptMnemonic(generated.mnemonic, this.config.mnemonic);
+        const encrypted = await encryptMnemonic(generated.mnemonic, this.config.mnemonic, this.config.network);
 
         setAgentWallet(this.db, agentId, generated.account.address, encrypted);
         saveKeystoreEntry(agent.name, generated.account.address, encrypted);


### PR DESCRIPTION
## Summary
- Adds missing `this.config.network` argument to the `encryptMnemonic` call in `recreateWallet()`, matching the existing call in `ensureWallet()`
- Prevents wallet encryption mismatch that could cause infinite recreation loops on localnet restarts

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` passes (773/773)

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)