### PR TITLE
docs: fix version to 0.8.0, remove duplicate Built by section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.0.0] - 2026-02-17
+## [0.8.0] - 2026-02-17
 
-Major release: CorvidAgent reaches v1.0.0 with 1726 server tests, 47 database migrations, and full-stack agent orchestration across five development phases.
+Major release with 1757 server tests, 47 database migrations, and full-stack agent orchestration across five development phases.
 
-### Phase 5 — Bridges, Personas, Skills, Voice (v1.0 release features)
+### Phase 5 — Bridges, Personas, Skills, Voice
 
 - **Bidirectional Telegram bridge** — talk to agents from your phone via long-polling; voice note support with automatic STT transcription; per-user sessions; authorization via `TELEGRAM_ALLOWED_USER_IDS`
 - **Bidirectional Discord bridge** — talk to agents from Discord via raw WebSocket gateway (no discord.js dependency); auto-reconnect with exponential backoff; heartbeat and session resume; per-user sessions

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.0.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.8.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">
   <img src="https://img.shields.io/badge/Angular-21-dd0031?logo=angular" alt="Angular 21">
-  <img src="https://img.shields.io/badge/tests-1837%20passing-brightgreen" alt="1837 Tests Passing">
+  <img src="https://img.shields.io/badge/tests-1757%20passing-brightgreen" alt="1757 Tests Passing">
 </p>
 
 # corvid-agent
@@ -212,20 +212,6 @@ e2e/             Playwright end-to-end tests (8 spec files)
 
 ---
 
-## Built by corvid-agent
-
-These full-stack applications were designed, coded, tested, and deployed autonomously by corvid-agent — no human-written application code. Each is an Angular 21 standalone app hosted on GitHub Pages.
-
-| App | Stack | Description |
-|-----|-------|-------------|
-| [bw-cinema](https://corvid-agent.github.io/bw-cinema/) | Angular + TMDb API | Classic black-and-white film browser with search, favorites, watch history, and responsive grid layout |
-| [pd-gallery](https://corvid-agent.github.io/pd-gallery/) | Angular + Art Institute of Chicago API | Public domain art explorer with collection management, genre browsing, and WCAG AA accessibility |
-| [weather-dashboard](https://corvid-agent.github.io/weather-dashboard/) | Angular + Open-Meteo API | Weather forecasts, hourly/daily charts, air quality index, UV meter, astronomy data, and design-token typography |
-| [space-dashboard](https://corvid-agent.github.io/space-dashboard/) | Angular + NASA APIs | Space exploration dashboard with APOD, Mars rover photos, ISS tracking, and near-Earth object data |
-| [pd-audiobooks](https://corvid-agent.github.io/pd-audiobooks/) | Angular + LibriVox API | Public domain audiobook player with chapter navigation, playback controls, and reading lists |
-
----
-
 ## MCP Tools (34)
 
 Extensible tool system via [Model Context Protocol](https://github.com/modelcontextprotocol/sdk):
@@ -277,12 +263,12 @@ Tools are permission-scoped per agent via skill bundles and agent-level allowlis
 ## Testing
 
 ```bash
-bun test              # 1726 server tests (~27s)
-cd client && npx vitest run   # 111 Angular tests (~2s)
-bun run test:e2e      # 8 Playwright e2e spec files
+bun test              # 1757 server tests (~30s)
+cd client && npx vitest run   # Angular component tests (~2s)
+bun run test:e2e      # Playwright e2e spec files
 ```
 
-**1837 total tests** covering: API routes, audit logging, authentication, bash security, billing, CLI, credit system, crypto, database migrations, Discord bridge, GitHub tools, marketplace, MCP tool handlers, notifications, multi-model routing, observability, owner communication, personas, plugins, process lifecycle, rate limiting, reputation, sandbox isolation, scheduling, skill bundles, Telegram bridge, tenant isolation, validation, voice TTS/STT, wallet keystore, web search, workflows, work tasks, and Angular components.
+**1757+ tests** covering: API routes, audit logging, authentication, bash security, billing, CLI, credit system, crypto, database migrations, Discord bridge, GitHub tools, marketplace, MCP tool handlers, notifications, multi-model routing, observability, owner communication, personas, plugins, process lifecycle, rate limiting, reputation, sandbox isolation, scheduling, skill bundles, Telegram bridge, tenant isolation, validation, voice TTS/STT, wallet keystore, web search, workflows, work tasks, and Angular components.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "1.0.0",
+  "version": "0.8.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Version badge, package.json, and CHANGELOG all incorrectly said 1.0.0 — fixed to 0.8.0
- Removed duplicate "Built by corvid-agent" section from README (kept the complete 9-app version at the bottom)
- Updated test counts to 1757

🤖 Generated with [Claude Code](https://claude.com/claude-code)