### PR TITLE
Fix: mark failed on-chain sends as failed, not completed

### DIFF
--- a/server/algochat/agent-messenger.ts
+++ b/server/algochat/agent-messenger.ts
@@ -314,8 +314,8 @@ export class AgentMessenger {
                     log.info(`Agent message completed`, { messageId, responseTxid });
                 })
                 .catch((err) => {
-                    // Still mark completed even if on-chain response fails
-                    updateAgentMessageStatus(this.db, messageId, 'completed', { response });
+                    // Mark failed — response was generated but on-chain send didn't succeed
+                    updateAgentMessageStatus(this.db, messageId, 'failed', { response });
                     this.emitMessageUpdate(messageId);
                     log.warn('On-chain response send failed', {
                         messageId,


### PR DESCRIPTION
## Summary
- Fixed data integrity bug where failed on-chain sends were marked as `completed` instead of `failed`
- One-line change in `agent-messenger.ts:318` `.catch()` handler
- Response text is still preserved in the record for retry/debugging

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` — 0 errors
- [x] `bun test` — 1757 pass, 0 fail

Fixes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)