### PR TITLE
Fix: support Claude Code subscription auth

### DIFF
--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -11,6 +11,7 @@ import { getProject } from '../db/projects';
 import { getAgent, getAlgochatEnabledAgents } from '../db/agents';
 import { LlmProviderRegistry } from '../providers/registry';
 import type { LlmProviderType } from '../providers/types';
+import { hasClaudeAccess } from '../providers/router';
 import { getSession, getSessionMessages, updateSessionPid, updateSessionStatus, updateSessionCost, updateSessionAgent, addSessionMessage } from '../db/sessions';
 import type { AgentMessenger } from '../algochat/agent-messenger';
 import type { AgentDirectory } from '../algochat/agent-directory';
@@ -236,11 +237,11 @@ export class ProcessManager {
         const registry = LlmProviderRegistry.getInstance();
         let provider = providerType ? registry.get(providerType) : undefined;
 
-        // Auto-fallback: no explicit provider + no Anthropic API key → try Ollama
-        if (!provider && !providerType && !process.env.ANTHROPIC_API_KEY) {
+        // Auto-fallback: no explicit provider + no Claude access → try Ollama
+        if (!provider && !providerType && !hasClaudeAccess()) {
             const ollamaFallback = registry.get('ollama');
             if (ollamaFallback) {
-                log.info(`No ANTHROPIC_API_KEY — falling back to Ollama for session ${session.id}`);
+                log.info(`No Claude access — falling back to Ollama for session ${session.id}`);
                 provider = ollamaFallback;
                 // Clear agent's non-Ollama model so direct-process uses the Ollama default
                 if (effectiveAgent && effectiveAgent.model && !effectiveAgent.model.includes(':') && !effectiveAgent.model.startsWith('qwen') && !effectiveAgent.model.startsWith('llama')) {
@@ -488,11 +489,11 @@ export class ProcessManager {
         const registry = LlmProviderRegistry.getInstance();
         let providerInstance = providerType ? registry.get(providerType) : undefined;
 
-        // Auto-fallback: no explicit provider + no Anthropic API key → try Ollama
-        if (!providerInstance && !providerType && !process.env.ANTHROPIC_API_KEY) {
+        // Auto-fallback: no explicit provider + no Claude access → try Ollama
+        if (!providerInstance && !providerType && !hasClaudeAccess()) {
             const ollamaFallback = registry.get('ollama');
             if (ollamaFallback) {
-                log.info(`No ANTHROPIC_API_KEY — falling back to Ollama for resumed session ${session.id}`);
+                log.info(`No Claude access — falling back to Ollama for resumed session ${session.id}`);
                 providerInstance = ollamaFallback;
                 // Clear agent's non-Ollama model so direct-process uses the Ollama default
                 if (effectiveAgent && effectiveAgent.model && !effectiveAgent.model.includes(':') && !effectiveAgent.model.startsWith('qwen') && !effectiveAgent.model.startsWith('llama')) {

--- a/server/providers/registry.ts
+++ b/server/providers/registry.ts
@@ -1,4 +1,5 @@
 import type { LlmProvider, LlmProviderType } from './types';
+import { hasClaudeAccess } from './router';
 import { createLogger } from '../lib/logger';
 
 const log = createLogger('ProviderRegistry');
@@ -24,7 +25,7 @@ export class LlmProviderRegistry {
         let enabled: string[] | null = null;
         if (enabledRaw) {
             enabled = enabledRaw.split(',').map((s) => s.trim().toLowerCase());
-        } else if (!process.env.ANTHROPIC_API_KEY && !process.env.OPENAI_API_KEY) {
+        } else if (!hasClaudeAccess() && !process.env.OPENAI_API_KEY) {
             enabled = ['ollama'];
             if (!this.loggedLocalOnly) {
                 log.info('Running in local-only mode (Ollama) — no cloud API keys detected');


### PR DESCRIPTION
## Summary

- Add `hasClaudeAccess()` helper that detects either `ANTHROPIC_API_KEY` or the `claude` CLI (subscription auth via Agent SDK)
- Replace all direct API key checks so sessions use the SDK path instead of falling back to Ollama when a Claude subscription is available
- Update tests to control CLI detection cache for deterministic local-only scenarios

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — 1758 pass, 0 fail
- [ ] Manual: start corvid-agent without `ANTHROPIC_API_KEY` set, confirm sessions use SDK path (not Ollama fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)