### PR TITLE
Fix: Ollama slot weight leak on session kill

### DIFF
--- a/server/providers/types.ts
+++ b/server/providers/types.ts
@@ -65,7 +65,7 @@ export interface LlmProvider {
      * so the model stays loaded in memory (avoids KV cache eviction between
      * turns). No-op for providers without concurrency limits.
      */
-    acquireSlot?(model: string, signal?: AbortSignal, onStatus?: (msg: string) => void): Promise<void>;
+    acquireSlot?(model: string, signal?: AbortSignal, onStatus?: (msg: string) => void): Promise<boolean>;
 
     /** Release a previously acquired slot. */
     releaseSlot?(model: string): void;


### PR DESCRIPTION
## Summary

- **`acquireSlot` now returns `boolean`** — `true` if slot was acquired, `false` if aborted before acquiring. Fixes the race between `releaseWaiters()` and the abort handler by tracking whether the waiter was already popped from the queue.
- **Conditional `releaseSlot` in `direct-process.ts`** — both the early-abort path and the `finally` block now only release if the slot was actually acquired, preventing spurious decrements.
- **Safety clamp in `releaseSlot`** — `activeWeight` is clamped to 0 with a warning log if it would go negative, preventing permanent scheduling corruption.

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` passes (1758 tests, 0 failures)
- [ ] Manual: start corvid-agent, create multiple Ollama sessions, kill some, verify new sessions aren't stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)