### PR TITLE
Fix GitHub mention dedup race condition and improve Ollama reliability

### DIFF
--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,6 +1,6 @@
 import { Database } from 'bun:sqlite';
 
-const SCHEMA_VERSION = 49;
+const SCHEMA_VERSION = 50;
 
 const MIGRATIONS: Record<number, string[]> = {
     1: [
@@ -978,6 +978,9 @@ const MIGRATIONS: Record<number, string[]> = {
             updated_at  TEXT DEFAULT (datetime('now'))
         )`,
         `CREATE INDEX IF NOT EXISTS idx_mcp_server_configs_agent ON mcp_server_configs(agent_id)`,
+    ],
+    50: [
+        `ALTER TABLE owner_question_dispatches ADD COLUMN answered_at TEXT DEFAULT NULL`,
     ],
 };
 


### PR DESCRIPTION
## Summary

- **Fix duplicate "Answer received" comments**: Added `answered_at` column (migration 50) with atomic `markDispatchAnswered()` guard so only one poll cycle posts the acknowledgment comment and closes the issue
- **Expand session dedup**: Session guard now checks `running`, `idle`, and `completed` statuses (not just `running`) to prevent re-triggering for the same issue after session completion
- **Agent dedup instruction**: Agents are now told to check existing comments before posting, preventing duplicates on session restart
- **Truncate large tool results**: Ollama tool results exceeding 20K chars are truncated to prevent context overflow
- **Log stream parse failures**: Malformed Ollama stream lines are now logged instead of silently swallowed
- **Clamp fuzzy tool matching**: Reject fuzzy matches for tool names shorter than 3 chars and require minimum 4-char length for substring matching to avoid false positives

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — 1758 tests pass, 0 failures
- [ ] Manual: create a question dispatch, respond on GitHub, verify only one "Answer received" comment
- [ ] Manual: kill an Ollama session with a large tool result, verify no context overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)