### PR TITLE
Add skill bundle presets, project-level skills, and wire tool resolution

### DIFF
--- a/server/__tests__/skill-bundles.test.ts
+++ b/server/__tests__/skill-bundles.test.ts
@@ -2,10 +2,13 @@ import { test, expect, beforeEach, afterEach, describe } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { runMigrations } from '../db/schema';
 import { createAgent } from '../db/agents';
+import { createProject } from '../db/projects';
 import {
     listBundles, getBundle, createBundle, updateBundle, deleteBundle,
     getAgentBundles, assignBundle, unassignBundle,
     resolveAgentTools, resolveAgentPromptAdditions,
+    getProjectBundles, assignProjectBundle, unassignProjectBundle,
+    resolveProjectPromptAdditions, resolveProjectTools,
 } from '../db/skill-bundles';
 
 let db: Database;
@@ -21,15 +24,20 @@ afterEach(() => {
 });
 
 describe('Skill Bundle CRUD', () => {
-    test('list includes preset bundles', () => {
+    test('list includes all 9 preset bundles', () => {
         const bundles = listBundles(db);
-        expect(bundles.length).toBeGreaterThanOrEqual(5);
-        const names = bundles.map(b => b.name);
+        const presets = bundles.filter(b => b.preset);
+        expect(presets.length).toBe(9);
+        const names = presets.map(b => b.name);
         expect(names).toContain('Code Reviewer');
         expect(names).toContain('DevOps');
         expect(names).toContain('Researcher');
         expect(names).toContain('Communicator');
         expect(names).toContain('Analyst');
+        expect(names).toContain('Coder');
+        expect(names).toContain('GitHub Ops');
+        expect(names).toContain('Full Stack');
+        expect(names).toContain('Memory Manager');
     });
 
     test('preset bundles have correct fields', () => {
@@ -38,6 +46,28 @@ describe('Skill Bundle CRUD', () => {
         expect(reviewer!.preset).toBe(true);
         expect(reviewer!.tools.length).toBeGreaterThan(0);
         expect(reviewer!.promptAdditions).toBeTruthy();
+    });
+
+    test('new preset bundles have correct tools', () => {
+        const coder = getBundle(db, 'preset-coder');
+        expect(coder).not.toBeNull();
+        expect(coder!.tools).toEqual(['read_file', 'write_file', 'edit_file', 'run_command', 'list_files', 'search_files']);
+
+        const githubOps = getBundle(db, 'preset-github-ops');
+        expect(githubOps).not.toBeNull();
+        expect(githubOps!.tools).toContain('corvid_github_list_prs');
+        expect(githubOps!.tools).toContain('corvid_github_repo_info');
+
+        const fullStack = getBundle(db, 'preset-full-stack');
+        expect(fullStack).not.toBeNull();
+        expect(fullStack!.tools).toContain('read_file');
+        expect(fullStack!.tools).toContain('corvid_github_create_pr');
+        expect(fullStack!.tools).toContain('corvid_web_search');
+
+        const memMgr = getBundle(db, 'preset-memory-manager');
+        expect(memMgr).not.toBeNull();
+        expect(memMgr!.tools).toContain('corvid_save_memory');
+        expect(memMgr!.tools).toContain('corvid_deep_research');
     });
 
     test('create custom bundle', () => {
@@ -137,6 +167,91 @@ describe('Agent-Bundle Assignment', () => {
     });
 });
 
+describe('Project-Bundle Assignment', () => {
+    test('assign and get project bundles', () => {
+        const project = createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+        const bundle = createBundle(db, { name: 'Test' });
+
+        const assigned = assignProjectBundle(db, project.id, bundle.id);
+        expect(assigned).toBe(true);
+
+        const bundles = getProjectBundles(db, project.id);
+        expect(bundles).toHaveLength(1);
+        expect(bundles[0].id).toBe(bundle.id);
+    });
+
+    test('assign multiple bundles with sort order', () => {
+        const project = createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+        const b1 = createBundle(db, { name: 'Bundle A' });
+        const b2 = createBundle(db, { name: 'Bundle B' });
+
+        assignProjectBundle(db, project.id, b1.id, 1);
+        assignProjectBundle(db, project.id, b2.id, 0);
+
+        const bundles = getProjectBundles(db, project.id);
+        expect(bundles).toHaveLength(2);
+        expect(bundles[0].name).toBe('Bundle B');
+        expect(bundles[1].name).toBe('Bundle A');
+    });
+
+    test('assign preset bundle to project', () => {
+        const project = createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+        const assigned = assignProjectBundle(db, project.id, 'preset-coder');
+        expect(assigned).toBe(true);
+
+        const bundles = getProjectBundles(db, project.id);
+        expect(bundles).toHaveLength(1);
+        expect(bundles[0].name).toBe('Coder');
+    });
+
+    test('unassign bundle from project', () => {
+        const project = createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+        const bundle = createBundle(db, { name: 'Test' });
+        assignProjectBundle(db, project.id, bundle.id);
+
+        const removed = unassignProjectBundle(db, project.id, bundle.id);
+        expect(removed).toBe(true);
+        expect(getProjectBundles(db, project.id)).toHaveLength(0);
+    });
+
+    test('unassign non-existent returns false', () => {
+        const project = createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+        const removed = unassignProjectBundle(db, project.id, 'nonexistent');
+        expect(removed).toBe(false);
+    });
+
+    test('assign non-existent bundle to project returns false', () => {
+        const project = createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+        const assigned = assignProjectBundle(db, project.id, 'nonexistent');
+        expect(assigned).toBe(false);
+    });
+
+    test('cascade delete: removing project deletes assignments', () => {
+        const project = createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+        assignProjectBundle(db, project.id, 'preset-coder');
+        assignProjectBundle(db, project.id, 'preset-github-ops');
+
+        // Delete the project
+        db.query('DELETE FROM projects WHERE id = ?').run(project.id);
+
+        // Verify assignments are gone
+        const rows = db.query('SELECT * FROM project_skills WHERE project_id = ?').all(project.id);
+        expect(rows).toHaveLength(0);
+    });
+
+    test('cascade delete: removing bundle deletes assignments', () => {
+        const project = createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+        const bundle = createBundle(db, { name: 'Custom' });
+        assignProjectBundle(db, project.id, bundle.id);
+
+        // Delete the bundle
+        db.query('DELETE FROM skill_bundles WHERE id = ?').run(bundle.id);
+
+        const bundles = getProjectBundles(db, project.id);
+        expect(bundles).toHaveLength(0);
+    });
+});
+
 describe('Tool and Prompt Resolution', () => {
     test('resolveAgentTools with no bundles returns base', () => {
         const agent = createAgent(db, { name: 'TestAgent' });
@@ -164,6 +279,21 @@ describe('Tool and Prompt Resolution', () => {
         expect(result).toEqual(['corvid_web_search']);
     });
 
+    test('resolveAgentTools deduplicates overlapping tools', () => {
+        const agent = createAgent(db, { name: 'TestAgent' });
+        const b1 = createBundle(db, { name: 'B1', tools: ['read_file', 'write_file'] });
+        const b2 = createBundle(db, { name: 'B2', tools: ['read_file', 'edit_file'] });
+        assignBundle(db, agent.id, b1.id, 0);
+        assignBundle(db, agent.id, b2.id, 1);
+
+        const result = resolveAgentTools(db, agent.id, ['read_file']);
+        // read_file appears in base + both bundles but should only appear once
+        const readCount = result!.filter(t => t === 'read_file').length;
+        expect(readCount).toBe(1);
+        expect(result).toContain('write_file');
+        expect(result).toContain('edit_file');
+    });
+
     test('resolveAgentPromptAdditions with no bundles returns empty', () => {
         const agent = createAgent(db, { name: 'TestAgent' });
         const result = resolveAgentPromptAdditions(db, agent.id);
@@ -180,5 +310,72 @@ describe('Tool and Prompt Resolution', () => {
         const result = resolveAgentPromptAdditions(db, agent.id);
         expect(result).toContain('Be concise.');
         expect(result).toContain('Be thorough.');
+    });
+});
+
+describe('Project Tool and Prompt Resolution', () => {
+    test('resolveProjectTools with no bundles returns base', () => {
+        const project = createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+        const result = resolveProjectTools(db, project.id, ['corvid_send_message']);
+        expect(result).toEqual(['corvid_send_message']);
+    });
+
+    test('resolveProjectTools merges bundle tools', () => {
+        const project = createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+        assignProjectBundle(db, project.id, 'preset-coder');
+
+        const result = resolveProjectTools(db, project.id, ['corvid_send_message']);
+        expect(result).toContain('corvid_send_message');
+        expect(result).toContain('read_file');
+        expect(result).toContain('write_file');
+        expect(result).toContain('edit_file');
+        expect(result).toContain('run_command');
+    });
+
+    test('resolveProjectTools with null base returns bundle tools', () => {
+        const project = createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+        assignProjectBundle(db, project.id, 'preset-coder');
+
+        const result = resolveProjectTools(db, project.id, null);
+        expect(result).toContain('read_file');
+        expect(result).toContain('write_file');
+        expect(result!.length).toBe(6); // Coder has exactly 6 tools
+    });
+
+    test('resolveProjectPromptAdditions with no bundles returns empty', () => {
+        const project = createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+        const result = resolveProjectPromptAdditions(db, project.id);
+        expect(result).toBe('');
+    });
+
+    test('resolveProjectPromptAdditions concatenates bundle prompts', () => {
+        const project = createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+        assignProjectBundle(db, project.id, 'preset-coder', 0);
+        assignProjectBundle(db, project.id, 'preset-github-ops', 1);
+
+        const result = resolveProjectPromptAdditions(db, project.id);
+        expect(result).toContain('expert coder');
+        expect(result).toContain('GitHub operations');
+    });
+
+    test('agent + project tools merge together', () => {
+        const agent = createAgent(db, { name: 'TestAgent' });
+        const project = createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+
+        // Agent has GitHub Ops skills
+        assignBundle(db, agent.id, 'preset-github-ops');
+        // Project has Coder skills
+        assignProjectBundle(db, project.id, 'preset-coder');
+
+        // Resolve agent tools first
+        const agentTools = resolveAgentTools(db, agent.id, null);
+        expect(agentTools).toContain('corvid_github_list_prs');
+        expect(agentTools).not.toContain('read_file');
+
+        // Then merge project tools on top
+        const merged = resolveProjectTools(db, project.id, agentTools);
+        expect(merged).toContain('corvid_github_list_prs'); // from agent
+        expect(merged).toContain('read_file'); // from project
+        expect(merged).toContain('edit_file'); // from project
     });
 });

--- a/server/mcp/sdk-tools.ts
+++ b/server/mcp/sdk-tools.ts
@@ -450,8 +450,10 @@ export function createCorvidMcpServer(ctx: McpToolContext, pluginTools?: ReturnT
     // remote sessions (algochat, agent-to-agent) where untrusted input is possible.
     let filteredTools = tools;
     if (ctx.sessionSource !== 'web') {
-        const agent = getAgent(ctx.db, ctx.agentId);
-        const permissions = agent?.mcpToolPermissions;
+        // Prefer pre-resolved permissions (includes skill bundle merging)
+        const permissions = ctx.resolvedToolPermissions !== undefined
+            ? ctx.resolvedToolPermissions
+            : getAgent(ctx.db, ctx.agentId)?.mcpToolPermissions ?? null;
         const allowedSet = permissions ? new Set(permissions) : DEFAULT_ALLOWED_TOOLS;
         filteredTools = tools.filter((t) => allowedSet.has(t.name));
     }

--- a/server/mcp/tool-handlers.ts
+++ b/server/mcp/tool-handlers.ts
@@ -106,6 +106,9 @@ export interface McpToolContext {
     reputationAttestation?: ReputationAttestation;
     /** Reputation verifier for scanning remote agent attestations. */
     reputationVerifier?: ReputationVerifier;
+    /** Pre-resolved tool permissions (agent base + skill bundle tools + project bundle tools).
+     *  When set, used instead of reading agent.mcpToolPermissions directly. */
+    resolvedToolPermissions?: string[] | null;
 }
 
 function textResult(text: string): CallToolResult {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -753,6 +753,13 @@ export interface AgentSkillAssignment {
     sortOrder: number;
 }
 
+export interface ProjectSkillAssignment {
+    projectId: string;
+    bundleId: string;
+    sortOrder: number;
+    createdAt: string;
+}
+
 // MARK: - A2A Protocol (Agent-to-Agent Agent Card)
 
 export interface A2AAgentProvider {


### PR DESCRIPTION
## Summary
- Add 4 new preset skill bundles: **Coder**, **GitHub Ops**, **Full Stack**, **Memory Manager** — covering coding tools and GitHub operations that existing presets didn't include
- Add **project-level skill assignments** (`project_skills` table, migration 51) so all agents in a project can inherit shared skills
- **Wire `resolveAgentTools` into MCP tool filtering** — bundle tools now actually affect which tools agents can use (was defined but never called in production)
- **Fix resume bug**: `resumeProcess()` was missing persona and skill prompt resolution, so resumed sessions lost their skill instructions
- Expand skill bundle test suite from 13 → 33 tests

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — 1774 tests pass, 0 failures (16 new tests)
- [x] Skill bundle tests specifically: 33 pass covering CRUD, project assignment, cascade deletes, tool/prompt resolution, agent+project merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)