### PR TITLE
Fix: skip project bundle tool merging for explicitly scoped agents

### DIFF
--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -208,11 +208,13 @@ export class ProcessManager {
         const agent = getAgent(this.db, agentId);
         const basePermissions = agent?.mcpToolPermissions ?? null;
 
-        // Merge agent-level skill bundle tools
+        // Merge agent-level skill bundle tools (explicitly assigned by owner)
         let merged = resolveAgentTools(this.db, agentId, basePermissions);
 
-        // Merge project-level skill bundle tools
-        if (projectId) {
+        // Merge project-level skill bundle tools ONLY if agent has no explicit tool permissions.
+        // Agents with explicit mcp_tool_permissions have been deliberately scoped — project bundles
+        // contribute prompt additions but should not expand the tool set.
+        if (projectId && basePermissions === null) {
             merged = resolveProjectTools(this.db, projectId, merged);
         }
 


### PR DESCRIPTION
## Summary
- Project-level skill bundles no longer expand tool permissions for agents with explicit `mcp_tool_permissions` — prompt additions still apply, but tools are not merged
- Unassigned `preset-github-ops` from Qwen DevOps and Qwen Reviewer since their role-specific bundles already include the GitHub tools they need

This fixes 8B Ollama agents exceeding the ~12 tool threshold where small models start hallucinating tool names and confusing parameters.

**Before/after effective tool counts:**
| Agent | Before | After |
|---|---|---|
| Qwen DevOps (8B) | 20 | 11 |
| Qwen Reviewer (8B) | 18 | 11 |
| Qwen Architect (8B) | 16 | 13 |
| Qwen Coder 14B | 20 | 20 (unchanged) |

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — 1774 tests pass, 0 failures
- [x] Verified effective tool counts for all 5 Ollama agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)