### PR TITLE
Sprint 1: Ollama reliability + AST code navigation tools

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -307,7 +307,7 @@ async function initAlgoChat(): Promise<void> {
         serverMnemonic: algochatConfig.mnemonic,
         network: agentNetworkConfig.network,
     }, workTaskService, schedulerService, workflowService, notificationService, questionDispatcher,
-    reputationScorer, reputationAttestation, reputationVerifier);
+    reputationScorer, reputationAttestation, reputationVerifier, astParserService);
 
     // Forward AlgoChat events to WebSocket clients
     algochatBridge.onEvent((participant, content, direction) => {

--- a/server/mcp/tool-handlers.ts
+++ b/server/mcp/tool-handlers.ts
@@ -11,6 +11,8 @@ import type { QuestionDispatcher } from '../notifications/question-dispatcher';
 import type { ReputationScorer } from '../reputation/scorer';
 import type { ReputationAttestation } from '../reputation/attestation';
 import type { ReputationVerifier } from '../reputation/verifier';
+import type { AstParserService } from '../ast/service';
+import type { AstSymbolKind } from '../ast/types';
 import { getRecentSnapshots, computeTrends, formatTrendsForPrompt } from '../improvement/health-store';
 import { invokeRemoteAgent } from '../a2a/client';
 import {
@@ -20,6 +22,8 @@ import {
     deleteChannel,
     getChannelByAgentAndType,
 } from '../db/notifications';
+import { getAgent } from '../db/agents';
+import { getProject } from '../db/projects';
 import { listSchedules, createSchedule, updateSchedule, listExecutions } from '../db/schedules';
 import { listWorkflows, createWorkflow, updateWorkflow, getWorkflow, listWorkflowRuns, getWorkflowRun } from '../db/workflows';
 import { validateScheduleFrequency } from '../scheduler/service';
@@ -109,6 +113,8 @@ export interface McpToolContext {
     /** Pre-resolved tool permissions (agent base + skill bundle tools + project bundle tools).
      *  When set, used instead of reading agent.mcpToolPermissions directly. */
     resolvedToolPermissions?: string[] | null;
+    /** AST parser service for structural code navigation (corvid_code_symbols, corvid_find_references). */
+    astParserService?: AstParserService;
 }
 
 function textResult(text: string): CallToolResult {
@@ -1482,5 +1488,146 @@ export async function handleInvokeRemoteAgent(
         const message = err instanceof Error ? err.message : String(err);
         log.error('MCP invoke_remote_agent failed', { error: message });
         return errorResult(`Failed to invoke remote agent: ${message}`);
+    }
+}
+
+// ─── AST / Code navigation handlers ──────────────────────────────────────
+
+/** Resolve the project directory for AST tools: explicit arg → agent's default project. */
+function resolveProjectDir(ctx: McpToolContext, explicitDir?: string): string | null {
+    if (explicitDir?.trim()) return explicitDir;
+    const agent = getAgent(ctx.db, ctx.agentId);
+    const projectId = agent?.defaultProjectId;
+    if (!projectId) return null;
+    const project = getProject(ctx.db, projectId);
+    return project?.workingDir ?? null;
+}
+
+export async function handleCodeSymbols(
+    ctx: McpToolContext,
+    args: { project_dir?: string; query: string; kinds?: string[]; limit?: number },
+): Promise<CallToolResult> {
+    if (!ctx.astParserService) {
+        return errorResult('AST parser service is not available.');
+    }
+
+    if (!args.query?.trim()) {
+        return errorResult('A search query is required.');
+    }
+
+    const projectDir = resolveProjectDir(ctx, args.project_dir);
+    if (!projectDir) {
+        return errorResult('Could not resolve project directory. Provide project_dir or ensure the agent has a default project.');
+    }
+
+    try {
+        // Ensure the project is indexed (uses cache if already indexed)
+        if (!ctx.astParserService.getProjectIndex(projectDir)) {
+            ctx.emitStatus?.('Indexing project symbols...');
+            await ctx.astParserService.indexProject(projectDir);
+        }
+
+        const validKinds = args.kinds?.filter(
+            (k): k is AstSymbolKind => ['function', 'class', 'interface', 'type_alias', 'enum', 'import', 'export', 'variable', 'method'].includes(k),
+        );
+
+        const results = ctx.astParserService.searchSymbols(projectDir, args.query, {
+            kinds: validKinds?.length ? validKinds : undefined,
+            limit: args.limit ?? 50,
+        });
+
+        if (results.length === 0) {
+            return textResult(`No symbols matching "${args.query}" found in ${projectDir}.`);
+        }
+
+        const lines = results.map((s) => {
+            const exported = s.isExported ? 'export ' : '';
+            const children = s.children?.length ? ` (${s.children.length} members)` : '';
+            return `${exported}${s.kind} ${s.name} [lines ${s.startLine}-${s.endLine}]${children}`;
+        });
+
+        return textResult(`Found ${results.length} symbol(s) matching "${args.query}":\n\n${lines.join('\n')}`);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.error('MCP code_symbols failed', { error: message });
+        return errorResult(`Failed to search code symbols: ${message}`);
+    }
+}
+
+export async function handleFindReferences(
+    ctx: McpToolContext,
+    args: { project_dir?: string; symbol_name: string; limit?: number },
+): Promise<CallToolResult> {
+    if (!ctx.astParserService) {
+        return errorResult('AST parser service is not available.');
+    }
+
+    if (!args.symbol_name?.trim()) {
+        return errorResult('A symbol_name is required.');
+    }
+
+    const projectDir = resolveProjectDir(ctx, args.project_dir);
+    if (!projectDir) {
+        return errorResult('Could not resolve project directory. Provide project_dir or ensure the agent has a default project.');
+    }
+
+    try {
+        // Index project for definition lookup
+        if (!ctx.astParserService.getProjectIndex(projectDir)) {
+            ctx.emitStatus?.('Indexing project symbols...');
+            await ctx.astParserService.indexProject(projectDir);
+        }
+
+        // Find definitions via AST
+        const definitions = ctx.astParserService.searchSymbols(projectDir, args.symbol_name, { limit: 10 });
+        const exactDefs = definitions.filter((s) => s.name === args.symbol_name);
+
+        // Find references via grep (text search across all TS/JS files)
+        ctx.emitStatus?.(`Searching for references to "${args.symbol_name}"...`);
+        const maxResults = args.limit ?? 50;
+
+        const grepProc = Bun.spawn([
+            'grep', '-rn', '--include=*.ts', '--include=*.tsx', '--include=*.js', '--include=*.jsx',
+            '--exclude-dir=node_modules', '--exclude-dir=dist', '--exclude-dir=.git',
+            '-w', args.symbol_name, projectDir,
+        ], { stdout: 'pipe', stderr: 'pipe' });
+
+        const grepStdout = await new Response(grepProc.stdout).text();
+        await grepProc.exited;
+
+        const referenceLines = grepStdout.trim().split('\n').filter(Boolean);
+        const truncated = referenceLines.length > maxResults;
+        const displayLines = referenceLines.slice(0, maxResults);
+
+        // Format output
+        const sections: string[] = [];
+
+        if (exactDefs.length > 0) {
+            const defLines = exactDefs.map((s) => {
+                const exported = s.isExported ? 'export ' : '';
+                return `  ${exported}${s.kind} ${s.name} [lines ${s.startLine}-${s.endLine}]`;
+            });
+            sections.push(`Definitions (${exactDefs.length}):\n${defLines.join('\n')}`);
+        } else {
+            sections.push(`No AST definition found for "${args.symbol_name}" (may be an external import).`);
+        }
+
+        if (displayLines.length > 0) {
+            // Strip project dir prefix for readability
+            const shortLines = displayLines.map((line) =>
+                line.startsWith(projectDir) ? line.slice(projectDir.length + 1) : line,
+            );
+            sections.push(
+                `References (${referenceLines.length}${truncated ? `, showing first ${maxResults}` : ''}):\n${shortLines.join('\n')}`,
+            );
+        } else {
+            sections.push(`No text references found for "${args.symbol_name}".`);
+        }
+
+        return textResult(sections.join('\n\n'));
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.error('MCP find_references failed', { error: message });
+        return errorResult(`Failed to find references: ${message}`);
     }
 }

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -24,6 +24,7 @@ import type { QuestionDispatcher } from '../notifications/question-dispatcher';
 import type { ReputationScorer } from '../reputation/scorer';
 import type { ReputationAttestation } from '../reputation/attestation';
 import type { ReputationVerifier } from '../reputation/verifier';
+import type { AstParserService } from '../ast/service';
 import { createCorvidMcpServer } from '../mcp/sdk-tools';
 import type { McpToolContext } from '../mcp/tool-handlers';
 import { recordApiCost } from '../db/spending';
@@ -113,6 +114,7 @@ export class ProcessManager {
     private mcpReputationScorer: ReputationScorer | null = null;
     private mcpReputationAttestation: ReputationAttestation | null = null;
     private mcpReputationVerifier: ReputationVerifier | null = null;
+    private mcpAstParserService: AstParserService | null = null;
 
     constructor(db: Database) {
         this.db = db;
@@ -150,6 +152,7 @@ export class ProcessManager {
         reputationScorer?: ReputationScorer,
         reputationAttestation?: ReputationAttestation,
         reputationVerifier?: ReputationVerifier,
+        astParserService?: AstParserService,
     ): void {
         this.mcpMessenger = messenger;
         this.mcpDirectory = directory;
@@ -163,6 +166,7 @@ export class ProcessManager {
         this.mcpReputationScorer = reputationScorer ?? null;
         this.mcpReputationAttestation = reputationAttestation ?? null;
         this.mcpReputationVerifier = reputationVerifier ?? null;
+        this.mcpAstParserService = astParserService ?? null;
         log.info('MCP services registered — agent sessions will receive corvid_* tools');
     }
 
@@ -200,6 +204,7 @@ export class ProcessManager {
             reputationAttestation: this.mcpReputationAttestation ?? undefined,
             reputationVerifier: this.mcpReputationVerifier ?? undefined,
             resolvedToolPermissions,
+            astParserService: this.mcpAstParserService ?? undefined,
         };
     }
 


### PR DESCRIPTION
## Summary
- **#182** — Service-level PR creation fallback: when Ollama agents complete work tasks but fail to output a PR URL, `WorkTaskService` now pushes the branch and runs `gh pr create` itself
- **#181** — Final summary epilogue: after tool loop breaks abnormally (repeat detection, max iterations), runs one last inference call with tools disabled to produce a coherent text summary
- **#139** — `corvid_code_symbols` MCP tool: AST-based symbol search via `AstParserService.searchSymbols()`, registered in both SDK and direct (Ollama) tool paths
- **#140** — `corvid_find_references` MCP tool: combines AST definition lookup with grep-based text search for cross-project reference finding
- Plumbs `AstParserService` through `McpToolContext` → `ProcessManager` → `index.ts`

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` passes (1774 tests, 0 failures)
- [x] `bun run spec:check` passes (11 specs, 0 failures)
- [ ] Create a work task for Ollama agent → PR created automatically via fallback
- [ ] Run 3-tool AlgoChat session → final text summary produced after tool chain
- [ ] Agent calls `corvid_code_symbols` → returns real symbol data
- [ ] Agent calls `corvid_find_references` → returns definitions + references

🤖 Generated with [Claude Code](https://claude.com/claude-code)