### PR TITLE
Sprint 2: WebSocket auth + AST work task repo maps (#156, #141)

### DIFF
--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -1,4 +1,5 @@
 export type ClientMessage =
+    | { type: 'auth'; key: string }
     | { type: 'subscribe'; sessionId: string }
     | { type: 'unsubscribe'; sessionId: string }
     | { type: 'send_message'; sessionId: string; content: string }
@@ -45,6 +46,8 @@ export function isClientMessage(data: unknown): data is ClientMessage {
     if (typeof msg.type !== 'string') return false;
 
     switch (msg.type) {
+        case 'auth':
+            return typeof msg.key === 'string';
         case 'subscribe':
         case 'unsubscribe':
             return typeof msg.sessionId === 'string';


### PR DESCRIPTION
## Summary
- **#156 WebSocket authentication**: Add first-message auth (`{ type: "auth", key: "<key>" }`) for clients that can't set headers/query params. All WS messages gated behind auth when `API_KEY` is configured. Unauthenticated connections are upgraded but held in pending state until auth completes. Invalid keys close the connection with code 4001.
- **#141 AST integration into work tasks**: `WorkTaskService` now generates a lightweight repo map (exported symbols per file) via `AstParserService` and includes it in the agent's initial work prompt, giving agents structural codebase awareness before they start exploring.

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 1783 tests pass (9 new auth tests added)
- [x] `bun run spec:check` — 11 specs pass
- [ ] Manual: connect WS without auth → verify messages are rejected
- [ ] Manual: send `{ type: "auth", key: "<valid>" }` → verify auth succeeds and topics are subscribed
- [ ] Manual: create work task → verify repo map appears in agent prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)