### PR TITLE
Fix spec drift across 7 spec files (#190)

### DIFF
--- a/specs/algochat/bridge.spec.md
+++ b/specs/algochat/bridge.spec.md
@@ -154,7 +154,7 @@ Central orchestrator for the AlgoChat on-chain messaging system. Bridges Algoran
 |--------|-------------|
 | `server/index.ts` | Lifecycle: construction, `start()`, `stop()`, service wiring |
 | `server/ws/handler.ts` | `onEvent`, `offEvent` for WebSocket event forwarding |
-| `server/routes/algochat.ts` | All PSK contact methods, `getStatus`, `handleLocalMessage` |
+| `server/routes/index.ts` | All PSK contact methods, `getStatus`, `handleLocalMessage` (inline AlgoChat routes) |
 
 ## Change Log
 

--- a/specs/client/sidebar-navigation.spec.md
+++ b/specs/client/sidebar-navigation.spec.md
@@ -1,0 +1,81 @@
+---
+module: sidebar-navigation
+version: 1
+status: active
+files:
+  - client/src/app/shared/components/sidebar.component.ts
+  - client/src/app/app.routes.ts
+db_tables: []
+depends_on: []
+---
+
+# Sidebar Navigation
+
+## Purpose
+
+Provides the main navigation sidebar for the web client. The `SidebarComponent` renders navigation links to all top-level routes, supports responsive mobile overlay mode, and persists a collapsed/expanded state in localStorage. The `routes` array defines all lazy-loaded Angular routes for the application.
+
+## Public API
+
+### Exported Classes
+
+| Class | Description |
+|-------|-------------|
+| `SidebarComponent` | Angular component rendering the main navigation sidebar with responsive collapse and mobile overlay |
+
+### Exported Variables
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `routes` | `Routes` | Angular route configuration array defining all application routes with lazy-loaded components |
+
+## Invariants
+
+1. **Sidebar closes on navigation**: Route changes (NavigationEnd events) automatically close the mobile sidebar overlay
+2. **Collapsed state persistence**: The collapsed/expanded state is persisted in `localStorage` under key `sidebar_collapsed`
+3. **Mobile overlay**: Below 768px viewport width, the sidebar renders as a slide-out overlay with backdrop, ignoring collapsed state
+4. **Escape key closes sidebar**: Pressing Escape closes the sidebar overlay when open
+5. **Route lazy loading**: All routes use `loadComponent` with dynamic imports for code splitting
+
+## Behavioral Examples
+
+### Scenario: Toggle sidebar collapse on desktop
+
+- **Given** the sidebar is expanded on desktop
+- **When** the collapse button is clicked
+- **Then** the sidebar width shrinks to 48px, labels are replaced with abbreviations, and `localStorage` stores `sidebar_collapsed = 'true'`
+
+### Scenario: Mobile sidebar open and navigate
+
+- **Given** the sidebar is open on a mobile viewport
+- **When** a navigation link is clicked
+- **Then** the route changes and the sidebar closes automatically
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| `localStorage` unavailable | Collapsed state defaults to `false` (expanded) |
+| Route not matched | Angular default behavior (no component loaded) |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| `@angular/core` | `Component`, `ChangeDetectionStrategy`, `model`, `signal`, `inject`, `viewChild` |
+| `@angular/router` | `Router`, `RouterLink`, `RouterLinkActive`, `NavigationEnd`, `Routes` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| `client/src/app/app.ts` | `SidebarComponent` used in the root App template |
+| `client/src/app/app.config.ts` | `routes` imported for Angular router configuration |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-20 | corvid-agent | Initial spec |

--- a/specs/db/credits.spec.md
+++ b/specs/db/credits.spec.md
@@ -128,7 +128,8 @@ This module must be correct -- bugs mean real money lost. All balance mutations 
 |--------|-------------|
 | `server/process/manager.ts` | `deductTurnCredits`, `getCreditConfig`, `getParticipantForSession` |
 | `server/algochat/bridge.ts` | `getBalance`, `purchaseCredits`, `maybeGrantFirstTimeCredits`, `canStartSession`, `deductAgentMessageCredits` |
-| `server/routes/credits.ts` | All query functions |
+| `server/routes/settings.ts` | Credit config read/write via `/api/settings/credits` |
+| `server/routes/system-logs.ts` | Credit transaction history via `/api/system-logs/credit-transactions` |
 | `server/mcp/tool-handlers.ts` | `grantCredits`, `updateCreditConfig`, `getBalance` |
 
 ## Database Tables

--- a/specs/db/sessions.spec.md
+++ b/specs/db/sessions.spec.md
@@ -44,6 +44,7 @@ No business logic lives here -- just SQL queries with row-to-domain mapping.
 | `updateConversationRound` | `(db: Database, id: string, lastRound: number)` | `void` | Update the last-seen Algorand round |
 | `updateConversationSession` | `(db: Database, id: string, sessionId: string)` | `void` | Link a conversation to a session |
 | `updateConversationAgent` | `(db: Database, id: string, agentId: string, sessionId: string)` | `void` | Update both agent and session for a conversation |
+| `listPollingActivity` | `(db: Database, repo: string, limit?: number)` | `Session[]` | List sessions related to a repo for polling activity display. Default limit 25 |
 | `getParticipantForSession` | `(db: Database, sessionId: string)` | `string \| null` | Reverse lookup: get wallet address for a session via conversations |
 
 ## Invariants
@@ -119,7 +120,7 @@ No business logic lives here -- just SQL queries with row-to-domain mapping.
 | Column | Type | Constraints | Description |
 |--------|------|-------------|-------------|
 | id | TEXT | PRIMARY KEY | UUID |
-| project_id | TEXT | NOT NULL, FK projects(id) | Owning project |
+| project_id | TEXT | FK projects(id), nullable | Owning project |
 | agent_id | TEXT | FK agents(id), nullable | Assigned agent |
 | name | TEXT | DEFAULT '' | Display name |
 | status | TEXT | DEFAULT 'idle' | idle/running/stopped/error/paused |

--- a/specs/mcp/tool-handlers.spec.md
+++ b/specs/mcp/tool-handlers.spec.md
@@ -63,6 +63,8 @@ Implements every `corvid_*` MCP tool handler. Each exported function takes an `M
 | `handlePublishAttestation` | `(ctx, {})` | `Promise<CallToolResult>` | Compute and publish on-chain reputation attestation |
 | `handleVerifyAgentReputation` | `(ctx, { agent_url })` | `Promise<CallToolResult>` | Verify a remote agent's reputation attestation |
 | `handleInvokeRemoteAgent` | `(ctx, { agent_url, message })` | `Promise<CallToolResult>` | Invoke a remote agent via A2A protocol |
+| `handleCodeSymbols` | `(ctx, { project_id?, path?, query? })` | `Promise<CallToolResult>` | Search code symbols (functions, classes, types) in a project using AST parsing |
+| `handleFindReferences` | `(ctx, { project_id?, symbol, path? })` | `Promise<CallToolResult>` | Find references to a symbol across project files using AST parsing |
 
 ## Invariants
 

--- a/specs/process/process-manager.spec.md
+++ b/specs/process/process-manager.spec.md
@@ -18,7 +18,7 @@ depends_on:
 
 Central orchestration hub for agent session lifecycles. Manages starting, stopping, resuming, and monitoring Claude agent processes. Integrates every subsystem: persona/skill prompt injection, MCP tool resolution, credit deduction, provider routing (SDK vs direct, Claude vs Ollama), approval workflows, timeout management, auto-restart for AlgoChat sessions, and API outage recovery.
 
-This is the most complex module in the system (1253 lines). It is the single point through which all agent sessions are created and managed.
+This is the most complex module in the system (1258 lines). It is the single point through which all agent sessions are created and managed.
 
 ## Public API
 


### PR DESCRIPTION
## Summary
- **sessions.spec.md**: Fixed `project_id` constraint from `NOT NULL` to `nullable` per migration 48; added missing `listPollingActivity` to Public API table
- **sdk-tools.spec.md**: Updated `DEFAULT_ALLOWED_TOOLS` count from 31 to 35; updated handler count from 33 to 36; added invariant #7 for conditional tool registration (`corvid_create_work_task`, `corvid_code_symbols`, `corvid_find_references`)
- **tool-handlers.spec.md**: Added missing `handleCodeSymbols` and `handleFindReferences` exports (36 total handlers)
- **credits.spec.md**: Replaced nonexistent `server/routes/credits.ts` reference with actual consumers `server/routes/settings.ts` and `server/routes/system-logs.ts`
- **bridge.spec.md**: Replaced nonexistent `server/routes/algochat.ts` reference with `server/routes/index.ts` (inline AlgoChat routes)
- **process-manager.spec.md**: Updated line count from 1253 to 1258
- **sidebar-navigation.spec.md**: Created new spec with all required sections (Public API, Dependencies, Invariants, etc.)

## Test plan
- [x] `bun run spec:check` passes with 17/17 specs, 0 failures
- [x] `bunx tsc --noEmit --skipLibCheck` compiles cleanly
- [x] `bun test` — 2075 tests pass

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)