### PR TITLE
Add specs for 6 critical unspecced modules

### DIFF
--- a/specs/discord/bridge.spec.md
+++ b/specs/discord/bridge.spec.md
@@ -1,0 +1,155 @@
+---
+module: discord-bridge
+version: 1
+status: active
+files:
+  - server/discord/bridge.ts
+  - server/discord/types.ts
+db_tables: []
+depends_on: []
+---
+
+# Discord Bridge
+
+## Purpose
+
+Bidirectional Discord bridge using a raw WebSocket connection to the Discord Gateway (no discord.js dependency). Handles gateway lifecycle (identify, heartbeat, resume, reconnect), routes Discord messages to agent sessions, and sends responses back with 2000-character chunking.
+
+## Public API
+
+### Exported Classes
+
+| Class | Description |
+|-------|-------------|
+| `DiscordBridge` | Raw WebSocket Discord gateway client that routes messages to agent sessions |
+
+#### DiscordBridge Constructor
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `db` | `Database` | SQLite database handle |
+| `processManager` | `ProcessManager` | For starting sessions and subscribing to events |
+| `config` | `DiscordBridgeConfig` | Bot token, channel ID, allowed user IDs |
+
+#### DiscordBridge Methods
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `start` | `()` | `void` | Connect to Discord gateway and begin processing |
+| `stop` | `()` | `void` | Close WebSocket, stop heartbeat, set running=false |
+| `sendMessage` | `(channelId: string, content: string)` | `Promise<void>` | Send a message via Discord REST API, chunking at 2000 chars |
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+| `DiscordBridgeConfig` | `{ botToken: string; channelId: string; allowedUserIds: string[] }` |
+| `DiscordGatewayPayload` | `{ op: number; d: unknown; s: number \| null; t: string \| null }` |
+| `DiscordHelloData` | `{ heartbeat_interval: number }` |
+| `DiscordReadyData` | `{ session_id: string; resume_gateway_url: string }` |
+| `DiscordMessageData` | `{ id: string; channel_id: string; author: DiscordAuthor; content: string; timestamp: string }` |
+| `DiscordAuthor` | `{ id: string; username: string; bot?: boolean }` |
+| `GatewayOp` | Gateway opcode constants (DISPATCH=0, HEARTBEAT=1, IDENTIFY=2, RESUME=6, RECONNECT=7, INVALID_SESSION=9, HELLO=10, HEARTBEAT_ACK=11) |
+| `GatewayIntent` | Intent bit flags (GUILD_MESSAGES=1<<9, MESSAGE_CONTENT=1<<15) |
+
+## Invariants
+
+1. **Raw WebSocket (no discord.js)**: Uses the native `WebSocket` API directly against `wss://gateway.discord.gg/?v=10&encoding=json`
+2. **Hardcoded gateway URL (SSRF prevention)**: The `resume_gateway_url` from Discord's READY event is intentionally not stored or used. All connections go through the hardcoded gateway URL to prevent SSRF
+3. **Fixed heartbeat 41.25s**: The heartbeat interval is hardcoded at 41,250ms regardless of the server-provided value. Out-of-range values (< 10s or > 120s) are logged as warnings
+4. **Heartbeat ACK tracking**: If a heartbeat is not acknowledged before the next heartbeat interval, the connection is closed with code 4000 and a reconnect is scheduled
+5. **Exponential backoff reconnect (max 10 attempts)**: Reconnect delay is `min(1000 * 2^attempt, 60000)` ms. After 10 failed attempts, `running` is set to false and the bridge gives up
+6. **2000-character chunking**: Outbound messages are split into 2000-character chunks to respect Discord's message size limit
+7. **Per-user sessions**: Each Discord user maps to one active agent session. Sessions are reused across messages and cleared with `/new`
+8. **Response debounce 1500ms**: Agent responses are buffered and flushed after 1500ms of inactivity (or on session result)
+9. **Bot messages ignored**: Messages from bot users (`author.bot === true`) are silently ignored
+10. **Channel filtering**: Only messages in the configured `channelId` are processed
+11. **User auth via allowedUserIds**: If `config.allowedUserIds` is non-empty, only listed users may interact
+12. **Per-user rate limit 10/60s**: Each user is limited to 10 messages per 60-second window
+13. **Gateway session resume**: On reconnect, if a `sessionId` exists, the bridge sends a RESUME opcode; otherwise it re-IDENTIFYs
+14. **Invalid session handling**: Non-resumable invalid sessions clear the stored sessionId and wait 1-5s (random jitter) before re-identifying
+
+## Behavioral Examples
+
+### Scenario: Initial gateway connection
+
+- **Given** the bridge is started
+- **When** the WebSocket connects and receives HELLO (op 10)
+- **Then** heartbeating starts at 41.25s interval and an IDENTIFY payload is sent with bot token and intents
+
+### Scenario: Message from authorized user
+
+- **Given** user "123" sends "Hello" in the configured channel
+- **When** the MESSAGE_CREATE dispatch is received
+- **Then** a new agent session is created, the message is sent as initial prompt, and the bridge subscribes for responses
+
+### Scenario: Reconnect with exponential backoff
+
+- **Given** the WebSocket disconnects unexpectedly on attempt 3
+- **When** `scheduleReconnect` is called
+- **Then** reconnect is scheduled after `min(1000 * 2^3, 60000)` = 8000ms
+
+### Scenario: Max reconnect attempts exceeded
+
+- **Given** 10 reconnect attempts have been made
+- **When** the 11th disconnect occurs
+- **Then** `running` is set to false and no further reconnect is attempted
+
+### Scenario: Heartbeat timeout
+
+- **Given** a heartbeat was sent but not acknowledged
+- **When** the next heartbeat interval fires
+- **Then** the WebSocket is closed with code 4000 and reconnect is triggered
+
+### Scenario: Long response chunked
+
+- **Given** an agent produces a 3500-character response
+- **When** the response is flushed
+- **Then** two Discord messages are sent: one with 2000 characters and one with 1500 characters
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Unauthorized user | Sends "Unauthorized." in the channel |
+| Rate limit exceeded | Sends "Rate limit exceeded. Please wait before sending more messages." |
+| No agents configured | Sends "No agents configured. Create an agent first." |
+| No projects configured | Sends "No projects configured." |
+| Bot message received | Silently ignored |
+| Wrong channel | Silently ignored |
+| Gateway parse error | Logged, message ignored |
+| Discord REST API error | Logged (status + first 200 chars of error body) |
+| Max reconnect attempts | `running` set to false, bridge stops |
+| Heartbeat not ACKed | Connection closed (code 4000), reconnect scheduled |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| `server/process/manager.ts` | `ProcessManager` (startProcess, sendMessage, subscribe) |
+| `server/db/agents.ts` | `listAgents` |
+| `server/db/sessions.ts` | `createSession`, `getSession` |
+| `server/db/projects.ts` | `listProjects` |
+| `server/lib/logger.ts` | `createLogger` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| `server/index.ts` | `DiscordBridge` (initialized when `DISCORD_BOT_TOKEN` is set) |
+
+## Configuration
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `DISCORD_BOT_TOKEN` | (required) | Discord bot token |
+| `DISCORD_CHANNEL_ID` | (required) | Discord channel ID to operate in |
+| `DISCORD_ALLOWED_USERS` | `""` | Comma-separated Discord user IDs allowed to interact |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-20 | corvid-agent | Initial spec |

--- a/specs/middleware/auth.spec.md
+++ b/specs/middleware/auth.spec.md
@@ -1,0 +1,123 @@
+---
+module: auth
+version: 1
+status: active
+files:
+  - server/middleware/auth.ts
+db_tables: []
+depends_on: []
+---
+
+# Auth Middleware
+
+## Purpose
+
+HTTP and WebSocket authentication, CORS handling, and startup security validation. Ensures non-localhost deployments require an API key, validates credentials with timing-safe comparison, and manages CORS origin reflection.
+
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `loadAuthConfig` | `()` | `AuthConfig` | Reads `API_KEY`, `BIND_HOST`, `ALLOWED_ORIGINS` from env |
+| `validateStartupSecurity` | `(config: AuthConfig)` | `void` | Exits process if non-localhost without API_KEY |
+| `checkHttpAuth` | `(req: Request, url: URL, config: AuthConfig)` | `Response \| null` | Returns null if authenticated, 401/403 Response otherwise |
+| `checkWsAuth` | `(req: Request, url: URL, config: AuthConfig)` | `boolean` | Returns true if WebSocket upgrade is authenticated |
+| `buildCorsHeaders` | `(req: Request, config: AuthConfig)` | `Record<string, string>` | Builds CORS headers with origin reflection |
+| `applyCors` | `(response: Response, req: Request, config: AuthConfig)` | `void` | Sets CORS headers on an existing Response |
+| `timingSafeEqual` | `(a: string, b: string)` | `boolean` | Constant-time string comparison |
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+| `AuthConfig` | `{ apiKey: string \| null; allowedOrigins: string[]; bindHost: string }` |
+
+## Invariants
+
+1. **Non-localhost without API_KEY exits process**: `validateStartupSecurity` calls `process.exit(1)` if `BIND_HOST` is not `127.0.0.1`, `localhost`, or `::1` and no `API_KEY` is set
+2. **Timing-safe comparison**: All API key comparisons use `timingSafeEqual`, which pads to equal length and XORs every byte to prevent timing side-channels
+3. **Public path bypass**: `/api/health` and `/.well-known/agent-card.json` bypass HTTP authentication regardless of API key configuration
+4. **OPTIONS bypass**: HTTP OPTIONS requests bypass authentication (CORS preflight)
+5. **No-key mode**: When `apiKey` is null (localhost-only), `checkHttpAuth` returns null and `checkWsAuth` returns true for all requests
+6. **WebSocket auth via Bearer or query param**: `checkWsAuth` checks `Authorization: Bearer <key>` header first, then `?key=<key>` query parameter
+7. **CORS origin reflection with Vary**: When `allowedOrigins` is configured, the request origin is reflected if it matches the allowlist; `Vary: Origin` is set when the reflected origin is not `*`
+8. **Disallowed origin**: When `allowedOrigins` is set and the request origin is not in the list, `Access-Control-Allow-Origin` is set to empty string (browser blocks the response)
+
+## Behavioral Examples
+
+### Scenario: Non-localhost deployment without API_KEY
+
+- **Given** `BIND_HOST=0.0.0.0` and no `API_KEY` set
+- **When** `validateStartupSecurity` is called
+- **Then** the process exits with code 1
+
+### Scenario: Authenticated HTTP request
+
+- **Given** `API_KEY=my-secret-key`
+- **When** a POST request arrives with `Authorization: Bearer my-secret-key`
+- **Then** `checkHttpAuth` returns null (allowed)
+
+### Scenario: Missing auth header
+
+- **Given** `API_KEY=my-secret-key`
+- **When** a GET request arrives without an Authorization header
+- **Then** `checkHttpAuth` returns a 401 Response with `WWW-Authenticate: Bearer`
+
+### Scenario: Invalid API key
+
+- **Given** `API_KEY=my-secret-key`
+- **When** a request arrives with `Authorization: Bearer wrong-key`
+- **Then** `checkHttpAuth` returns a 403 Response
+
+### Scenario: WebSocket auth via query param
+
+- **Given** `API_KEY=my-secret-key`
+- **When** a WebSocket upgrade request arrives with `?key=my-secret-key`
+- **Then** `checkWsAuth` returns true
+
+### Scenario: CORS with allowed origins
+
+- **Given** `ALLOWED_ORIGINS=https://app.example.com`
+- **When** a request arrives with `Origin: https://app.example.com`
+- **Then** `buildCorsHeaders` returns `Access-Control-Allow-Origin: https://app.example.com` with `Vary: Origin`
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Non-localhost without API_KEY | `process.exit(1)` during startup |
+| Missing Authorization header | 401 with `WWW-Authenticate: Bearer` |
+| Malformed Authorization header | 401 with `WWW-Authenticate: Bearer` |
+| Invalid API key | 403 with `{ error: "Invalid API key" }` |
+| WebSocket with invalid/missing auth | Returns false, logs warning |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| `server/lib/logger.ts` | `createLogger` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| `server/index.ts` | `loadAuthConfig`, `validateStartupSecurity`, `checkHttpAuth`, `checkWsAuth`, `buildCorsHeaders`, `applyCors` |
+| `server/ws/handler.ts` | `AuthConfig`, `timingSafeEqual` |
+
+## Configuration
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `API_KEY` | `null` | API key for authentication. Null disables auth (localhost-only) |
+| `BIND_HOST` | `127.0.0.1` | Server bind address. Non-localhost requires API_KEY |
+| `ALLOWED_ORIGINS` | `""` (allow all) | Comma-separated list of allowed CORS origins |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-20 | corvid-agent | Initial spec |

--- a/specs/middleware/rate-limit.spec.md
+++ b/specs/middleware/rate-limit.spec.md
@@ -1,0 +1,116 @@
+---
+module: rate-limit
+version: 1
+status: active
+files:
+  - server/middleware/rate-limit.ts
+db_tables: []
+depends_on: []
+---
+
+# Rate Limit Middleware
+
+## Purpose
+
+Per-IP HTTP rate limiting using a sliding-window algorithm. Maintains separate read and mutation request buckets per IP address, returns 429 responses with `Retry-After` headers when limits are exceeded, and periodically sweeps stale entries to bound memory usage.
+
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `loadRateLimitConfig` | `()` | `RateLimitConfig` | Reads `RATE_LIMIT_GET` and `RATE_LIMIT_MUTATION` from env |
+| `checkRateLimit` | `(req: Request, url: URL, limiter: RateLimiter)` | `Response \| null` | Returns null if allowed, or a 429 Response |
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+| `RateLimitConfig` | `{ maxGet: number; maxMutation: number; windowMs: number }` |
+
+### Exported Classes
+
+| Class | Description |
+|-------|-------------|
+| `RateLimiter` | Per-IP sliding-window rate limiter with separate read/mutation buckets |
+
+#### RateLimiter Methods
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `check` | `(ip: string, method: string)` | `Response \| null` | Check if request is allowed; returns 429 if rate-limited |
+| `stop` | `()` | `void` | Stop the periodic sweep timer |
+| `reset` | `()` | `void` | Clear all tracked clients (for testing) |
+
+## Invariants
+
+1. **Separate read/mutation buckets**: GET/HEAD/OPTIONS requests count against the `read` bucket; POST/PUT/DELETE count against the `mutation` bucket. Each bucket is independently rate-limited per IP
+2. **Sliding window (1 minute)**: The window is fixed at 60,000ms. Expired timestamps are pruned on each `check()` call
+3. **Exempt paths**: `/api/health` and `/webhooks/github` bypass rate limiting entirely
+4. **WebSocket exempt**: Requests to `/ws` bypass rate limiting
+5. **5-minute sweep timer**: A periodic sweep runs every 5 minutes to remove IP entries with no activity within the window. The timer is `unref`'d so it does not keep the process alive
+6. **429 with Retry-After**: When a limit is exceeded, a JSON response with status 429 is returned, including a `Retry-After` header (in seconds, minimum 1)
+7. **IP from X-Forwarded-For**: Client IP is extracted from `X-Forwarded-For` (first IP), then `X-Real-IP`, falling back to `'unknown'`
+8. **Default limits**: Read defaults to 600/min, mutation defaults to 60/min. Invalid or non-positive env values fall back to 240 (read) and 60 (mutation)
+
+## Behavioral Examples
+
+### Scenario: Normal request within limits
+
+- **Given** a RateLimiter with default config (600 GET/min)
+- **When** IP `1.2.3.4` sends a GET request
+- **Then** `check` returns null (allowed) and records the timestamp
+
+### Scenario: Rate limit exceeded
+
+- **Given** a RateLimiter with `maxMutation=2`
+- **When** IP `1.2.3.4` sends 3 POST requests within 1 minute
+- **Then** the 3rd request returns a 429 Response with `Retry-After` header
+
+### Scenario: Exempt path bypasses limit
+
+- **Given** a fully exhausted rate limit for IP `1.2.3.4`
+- **When** a GET to `/api/health` arrives from that IP
+- **Then** `checkRateLimit` returns null (allowed)
+
+### Scenario: Sweep clears stale entries
+
+- **Given** IP `1.2.3.4` last sent a request 2 minutes ago
+- **When** the 5-minute sweep runs
+- **Then** the entry for `1.2.3.4` is removed from the client map
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Rate limit exceeded | 429 response with JSON `{ error, retryAfter }` and `Retry-After` header |
+| Invalid `RATE_LIMIT_GET` env var | Falls back to 240 |
+| Invalid `RATE_LIMIT_MUTATION` env var | Falls back to 60 |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| `server/lib/logger.ts` | `createLogger` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| `server/index.ts` | `loadRateLimitConfig`, `RateLimiter`, `checkRateLimit` |
+
+## Configuration
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `RATE_LIMIT_GET` | `600` | Max GET/HEAD/OPTIONS requests per minute per IP |
+| `RATE_LIMIT_MUTATION` | `60` | Max POST/PUT/DELETE requests per minute per IP |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-20 | corvid-agent | Initial spec |

--- a/specs/telegram/bridge.spec.md
+++ b/specs/telegram/bridge.spec.md
@@ -1,0 +1,146 @@
+---
+module: telegram-bridge
+version: 1
+status: active
+files:
+  - server/telegram/bridge.ts
+  - server/telegram/types.ts
+db_tables: []
+depends_on:
+  - specs/voice/voice.spec.md
+---
+
+# Telegram Bridge
+
+## Purpose
+
+Bidirectional Telegram bridge that routes Telegram messages to agent sessions and sends responses back. Supports voice messages via STT (Whisper), voice responses via TTS, per-user sessions, user authorization, rate limiting, and message chunking for Telegram's 4096-character limit.
+
+## Public API
+
+### Exported Classes
+
+| Class | Description |
+|-------|-------------|
+| `TelegramBridge` | Long-polling Telegram bot that routes messages to agent sessions |
+
+#### TelegramBridge Constructor
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `db` | `Database` | SQLite database handle |
+| `processManager` | `ProcessManager` | For starting sessions and subscribing to events |
+| `config` | `TelegramBridgeConfig` | Bot token, chat ID, allowed user IDs |
+
+#### TelegramBridge Methods
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `start` | `()` | `void` | Begin long-polling for Telegram updates |
+| `stop` | `()` | `void` | Stop polling and clear timers |
+| `sendText` | `(chatId: number, text: string, replyTo?: number)` | `Promise<void>` | Send a text message, chunking at 4096 chars |
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+| `TelegramBridgeConfig` | `{ botToken: string; chatId: string; allowedUserIds: string[] }` |
+| `TelegramUpdate` | Telegram update object with optional `message` and `callback_query` |
+| `TelegramMessage` | Message with `from`, `chat`, `text`, `voice` fields |
+| `TelegramUser` | `{ id: number; is_bot: boolean; first_name: string; username?: string }` |
+| `TelegramChat` | `{ id: number; type: string }` |
+| `TelegramVoice` | `{ file_id: string; file_unique_id: string; duration: number; mime_type?: string; file_size?: number }` |
+| `TelegramCallbackQuery` | Callback query from inline keyboard |
+| `TelegramFile` | `{ file_id: string; file_unique_id: string; file_size?: number; file_path?: string }` |
+
+## Invariants
+
+1. **Long-polling with 30s timeout**: `getUpdates` uses `timeout: 30` for Telegram long-polling. Next poll is scheduled 500ms after the previous completes
+2. **User auth via allowedUserIds**: If `config.allowedUserIds` is non-empty, only users whose Telegram ID appears in the list may interact. Others receive "Unauthorized."
+3. **Per-user rate limit 10/60s**: Each user is limited to 10 messages per 60-second window. Exceeding the limit returns a rate-limit message
+4. **Voice STT via Whisper (10 MB limit)**: Voice messages are downloaded, transcribed via `transcribe()`, and the transcription is echoed back before routing to the agent. Files over 10 MB are rejected
+5. **4096-character chunking**: Outbound messages are split into 4096-character chunks to respect Telegram's message size limit
+6. **Per-user sessions**: Each Telegram user maps to one active agent session. Sessions are reused across messages and cleared with `/new`
+7. **Response debounce 1500ms**: Agent responses are buffered and flushed after 1500ms of inactivity (or on session result), preventing message spam during streaming
+8. **Voice responses when enabled**: If the agent has `voiceEnabled` and `OPENAI_API_KEY` is set, responses are sent as Telegram voice notes (via `synthesizeWithCache`) in addition to text
+9. **Bot commands**: `/start` sends welcome, `/status` shows current session, `/new` clears session
+10. **Session lifecycle**: If a session is stopped/errored, it is discarded and a new one is created on the next message. If `sendMessage` fails (process not running), the session is restarted
+
+## Behavioral Examples
+
+### Scenario: New user sends first message
+
+- **Given** a Telegram user with no active session
+- **When** the user sends "Hello"
+- **Then** a new agent session is created, the message is sent as the initial prompt, and the bridge subscribes for responses
+
+### Scenario: Voice message transcription
+
+- **Given** a Telegram user sends a voice note (3 MB OGG)
+- **When** the bridge processes the message
+- **Then** the voice file is downloaded, transcribed via Whisper, the transcription is echoed back, and the text is routed to the agent session
+
+### Scenario: Rate limit exceeded
+
+- **Given** a Telegram user has sent 10 messages in the last 60 seconds
+- **When** the user sends an 11th message
+- **Then** the bridge replies "Rate limit exceeded. Please wait before sending more messages."
+
+### Scenario: Unauthorized user
+
+- **Given** `allowedUserIds` is `["123", "456"]`
+- **When** user with Telegram ID 789 sends a message
+- **Then** the bridge replies "Unauthorized."
+
+### Scenario: Long response chunked
+
+- **Given** an agent produces a 5000-character response
+- **When** the response is flushed
+- **Then** two messages are sent: one with 4096 characters and one with 904 characters
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Unauthorized user | Replies "Unauthorized." |
+| Rate limit exceeded | Replies "Rate limit exceeded. Please wait before sending more messages." |
+| Voice file > 10 MB | Replies "Voice message too large (max 10 MB)." |
+| STT transcription fails | Replies "Failed to transcribe voice message. Is OPENAI_API_KEY set?" |
+| No agents configured | Replies "No agents configured. Create an agent first." |
+| No projects configured | Replies "No projects configured." |
+| Telegram API error | Throws `"Telegram API error ({method}): status {N}"` (logged, not sent to user) |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| `server/process/manager.ts` | `ProcessManager` (startProcess, sendMessage, subscribe) |
+| `server/voice/stt.ts` | `transcribe` |
+| `server/voice/tts.ts` | `synthesizeWithCache` |
+| `server/db/agents.ts` | `getAgent`, `listAgents` |
+| `server/db/sessions.ts` | `createSession`, `getSession` |
+| `server/db/projects.ts` | `listProjects` |
+| `server/lib/logger.ts` | `createLogger` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| `server/index.ts` | `TelegramBridge` (initialized when `TELEGRAM_BOT_TOKEN` is set) |
+
+## Configuration
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `TELEGRAM_BOT_TOKEN` | (required) | Telegram Bot API token |
+| `TELEGRAM_CHAT_ID` | (required) | Target chat ID |
+| `TELEGRAM_ALLOWED_USERS` | `""` | Comma-separated Telegram user IDs allowed to interact |
+| `OPENAI_API_KEY` | (optional) | Required for voice notes (STT/TTS) |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-20 | corvid-agent | Initial spec |

--- a/specs/voice/voice.spec.md
+++ b/specs/voice/voice.spec.md
@@ -1,0 +1,127 @@
+---
+module: voice
+version: 1
+status: active
+files:
+  - server/voice/tts.ts
+  - server/voice/stt.ts
+  - server/voice/types.ts
+db_tables:
+  - voice_cache
+depends_on: []
+---
+
+# Voice (TTS / STT)
+
+## Purpose
+
+Text-to-speech synthesis via OpenAI TTS API and speech-to-text transcription via OpenAI Whisper API. TTS results are cached in a SQLite table using SHA-256 content hashing with LRU eviction. Both services require `OPENAI_API_KEY`.
+
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `synthesize` | `(options: TTSOptions)` | `Promise<TTSResult>` | Calls OpenAI TTS API to convert text to MP3 audio |
+| `synthesizeWithCache` | `(db: Database, text: string, voice: VoicePreset)` | `Promise<TTSResult>` | Cache-aware TTS: checks `voice_cache` table first, synthesizes and caches on miss |
+| `transcribe` | `(options: STTOptions)` | `Promise<STTResult>` | Calls OpenAI Whisper API to convert audio to text |
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+| `TTSOptions` | `{ text: string; voice: VoicePreset; model?: string; speed?: number }` |
+| `TTSResult` | `{ audio: Buffer; format: 'mp3'; durationMs: number }` |
+| `STTOptions` | `{ audio: Buffer; format?: 'ogg' \| 'mp3' \| 'wav' \| 'webm'; language?: string }` |
+| `STTResult` | `{ text: string }` |
+
+## Invariants
+
+1. **OPENAI_API_KEY required**: Both `synthesize` and `transcribe` throw if `OPENAI_API_KEY` is not set
+2. **TTS 4096 char limit**: `synthesize` throws if `options.text.length > 4096`
+3. **TTS empty text rejected**: `synthesize` throws if text is empty or whitespace-only
+4. **SHA-256 cache key**: `synthesizeWithCache` hashes text with `Bun.CryptoHasher('sha256')` and looks up by `(text_hash, voice_preset)` pair
+5. **LRU eviction at 10,000 entries**: After inserting a new cache entry, if `voice_cache` exceeds 10,000 rows, the oldest entries (by `created_at ASC`) are deleted
+6. **STT 25 MB limit**: `transcribe` throws if `options.audio.length > 25 * 1024 * 1024`
+7. **STT format support**: Supports `ogg`, `mp3`, `wav`, `webm` formats with corresponding MIME types. Defaults to `ogg`
+8. **TTS output format**: Always returns MP3 (`response_format: 'mp3'`)
+9. **TTS default model**: Uses `tts-1` model by default, configurable via `options.model`
+
+## Behavioral Examples
+
+### Scenario: TTS cache hit
+
+- **Given** text "Hello world" with voice "alloy" was previously synthesized
+- **When** `synthesizeWithCache(db, "Hello world", "alloy")` is called
+- **Then** the cached audio is returned without calling OpenAI API
+
+### Scenario: TTS cache miss
+
+- **Given** text "New text" has never been synthesized
+- **When** `synthesizeWithCache(db, "New text", "alloy")` is called
+- **Then** OpenAI TTS API is called, the result is stored in `voice_cache`, and the audio is returned
+
+### Scenario: Cache eviction
+
+- **Given** the `voice_cache` table has 10,001 entries after a new insert
+- **When** eviction runs
+- **Then** the oldest entry (by `created_at`) is deleted, bringing the count to 10,000
+
+### Scenario: Voice transcription
+
+- **Given** a valid OGG audio buffer under 25 MB
+- **When** `transcribe({ audio, format: 'ogg' })` is called
+- **Then** OpenAI Whisper API is called and the transcribed text is returned
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| No `OPENAI_API_KEY` (TTS) | Throws `"OPENAI_API_KEY is required for text-to-speech"` |
+| No `OPENAI_API_KEY` (STT) | Throws `"OPENAI_API_KEY is required for speech-to-text"` |
+| TTS text > 4096 chars | Throws `"TTS text exceeds maximum length of 4096 characters"` |
+| TTS empty text | Throws `"TTS text must not be empty"` |
+| STT audio > 25 MB | Throws `"Audio file too large (X MB). Maximum is 25 MB."` |
+| OpenAI TTS API error | Throws `"Text-to-speech failed (status N)"` |
+| OpenAI Whisper API error | Throws `"Speech-to-text failed (status N)"` |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| `server/lib/logger.ts` | `createLogger` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| `server/telegram/bridge.ts` | `transcribe` (STT for voice notes), `synthesizeWithCache` (TTS for voice responses) |
+
+## Database Tables
+
+### voice_cache
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | TEXT | PRIMARY KEY | UUID |
+| text_hash | TEXT | NOT NULL | SHA-256 hex hash of the input text |
+| voice_preset | TEXT | NOT NULL | Voice preset used for synthesis |
+| audio_data | BLOB | NOT NULL | Cached MP3 audio bytes |
+| format | TEXT | NOT NULL | Audio format (always 'mp3') |
+| duration_ms | INTEGER | NOT NULL | Estimated audio duration |
+| created_at | TEXT | DEFAULT datetime('now') | Creation timestamp (used for LRU eviction) |
+
+## Configuration
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `OPENAI_API_KEY` | (required) | OpenAI API key for TTS and STT services |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-20 | corvid-agent | Initial spec |

--- a/specs/ws/handler.spec.md
+++ b/specs/ws/handler.spec.md
@@ -1,0 +1,123 @@
+---
+module: ws-handler
+version: 1
+status: active
+files:
+  - server/ws/handler.ts
+db_tables: []
+depends_on:
+  - specs/middleware/auth.spec.md
+---
+
+# WebSocket Handler
+
+## Purpose
+
+Manages WebSocket connections for the corvid-agent dashboard. Handles client authentication (first-message or pre-authenticated via upgrade), routes 11 client message types to the appropriate services, manages per-connection session event subscriptions, and broadcasts server messages to topic subscribers.
+
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `createWebSocketHandler` | `(processManager, getBridge, authConfig, getMessenger?, getWorkTaskService?, getSchedulerService?, getOwnerQuestionManager?)` | `{ open, message, close }` | Creates Bun WebSocket handler with auth, routing, and cleanup |
+| `broadcastAlgoChatMessage` | `(server, participant, content, direction)` | `void` | Publish an AlgoChat message to all subscribed WebSocket clients |
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+| `WsData` | Per-connection data: `{ subscriptions: Map<string, EventCallback>; walletAddress?: string; authenticated: boolean }` |
+
+## Invariants
+
+1. **Auth gate**: Unauthenticated connections can only send `{ type: "auth" }`. All other message types are rejected with "Authentication required" until authenticated
+2. **Pre-authenticated via upgrade**: Connections authenticated during HTTP upgrade (via `?key=` query param) have `authenticated=true` set in `ws.data` before `open` fires; they subscribe to broadcast topics immediately
+3. **First-message auth**: The first message on an unauthenticated connection must be `{ type: "auth", key: "<key>" }`. Invalid key closes the connection with code 4001
+4. **Subscription cleanup on close**: When a WebSocket connection closes, all session subscriptions are unsubscribed via `processManager.unsubscribe` and the subscriptions map is cleared
+5. **safeSend wraps errors**: The `safeSend` helper catches exceptions from `ws.send` (e.g., closed connection during async callback) and silently ignores them
+6. **11 client message types**: `auth`, `subscribe`, `unsubscribe`, `send_message`, `chat_send`, `agent_invoke`, `approval_response`, `create_work_task`, `agent_reward`, `schedule_approval`, `question_response`
+7. **Broadcast topics**: Authenticated connections subscribe to 5 topics: `council`, `algochat`, `scheduler`, `ollama`, `owner`
+8. **Invalid JSON/format**: Non-JSON messages receive an error response "Invalid JSON"; messages that fail `isClientMessage` validation receive "Invalid message format"
+
+## Behavioral Examples
+
+### Scenario: Pre-authenticated WebSocket connection
+
+- **Given** a WebSocket upgrade with `?key=<valid-key>` (authenticated at upgrade)
+- **When** the connection opens
+- **Then** `ws.data.authenticated` is true, and the client is subscribed to all 5 broadcast topics
+
+### Scenario: First-message authentication
+
+- **Given** an unauthenticated WebSocket connection
+- **When** the client sends `{ "type": "auth", "key": "<valid-key>" }`
+- **Then** `ws.data.authenticated` is set to true, broadcast topics are subscribed
+
+### Scenario: Invalid auth key closes connection
+
+- **Given** an unauthenticated WebSocket connection
+- **When** the client sends `{ "type": "auth", "key": "wrong" }`
+- **Then** an error message is sent and the connection is closed with code 4001
+
+### Scenario: Message before auth is rejected
+
+- **Given** an unauthenticated WebSocket connection
+- **When** the client sends `{ "type": "subscribe", "sessionId": "..." }`
+- **Then** the server responds with an error: "Authentication required"
+
+### Scenario: Subscribe to session events
+
+- **Given** an authenticated WebSocket connection
+- **When** the client sends `{ "type": "subscribe", "sessionId": "abc" }`
+- **Then** `processManager.subscribe("abc", callback)` is called and the callback is stored in `ws.data.subscriptions`
+
+### Scenario: Connection close cleans up subscriptions
+
+- **Given** an authenticated WebSocket with subscriptions to sessions "abc" and "def"
+- **When** the connection closes
+- **Then** `processManager.unsubscribe` is called for both sessions and the subscriptions map is cleared
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Invalid JSON | Error message: "Invalid JSON" |
+| Invalid message format | Error message: "Invalid message format" |
+| Already authenticated | Error message: "Already authenticated" |
+| Auth required | Error message: "Authentication required. Send { \"type\": \"auth\", \"key\": \"<key>\" } first." |
+| Invalid API key (WS auth) | Error sent, connection closed with code 4001 |
+| Session not running (`send_message`) | Error: "Session {id} is not running" |
+| Bridge not available (`chat_send`) | Error: "AlgoChat is not available" |
+| Messenger not available (`agent_invoke`) | Error: "Agent messaging not available" |
+| Work task service not available | Error: "Work task service not available" |
+| Scheduler not available | Error: "Scheduler service not available" |
+| Question manager not available | Error: "Owner question service not available" |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| `server/process/manager.ts` | `ProcessManager` (subscribe, unsubscribe, sendMessage, approvalManager) |
+| `server/middleware/auth.ts` | `AuthConfig`, `timingSafeEqual` |
+| `server/algochat/bridge.ts` | `AlgoChatBridge` (handleLocalMessage) |
+| `server/algochat/agent-messenger.ts` | `AgentMessenger` (invoke) |
+| `server/work/service.ts` | `WorkTaskService` (create, onComplete) |
+| `server/scheduler/service.ts` | `SchedulerService` (resolveApproval) |
+| `server/process/owner-question-manager.ts` | `OwnerQuestionManager` (resolveQuestion) |
+| `shared/ws-protocol.ts` | `ClientMessage`, `ServerMessage`, `isClientMessage` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| `server/index.ts` | `createWebSocketHandler`, `broadcastAlgoChatMessage` |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-20 | corvid-agent | Initial spec |


### PR DESCRIPTION
## Summary

- Write specs for the 6 highest-impact unspecced modules identified in #189:
  - `specs/middleware/auth.spec.md` — HTTP/WS auth, CORS, startup security
  - `specs/middleware/rate-limit.spec.md` — per-IP sliding-window rate limiter
  - `specs/ws/handler.spec.md` — WebSocket handler (11 message types, auth gate)
  - `specs/voice/voice.spec.md` — TTS/STT via OpenAI, SHA-256 cache with LRU eviction
  - `specs/telegram/bridge.spec.md` — long-polling Telegram bridge, voice notes, per-user sessions
  - `specs/discord/bridge.spec.md` — raw WebSocket Discord gateway, heartbeat, exponential backoff
- Fix stale invariant #6 in `specs/work/work-task-service.spec.md` to reflect PR creation fallback via `createPrFallback()`
- Close #181 (multi-tool chain summary) and #182 (work task PR creation) — both fixed in `628eb34`

Refs #189

## Test plan

- [x] `bun run spec:check` — 24 specs, 0 failures
- [x] `bunx tsc --noEmit --skipLibCheck` — no regressions
- [x] Issues #181 and #182 closed with comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)