### PR TITLE
refactor: extract [WORK] command routing into WorkCommandRouter

### DIFF
--- a/server/__tests__/work-command-router.test.ts
+++ b/server/__tests__/work-command-router.test.ts
@@ -1,0 +1,399 @@
+import { test, expect, beforeEach, describe, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import { createAgent } from '../db/agents';
+import { createProject } from '../db/projects';
+import { getAgentMessage } from '../db/agent-messages';
+import { WorkCommandRouter } from '../algochat/work-command-router';
+import type { WorkTaskService } from '../work/service';
+import type { Agent } from '../../shared/types';
+
+// ─── Test state ──────────────────────────────────────────────────────────────
+
+let db: Database;
+let router: WorkCommandRouter;
+let agentA: Agent;
+let agentB: Agent;
+let projectId: string;
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+
+    const project = createProject(db, {
+        name: 'Test Project',
+        workingDir: '/tmp/test',
+    });
+    projectId = project.id;
+
+    agentA = createAgent(db, { name: 'Agent A' });
+    agentB = createAgent(db, { name: 'Agent B' });
+
+    router = new WorkCommandRouter(db);
+});
+
+// ─── handleSlashCommand() ────────────────────────────────────────────────────
+
+describe('handleSlashCommand()', () => {
+    test('responds with usage when description is empty', () => {
+        const responses: string[] = [];
+        const respond = (text: string) => responses.push(text);
+
+        router.handleSlashCommand('participant-1', '', respond, () => agentA.id);
+
+        expect(responses.length).toBe(1);
+        expect(responses[0]).toContain('Usage');
+    });
+
+    test('responds when work task service is not available', () => {
+        const responses: string[] = [];
+        const respond = (text: string) => responses.push(text);
+
+        router.handleSlashCommand('participant-1', 'do something', respond, () => agentA.id);
+
+        expect(responses.length).toBe(1);
+        expect(responses[0]).toContain('not available');
+    });
+
+    test('responds when no agent is available', () => {
+        const mockService = {
+            create: mock(() => Promise.resolve({})),
+            onComplete: mock(() => {}),
+        } as unknown as WorkTaskService;
+        router.setWorkTaskService(mockService);
+
+        const responses: string[] = [];
+        const respond = (text: string) => responses.push(text);
+
+        router.handleSlashCommand('participant-1', 'do something', respond, () => null);
+
+        expect(responses.length).toBe(1);
+        expect(responses[0]).toContain('No agent available');
+    });
+
+    test('creates a work task and responds with task info', async () => {
+        const mockCreate = mock(() =>
+            Promise.resolve({
+                id: 'task-123',
+                branchName: 'agent/test/branch',
+                status: 'running',
+            }),
+        );
+        const mockOnComplete = mock(() => {});
+        const mockService = {
+            create: mockCreate,
+            onComplete: mockOnComplete,
+        } as unknown as WorkTaskService;
+        router.setWorkTaskService(mockService);
+
+        const responses: string[] = [];
+        const respond = (text: string) => responses.push(text);
+
+        router.handleSlashCommand('participant-1', 'implement feature X', respond, () => agentA.id);
+
+        // Wait for the promise to resolve
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect(mockCreate).toHaveBeenCalledTimes(1);
+        const createCall = (mockCreate.mock.calls as unknown as Array<[Record<string, unknown>]>)[0][0];
+        expect(createCall.agentId).toBe(agentA.id);
+        expect(createCall.description).toBe('implement feature X');
+        expect(createCall.source).toBe('algochat');
+        expect((createCall.requesterInfo as Record<string, string>).participant).toBe('participant-1');
+
+        expect(responses.length).toBe(1);
+        expect(responses[0]).toContain('task-123');
+        expect(responses[0]).toContain('agent/test/branch');
+
+        // Verify onComplete was registered
+        expect(mockOnComplete).toHaveBeenCalledTimes(1);
+    });
+
+    test('completion callback sends success message with PR URL', async () => {
+        let completionCallback: ((task: Record<string, unknown>) => void) | null = null;
+
+        const mockService = {
+            create: mock(() =>
+                Promise.resolve({
+                    id: 'task-456',
+                    branchName: 'agent/test/branch',
+                    status: 'running',
+                }),
+            ),
+            onComplete: mock((_taskId: string, cb: (task: Record<string, unknown>) => void) => {
+                completionCallback = cb;
+            }),
+        } as unknown as WorkTaskService;
+        router.setWorkTaskService(mockService);
+
+        const responses: string[] = [];
+        const respond = (text: string) => responses.push(text);
+
+        router.handleSlashCommand('participant-1', 'fix bug', respond, () => agentA.id);
+        await new Promise((r) => setTimeout(r, 50));
+
+        // Simulate completion with PR URL
+        expect(completionCallback).not.toBeNull();
+        completionCallback!({ status: 'completed', prUrl: 'https://github.com/test/pr/1' });
+
+        expect(responses.length).toBe(2);
+        expect(responses[1]).toContain('completed');
+        expect(responses[1]).toContain('https://github.com/test/pr/1');
+    });
+
+    test('completion callback sends failure message', async () => {
+        let completionCallback: ((task: Record<string, unknown>) => void) | null = null;
+
+        const mockService = {
+            create: mock(() =>
+                Promise.resolve({
+                    id: 'task-789',
+                    branchName: 'agent/test/branch',
+                    status: 'running',
+                }),
+            ),
+            onComplete: mock((_taskId: string, cb: (task: Record<string, unknown>) => void) => {
+                completionCallback = cb;
+            }),
+        } as unknown as WorkTaskService;
+        router.setWorkTaskService(mockService);
+
+        const responses: string[] = [];
+        const respond = (text: string) => responses.push(text);
+
+        router.handleSlashCommand('participant-1', 'fix bug', respond, () => agentA.id);
+        await new Promise((r) => setTimeout(r, 50));
+
+        completionCallback!({ status: 'failed', error: 'tsc failed' });
+
+        expect(responses.length).toBe(2);
+        expect(responses[1]).toContain('failed');
+        expect(responses[1]).toContain('tsc failed');
+    });
+
+    test('responds with error when task creation throws', async () => {
+        const mockService = {
+            create: mock(() => Promise.reject(new Error('git worktree error'))),
+            onComplete: mock(() => {}),
+        } as unknown as WorkTaskService;
+        router.setWorkTaskService(mockService);
+
+        const responses: string[] = [];
+        const respond = (text: string) => responses.push(text);
+
+        router.handleSlashCommand('participant-1', 'do stuff', respond, () => agentA.id);
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect(responses.length).toBe(1);
+        expect(responses[0]).toContain('Work task error');
+        expect(responses[0]).toContain('git worktree error');
+    });
+});
+
+// ─── handleAgentWorkRequest() ────────────────────────────────────────────────
+
+describe('handleAgentWorkRequest()', () => {
+    test('throws when description is empty', async () => {
+        const mockService = {
+            create: mock(() => Promise.resolve({})),
+            onComplete: mock(() => {}),
+        } as unknown as WorkTaskService;
+        router.setWorkTaskService(mockService);
+
+        await expect(
+            router.handleAgentWorkRequest({
+                fromAgentId: agentA.id,
+                fromAgentName: agentA.name,
+                toAgentId: agentB.id,
+                content: '[WORK]',
+                paymentMicro: 1000,
+                threadId: crypto.randomUUID(),
+                emitMessageUpdate: () => {},
+            }),
+        ).rejects.toThrow('[WORK] prefix requires a task description');
+    });
+
+    test('throws when work task service is not available', async () => {
+        await expect(
+            router.handleAgentWorkRequest({
+                fromAgentId: agentA.id,
+                fromAgentName: agentA.name,
+                toAgentId: agentB.id,
+                content: '[WORK] do something',
+                paymentMicro: 1000,
+                threadId: crypto.randomUUID(),
+                emitMessageUpdate: () => {},
+            }),
+        ).rejects.toThrow('Work task service not available');
+    });
+
+    test('creates agent message and work task successfully', async () => {
+        const mockCreate = mock(() =>
+            Promise.resolve({
+                id: 'task-agent-1',
+                sessionId: 'session-agent-1',
+                status: 'running',
+            }),
+        );
+        const mockOnComplete = mock(() => {});
+        const mockService = {
+            create: mockCreate,
+            onComplete: mockOnComplete,
+        } as unknown as WorkTaskService;
+        router.setWorkTaskService(mockService);
+
+        const emitCalls: string[] = [];
+
+        const result = await router.handleAgentWorkRequest({
+            fromAgentId: agentA.id,
+            fromAgentName: agentA.name,
+            toAgentId: agentB.id,
+            content: '[WORK] Implement feature Y',
+            paymentMicro: 1000,
+            threadId: crypto.randomUUID(),
+            projectId,
+            emitMessageUpdate: (id) => emitCalls.push(id),
+        });
+
+        // Verify task was created with correct params
+        expect(mockCreate).toHaveBeenCalledTimes(1);
+        const createCall = (mockCreate.mock.calls as unknown as Array<[Record<string, unknown>]>)[0][0];
+        expect(createCall.agentId).toBe(agentB.id);
+        expect(createCall.description).toBe('Implement feature Y');
+        expect(createCall.source).toBe('agent');
+        expect(createCall.projectId).toBe(projectId);
+
+        // Verify result
+        expect(result.sessionId).toBe('session-agent-1');
+        expect(result.message).toBeDefined();
+        expect(result.message.fromAgentId).toBe(agentA.id);
+        expect(result.message.toAgentId).toBe(agentB.id);
+
+        // Verify message was emitted as processing
+        expect(emitCalls.length).toBe(1);
+
+        // Verify agent message exists in DB
+        const dbMessage = getAgentMessage(db, result.message.id);
+        expect(dbMessage).not.toBeNull();
+        expect(dbMessage!.content).toBe('[WORK] Implement feature Y');
+    });
+
+    test('completion callback updates message status to completed with PR URL', async () => {
+        let completionCallback: ((task: Record<string, unknown>) => void) | null = null;
+        const emitCalls: string[] = [];
+
+        const mockService = {
+            create: mock(() =>
+                Promise.resolve({
+                    id: 'task-agent-2',
+                    sessionId: 'session-agent-2',
+                    status: 'running',
+                }),
+            ),
+            onComplete: mock((_taskId: string, cb: (task: Record<string, unknown>) => void) => {
+                completionCallback = cb;
+            }),
+        } as unknown as WorkTaskService;
+        router.setWorkTaskService(mockService);
+
+        const result = await router.handleAgentWorkRequest({
+            fromAgentId: agentA.id,
+            fromAgentName: agentA.name,
+            toAgentId: agentB.id,
+            content: '[WORK] Build widget',
+            paymentMicro: 1000,
+            threadId: crypto.randomUUID(),
+            emitMessageUpdate: (id) => emitCalls.push(id),
+        });
+
+        expect(completionCallback).not.toBeNull();
+
+        // Simulate successful completion
+        completionCallback!({ status: 'completed', prUrl: 'https://github.com/test/pr/42' });
+
+        // Verify message was updated
+        const dbMessage = getAgentMessage(db, result.message.id);
+        expect(dbMessage!.status).toBe('completed');
+        expect(dbMessage!.response).toContain('https://github.com/test/pr/42');
+
+        // Two emitCalls: one for 'processing', one for completion
+        expect(emitCalls.length).toBe(2);
+    });
+
+    test('completion callback updates message status to failed', async () => {
+        let completionCallback: ((task: Record<string, unknown>) => void) | null = null;
+
+        const mockService = {
+            create: mock(() =>
+                Promise.resolve({
+                    id: 'task-agent-3',
+                    sessionId: 'session-agent-3',
+                    status: 'running',
+                }),
+            ),
+            onComplete: mock((_taskId: string, cb: (task: Record<string, unknown>) => void) => {
+                completionCallback = cb;
+            }),
+        } as unknown as WorkTaskService;
+        router.setWorkTaskService(mockService);
+
+        const result = await router.handleAgentWorkRequest({
+            fromAgentId: agentA.id,
+            fromAgentName: agentA.name,
+            toAgentId: agentB.id,
+            content: '[WORK] Build broken widget',
+            paymentMicro: 1000,
+            threadId: crypto.randomUUID(),
+            emitMessageUpdate: () => {},
+        });
+
+        completionCallback!({ status: 'failed', error: 'Build failed' });
+
+        const dbMessage = getAgentMessage(db, result.message.id);
+        expect(dbMessage!.status).toBe('failed');
+        expect(dbMessage!.response).toContain('Build failed');
+    });
+
+    test('marks message as failed when task creation throws', async () => {
+        const mockService = {
+            create: mock(() => Promise.reject(new Error('concurrent task limit'))),
+            onComplete: mock(() => {}),
+        } as unknown as WorkTaskService;
+        router.setWorkTaskService(mockService);
+
+        const emitCalls: string[] = [];
+
+        await expect(
+            router.handleAgentWorkRequest({
+                fromAgentId: agentA.id,
+                fromAgentName: agentA.name,
+                toAgentId: agentB.id,
+                content: '[WORK] Will fail creation',
+                paymentMicro: 1000,
+                threadId: crypto.randomUUID(),
+                emitMessageUpdate: (id) => emitCalls.push(id),
+            }),
+        ).rejects.toThrow('concurrent task limit');
+
+        // Message should still be in the DB as failed
+        expect(emitCalls.length).toBe(1);
+    });
+});
+
+// ─── hasService ──────────────────────────────────────────────────────────────
+
+describe('hasService', () => {
+    test('returns false when no service is set', () => {
+        expect(router.hasService).toBe(false);
+    });
+
+    test('returns true after setWorkTaskService', () => {
+        const mockService = {
+            create: mock(() => Promise.resolve({})),
+            onComplete: mock(() => {}),
+        } as unknown as WorkTaskService;
+        router.setWorkTaskService(mockService);
+
+        expect(router.hasService).toBe(true);
+    });
+});

--- a/server/algochat/bridge.ts
+++ b/server/algochat/bridge.ts
@@ -34,6 +34,7 @@ import type { ApprovalManager } from '../process/approval-manager';
 import type { ApprovalRequestWire } from '../process/approval-types';
 import type { OwnerQuestionManager } from '../process/owner-question-manager';
 import type { WorkTaskService } from '../work/service';
+import { WorkCommandRouter } from './work-command-router';
 import { formatApprovalForChain, parseApprovalResponse } from './approval-format';
 // Credit functions — will be used when guest access is enabled
 // import { getBalance, purchaseCredits, maybeGrantFirstTimeCredits, canStartSession, getCreditConfig } from '../db/credits';
@@ -169,9 +170,11 @@ export class AlgoChatBridge {
         this.ownerQuestionManager = manager;
     }
 
-    /** Inject the work task service for /work command support. */
+    /** Inject the work task service for /work command support. Wraps it in a WorkCommandRouter. */
     setWorkTaskService(service: WorkTaskService): void {
-        this.commandHandler.setWorkTaskService(service);
+        const router = new WorkCommandRouter(this.db);
+        router.setWorkTaskService(service);
+        this.commandHandler.setWorkCommandRouter(router);
     }
 
     /** Inject the agent messenger for council and inter-agent messaging. */

--- a/server/algochat/work-command-router.ts
+++ b/server/algochat/work-command-router.ts
@@ -1,0 +1,185 @@
+/**
+ * WorkCommandRouter — Consolidates all [WORK] command routing logic.
+ *
+ * Two entry points feed into the same WorkTaskService:
+ *
+ * 1. **Slash command** (`/work <description>`) — from CommandHandler
+ * 2. **Agent prefix** (`[WORK] <description>`) — from AgentMessenger
+ *
+ * Extracted from command-handler.ts and agent-messenger.ts to centralize
+ * work task creation, completion callback registration, and error handling.
+ *
+ * @module
+ */
+import type { Database } from 'bun:sqlite';
+import type { WorkTaskService } from '../work/service';
+import {
+    createAgentMessage,
+    updateAgentMessageStatus,
+    getAgentMessage,
+} from '../db/agent-messages';
+
+/** Parameters for handling an agent-to-agent [WORK] request. */
+export interface AgentWorkRequestParams {
+    fromAgentId: string;
+    fromAgentName: string;
+    toAgentId: string;
+    content: string;
+    paymentMicro: number;
+    threadId: string;
+    projectId?: string;
+    /** Callback to emit message update events (for WS broadcast). */
+    emitMessageUpdate: (messageId: string) => void;
+}
+
+/** Result of handling an agent [WORK] request. */
+export interface AgentWorkRequestResult {
+    message: import('../../shared/types').AgentMessage;
+    sessionId: string | null;
+}
+
+export class WorkCommandRouter {
+    private workTaskService: WorkTaskService | null = null;
+    private db: Database;
+
+    constructor(db: Database) {
+        this.db = db;
+    }
+
+    /** Inject or update the WorkTaskService dependency. */
+    setWorkTaskService(service: WorkTaskService): void {
+        this.workTaskService = service;
+    }
+
+    /** Check whether a WorkTaskService is available. */
+    get hasService(): boolean {
+        return this.workTaskService !== null;
+    }
+
+    /**
+     * Handle the `/work <description>` slash command from AlgoChat.
+     *
+     * @param participant - The sender's address
+     * @param description - The task description (already parsed, without `/work` prefix)
+     * @param respond - Callback to send a response message
+     * @param findAgent - Callback to resolve the agent for new conversations
+     */
+    handleSlashCommand(
+        participant: string,
+        description: string,
+        respond: (text: string) => void,
+        findAgent: () => string | null,
+    ): void {
+        if (!description) {
+            respond('Usage: /work <task description>');
+            return;
+        }
+
+        if (!this.workTaskService) {
+            respond('Work task service not available');
+            return;
+        }
+
+        const agentId = findAgent();
+        if (!agentId) {
+            respond('No agent available for work tasks');
+            return;
+        }
+
+        this.workTaskService.create({
+            agentId,
+            description,
+            source: 'algochat',
+            requesterInfo: { participant },
+        }).then((task) => {
+            respond(`Work task started: ${task.id}\nBranch: ${task.branchName ?? 'creating...'}\nStatus: ${task.status}`);
+
+            this.workTaskService?.onComplete(task.id, (completed) => {
+                if (completed.status === 'completed' && completed.prUrl) {
+                    respond(`Work task completed!\nPR: ${completed.prUrl}`);
+                } else {
+                    respond(`Work task failed: ${completed.error ?? 'Unknown error'}`);
+                }
+            });
+        }).catch((err) => {
+            respond(`Work task error: ${err instanceof Error ? err.message : String(err)}`);
+        });
+    }
+
+    /**
+     * Handle a [WORK] prefix in an agent-to-agent message.
+     *
+     * Creates an agent_messages row, delegates to WorkTaskService for task
+     * creation, and registers a completion callback that updates the message
+     * status.
+     *
+     * @returns The created agent message and session ID, or throws on error.
+     */
+    async handleAgentWorkRequest(params: AgentWorkRequestParams): Promise<AgentWorkRequestResult> {
+        const {
+            fromAgentId,
+            fromAgentName,
+            toAgentId,
+            content,
+            paymentMicro,
+            threadId,
+            projectId,
+            emitMessageUpdate,
+        } = params;
+
+        const description = content.slice('[WORK]'.length).trim();
+        if (!description) {
+            throw new Error('[WORK] prefix requires a task description');
+        }
+
+        if (!this.workTaskService) {
+            throw new Error('Work task service not available');
+        }
+
+        const agentMessage = createAgentMessage(this.db, {
+            fromAgentId,
+            toAgentId,
+            content,
+            paymentMicro,
+            threadId,
+        });
+
+        try {
+            const task = await this.workTaskService.create({
+                agentId: toAgentId,
+                description,
+                projectId,
+                source: 'agent',
+                sourceId: agentMessage.id,
+                requesterInfo: { fromAgentId, fromAgentName },
+            });
+
+            updateAgentMessageStatus(this.db, agentMessage.id, 'processing', { sessionId: task.sessionId ?? undefined });
+            emitMessageUpdate(agentMessage.id);
+
+            this.workTaskService.onComplete(task.id, (completed) => {
+                if (completed.status === 'completed' && completed.prUrl) {
+                    updateAgentMessageStatus(this.db, agentMessage.id, 'completed', {
+                        response: `PR created: ${completed.prUrl}`,
+                    });
+                } else {
+                    updateAgentMessageStatus(this.db, agentMessage.id, 'failed', {
+                        response: completed.error ?? 'Work task failed',
+                    });
+                }
+                emitMessageUpdate(agentMessage.id);
+            });
+
+            return {
+                message: getAgentMessage(this.db, agentMessage.id) ?? agentMessage,
+                sessionId: task.sessionId,
+            };
+        } catch (err) {
+            updateAgentMessageStatus(this.db, agentMessage.id, 'failed', {
+                response: `Work task error: ${err instanceof Error ? err.message : String(err)}`,
+            });
+            emitMessageUpdate(agentMessage.id);
+            throw err;
+        }
+    }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import { AlgoChatBridge } from './algochat/bridge';
 import { AgentWalletService } from './algochat/agent-wallet';
 import { AgentDirectory } from './algochat/agent-directory';
 import { AgentMessenger } from './algochat/agent-messenger';
+import { WorkCommandRouter } from './algochat/work-command-router';
 import { SelfTestService } from './selftest/service';
 import { WorkTaskService } from './work/service';
 import { SchedulerService } from './scheduler/service';
@@ -299,7 +300,9 @@ async function initAlgoChat(): Promise<void> {
     algochatBridge.setOwnerQuestionManager(processManager.ownerQuestionManager);
     algochatBridge.setWorkTaskService(workTaskService);
     agentMessenger = new AgentMessenger(db, agentNetworkConfig, agentService, agentWalletService, agentDirectory, processManager);
-    agentMessenger.setWorkTaskService(workTaskService);
+    const workCommandRouter = new WorkCommandRouter(db);
+    workCommandRouter.setWorkTaskService(workTaskService);
+    agentMessenger.setWorkCommandRouter(workCommandRouter);
     algochatBridge.setAgentMessenger(agentMessenger);
 
     // Register MCP services so agent sessions get corvid_* tools

--- a/specs/algochat/bridge.spec.md
+++ b/specs/algochat/bridge.spec.md
@@ -55,7 +55,7 @@ Central orchestrator for the AlgoChat on-chain messaging system. Bridges Algoran
 | `setAgentDirectory` | `(directory: AgentDirectory)` | `void` | Late-inject agent directory |
 | `setApprovalManager` | `(manager: ApprovalManager)` | `void` | Late-inject approval manager for forwarding approvals to chat |
 | `setOwnerQuestionManager` | `(manager: OwnerQuestionManager)` | `void` | Late-inject owner question manager |
-| `setWorkTaskService` | `(service: WorkTaskService)` | `void` | Late-inject work task service |
+| `setWorkTaskService` | `(service: WorkTaskService)` | `void` | Late-inject work task service (wraps in a `WorkCommandRouter` for the command handler) |
 | `setAgentMessenger` | `(messenger: AgentMessenger)` | `void` | Late-inject agent messenger |
 | `sendApprovalRequest` | `(participant: string, request: ApprovalRequestWire)` | `Promise<void>` | Send a tool approval request to a participant via on-chain message |
 | `start` | `()` | `void` | Start all PSK managers, sync polling, and discovery polling |
@@ -145,6 +145,7 @@ Central orchestrator for the AlgoChat on-chain messaging system. Bridges Algoran
 | `server/algochat/command-handler.ts` | `CommandHandler` |
 | `server/algochat/subscription-manager.ts` | `SubscriptionManager` |
 | `server/algochat/discovery-service.ts` | `DiscoveryService` |
+| `server/algochat/work-command-router.ts` | `WorkCommandRouter` for [WORK] command routing |
 | `server/algochat/group-sender.ts` | `parseGroupPrefix`, `reassembleGroupMessage` |
 | `server/algochat/approval-format.ts` | `formatApprovalForChain`, `parseApprovalResponse` |
 


### PR DESCRIPTION
## Summary

- Introduces a new `WorkCommandRouter` module (`server/algochat/work-command-router.ts`) that consolidates all [WORK] routing logic from two entry points into one place
- Updates `command-handler.ts` to delegate `/work` slash commands to the router instead of handling inline
- Updates `agent-messenger.ts` to delegate `[WORK]` agent prefix messages to the router instead of handling inline
- Updates `bridge.ts` and `server/index.ts` to wire the new router
- Adds 15 tests for the new router covering slash commands, agent requests, completion callbacks, and error handling
- Updates existing agent-messenger tests to use the new routing API
- Pure refactor — no behavioral changes

Closes #150

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` compiles clean
- [x] `bun test` — all 2119 tests pass (0 failures)
- [x] New `work-command-router.test.ts` covers: missing description, no service, no agent, successful creation, completion callbacks (success + failure), error handling
- [x] Existing agent-messenger [WORK] tests updated and passing
- [x] `command-handler.ts` LoC reduced (48 lines removed, net -49 lines from inline code)
- [x] `agent-messenger.ts` LoC reduced (60 lines removed, net -53 lines from inline code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)