### PR TITLE
fix: remove unused import (CodeQL #22)

### DIFF
--- a/packages/env/tests/env.test.ts
+++ b/packages/env/tests/env.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   string,
   number,


### PR DESCRIPTION
## Summary
- Remove unused `beforeEach` import from `packages/env/tests/env.test.ts` (CodeQL alert #22)
- Dismissed 4 other alerts (#2, #17, #21, #36) as false positives with explanations

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — 2135 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)