### PR TITLE
feat: add ChannelAdapter interface and refactor AlgoChatBridge

### DIFF
--- a/server/channels/index.ts
+++ b/server/channels/index.ts
@@ -1,0 +1,1 @@
+export type { ChannelAdapter, SessionMessage, ChannelStatus } from './types';

--- a/server/channels/types.ts
+++ b/server/channels/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Channel adapter abstraction for multi-channel messaging.
+ *
+ * Defines the `ChannelAdapter` interface that all messaging channels
+ * (AlgoChat, Slack, Discord, etc.) implement, along with the unified
+ * `SessionMessage` format and `ChannelStatus` type.
+ *
+ * @module
+ */
+
+/**
+ * Unified message format that all channel adapters convert to/from.
+ * Provides a channel-agnostic representation of a message flowing
+ * through the system.
+ */
+export interface SessionMessage {
+    id: string;
+    channelType: string;
+    participant: string;
+    content: string;
+    direction: 'inbound' | 'outbound';
+    timestamp: Date;
+    metadata?: Record<string, unknown>;
+}
+
+/**
+ * Channel health/status information returned by `getStatus()`.
+ * Each adapter populates the fields relevant to its channel type
+ * and may include additional data in `details`.
+ */
+export interface ChannelStatus {
+    channelType: string;
+    enabled: boolean;
+    connected: boolean;
+    details?: Record<string, unknown>;
+}
+
+/**
+ * Interface for messaging channel adapters.
+ *
+ * Implementations bridge external messaging systems (Algorand on-chain
+ * chat, Slack, Discord, etc.) with the internal agent session system.
+ * Each adapter handles protocol-specific concerns (authentication,
+ * message encoding, transport) while exposing a uniform API.
+ */
+export interface ChannelAdapter {
+    /** Identifier for the channel type (e.g., 'algochat', 'slack', 'discord'). */
+    readonly channelType: string;
+
+    /** Send an outbound message to a participant. */
+    sendMessage(participant: string, content: string): Promise<void>;
+
+    /** Register a handler for inbound messages. */
+    onMessage(handler: (msg: SessionMessage) => void): void;
+
+    /** Start the channel adapter (begin listening for messages). */
+    start(): void;
+
+    /** Stop the channel adapter (cease listening, clean up resources). */
+    stop(): void;
+
+    /** Get the current health/status of the channel. */
+    getStatus(): Promise<ChannelStatus>;
+}


### PR DESCRIPTION
## Summary
- Defines `ChannelAdapter` interface, `SessionMessage`, and `ChannelStatus` types in `server/channels/types.ts` with barrel export in `server/channels/index.ts`
- Refactors `AlgoChatBridge` to `implements ChannelAdapter` — adds `channelType`, `sendMessage()`, `onMessage()`, and updates `getStatus()` to return `ChannelStatus`-compatible shape
- Pure abstraction extraction with zero behavioral changes — all existing tests pass (2135/2135), `tsc --noEmit` clean

Closes #142

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — all 2135 tests pass, 0 failures
- [x] Existing AlgoChat bridge tests unmodified and passing
- [x] `getStatus()` returns intersection type preserving backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)