### PR TITLE
feat: add Slack integration (bridge, notifications, questions)

### DIFF
--- a/server/mcp/tool-handlers.ts
+++ b/server/mcp/tool-handlers.ts
@@ -1205,7 +1205,7 @@ export async function handleDeepResearch(
 
 // ─── Notification configuration handler ──────────────────────────────────
 
-const VALID_CHANNEL_TYPES = ['discord', 'telegram', 'github', 'algochat'];
+const VALID_CHANNEL_TYPES = ['discord', 'telegram', 'github', 'algochat', 'slack'];
 
 export async function handleConfigureNotifications(
     ctx: McpToolContext,

--- a/server/notifications/channels/slack-question.ts
+++ b/server/notifications/channels/slack-question.ts
@@ -1,0 +1,103 @@
+import type { ChannelSendResult } from '../types';
+import { createLogger } from '../../lib/logger';
+
+const log = createLogger('QuestionSlack');
+
+export async function sendSlackQuestion(
+    botToken: string,
+    channelId: string,
+    questionId: string,
+    question: string,
+    options: string[] | null,
+    context: string | null,
+    agentId: string,
+): Promise<ChannelSendResult> {
+    try {
+        const shortId = questionId.slice(0, 8);
+        const blocks: Array<Record<string, unknown>> = [];
+
+        // Header
+        blocks.push({
+            type: 'header',
+            text: { type: 'plain_text', text: 'Agent Question', emoji: true },
+        });
+
+        // Question text
+        blocks.push({
+            type: 'section',
+            text: { type: 'mrkdwn', text: question },
+        });
+
+        // Context if provided
+        if (context) {
+            blocks.push({
+                type: 'context',
+                elements: [{ type: 'mrkdwn', text: `_Context: ${context}_` }],
+            });
+        }
+
+        // Options as numbered list
+        if (options?.length) {
+            const optionsText = options.map((opt, i) => `${i + 1}. ${opt}`).join('\n');
+            blocks.push({
+                type: 'section',
+                text: { type: 'mrkdwn', text: `*Options:*\n${optionsText}` },
+            });
+
+            // Interactive buttons for options
+            const actionElements = options.map((opt, i) => ({
+                type: 'button',
+                text: { type: 'plain_text', text: `${i + 1}. ${opt.slice(0, 30)}`, emoji: true },
+                action_id: `q_${shortId}_${i}`,
+                value: `q:${shortId}:${i}`,
+            }));
+
+            blocks.push({
+                type: 'actions',
+                elements: actionElements.slice(0, 5), // Slack limits to 5 buttons per block
+            });
+        }
+
+        // Footer
+        blocks.push({
+            type: 'context',
+            elements: [{
+                type: 'mrkdwn',
+                text: `Agent: ${agentId.slice(0, 8)}... | Q: ${shortId}`,
+            }],
+        });
+
+        const body = {
+            channel: channelId,
+            text: `Agent Question: ${question}`, // Fallback text
+            blocks,
+        };
+
+        const response = await fetch('https://slack.com/api/chat.postMessage', {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${botToken}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(body),
+            signal: AbortSignal.timeout(10_000),
+        });
+
+        const data = await response.json() as {
+            ok: boolean;
+            ts?: string;
+            error?: string;
+        };
+
+        if (!data.ok) {
+            log.warn('Slack API error', { error: data.error });
+            return { success: false, error: data.error ?? 'Slack API error' };
+        }
+
+        return { success: true, externalRef: data.ts ?? '' };
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn('Slack question send error', { error: message });
+        return { success: false, error: message };
+    }
+}

--- a/server/notifications/channels/slack.ts
+++ b/server/notifications/channels/slack.ts
@@ -1,0 +1,70 @@
+import type { NotificationPayload, ChannelSendResult } from '../types';
+import { createLogger } from '../../lib/logger';
+
+const log = createLogger('NotifySlack');
+
+const LEVEL_COLORS: Record<string, string> = {
+    info: '#3498db',     // blue
+    success: '#2ecc71',  // green
+    warning: '#f39c12',  // orange
+    error: '#e74c3c',    // red
+};
+
+function validateWebhookUrl(url: string): void {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        throw new Error('Invalid webhook URL');
+    }
+    if (parsed.protocol !== 'https:') {
+        throw new Error('Slack webhook URL must use HTTPS');
+    }
+    const hostname = parsed.hostname;
+    if (!hostname.endsWith('.slack.com') && hostname !== 'slack.com' && hostname !== 'hooks.slack.com') {
+        throw new Error('Slack webhook URL must point to slack.com');
+    }
+}
+
+export async function sendSlack(
+    webhookUrl: string,
+    payload: NotificationPayload,
+): Promise<ChannelSendResult> {
+    try {
+        validateWebhookUrl(webhookUrl);
+
+        const color = LEVEL_COLORS[payload.level] ?? LEVEL_COLORS.info;
+        const title = payload.title ?? 'Agent Notification';
+
+        const body = {
+            attachments: [
+                {
+                    color,
+                    title,
+                    text: payload.message,
+                    footer: `Agent: ${payload.agentId.slice(0, 8)}... | ${payload.level}`,
+                    ts: Math.floor(new Date(payload.timestamp).getTime() / 1000),
+                },
+            ],
+        };
+
+        const response = await fetch(webhookUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+            signal: AbortSignal.timeout(10_000),
+        });
+
+        if (!response.ok) {
+            const text = await response.text().catch(() => '');
+            log.warn('Slack webhook failed', { status: response.status, body: text.slice(0, 200) });
+            return { success: false, error: `HTTP ${response.status}: ${text.slice(0, 200)}` };
+        }
+
+        return { success: true };
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn('Slack send error', { error: message });
+        return { success: false, error: message };
+    }
+}

--- a/server/notifications/question-dispatcher.ts
+++ b/server/notifications/question-dispatcher.ts
@@ -7,6 +7,7 @@ import { sendTelegramQuestion } from './channels/telegram-question';
 import { sendAlgoChatQuestion } from './channels/algochat-question';
 import { sendWhatsAppQuestion } from './channels/whatsapp-question';
 import { sendSignalQuestion } from './channels/signal-question';
+import { sendSlackQuestion } from './channels/slack-question';
 import { createLogger } from '../lib/logger';
 
 const log = createLogger('QuestionDispatcher');
@@ -148,6 +149,20 @@ export class QuestionDispatcher {
                     signalApiUrl,
                     senderNumber,
                     recipientNumber,
+                    question.id,
+                    question.question,
+                    question.options,
+                    question.context,
+                    question.agentId,
+                );
+            }
+            case 'slack': {
+                const slackBotToken = (config.botToken as string) || process.env.SLACK_BOT_TOKEN;
+                const slackChannelId = (config.channelId as string) || process.env.SLACK_CHANNEL_ID;
+                if (!slackBotToken || !slackChannelId) return { success: false, error: 'Slack botToken and channelId required' };
+                return sendSlackQuestion(
+                    slackBotToken,
+                    slackChannelId,
                     question.id,
                     question.question,
                     question.options,

--- a/server/notifications/service.ts
+++ b/server/notifications/service.ts
@@ -15,6 +15,7 @@ import { sendGitHub } from './channels/github';
 import { sendAlgoChat } from './channels/algochat';
 import { sendWhatsApp } from './channels/whatsapp';
 import { sendSignal } from './channels/signal';
+import { sendSlack } from './channels/slack';
 import { createLogger } from '../lib/logger';
 
 const log = createLogger('NotificationService');
@@ -194,6 +195,15 @@ export class NotificationService {
                         break;
                     }
                     result = await sendSignal(signalApiUrl, senderNumber, recipientNumber, payload);
+                    break;
+                }
+                case 'slack': {
+                    const webhookUrl = (config.webhookUrl as string) || process.env.SLACK_WEBHOOK_URL;
+                    if (!webhookUrl) {
+                        result = { success: false, error: 'No Slack webhook URL configured' };
+                        break;
+                    }
+                    result = await sendSlack(webhookUrl, payload);
                     break;
                 }
                 default:

--- a/server/slack/bridge.ts
+++ b/server/slack/bridge.ts
@@ -1,0 +1,355 @@
+import type { Database } from 'bun:sqlite';
+import type { ProcessManager } from '../process/manager';
+import type { SessionSource } from '../../shared/types';
+import type {
+    SlackBridgeConfig,
+    SlackEventPayload,
+    SlackMessageEvent,
+} from './types';
+import { listAgents } from '../db/agents';
+import { createSession, getSession } from '../db/sessions';
+import { listProjects } from '../db/projects';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('SlackBridge');
+
+const MAX_MESSAGE_LENGTH = 4000; // Slack block text limit
+
+/**
+ * Bidirectional Slack bridge using Events API (webhook-based).
+ * Receives messages via POST /api/slack/events and responds via Slack Web API.
+ */
+export class SlackBridge {
+    private db: Database;
+    private processManager: ProcessManager;
+    private config: SlackBridgeConfig;
+    private running = false;
+
+    // Map Slack userId -> active sessionId
+    private userSessions: Map<string, string> = new Map();
+
+    // Per-user rate limiting: userId -> timestamps of recent messages
+    private userMessageTimestamps: Map<string, number[]> = new Map();
+    private readonly RATE_LIMIT_WINDOW_MS = 60_000;
+    private readonly RATE_LIMIT_MAX_MESSAGES = 10;
+
+    // Track processed event timestamps to avoid duplicates
+    private processedEvents: Set<string> = new Set();
+    private processedEventsCleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+    constructor(db: Database, processManager: ProcessManager, config: SlackBridgeConfig) {
+        this.db = db;
+        this.processManager = processManager;
+        this.config = config;
+    }
+
+    start(): void {
+        if (this.running) return;
+        this.running = true;
+        // Clean up processed events set periodically to prevent memory growth
+        this.processedEventsCleanupTimer = setInterval(() => {
+            this.processedEvents.clear();
+        }, 300_000); // 5 minutes
+        log.info('Slack bridge started', { channelId: this.config.channelId });
+    }
+
+    stop(): void {
+        this.running = false;
+        if (this.processedEventsCleanupTimer) {
+            clearInterval(this.processedEventsCleanupTimer);
+            this.processedEventsCleanupTimer = null;
+        }
+        log.info('Slack bridge stopped');
+    }
+
+    /**
+     * Handle an incoming Slack Events API request.
+     * Called from the HTTP route handler.
+     */
+    async handleEventRequest(req: Request): Promise<Response> {
+        // Verify the request signature
+        const isValid = await this.verifySignature(req.clone());
+        if (!isValid) {
+            return new Response(JSON.stringify({ error: 'Invalid signature' }), {
+                status: 401,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        let body: SlackEventPayload;
+        try {
+            body = await req.json() as SlackEventPayload;
+        } catch {
+            return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+                status: 400,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        // Handle URL verification challenge
+        if (body.type === 'url_verification') {
+            return new Response(JSON.stringify({ challenge: body.challenge }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        // Handle event callbacks
+        if (body.type === 'event_callback' && body.event) {
+            // Process async to respond quickly (Slack requires response within 3s)
+            this.handleEvent(body.event as SlackMessageEvent).catch(err => {
+                log.error('Error handling Slack event', {
+                    error: err instanceof Error ? err.message : String(err),
+                });
+            });
+        }
+
+        return new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+        });
+    }
+
+    private async verifySignature(req: Request): Promise<boolean> {
+        const timestamp = req.headers.get('x-slack-request-timestamp');
+        const signature = req.headers.get('x-slack-signature');
+
+        if (!timestamp || !signature) return false;
+
+        // Reject requests older than 5 minutes to prevent replay attacks
+        const now = Math.floor(Date.now() / 1000);
+        if (Math.abs(now - parseInt(timestamp, 10)) > 300) return false;
+
+        const rawBody = await req.text();
+        const sigBasestring = `v0:${timestamp}:${rawBody}`;
+
+        const encoder = new TextEncoder();
+        const key = await crypto.subtle.importKey(
+            'raw',
+            encoder.encode(this.config.signingSecret),
+            { name: 'HMAC', hash: 'SHA-256' },
+            false,
+            ['sign'],
+        );
+        const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(sigBasestring));
+        const hexSig = 'v0=' + Array.from(new Uint8Array(sig))
+            .map(b => b.toString(16).padStart(2, '0'))
+            .join('');
+
+        // Timing-safe comparison
+        if (hexSig.length !== signature.length) return false;
+        let mismatch = 0;
+        for (let i = 0; i < hexSig.length; i++) {
+            mismatch |= hexSig.charCodeAt(i) ^ signature.charCodeAt(i);
+        }
+        return mismatch === 0;
+    }
+
+    private async handleEvent(event: SlackMessageEvent): Promise<void> {
+        if (!this.running) return;
+
+        // Only handle message and app_mention events
+        if (event.type !== 'message' && event.type !== 'app_mention') return;
+
+        // Filter bot messages to avoid echo loops
+        if (event.bot_id || event.subtype) return;
+
+        // Deduplicate events (Slack may retry)
+        const eventKey = `${event.channel}:${event.ts}`;
+        if (this.processedEvents.has(eventKey)) return;
+        this.processedEvents.add(eventKey);
+
+        const userId = event.user;
+        const text = event.text;
+        const channelId = event.channel;
+
+        if (!userId || !text || !channelId) return;
+
+        // Only respond in configured channel (if set)
+        if (this.config.channelId && channelId !== this.config.channelId) return;
+
+        // Authorization check
+        if (this.config.allowedUserIds.length > 0 && !this.config.allowedUserIds.includes(userId)) {
+            log.warn('Unauthorized Slack user', { userId });
+            await this.sendMessage(channelId, 'Unauthorized.', event.thread_ts ?? event.ts);
+            return;
+        }
+
+        // Per-user rate limiting (10 messages per 60 seconds)
+        if (!this.checkRateLimit(userId)) {
+            await this.sendMessage(
+                channelId,
+                'Rate limit exceeded. Please wait before sending more messages.',
+                event.thread_ts ?? event.ts,
+            );
+            return;
+        }
+
+        // Handle /status command
+        if (text.trim() === '/status') {
+            const sessionId = this.userSessions.get(userId) ?? 'none';
+            await this.sendMessage(channelId, `Your session: ${sessionId}`, event.thread_ts ?? event.ts);
+            return;
+        }
+
+        // Handle /new command
+        if (text.trim() === '/new') {
+            this.userSessions.delete(userId);
+            await this.sendMessage(
+                channelId,
+                'Session cleared. Your next message will start a new session.',
+                event.thread_ts ?? event.ts,
+            );
+            return;
+        }
+
+        // Route to agent session, using thread_ts for conversation tracking
+        await this.routeToAgent(channelId, userId, text, event.thread_ts ?? event.ts);
+    }
+
+    private checkRateLimit(userId: string): boolean {
+        const now = Date.now();
+        const timestamps = this.userMessageTimestamps.get(userId) ?? [];
+        const recent = timestamps.filter(t => now - t < this.RATE_LIMIT_WINDOW_MS);
+        if (recent.length >= this.RATE_LIMIT_MAX_MESSAGES) return false;
+        recent.push(now);
+        this.userMessageTimestamps.set(userId, recent);
+        return true;
+    }
+
+    private async routeToAgent(channelId: string, userId: string, text: string, threadTs: string): Promise<void> {
+        let sessionId = this.userSessions.get(userId);
+        const source: SessionSource = 'slack';
+
+        // Check if session still exists and is active
+        if (sessionId) {
+            const session = getSession(this.db, sessionId);
+            if (!session || session.status === 'stopped' || session.status === 'error') {
+                this.userSessions.delete(userId);
+                sessionId = undefined;
+            }
+        }
+
+        // Find or create session
+        if (!sessionId) {
+            const agents = listAgents(this.db);
+            const agent = agents[0];
+            if (!agent) {
+                await this.sendMessage(channelId, 'No agents configured. Create an agent first.', threadTs);
+                return;
+            }
+
+            const projects = listProjects(this.db);
+            const project = agent.defaultProjectId
+                ? projects.find(p => p.id === agent.defaultProjectId) ?? projects[0]
+                : projects[0];
+
+            if (!project) {
+                await this.sendMessage(channelId, 'No projects configured.', threadTs);
+                return;
+            }
+
+            const session = createSession(this.db, {
+                projectId: project.id,
+                agentId: agent.id,
+                name: `Slack (user ${userId})`,
+                initialPrompt: text,
+                source,
+            });
+
+            sessionId = session.id;
+            this.userSessions.set(userId, sessionId);
+
+            this.processManager.startProcess(session, text);
+            this.subscribeForResponse(sessionId, channelId, threadTs);
+            return;
+        }
+
+        const sent = this.processManager.sendMessage(sessionId, text);
+        if (!sent) {
+            const session = getSession(this.db, sessionId);
+            if (session) {
+                this.processManager.startProcess(session, text);
+                this.subscribeForResponse(sessionId, channelId, threadTs);
+            } else {
+                this.userSessions.delete(userId);
+                await this.sendMessage(channelId, 'Session expired. Send another message to start a new one.', threadTs);
+            }
+            return;
+        }
+
+        this.subscribeForResponse(sessionId, channelId, threadTs);
+    }
+
+    private subscribeForResponse(sessionId: string, channelId: string, threadTs: string): void {
+        let buffer = '';
+        let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+        const flush = async () => {
+            if (!buffer) return;
+            const text = buffer;
+            buffer = '';
+            await this.sendMessage(channelId, text, threadTs);
+        };
+
+        this.processManager.subscribe(sessionId, (_sid, event) => {
+            if (event.type === 'assistant' && event.message) {
+                const content = typeof event.message === 'string'
+                    ? event.message
+                    : (event.message as { content?: string })?.content ?? '';
+
+                if (content) {
+                    buffer += content;
+                    if (debounceTimer) clearTimeout(debounceTimer);
+                    debounceTimer = setTimeout(() => flush(), 1500);
+                }
+            }
+
+            if (event.type === 'result') {
+                if (debounceTimer) clearTimeout(debounceTimer);
+                flush();
+            }
+        });
+    }
+
+    async sendMessage(channelId: string, content: string, threadTs?: string): Promise<void> {
+        // Split messages that exceed Slack's limit
+        const chunks: string[] = [];
+        if (content.length <= MAX_MESSAGE_LENGTH) {
+            chunks.push(content);
+        } else {
+            for (let i = 0; i < content.length; i += MAX_MESSAGE_LENGTH) {
+                chunks.push(content.slice(i, i + MAX_MESSAGE_LENGTH));
+            }
+        }
+
+        for (const chunk of chunks) {
+            const body: Record<string, unknown> = {
+                channel: channelId,
+                text: chunk,
+            };
+            if (threadTs) {
+                body.thread_ts = threadTs;
+            }
+
+            const response = await fetch('https://slack.com/api/chat.postMessage', {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${this.config.botToken}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(body),
+            });
+
+            if (!response.ok) {
+                const error = await response.text();
+                log.error('Failed to send Slack message', { status: response.status, error: error.slice(0, 200) });
+            } else {
+                const data = await response.json() as { ok: boolean; error?: string };
+                if (!data.ok) {
+                    log.error('Slack API error', { error: data.error });
+                }
+            }
+        }
+    }
+}

--- a/server/slack/types.ts
+++ b/server/slack/types.ts
@@ -1,0 +1,39 @@
+export interface SlackBridgeConfig {
+    botToken: string;
+    signingSecret: string;
+    channelId: string;
+    allowedUserIds: string[];
+}
+
+export interface SlackEventPayload {
+    token: string;
+    type: 'url_verification' | 'event_callback';
+    challenge?: string;
+    event?: SlackEvent;
+}
+
+export interface SlackEvent {
+    type: string;
+    user?: string;
+    text?: string;
+    channel?: string;
+    ts?: string;
+    thread_ts?: string;
+    bot_id?: string;
+    subtype?: string;
+}
+
+export interface SlackMessageEvent extends SlackEvent {
+    type: 'message' | 'app_mention';
+    user: string;
+    text: string;
+    channel: string;
+    ts: string;
+    thread_ts?: string;
+}
+
+export interface SlackChallenge {
+    token: string;
+    type: 'url_verification';
+    challenge: string;
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -35,7 +35,7 @@ export interface Agent {
 }
 
 export type SessionStatus = 'idle' | 'running' | 'paused' | 'stopped' | 'error';
-export type SessionSource = 'web' | 'algochat' | 'agent' | 'telegram' | 'discord';
+export type SessionSource = 'web' | 'algochat' | 'agent' | 'telegram' | 'discord' | 'slack';
 
 export interface Session {
     id: string;
@@ -691,7 +691,7 @@ export interface WorkflowNodeRun {
 
 // MARK: - Notifications (Multi-Channel)
 
-export type NotificationChannelType = 'websocket' | 'discord' | 'telegram' | 'github' | 'algochat' | 'whatsapp' | 'signal';
+export type NotificationChannelType = 'websocket' | 'discord' | 'telegram' | 'github' | 'algochat' | 'whatsapp' | 'signal' | 'slack';
 
 // MARK: - Voice
 


### PR DESCRIPTION
## Summary
- Add bidirectional Slack bridge using Events API webhooks (`/api/slack/events`) with HMAC signature verification, per-user rate limiting (10 msg/60s), thread-based conversation tracking, and message splitting for Slack's 4000-char limit
- Add Slack notification channel using incoming webhooks with color-coded attachments based on notification level
- Add Slack question channel for dispatching interactive agent questions via Block Kit
- Register `'slack'` in `SessionSource` and `NotificationChannelType` type unions, notification service, question dispatcher, and MCP tool validation

Closes #112

## New Files
- `server/slack/types.ts` — TypeScript interfaces (SlackBridgeConfig, SlackEventPayload, SlackEvent, SlackMessageEvent, SlackChallenge)
- `server/slack/bridge.ts` — Events API webhook bridge with signature verification, rate limiting, session routing, response streaming
- `server/notifications/channels/slack.ts` — Webhook-based notifications with color-coded attachments
- `server/notifications/channels/slack-question.ts` — Block Kit interactive questions via Web API

## Modified Files
- `shared/types.ts` — Add `'slack'` to `SessionSource` and `NotificationChannelType`
- `server/index.ts` — Initialize SlackBridge from `SLACK_BOT_TOKEN` + `SLACK_SIGNING_SECRET` env vars, register `/api/slack/events` webhook route, add to graceful shutdown
- `server/notifications/service.ts` — Add `'slack'` dispatch case using `SLACK_WEBHOOK_URL`
- `server/notifications/question-dispatcher.ts` — Add `'slack'` dispatch case using `SLACK_BOT_TOKEN` + `SLACK_CHANNEL_ID`
- `server/mcp/tool-handlers.ts` — Add `'slack'` to `VALID_CHANNEL_TYPES` for `corvid_configure_notifications`

## Environment Variables
- `SLACK_BOT_TOKEN` — Bot User OAuth Token (required for bridge)
- `SLACK_SIGNING_SECRET` — App Signing Secret for webhook verification (required for bridge)
- `SLACK_CHANNEL_ID` — Default channel to listen in (optional)
- `SLACK_ALLOWED_USER_IDS` — Comma-separated user IDs for authorization (optional)
- `SLACK_WEBHOOK_URL` — Incoming webhook URL for notifications (optional)

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` passes (2135 tests, 0 failures)
- [ ] Configure Slack app with Events API webhook pointed to `/api/slack/events`
- [ ] Verify URL verification challenge handshake completes
- [ ] Send message in Slack channel, verify agent session is created and response posted back in thread
- [ ] Verify rate limiting blocks >10 messages per 60s per user
- [ ] Configure Slack webhook URL and verify notifications are posted with correct color-coding
- [ ] Configure Slack question channel and verify interactive Block Kit questions are sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)