### PR TITLE
feat: add Slack integration channel (#143)

### DIFF
--- a/server/__tests__/notification-channels.test.ts
+++ b/server/__tests__/notification-channels.test.ts
@@ -5,6 +5,7 @@
  * - sendWebSocket (websocket.ts)
  * - sendGitHub (github.ts)
  * - sendAlgoChat (algochat.ts)
+ * - sendSlack (slack.ts)
  *
  * These tests validate each channel in isolation without hitting real external APIs.
  */
@@ -14,6 +15,7 @@ import { sendDiscord } from '../notifications/channels/discord';
 import { sendTelegram } from '../notifications/channels/telegram';
 import { sendWebSocket } from '../notifications/channels/websocket';
 import { sendAlgoChat } from '../notifications/channels/algochat';
+import { sendSlack } from '../notifications/channels/slack';
 import type { NotificationPayload } from '../notifications/types';
 import type { AgentMessenger } from '../algochat/agent-messenger';
 
@@ -348,5 +350,36 @@ describe('sendAlgoChat', () => {
         const result = await sendAlgoChat(messenger, 'ADDR', TEST_PAYLOAD);
         expect(result.success).toBe(false);
         expect(result.error).toBe('string-error');
+    });
+});
+
+// ─── Slack ────────────────────────────────────────────────────────────────
+
+describe('sendSlack', () => {
+    test('returns success: false with error for invalid bot token', async () => {
+        const result = await sendSlack('xoxb-invalid-token', '#test', TEST_PAYLOAD);
+        expect(result.success).toBe(false);
+        expect(result.error).toBeTruthy();
+        expect(typeof result.error).toBe('string');
+    });
+
+    test('returns success: false for unreachable API', async () => {
+        const result = await sendSlack('xoxb-fake', '#test', TEST_PAYLOAD);
+        expect(result.success).toBe(false);
+        expect(result.error).toBeTruthy();
+    });
+
+    test('handles payload with null title gracefully', async () => {
+        const payloadNoTitle: NotificationPayload = { ...TEST_PAYLOAD, title: null };
+        const result = await sendSlack('xoxb-fake', '#test', payloadNoTitle);
+        expect(result.success).toBe(false);
+        expect(result.error).toBeTruthy();
+    });
+
+    test('handles payload with null sessionId gracefully', async () => {
+        const payloadNoSession: NotificationPayload = { ...TEST_PAYLOAD, sessionId: null };
+        const result = await sendSlack('xoxb-fake', '#test', payloadNoSession);
+        expect(result.success).toBe(false);
+        expect(result.error).toBeTruthy();
     });
 });

--- a/server/mcp/sdk-tools.ts
+++ b/server/mcp/sdk-tools.ts
@@ -272,13 +272,13 @@ export function createCorvidMcpServer(ctx: McpToolContext, pluginTools?: ReturnT
         tool(
             'corvid_configure_notifications',
             'Manage notification channels for this agent. Channels control where corvid_notify_owner sends messages. ' +
-            'Supported channel types: discord (webhook), telegram (bot), github (issues), algochat (on-chain). ' +
+            'Supported channel types: discord (webhook), telegram (bot), github (issues), algochat (on-chain), slack (bot). ' +
             'WebSocket is always active. Use action="list" to view, "set" to configure, "enable"/"disable" to toggle, "remove" to delete.',
             {
                 action: z.enum(['list', 'set', 'enable', 'disable', 'remove']).describe('What to do'),
-                channel_type: z.string().optional().describe('Channel type: discord, telegram, github, or algochat'),
+                channel_type: z.string().optional().describe('Channel type: discord, telegram, github, algochat, or slack'),
                 config: z.record(z.string(), z.unknown()).optional().describe(
-                    'Channel configuration. Discord: {webhookUrl}. Telegram: {botToken, chatId}. GitHub: {repo, labels?}. AlgoChat: {toAddress}.',
+                    'Channel configuration. Discord: {webhookUrl}. Telegram: {botToken, chatId}. GitHub: {repo, labels?}. AlgoChat: {toAddress}. Slack: {botToken, channel}.',
                 ),
             },
             async (args) => handleConfigureNotifications(ctx, args),

--- a/server/mcp/tool-handlers.ts
+++ b/server/mcp/tool-handlers.ts
@@ -1222,7 +1222,7 @@ export async function handleConfigureNotifications(
                 if (channels.length === 0) {
                     return textResult(
                         'No notification channels configured.\n\n' +
-                        'Available channel types: discord, telegram, github, algochat\n' +
+                        'Available channel types: discord, telegram, github, algochat, slack\n' +
                         'Use action="set" with channel_type and config to add one.',
                     );
                 }

--- a/server/notifications/question-dispatcher.ts
+++ b/server/notifications/question-dispatcher.ts
@@ -157,12 +157,12 @@ export class QuestionDispatcher {
                 );
             }
             case 'slack': {
-                const slackBotToken = (config.botToken as string) || process.env.SLACK_BOT_TOKEN;
-                const slackChannelId = (config.channelId as string) || process.env.SLACK_CHANNEL_ID;
-                if (!slackBotToken || !slackChannelId) return { success: false, error: 'Slack botToken and channelId required' };
+                const token = (config.botToken as string) || process.env.SLACK_BOT_TOKEN;
+                const channel = config.channel as string;
+                if (!token || !channel) return { success: false, error: 'Slack botToken and channel required' };
                 return sendSlackQuestion(
-                    slackBotToken,
-                    slackChannelId,
+                    token,
+                    channel,
                     question.id,
                     question.question,
                     question.options,

--- a/server/notifications/service.ts
+++ b/server/notifications/service.ts
@@ -198,12 +198,13 @@ export class NotificationService {
                     break;
                 }
                 case 'slack': {
-                    const webhookUrl = (config.webhookUrl as string) || process.env.SLACK_WEBHOOK_URL;
-                    if (!webhookUrl) {
-                        result = { success: false, error: 'No Slack webhook URL configured' };
+                    const token = (config.botToken as string) || process.env.SLACK_BOT_TOKEN;
+                    const channel = config.channel as string;
+                    if (!token || !channel) {
+                        result = { success: false, error: 'Slack botToken and channel required' };
                         break;
                     }
-                    result = await sendSlack(webhookUrl, payload);
+                    result = await sendSlack(token, channel, payload);
                     break;
                 }
                 default:

--- a/server/routes/slack.ts
+++ b/server/routes/slack.ts
@@ -1,0 +1,253 @@
+import type { Database } from 'bun:sqlite';
+import type { ProcessManager } from '../process/manager';
+import {
+    listActiveQuestionDispatches,
+    markDispatchAnswered,
+    getQuestionDispatchesByQuestionId,
+    updateQuestionDispatchStatus,
+} from '../db/notifications';
+import { sendSlack } from '../notifications/channels/slack';
+import { createLogger } from '../lib/logger';
+import { json } from '../lib/response';
+import * as crypto from 'crypto';
+
+const log = createLogger('SlackRoutes');
+
+async function verifySlackSignature(
+    req: Request,
+    body: string,
+    signingSecret: string,
+): Promise<boolean> {
+    const timestamp = req.headers.get('X-Slack-Request-Timestamp');
+    const slackSignature = req.headers.get('X-Slack-Signature');
+    if (!timestamp || !slackSignature) return false;
+
+    // Reject requests older than 5 minutes
+    const now = Math.floor(Date.now() / 1000);
+    if (Math.abs(now - parseInt(timestamp, 10)) > 300) return false;
+
+    const sigBasestring = `v0:${timestamp}:${body}`;
+    const hmac = crypto.createHmac('sha256', signingSecret);
+    hmac.update(sigBasestring);
+    const mySignature = `v0=${hmac.digest('hex')}`;
+
+    // Timing-safe comparison
+    try {
+        return crypto.timingSafeEqual(
+            Buffer.from(mySignature),
+            Buffer.from(slackSignature),
+        );
+    } catch {
+        return false;
+    }
+}
+
+export function handleSlackRoutes(
+    req: Request,
+    url: URL,
+    db: Database,
+    processManager: ProcessManager,
+): Response | Promise<Response> | null {
+    // POST /slack/events — Slack Events API + Interactivity
+    if (url.pathname === '/slack/events' && req.method === 'POST') {
+        return handleSlackEvents(req, db, processManager);
+    }
+
+    return null;
+}
+
+async function handleSlackEvents(
+    req: Request,
+    db: Database,
+    processManager: ProcessManager,
+): Promise<Response> {
+    const signingSecret = process.env.SLACK_SIGNING_SECRET;
+    const botToken = process.env.SLACK_BOT_TOKEN;
+
+    if (!signingSecret) {
+        log.warn('SLACK_SIGNING_SECRET not configured');
+        return json({ error: 'Slack not configured' }, 503);
+    }
+
+    const rawBody = await req.text();
+
+    // Verify signature
+    const valid = await verifySlackSignature(req, rawBody, signingSecret);
+    if (!valid) {
+        log.warn('Slack signature verification failed');
+        return json({ error: 'Invalid signature' }, 401);
+    }
+
+    // Check content type — Slack sends interactive payloads as application/x-www-form-urlencoded
+    const contentType = req.headers.get('content-type') ?? '';
+
+    if (contentType.includes('application/x-www-form-urlencoded')) {
+        // Interactive payload (button clicks)
+        const params = new URLSearchParams(rawBody);
+        const payloadStr = params.get('payload');
+        if (!payloadStr) return json({ error: 'Missing payload' }, 400);
+
+        const payload = JSON.parse(payloadStr) as {
+            type: string;
+            actions?: Array<{ action_id: string; value: string }>;
+            channel?: { id: string };
+            message?: { ts: string; thread_ts?: string };
+            user?: { id: string };
+        };
+
+        if (payload.type === 'block_actions' && payload.actions) {
+            for (const action of payload.actions) {
+                // Parse action_id: "q:shortId:optionIdx"
+                const match = action.action_id.match(/^q:([^:]+):(\d+)$/);
+                if (!match) continue;
+
+                const [, shortId, optionStr] = match;
+                const optionIdx = parseInt(optionStr, 10);
+
+                // Find the matching question dispatch
+                const dispatches = listActiveQuestionDispatches(db);
+                const dispatch = dispatches.find(
+                    (d) => d.channelType === 'slack' && d.questionId.startsWith(shortId),
+                );
+
+                if (dispatch) {
+                    // Look up options from the question
+                    const row = db.query(
+                        'SELECT options FROM owner_questions WHERE id = ?',
+                    ).get(dispatch.questionId) as { options: string | null } | null;
+
+                    const options: string[] = row?.options ? JSON.parse(row.options) : [];
+                    const answer = optionIdx < options.length ? options[optionIdx] : String(optionIdx);
+
+                    const resolved = processManager.ownerQuestionManager.resolveQuestion(dispatch.questionId, {
+                        questionId: dispatch.questionId,
+                        answer,
+                        selectedOption: optionIdx < options.length ? optionIdx : null,
+                    });
+
+                    if (resolved) {
+                        log.info('Resolved question via Slack button', { questionId: dispatch.questionId });
+                        markDispatchAnswered(db, dispatch.id);
+
+                        // Mark all other dispatches for this question as answered
+                        const allDispatches = getQuestionDispatchesByQuestionId(db, dispatch.questionId);
+                        for (const d of allDispatches) {
+                            if (d.status === 'sent') {
+                                updateQuestionDispatchStatus(db, d.id, 'answered');
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return json({ ok: true });
+    }
+
+    // JSON payload — Events API
+    let body: Record<string, unknown>;
+    try {
+        body = JSON.parse(rawBody) as Record<string, unknown>;
+    } catch {
+        return json({ error: 'Invalid JSON' }, 400);
+    }
+
+    // URL verification challenge
+    if (body.type === 'url_verification') {
+        return json({ challenge: body.challenge });
+    }
+
+    // Event callback
+    if (body.type === 'event_callback') {
+        const event = body.event as {
+            type: string;
+            text?: string;
+            thread_ts?: string;
+            ts?: string;
+            channel?: string;
+            user?: string;
+            bot_id?: string;
+        } | undefined;
+
+        if (!event) return json({ ok: true });
+
+        // Ignore bot messages to prevent loops
+        if (event.bot_id) return json({ ok: true });
+
+        // Only handle messages in threads (thread replies to question messages)
+        if (event.type === 'message' && event.thread_ts && event.text) {
+            const dispatches = listActiveQuestionDispatches(db);
+            const dispatch = dispatches.find((d) => {
+                if (d.channelType !== 'slack' || !d.externalRef) return false;
+                // externalRef format: "channel:ts"
+                const [, ts] = d.externalRef.split(':');
+                return ts === event.thread_ts;
+            });
+
+            if (dispatch) {
+                // Look up options to try to match
+                const row = db.query(
+                    'SELECT options FROM owner_questions WHERE id = ?',
+                ).get(dispatch.questionId) as { options: string | null } | null;
+
+                const options: string[] = row?.options ? JSON.parse(row.options) : [];
+                const trimmed = event.text.trim();
+                let answer = trimmed;
+                let selectedOption: number | null = null;
+
+                // Try to match by number
+                const numMatch = trimmed.match(/^(\d+)$/);
+                if (numMatch && options.length > 0) {
+                    const idx = parseInt(numMatch[1], 10) - 1;
+                    if (idx >= 0 && idx < options.length) {
+                        answer = options[idx];
+                        selectedOption = idx;
+                    }
+                }
+
+                // Try exact text match
+                if (selectedOption === null && options.length > 0) {
+                    const lowerTrimmed = trimmed.toLowerCase();
+                    const matchIdx = options.findIndex((opt) => opt.toLowerCase() === lowerTrimmed);
+                    if (matchIdx >= 0) {
+                        answer = options[matchIdx];
+                        selectedOption = matchIdx;
+                    }
+                }
+
+                const resolved = processManager.ownerQuestionManager.resolveQuestion(dispatch.questionId, {
+                    questionId: dispatch.questionId,
+                    answer,
+                    selectedOption,
+                });
+
+                if (resolved) {
+                    log.info('Resolved question via Slack thread reply', { questionId: dispatch.questionId });
+                    markDispatchAnswered(db, dispatch.id);
+
+                    const allDispatches = getQuestionDispatchesByQuestionId(db, dispatch.questionId);
+                    for (const d of allDispatches) {
+                        if (d.status === 'sent') {
+                            updateQuestionDispatchStatus(db, d.id, 'answered');
+                        }
+                    }
+
+                    // Send confirmation in thread
+                    if (botToken && event.channel) {
+                        sendSlack(botToken, event.channel, {
+                            notificationId: '',
+                            agentId: '',
+                            sessionId: null,
+                            title: null,
+                            message: 'Answer received!',
+                            level: 'success',
+                            timestamp: new Date().toISOString(),
+                        }, event.thread_ts).catch(() => {});
+                    }
+                }
+            }
+        }
+    }
+
+    return json({ ok: true });
+}


### PR DESCRIPTION
## Summary
- Add Slack bot integration as a notification channel so teams can interact with corvid-agent from Slack channels
- Implement `sendSlack()` notification sender with Block Kit formatting, level-based emoji/colors, and thread support
- Implement `sendSlackQuestion()` with interactive buttons for option selection and thread-based freeform answers
- Add `/slack/events` webhook endpoint with Slack signing secret verification (HMAC SHA256), handling URL verification challenges, `block_actions` interactive payloads, and `event_callback` thread replies
- Register Slack route before auth guards (validated by signing secret instead of API key)
- Add `'slack'` to `NotificationChannelType`, `VALID_CHANNEL_TYPES`, and MCP tool descriptions
- Add 4 tests for `sendSlack()` covering error handling and null field graceful handling

### Files Created
- `server/notifications/channels/slack.ts` — notification sender
- `server/notifications/channels/slack-question.ts` — question sender with interactive buttons
- `server/routes/slack.ts` — webhook endpoint with signature verification

### Files Modified
- `shared/types.ts` — add `'slack'` to `NotificationChannelType`
- `server/notifications/service.ts` — add Slack dispatch case
- `server/notifications/question-dispatcher.ts` — add Slack question dispatch
- `server/mcp/tool-handlers.ts` — add `'slack'` to valid channel types
- `server/mcp/sdk-tools.ts` — update tool description to include Slack
- `server/routes/index.ts` — register Slack routes before auth guards
- `server/__tests__/notification-channels.test.ts` — add Slack tests

### Environment Variables
- `SLACK_BOT_TOKEN` — fallback bot token (xoxb-...)
- `SLACK_SIGNING_SECRET` — for webhook signature verification

Closes #143

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` passes (2139 tests, 0 failures)
- [ ] Manual: Configure Slack bot token and signing secret, verify notification delivery
- [ ] Manual: Verify interactive button clicks resolve questions
- [ ] Manual: Verify thread replies resolve questions with freeform answers

🤖 Generated with [Claude Code](https://claude.com/claude-code)