### PR TITLE
feat: implement Koa-style middleware pipeline

### DIFF
--- a/server/__tests__/middleware-pipeline.test.ts
+++ b/server/__tests__/middleware-pipeline.test.ts
@@ -1,0 +1,811 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+    compose,
+    createMiddlewareContext,
+    MiddlewarePipeline,
+    type Middleware,
+    type MiddlewareContext,
+    type MiddlewareFn,
+} from '../middleware/pipeline';
+import {
+    errorHandlerMiddleware,
+    requestLogMiddleware,
+    corsMiddleware,
+    rateLimitMiddleware,
+    authMiddleware,
+    roleMiddleware,
+    ORDER,
+} from '../middleware/builtin';
+import type { AuthConfig } from '../middleware/auth';
+import { RateLimiter } from '../middleware/rate-limit';
+import { createRequestContext } from '../middleware/guards';
+
+// --- Helpers ----------------------------------------------------------------
+
+function makeRequest(path: string, options?: RequestInit & { headers?: Record<string, string> }): Request {
+    return new Request(`http://localhost:3000${path}`, options);
+}
+
+function makeUrl(path: string, params?: Record<string, string>): URL {
+    const url = new URL(`http://localhost:3000${path}`);
+    if (params) {
+        for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+    }
+    return url;
+}
+
+function makeCtx(path: string = '/api/test', method: string = 'GET'): MiddlewareContext {
+    const req = makeRequest(path, { method });
+    const url = makeUrl(path);
+    return createMiddlewareContext(req, url, createRequestContext());
+}
+
+function makeMiddleware(name: string, order: number, handler: MiddlewareFn): Middleware {
+    return { name, order, handler };
+}
+
+// Simple tracking middleware that records when it runs
+function trackingMiddleware(name: string, order: number, log: string[]): Middleware {
+    return makeMiddleware(name, order, async (_ctx, next) => {
+        log.push(`${name}:down`);
+        await next();
+        log.push(`${name}:up`);
+    });
+}
+
+// --- compose() --------------------------------------------------------------
+
+describe('compose', () => {
+    it('executes middleware in order (downstream) and reverse (upstream)', async () => {
+        const log: string[] = [];
+
+        const pipeline = compose([
+            trackingMiddleware('c', 30, log),
+            trackingMiddleware('a', 10, log),
+            trackingMiddleware('b', 20, log),
+        ]);
+
+        const ctx = makeCtx();
+        await pipeline(ctx);
+
+        expect(log).toEqual([
+            'a:down', 'b:down', 'c:down',
+            'c:up', 'b:up', 'a:up',
+        ]);
+    });
+
+    it('preserves registration order for equal order values', async () => {
+        const log: string[] = [];
+
+        const pipeline = compose([
+            trackingMiddleware('first', 10, log),
+            trackingMiddleware('second', 10, log),
+            trackingMiddleware('third', 10, log),
+        ]);
+
+        const ctx = makeCtx();
+        await pipeline(ctx);
+
+        expect(log).toEqual([
+            'first:down', 'second:down', 'third:down',
+            'third:up', 'second:up', 'first:up',
+        ]);
+    });
+
+    it('handles empty middleware list', async () => {
+        const pipeline = compose([]);
+        const ctx = makeCtx();
+        await pipeline(ctx); // Should not throw
+    });
+
+    it('handles single middleware', async () => {
+        const log: string[] = [];
+        const pipeline = compose([trackingMiddleware('only', 1, log)]);
+
+        const ctx = makeCtx();
+        await pipeline(ctx);
+
+        expect(log).toEqual(['only:down', 'only:up']);
+    });
+
+    it('rejects when next() is called multiple times', async () => {
+        const pipeline = compose([
+            makeMiddleware('double-next', 1, async (_ctx, next) => {
+                await next();
+                await next(); // Second call should reject
+            }),
+        ]);
+
+        const ctx = makeCtx();
+        await expect(pipeline(ctx)).rejects.toThrow('next() called multiple times');
+    });
+});
+
+// --- Abort semantics --------------------------------------------------------
+
+describe('abort semantics', () => {
+    it('stops downstream execution when middleware does not call next()', async () => {
+        const log: string[] = [];
+
+        const pipeline = compose([
+            trackingMiddleware('first', 10, log),
+            makeMiddleware('blocker', 20, async (ctx, _next) => {
+                log.push('blocker:abort');
+                ctx.response = new Response('Blocked', { status: 403 });
+                // Does NOT call next() — aborts the chain
+            }),
+            trackingMiddleware('never', 30, log),
+        ]);
+
+        const ctx = makeCtx();
+        await pipeline(ctx);
+
+        expect(log).toEqual([
+            'first:down',
+            'blocker:abort',
+            'first:up', // Upstream still runs for middleware that already entered
+        ]);
+        expect(ctx.response?.status).toBe(403);
+    });
+
+    it('stops downstream execution when ctx.aborted is set', async () => {
+        const log: string[] = [];
+
+        const pipeline = compose([
+            trackingMiddleware('first', 10, log),
+            makeMiddleware('aborter', 20, async (ctx, next) => {
+                log.push('aborter:abort');
+                ctx.aborted = true;
+                ctx.response = new Response('Aborted', { status: 429 });
+                await next(); // Calls next but pipeline checks aborted flag
+            }),
+            trackingMiddleware('skipped', 30, log),
+        ]);
+
+        const ctx = makeCtx();
+        await pipeline(ctx);
+
+        // - first:down runs
+        // - aborter:abort runs (its handler)
+        // - next() is called but ctx.aborted=true so dispatch(2) returns immediately
+        // - aborter handler completes
+        // - first's upstream runs
+        expect(log).toEqual([
+            'first:down',
+            'aborter:abort',
+            'first:up',
+        ]);
+    });
+
+    it('allows middleware to set response without calling next', async () => {
+        const pipeline = compose([
+            makeMiddleware('early-response', 10, async (ctx, _next) => {
+                ctx.response = new Response(JSON.stringify({ status: 'ok' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+                // No next() call — short-circuits
+            }),
+        ]);
+
+        const ctx = makeCtx();
+        await pipeline(ctx);
+
+        expect(ctx.response?.status).toBe(200);
+        const body = await ctx.response!.json();
+        expect(body.status).toBe('ok');
+    });
+});
+
+// --- Context sharing --------------------------------------------------------
+
+describe('context sharing', () => {
+    it('allows middleware to share data via ctx.state', async () => {
+        const pipeline = compose([
+            makeMiddleware('setter', 10, async (ctx, next) => {
+                ctx.state.userId = '12345';
+                ctx.state.startedAt = Date.now();
+                await next();
+            }),
+            makeMiddleware('reader', 20, async (ctx, next) => {
+                expect(ctx.state.userId).toBe('12345');
+                expect(ctx.state.startedAt).toBeTypeOf('number');
+                ctx.state.processed = true;
+                await next();
+            }),
+            makeMiddleware('verifier', 30, async (ctx, _next) => {
+                expect(ctx.state.processed).toBe(true);
+            }),
+        ]);
+
+        const ctx = makeCtx();
+        await pipeline(ctx);
+    });
+
+    it('allows middleware to modify requestContext', async () => {
+        const pipeline = compose([
+            makeMiddleware('auth', 10, async (ctx, next) => {
+                ctx.requestContext.authenticated = true;
+                ctx.requestContext.role = 'admin';
+                await next();
+            }),
+            makeMiddleware('checker', 20, async (ctx, _next) => {
+                expect(ctx.requestContext.authenticated).toBe(true);
+                expect(ctx.requestContext.role).toBe('admin');
+            }),
+        ]);
+
+        const ctx = makeCtx();
+        await pipeline(ctx);
+    });
+});
+
+// --- Error handling ---------------------------------------------------------
+
+describe('error handling', () => {
+    it('propagates errors to upstream middleware', async () => {
+        let caughtError: Error | null = null;
+
+        const pipeline = compose([
+            makeMiddleware('catcher', 10, async (_ctx, next) => {
+                try {
+                    await next();
+                } catch (err) {
+                    caughtError = err as Error;
+                }
+            }),
+            makeMiddleware('thrower', 20, async () => {
+                throw new Error('test error');
+            }),
+        ]);
+
+        const ctx = makeCtx();
+        await pipeline(ctx); // Should not reject because catcher handles it
+
+        expect(caughtError).not.toBeNull();
+        expect(caughtError!.message).toBe('test error');
+    });
+
+    it('propagates errors when no middleware catches them', async () => {
+        const pipeline = compose([
+            makeMiddleware('thrower', 10, async () => {
+                throw new Error('uncaught');
+            }),
+        ]);
+
+        const ctx = makeCtx();
+        await expect(pipeline(ctx)).rejects.toThrow('uncaught');
+    });
+});
+
+// --- MiddlewarePipeline class -----------------------------------------------
+
+describe('MiddlewarePipeline', () => {
+    it('registers and executes middleware', async () => {
+        const log: string[] = [];
+        const pipeline = new MiddlewarePipeline();
+
+        pipeline
+            .use(trackingMiddleware('second', 20, log))
+            .use(trackingMiddleware('first', 10, log));
+
+        const ctx = makeCtx();
+        await pipeline.execute(ctx);
+
+        expect(log).toEqual(['first:down', 'second:down', 'second:up', 'first:up']);
+    });
+
+    it('removes middleware by name', async () => {
+        const log: string[] = [];
+        const pipeline = new MiddlewarePipeline();
+
+        pipeline
+            .use(trackingMiddleware('a', 10, log))
+            .use(trackingMiddleware('b', 20, log))
+            .use(trackingMiddleware('c', 30, log));
+
+        pipeline.remove('b');
+
+        const ctx = makeCtx();
+        await pipeline.execute(ctx);
+
+        expect(log).toEqual(['a:down', 'c:down', 'c:up', 'a:up']);
+    });
+
+    it('getMiddlewares returns sorted list', () => {
+        const pipeline = new MiddlewarePipeline();
+
+        pipeline
+            .use(makeMiddleware('c', 30, async () => {}))
+            .use(makeMiddleware('a', 10, async () => {}))
+            .use(makeMiddleware('b', 20, async () => {}));
+
+        const middlewares = pipeline.getMiddlewares();
+        expect(middlewares.map((m) => m.name)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('catches unhandled errors and sets 500 response', async () => {
+        const pipeline = new MiddlewarePipeline();
+
+        pipeline.use(makeMiddleware('thrower', 10, async () => {
+            throw new Error('boom');
+        }));
+
+        const ctx = makeCtx();
+        await pipeline.execute(ctx);
+
+        expect(ctx.response).not.toBeNull();
+        expect(ctx.response!.status).toBe(500);
+        const body = await ctx.response!.json();
+        expect(body.error).toBe('Internal server error');
+    });
+
+    it('does not override response if middleware already set one during error', async () => {
+        const pipeline = new MiddlewarePipeline();
+
+        pipeline.use(makeMiddleware('handler', 10, async (ctx, next) => {
+            try {
+                await next();
+            } catch {
+                ctx.response = new Response(JSON.stringify({ error: 'Custom error' }), {
+                    status: 422,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+        }));
+        pipeline.use(makeMiddleware('thrower', 20, async () => {
+            throw new Error('handled');
+        }));
+
+        const ctx = makeCtx();
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.status).toBe(422);
+    });
+
+    it('recompiles pipeline when middleware list changes', async () => {
+        const log: string[] = [];
+        const pipeline = new MiddlewarePipeline();
+
+        pipeline.use(trackingMiddleware('first', 10, log));
+
+        // First execution
+        let ctx = makeCtx();
+        await pipeline.execute(ctx);
+        expect(log).toEqual(['first:down', 'first:up']);
+
+        log.length = 0;
+
+        // Add more middleware and re-execute
+        pipeline.use(trackingMiddleware('second', 20, log));
+
+        ctx = makeCtx();
+        await pipeline.execute(ctx);
+        expect(log).toEqual(['first:down', 'second:down', 'second:up', 'first:up']);
+    });
+});
+
+// --- Built-in middleware tests -----------------------------------------------
+
+describe('errorHandlerMiddleware', () => {
+    it('catches downstream errors and sets 500 response', async () => {
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(errorHandlerMiddleware());
+        pipeline.use(makeMiddleware('thrower', 100, async () => {
+            throw new Error('test error');
+        }));
+
+        const ctx = makeCtx();
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.status).toBe(500);
+        const body = await ctx.response!.json();
+        expect(body.error).toBe('Internal server error');
+    });
+
+    it('does not override existing response on error', async () => {
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(errorHandlerMiddleware());
+        pipeline.use(makeMiddleware('handler', 50, async (ctx, next) => {
+            try {
+                await next();
+            } catch {
+                ctx.response = new Response('Custom', { status: 400 });
+            }
+        }));
+        pipeline.use(makeMiddleware('thrower', 100, async () => {
+            throw new Error('caught');
+        }));
+
+        const ctx = makeCtx();
+        await pipeline.execute(ctx);
+
+        // Error was caught by 'handler', so errorHandlerMiddleware sees no error
+        expect(ctx.response!.status).toBe(400);
+    });
+
+    it('passes through when no error occurs', async () => {
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(errorHandlerMiddleware());
+        pipeline.use(makeMiddleware('ok', 100, async (ctx) => {
+            ctx.response = new Response('OK', { status: 200 });
+        }));
+
+        const ctx = makeCtx();
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.status).toBe(200);
+    });
+});
+
+describe('requestLogMiddleware', () => {
+    it('allows requests to pass through', async () => {
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(requestLogMiddleware());
+        pipeline.use(makeMiddleware('handler', 100, async (ctx) => {
+            ctx.response = new Response('OK', { status: 200 });
+        }));
+
+        const ctx = makeCtx('/api/test');
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.status).toBe(200);
+    });
+
+    it('runs upstream phase after downstream completes', async () => {
+        const log: string[] = [];
+        const pipeline = new MiddlewarePipeline();
+
+        // Use a custom version that tracks execution
+        pipeline.use(makeMiddleware('log', ORDER.REQUEST_LOG, async (_ctx, next) => {
+            log.push('log:before');
+            await next();
+            log.push('log:after');
+        }));
+        pipeline.use(makeMiddleware('handler', 100, async (ctx) => {
+            log.push('handler');
+            ctx.response = new Response('OK', { status: 200 });
+        }));
+
+        const ctx = makeCtx();
+        await pipeline.execute(ctx);
+
+        expect(log).toEqual(['log:before', 'handler', 'log:after']);
+    });
+});
+
+describe('corsMiddleware', () => {
+    const config: AuthConfig = {
+        apiKey: null,
+        allowedOrigins: [],
+        bindHost: '127.0.0.1',
+    };
+
+    it('handles OPTIONS preflight and aborts pipeline', async () => {
+        const log: string[] = [];
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(corsMiddleware(config));
+        pipeline.use(trackingMiddleware('handler', 100, log));
+
+        const req = makeRequest('/api/test', { method: 'OPTIONS' });
+        const url = makeUrl('/api/test');
+        const ctx = createMiddlewareContext(req, url, createRequestContext());
+
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.status).toBe(204);
+        expect(ctx.aborted).toBe(true);
+        expect(log).toEqual([]); // Handler never ran
+    });
+
+    it('applies CORS headers on upstream for normal requests', async () => {
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(corsMiddleware(config));
+        pipeline.use(makeMiddleware('handler', 100, async (ctx) => {
+            ctx.response = new Response('OK', { status: 200 });
+        }));
+
+        const ctx = makeCtx('/api/test');
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    });
+});
+
+describe('rateLimitMiddleware', () => {
+    let limiter: RateLimiter;
+
+    beforeEach(() => {
+        limiter = new RateLimiter({ maxGet: 2, maxMutation: 1, windowMs: 1000 });
+    });
+
+    afterEach(() => {
+        limiter.stop();
+    });
+
+    it('allows requests within rate limit', async () => {
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(rateLimitMiddleware(limiter));
+        pipeline.use(makeMiddleware('handler', 200, async (ctx) => {
+            ctx.response = new Response('OK', { status: 200 });
+        }));
+
+        const ctx = makeCtx('/api/test');
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.status).toBe(200);
+    });
+
+    it('blocks requests exceeding rate limit', async () => {
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(rateLimitMiddleware(limiter));
+        pipeline.use(makeMiddleware('handler', 200, async (ctx) => {
+            ctx.response = new Response('OK', { status: 200 });
+        }));
+
+        // Exhaust the limit
+        for (let i = 0; i < 2; i++) {
+            const ctx = makeCtx('/api/test');
+            await pipeline.execute(ctx);
+        }
+
+        // Third request should be blocked
+        const ctx = makeCtx('/api/test');
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.status).toBe(429);
+        expect(ctx.aborted).toBe(true);
+    });
+
+    it('exempts /api/health from rate limiting', async () => {
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(rateLimitMiddleware(limiter));
+        pipeline.use(makeMiddleware('handler', 200, async (ctx) => {
+            ctx.response = new Response('OK', { status: 200 });
+        }));
+
+        // Should never be blocked
+        for (let i = 0; i < 10; i++) {
+            const req = makeRequest('/api/health');
+            const url = makeUrl('/api/health');
+            const ctx = createMiddlewareContext(req, url, createRequestContext());
+            await pipeline.execute(ctx);
+            expect(ctx.response!.status).toBe(200);
+        }
+    });
+});
+
+describe('authMiddleware', () => {
+    const enabledConfig: AuthConfig = {
+        apiKey: 'test-secret-key-12345',
+        allowedOrigins: [],
+        bindHost: '0.0.0.0',
+    };
+
+    const disabledConfig: AuthConfig = {
+        apiKey: null,
+        allowedOrigins: [],
+        bindHost: '127.0.0.1',
+    };
+
+    it('allows authenticated requests', async () => {
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(authMiddleware(enabledConfig));
+        pipeline.use(makeMiddleware('handler', 200, async (ctx) => {
+            ctx.response = new Response('OK', { status: 200 });
+        }));
+
+        const req = makeRequest('/api/test', {
+            headers: { Authorization: `Bearer ${enabledConfig.apiKey}` },
+        });
+        const url = makeUrl('/api/test');
+        const ctx = createMiddlewareContext(req, url, createRequestContext());
+
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.status).toBe(200);
+        expect(ctx.requestContext.authenticated).toBe(true);
+        expect(ctx.requestContext.role).toBe('user');
+    });
+
+    it('denies unauthenticated requests', async () => {
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(authMiddleware(enabledConfig));
+        pipeline.use(makeMiddleware('handler', 200, async (ctx) => {
+            ctx.response = new Response('OK', { status: 200 });
+        }));
+
+        const ctx = makeCtx('/api/test');
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.status).toBe(401);
+        expect(ctx.aborted).toBe(true);
+    });
+
+    it('grants admin in dev mode (no API key)', async () => {
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(authMiddleware(disabledConfig));
+        pipeline.use(makeMiddleware('handler', 200, async (ctx) => {
+            ctx.response = new Response('OK', { status: 200 });
+        }));
+
+        const ctx = makeCtx('/api/test');
+        await pipeline.execute(ctx);
+
+        expect(ctx.requestContext.authenticated).toBe(true);
+        expect(ctx.requestContext.role).toBe('admin');
+    });
+});
+
+describe('roleMiddleware', () => {
+    it('allows requests with matching role', async () => {
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(roleMiddleware(['admin'], (p) => p === '/metrics'));
+        pipeline.use(makeMiddleware('handler', 200, async (ctx) => {
+            ctx.response = new Response('OK', { status: 200 });
+        }));
+
+        const req = makeRequest('/metrics');
+        const url = makeUrl('/metrics');
+        const ctx = createMiddlewareContext(req, url, { authenticated: true, role: 'admin' });
+
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.status).toBe(200);
+    });
+
+    it('denies requests with wrong role', async () => {
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(roleMiddleware(['admin'], (p) => p === '/metrics'));
+        pipeline.use(makeMiddleware('handler', 200, async (ctx) => {
+            ctx.response = new Response('OK', { status: 200 });
+        }));
+
+        const req = makeRequest('/metrics');
+        const url = makeUrl('/metrics');
+        const ctx = createMiddlewareContext(req, url, { authenticated: true, role: 'user' });
+
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.status).toBe(403);
+        expect(ctx.aborted).toBe(true);
+    });
+
+    it('skips role check for non-matching paths', async () => {
+        const pipeline = new MiddlewarePipeline();
+        pipeline.use(roleMiddleware(['admin'], (p) => p === '/metrics'));
+        pipeline.use(makeMiddleware('handler', 200, async (ctx) => {
+            ctx.response = new Response('OK', { status: 200 });
+        }));
+
+        const req = makeRequest('/api/sessions');
+        const url = makeUrl('/api/sessions');
+        const ctx = createMiddlewareContext(req, url, { authenticated: true, role: 'user' });
+
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.status).toBe(200); // Role check skipped
+    });
+});
+
+// --- Full pipeline integration test -----------------------------------------
+
+describe('full pipeline integration', () => {
+    let limiter: RateLimiter;
+
+    const config: AuthConfig = {
+        apiKey: null,
+        allowedOrigins: [],
+        bindHost: '127.0.0.1',
+    };
+
+    beforeEach(() => {
+        limiter = new RateLimiter({ maxGet: 100, maxMutation: 50, windowMs: 60_000 });
+    });
+
+    afterEach(() => {
+        limiter.stop();
+    });
+
+    it('runs full pipeline: cors → log → error → rateLimit → auth → role → handler', async () => {
+        const log: string[] = [];
+        const pipeline = new MiddlewarePipeline();
+
+        pipeline.use(corsMiddleware(config));
+        pipeline.use(requestLogMiddleware());
+        pipeline.use(errorHandlerMiddleware());
+        pipeline.use(rateLimitMiddleware(limiter));
+        pipeline.use(authMiddleware(config));
+        pipeline.use(roleMiddleware(['admin'], (p) => p === '/metrics'));
+
+        // Route handler
+        pipeline.use(makeMiddleware('handler', 300, async (ctx) => {
+            log.push('handler');
+            ctx.response = new Response(JSON.stringify({ ok: true }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }));
+
+        const ctx = makeCtx('/api/test');
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.status).toBe(200);
+        expect(ctx.requestContext.authenticated).toBe(true);
+        expect(ctx.response!.headers.get('Access-Control-Allow-Origin')).toBe('*');
+        expect(log).toEqual(['handler']);
+    });
+
+    it('error handler catches route handler errors', async () => {
+        const pipeline = new MiddlewarePipeline();
+
+        pipeline.use(corsMiddleware(config));
+        pipeline.use(errorHandlerMiddleware());
+        pipeline.use(authMiddleware(config));
+
+        pipeline.use(makeMiddleware('handler', 300, async () => {
+            throw new Error('Route handler failed');
+        }));
+
+        const ctx = makeCtx('/api/test');
+        await pipeline.execute(ctx);
+
+        expect(ctx.response!.status).toBe(500);
+        const body = await ctx.response!.json();
+        expect(body.error).toBe('Internal server error');
+        // CORS headers still applied (upstream phase of corsMiddleware)
+        expect(ctx.response!.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    });
+
+    it('ordering is deterministic regardless of registration order', async () => {
+        const log: string[] = [];
+        const pipeline = new MiddlewarePipeline();
+
+        // Register in reverse order — pipeline should still sort by order
+        pipeline.use(makeMiddleware('handler', 300, async (ctx) => {
+            log.push('handler');
+            ctx.response = new Response('OK');
+        }));
+        pipeline.use(makeMiddleware('auth', 110, async (ctx, next) => {
+            log.push('auth');
+            ctx.requestContext.authenticated = true;
+            await next();
+        }));
+        pipeline.use(makeMiddleware('rate-limit', 100, async (_ctx, next) => {
+            log.push('rate-limit');
+            await next();
+        }));
+        pipeline.use(makeMiddleware('cors', 10, async (_ctx, next) => {
+            log.push('cors');
+            await next();
+        }));
+
+        const ctx = makeCtx();
+        await pipeline.execute(ctx);
+
+        expect(log).toEqual(['cors', 'rate-limit', 'auth', 'handler']);
+    });
+});
+
+// --- ORDER constants --------------------------------------------------------
+
+describe('ORDER constants', () => {
+    it('CORS runs before everything else', () => {
+        expect(ORDER.CORS).toBeLessThan(ORDER.REQUEST_LOG);
+        expect(ORDER.CORS).toBeLessThan(ORDER.ERROR_HANDLER);
+        expect(ORDER.CORS).toBeLessThan(ORDER.RATE_LIMIT);
+    });
+
+    it('error handler runs before security middleware', () => {
+        expect(ORDER.ERROR_HANDLER).toBeLessThan(ORDER.RATE_LIMIT);
+        expect(ORDER.ERROR_HANDLER).toBeLessThan(ORDER.AUTH);
+    });
+
+    it('rate limit runs before auth', () => {
+        expect(ORDER.RATE_LIMIT).toBeLessThan(ORDER.AUTH);
+    });
+
+    it('auth runs before role check', () => {
+        expect(ORDER.AUTH).toBeLessThan(ORDER.ROLE);
+    });
+});

--- a/server/middleware/builtin.ts
+++ b/server/middleware/builtin.ts
@@ -1,0 +1,293 @@
+/**
+ * Built-in middleware implementations for the Koa-style pipeline.
+ *
+ * Each middleware is exported as a factory function that returns a `Middleware`
+ * object with name, order, and handler.
+ *
+ * @see pipeline.ts for the pipeline runner and types.
+ */
+
+import type { Middleware, MiddlewareContext, NextFn } from './pipeline';
+import type { AuthConfig } from './auth';
+import { buildCorsHeaders } from './auth';
+import { checkHttpAuth } from './auth';
+import type { RateLimiter } from './rate-limit';
+import { getClientIp } from './rate-limit';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('Middleware');
+
+// ---------------------------------------------------------------------------
+// Order constants — single source of truth for middleware ordering
+// ---------------------------------------------------------------------------
+
+export const ORDER = {
+    /** CORS preflight handling. */
+    CORS: 10,
+    /** Request logging (upstream: start timer; downstream: log result). */
+    REQUEST_LOG: 20,
+    /** Error boundary — catches errors from downstream middleware. */
+    ERROR_HANDLER: 30,
+    /** Rate limiting. */
+    RATE_LIMIT: 100,
+    /** Authentication. */
+    AUTH: 110,
+    /** Role-based access control. */
+    ROLE: 120,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Error handling middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Error boundary middleware.
+ *
+ * Wraps downstream middleware in a try/catch. If an error propagates up,
+ * it logs the error and sets a generic 500 response (never exposing internals
+ * to the client).
+ *
+ * Runs early (order 30) so it catches errors from auth, routing, etc.
+ */
+export function errorHandlerMiddleware(): Middleware {
+    return {
+        name: 'error-handler',
+        order: ORDER.ERROR_HANDLER,
+        handler: async (ctx: MiddlewareContext, next: NextFn): Promise<void> => {
+            try {
+                await next();
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                const stack = err instanceof Error ? err.stack : undefined;
+                log.error('Unhandled error in pipeline', { error: message, stack, path: ctx.url.pathname });
+
+                if (!ctx.response) {
+                    ctx.response = new Response(
+                        JSON.stringify({ error: 'Internal server error', timestamp: new Date().toISOString() }),
+                        { status: 500, headers: { 'Content-Type': 'application/json' } },
+                    );
+                }
+            }
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Request logging middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Request logging middleware.
+ *
+ * Logs the incoming request method + path on the way down, and the
+ * response status + duration on the way up. Uses structured logging
+ * with the shared logger.
+ */
+export function requestLogMiddleware(): Middleware {
+    return {
+        name: 'request-log',
+        order: ORDER.REQUEST_LOG,
+        handler: async (ctx: MiddlewareContext, next: NextFn): Promise<void> => {
+            const { method, url } = ctx;
+
+            await next();
+
+            const durationMs = performance.now() - ctx.startTime;
+            const status = ctx.response?.status ?? 0;
+            log.info(`${method} ${url.pathname} ${status}`, {
+                method,
+                path: url.pathname,
+                status,
+                durationMs: Math.round(durationMs * 100) / 100,
+            });
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// CORS middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * CORS middleware.
+ *
+ * Handles OPTIONS preflight requests (sets ctx.response and aborts) and
+ * applies CORS headers to all responses on the upstream phase.
+ */
+export function corsMiddleware(config: AuthConfig): Middleware {
+    return {
+        name: 'cors',
+        order: ORDER.CORS,
+        handler: async (ctx: MiddlewareContext, next: NextFn): Promise<void> => {
+            // Handle preflight
+            if (ctx.method === 'OPTIONS') {
+                const corsHeaders = buildCorsHeaders(ctx.req, config);
+                corsHeaders['Access-Control-Allow-Headers'] = 'Content-Type, Authorization';
+                ctx.response = new Response(null, { status: 204, headers: corsHeaders });
+                ctx.aborted = true;
+                return;
+            }
+
+            await next();
+
+            // Apply CORS headers to whatever response was set
+            if (ctx.response) {
+                const corsHeaders = buildCorsHeaders(ctx.req, config);
+                for (const [key, value] of Object.entries(corsHeaders)) {
+                    ctx.response.headers.set(key, value);
+                }
+            }
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Rate limit middleware
+// ---------------------------------------------------------------------------
+
+/** Paths that bypass rate limiting (monitoring probes, webhooks, etc.). */
+const RATE_LIMIT_EXEMPT = new Set(['/api/health', '/webhooks/github']);
+
+/**
+ * Rate limiting middleware.
+ *
+ * Uses the existing sliding-window RateLimiter. When a request exceeds
+ * the limit, sets a 429 response and aborts the pipeline.
+ */
+export function rateLimitMiddleware(limiter: RateLimiter): Middleware {
+    return {
+        name: 'rate-limit',
+        order: ORDER.RATE_LIMIT,
+        handler: async (ctx: MiddlewareContext, next: NextFn): Promise<void> => {
+            const { url, req, requestContext } = ctx;
+
+            // Exempt specific paths
+            if (RATE_LIMIT_EXEMPT.has(url.pathname) || url.pathname === '/ws') {
+                await next();
+                return;
+            }
+
+            // Prefer wallet address as rate limit key, fall back to IP
+            const key = requestContext.walletAddress || getClientIp(req);
+            const denied = limiter.check(key, req.method);
+            if (denied) {
+                ctx.response = denied;
+                ctx.aborted = true;
+                return;
+            }
+
+            await next();
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Auth middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Authentication middleware.
+ *
+ * Delegates to the existing checkHttpAuth function. On success, populates
+ * the requestContext with authenticated=true, role, and wallet address.
+ * On failure, sets a 401/403 response and aborts.
+ */
+export function authMiddleware(config: AuthConfig): Middleware {
+    return {
+        name: 'auth',
+        order: ORDER.AUTH,
+        handler: async (ctx: MiddlewareContext, next: NextFn): Promise<void> => {
+            const { req, url, requestContext } = ctx;
+
+            const denied = checkHttpAuth(req, url, config);
+            if (denied) {
+                ctx.response = denied;
+                ctx.aborted = true;
+                return;
+            }
+
+            // Auth passed — populate context
+            requestContext.authenticated = true;
+
+            // Derive role from API key type
+            if (config.apiKey) {
+                const adminKey = process.env.ADMIN_API_KEY;
+                const authHeader = req.headers.get('Authorization');
+                const token = authHeader?.replace(/^Bearer\s+/i, '') ?? '';
+
+                if (adminKey && token === adminKey) {
+                    requestContext.role = 'admin';
+                } else {
+                    requestContext.role = 'user';
+                }
+            } else {
+                requestContext.role = 'admin';
+            }
+
+            // Extract wallet address from query param
+            const wallet = url.searchParams.get('wallet');
+            if (wallet) {
+                requestContext.walletAddress = wallet;
+            }
+
+            await next();
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Role guard middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Role-based access control middleware.
+ *
+ * Checks that the authenticated user has one of the required roles.
+ * Must be placed after auth middleware in the pipeline.
+ *
+ * This is a factory that takes a predicate to decide which paths
+ * need role checking, avoiding hardcoding path sets here.
+ */
+export function roleMiddleware(
+    allowedRoles: string[],
+    pathPredicate: (pathname: string) => boolean,
+): Middleware {
+    return {
+        name: 'role',
+        order: ORDER.ROLE,
+        handler: async (ctx: MiddlewareContext, next: NextFn): Promise<void> => {
+            const { url, requestContext } = ctx;
+
+            // Only enforce role for matching paths
+            if (!pathPredicate(url.pathname)) {
+                await next();
+                return;
+            }
+
+            if (!requestContext.authenticated) {
+                ctx.response = new Response(
+                    JSON.stringify({ error: 'Authentication required' }),
+                    { status: 401, headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer' } },
+                );
+                ctx.aborted = true;
+                return;
+            }
+
+            if (!requestContext.role || !allowedRoles.includes(requestContext.role)) {
+                log.warn('Access denied: insufficient role', {
+                    path: url.pathname,
+                    role: requestContext.role ?? 'none',
+                    required: allowedRoles.join(', '),
+                });
+                ctx.response = new Response(
+                    JSON.stringify({ error: 'Forbidden: insufficient role', requiredRoles: allowedRoles }),
+                    { status: 403, headers: { 'Content-Type': 'application/json' } },
+                );
+                ctx.aborted = true;
+                return;
+            }
+
+            await next();
+        },
+    };
+}

--- a/server/middleware/pipeline.ts
+++ b/server/middleware/pipeline.ts
@@ -1,0 +1,230 @@
+/**
+ * Koa-style middleware pipeline for HTTP request processing.
+ *
+ * Middleware functions follow the signature:
+ *   (ctx: MiddlewareContext, next: () => Promise<void>) => Promise<void>
+ *
+ * Key features:
+ * - Explicit ordering via numeric `order` property
+ * - Abort semantics: middleware can halt the chain by not calling `next()`
+ * - Downstream/upstream phases: code before `next()` runs on the way "down",
+ *   code after `next()` runs on the way back "up" (like Koa)
+ * - Context object is shared and mutable across all middleware
+ *
+ * @see https://github.com/CorvidLabs/corvid-agent/issues/151
+ */
+
+import type { RequestContext } from './guards';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('Pipeline');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared context passed through the middleware pipeline.
+ * Middleware can read/write properties to communicate with downstream
+ * and upstream middleware.
+ */
+export interface MiddlewareContext {
+    /** The incoming HTTP request (immutable by convention). */
+    readonly req: Request;
+    /** Parsed URL of the request. */
+    readonly url: URL;
+    /** HTTP method shorthand. */
+    readonly method: string;
+    /** Request context populated by auth/guard middleware. */
+    requestContext: RequestContext;
+    /** The response to send back. Set by route handlers or error middleware. */
+    response: Response | null;
+    /** Arbitrary key-value state bag for middleware to share data. */
+    state: Record<string, unknown>;
+    /** Timestamp when the pipeline started processing (for timing). */
+    readonly startTime: number;
+    /**
+     * Signal that the pipeline should abort — no further downstream
+     * middleware will execute. The current middleware can still set
+     * `ctx.response` before returning.
+     */
+    aborted: boolean;
+}
+
+/** A `next` function that invokes the next middleware in the chain. */
+export type NextFn = () => Promise<void>;
+
+/**
+ * A middleware function. Receives the shared context and a `next` function
+ * to pass control to the next middleware. If `next()` is not called, the
+ * pipeline is aborted (no downstream middleware runs).
+ */
+export type MiddlewareFn = (ctx: MiddlewareContext, next: NextFn) => Promise<void>;
+
+/**
+ * A named middleware with an explicit execution order.
+ * Lower `order` values run first (upstream). Ties are broken by
+ * registration order.
+ */
+export interface Middleware {
+    /** Human-readable name for logging and debugging. */
+    name: string;
+    /**
+     * Execution order. Lower values run first.
+     * Suggested ranges:
+     *   0-99:   Pre-processing (CORS, tracing, request ID)
+     *   100-199: Security (rate-limit, auth, role)
+     *   200-299: Request enrichment (body parsing, validation)
+     *   300-399: Business logic / route handling
+     *   400-499: Post-processing (response headers, compression)
+     *   500+:    Observability (logging, metrics)
+     */
+    order: number;
+    /** The middleware function. */
+    handler: MiddlewareFn;
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a fresh MiddlewareContext for an incoming request.
+ */
+export function createMiddlewareContext(
+    req: Request,
+    url: URL,
+    requestContext: RequestContext,
+): MiddlewareContext {
+    return {
+        req,
+        url,
+        method: req.method,
+        requestContext,
+        response: null,
+        state: {},
+        startTime: performance.now(),
+        aborted: false,
+    };
+}
+
+/**
+ * Compose an ordered array of middleware into a single executable function.
+ *
+ * Returns a function that, given a context, runs the pipeline and returns
+ * the context (with `.response` potentially set).
+ *
+ * The composition follows Koa semantics:
+ * 1. Middleware are sorted by `order` (stable sort preserves registration order for ties).
+ * 2. Each middleware receives `ctx` and a `next()` function.
+ * 3. Calling `next()` passes control to the next middleware.
+ * 4. NOT calling `next()` aborts the downstream chain (abort semantics).
+ * 5. Code after `await next()` runs in reverse order (upstream phase).
+ */
+export function compose(middlewares: Middleware[]): (ctx: MiddlewareContext) => Promise<void> {
+    // Sort by order (stable sort — preserves registration order for equal `order` values)
+    const sorted = [...middlewares].sort((a, b) => a.order - b.order);
+
+    return function pipeline(ctx: MiddlewareContext): Promise<void> {
+        let index = -1;
+
+        function dispatch(i: number): Promise<void> {
+            // Guard against calling next() multiple times from the same middleware
+            if (i <= index) {
+                return Promise.reject(new Error('next() called multiple times'));
+            }
+            index = i;
+
+            // If the pipeline was aborted by a previous middleware, stop
+            if (ctx.aborted) {
+                return Promise.resolve();
+            }
+
+            const entry = sorted[i];
+            if (!entry) {
+                // End of chain — all middleware have been invoked
+                return Promise.resolve();
+            }
+
+            try {
+                return entry.handler(ctx, () => {
+                    // If the middleware set aborted, don't proceed
+                    if (ctx.aborted) return Promise.resolve();
+                    return dispatch(i + 1);
+                });
+            } catch (err) {
+                return Promise.reject(err);
+            }
+        }
+
+        return dispatch(0);
+    };
+}
+
+// ---------------------------------------------------------------------------
+// MiddlewarePipeline — builder / registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Builder for assembling and executing a middleware pipeline.
+ *
+ * Usage:
+ * ```ts
+ * const pipeline = new MiddlewarePipeline();
+ * pipeline.use({ name: 'logging', order: 500, handler: loggingMiddleware });
+ * pipeline.use({ name: 'auth', order: 100, handler: authMiddleware });
+ *
+ * const ctx = createMiddlewareContext(req, url, requestContext);
+ * await pipeline.execute(ctx);
+ * // ctx.response is now set
+ * ```
+ */
+export class MiddlewarePipeline {
+    private middlewares: Middleware[] = [];
+    private compiled: ((ctx: MiddlewareContext) => Promise<void>) | null = null;
+
+    /** Register a middleware. Invalidates the compiled pipeline. */
+    use(middleware: Middleware): this {
+        this.middlewares.push(middleware);
+        this.compiled = null; // Force recompile on next execute
+        return this;
+    }
+
+    /** Remove a middleware by name. */
+    remove(name: string): this {
+        this.middlewares = this.middlewares.filter((m) => m.name !== name);
+        this.compiled = null;
+        return this;
+    }
+
+    /** Get all registered middleware (sorted by order). */
+    getMiddlewares(): ReadonlyArray<Readonly<Middleware>> {
+        return [...this.middlewares].sort((a, b) => a.order - b.order);
+    }
+
+    /**
+     * Execute the pipeline with the given context.
+     * Returns the context after all middleware have run.
+     */
+    async execute(ctx: MiddlewareContext): Promise<MiddlewareContext> {
+        if (!this.compiled) {
+            this.compiled = compose(this.middlewares);
+        }
+
+        try {
+            await this.compiled(ctx);
+        } catch (err) {
+            // If no middleware caught the error and set a response, log and set 500
+            if (!ctx.response) {
+                const message = err instanceof Error ? err.message : String(err);
+                log.error('Unhandled pipeline error', { error: message });
+                ctx.response = new Response(
+                    JSON.stringify({ error: 'Internal server error', timestamp: new Date().toISOString() }),
+                    { status: 500, headers: { 'Content-Type': 'application/json' } },
+                );
+            }
+        }
+
+        return ctx;
+    }
+}


### PR DESCRIPTION
## Summary
- Implements a Koa-style middleware pipeline with composable `(ctx, next) => Promise<void>` semantics as decided in the Architecture Council Review (Feb 6, 2026)
- Adds `MiddlewarePipeline` class with explicit ordering (numeric `order` property), abort semantics (skip downstream by not calling `next()` or setting `ctx.aborted`), and downstream/upstream phases
- Includes 6 built-in middleware implementations: error handler, request logging, CORS, rate limiting, auth, and role-based access control — all replicating existing guard chain behavior as proof-of-concept

## Details
**New files:**
- `server/middleware/pipeline.ts` — Core types (`MiddlewareContext`, `MiddlewareFn`, `Middleware`), `compose()` function, and `MiddlewarePipeline` builder class
- `server/middleware/builtin.ts` — Built-in middleware factories with `ORDER` constants for consistent ordering
- `server/__tests__/middleware-pipeline.test.ts` — 41 tests covering pipeline execution, ordering, abort behavior, context sharing, error propagation, and all built-in middleware

**Design decisions:**
- No event bus introduced (per council consensus)
- Existing `guards.ts` is preserved — the new middleware adapts the same auth/rate-limit logic, providing a migration path without breaking existing code
- Order constants follow suggested ranges: 0-99 (pre-processing), 100-199 (security), 200-299 (enrichment), 300-399 (business logic), 400-499 (post-processing), 500+ (observability)

## Test plan
- [x] All 41 new middleware pipeline tests pass
- [x] All 29 existing guard chain tests pass (no regressions)
- [x] TypeScript compiles cleanly with `--noEmit`
- [ ] Integration into `handleRequest()` can be done incrementally in a follow-up PR

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)