### PR TITLE
fix: add PATH to LaunchAgent so claude CLI is discoverable

### DIFF
--- a/deploy/com.corvidlabs.corvid-agent.plist
+++ b/deploy/com.corvidlabs.corvid-agent.plist
@@ -22,6 +22,8 @@
         <string>info</string>
         <key>NODE_ENV</key>
         <string>production</string>
+        <key>PATH</key>
+        <string>__PATH__</string>
     </dict>
 
     <key>RunAtLoad</key>

--- a/deploy/daemon.sh
+++ b/deploy/daemon.sh
@@ -38,11 +38,15 @@ install_launchd() {
     mkdir -p "$log_dir"
     mkdir -p "$HOME/Library/LaunchAgents"
 
+    # Build a PATH that includes user tool directories (needed for claude CLI, gh, etc.)
+    local user_path="$HOME/.local/bin:$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
     # Generate plist with correct paths
     sed \
         -e "s|__BUN_PATH__|$bun_path|g" \
         -e "s|__WORKING_DIR__|$PROJECT_DIR|g" \
         -e "s|__LOG_DIR__|$log_dir|g" \
+        -e "s|__PATH__|$user_path|g" \
         "$plist_src" > "$plist_dst"
 
     # Install log rotation config (newsyslog picks this up automatically)


### PR DESCRIPTION
## Summary
- Adds `PATH` to the LaunchAgent plist template so the server can find `claude` CLI, `gh`, and other user-installed tools
- Updates `daemon.sh` to substitute the `__PATH__` placeholder with a comprehensive path including `~/.local/bin`, `~/.bun/bin`, `/opt/homebrew/bin`, and standard system directories

Without this fix, the LaunchAgent-managed server falls back to Ollama-only mode because `Bun.which('claude')` returns null with the default launchd PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). This breaks mention polling, scheduled tasks, and any feature requiring Claude access via subscription auth.

## Test plan
- [x] Verified LaunchAgent-started server now logs `Registered provider: anthropic`
- [x] Mention polling successfully triggered a session for issue #151
- [ ] Run `bash deploy/daemon.sh install` on a fresh setup to verify placeholder substitution

🤖 Generated with [Claude Code](https://claude.com/claude-code)