### PR TITLE
feat: add fire_and_forget async messaging to AgentMessenger

### DIFF
--- a/server/algochat/work-command-router.ts
+++ b/server/algochat/work-command-router.ts
@@ -165,6 +165,7 @@ export class WorkCommandRouter {
                 } else {
                     updateAgentMessageStatus(this.db, agentMessage.id, 'failed', {
                         response: completed.error ?? 'Work task failed',
+                        errorCode: 'WORK_TASK_ERROR',
                     });
                 }
                 emitMessageUpdate(agentMessage.id);
@@ -177,6 +178,7 @@ export class WorkCommandRouter {
         } catch (err) {
             updateAgentMessageStatus(this.db, agentMessage.id, 'failed', {
                 response: `Work task error: ${err instanceof Error ? err.message : String(err)}`,
+                errorCode: 'WORK_TASK_ERROR',
             });
             emitMessageUpdate(agentMessage.id);
             throw err;

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,6 +1,6 @@
 import { Database } from 'bun:sqlite';
 
-const SCHEMA_VERSION = 51;
+const SCHEMA_VERSION = 52;
 
 const MIGRATIONS: Record<number, string[]> = {
     1: [
@@ -1002,6 +1002,12 @@ const MIGRATIONS: Record<number, string[]> = {
             ('preset-full-stack', 'Full Stack', 'Code, GitHub, tasks, and web search combined', '["read_file","write_file","edit_file","run_command","list_files","search_files","corvid_github_list_prs","corvid_github_get_pr_diff","corvid_github_review_pr","corvid_github_comment_on_pr","corvid_github_create_pr","corvid_github_create_issue","corvid_github_list_issues","corvid_create_work_task","corvid_web_search"]', 'You are a full-stack developer agent. You can read and edit code, run commands, manage GitHub PRs and issues, and create work tasks. Approach problems methodically: understand the codebase first, make targeted changes, test your work, then create PRs or report findings.', 1)`,
         `INSERT OR IGNORE INTO skill_bundles (id, name, description, tools, prompt_additions, preset) VALUES
             ('preset-memory-manager', 'Memory Manager', 'Knowledge and memory management with research', '["corvid_save_memory","corvid_recall_memory","corvid_web_search","corvid_deep_research"]', 'You manage knowledge and memory. Save important findings, decisions, and context using structured keys. Recall relevant memories before starting new work. Use web search and deep research to fill knowledge gaps.', 1)`,
+    ],
+    52: [
+        // Fire-and-forget messaging and message versioning
+        `ALTER TABLE agent_messages ADD COLUMN fire_and_forget INTEGER DEFAULT 0`,
+        `ALTER TABLE agent_messages ADD COLUMN message_version INTEGER DEFAULT 1`,
+        `ALTER TABLE agent_messages ADD COLUMN error_code TEXT DEFAULT NULL`,
     ],
 };
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -142,6 +142,24 @@ export interface UpdateSessionInput {
 
 export type AgentMessageStatus = 'pending' | 'sent' | 'processing' | 'completed' | 'failed';
 
+/**
+ * Structured error codes for agent message delivery failures.
+ * Used to categorize failure reasons for programmatic handling.
+ */
+export type MessageErrorCode =
+    | 'DELIVERY_FAILED'       // Generic delivery failure
+    | 'SPENDING_LIMIT'        // Daily ALGO spending limit exceeded
+    | 'AGENT_NOT_FOUND'       // Target or source agent not found
+    | 'SELF_INVOKE'           // Agent tried to invoke itself
+    | 'NO_WALLET'             // Agent has no wallet configured
+    | 'CHAIN_ERROR'           // On-chain transaction failed
+    | 'EMPTY_RESPONSE'        // Agent session produced no response
+    | 'RESPONSE_SEND_FAILED'  // On-chain response delivery failed
+    | 'WORK_TASK_ERROR';      // Work task creation failed
+
+/** Current message protocol version for forward compatibility. */
+export const MESSAGE_PROTOCOL_VERSION = 1;
+
 export interface AgentMessage {
     id: string;
     fromAgentId: string;
@@ -156,6 +174,12 @@ export interface AgentMessage {
     threadId: string | null;
     provider?: string;
     model?: string;
+    /** Whether this was a fire-and-forget message (no response expected). */
+    fireAndForget: boolean;
+    /** Message protocol version for forward compatibility. */
+    messageVersion: number;
+    /** Structured error code when status is 'failed'. */
+    errorCode: MessageErrorCode | null;
     createdAt: string;
     completedAt: string | null;
 }


### PR DESCRIPTION
## Summary
- Add `fireAndForget` flag to `AgentInvokeRequest` — when true, `invoke()` dispatches the message and returns immediately without creating a session or waiting for a response
- Add `MessageErrorCode` string union type for structured failure categorization (`SPENDING_LIMIT`, `EMPTY_RESPONSE`, `RESPONSE_SEND_FAILED`, `WORK_TASK_ERROR`, etc.)
- Add `MESSAGE_PROTOCOL_VERSION` constant and `messageVersion` field on `AgentMessage` for forward-compatible message evolution
- DB migration (v52) adds `fire_and_forget`, `message_version`, and `error_code` columns to `agent_messages`

## Test plan
- [x] Fire-and-forget invoke returns immediately with `sessionId: null` and does not call `startProcess`
- [x] Fire-and-forget messages skip session event subscription
- [x] Fire-and-forget messages are marked `completed` with `completedAt` set
- [x] `fireAndForget` flag persists correctly in DB (true for F&F, false for normal)
- [x] Message updates emitted for both `sent` and `completed` transitions
- [x] Guard checks (self-invoke, missing agents) still apply to fire-and-forget
- [x] `messageVersion` set to `MESSAGE_PROTOCOL_VERSION` on all new messages
- [x] `errorCode` is null for successful messages
- [x] All 2228 existing tests continue to pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)