### PR TITLE
feat: circuit breaker + per-agent rate limiting (#154)

### DIFF
--- a/server/__tests__/messaging-guard.test.ts
+++ b/server/__tests__/messaging-guard.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { MessagingGuard } from '../algochat/messaging-guard';
+
+describe('MessagingGuard', () => {
+    let guard: MessagingGuard;
+
+    beforeEach(() => {
+        guard = new MessagingGuard({
+            failureThreshold: 3,
+            resetTimeoutMs: 50,     // Short timeout for tests
+            successThreshold: 2,
+            rateLimitPerWindow: 5,
+            rateLimitWindowMs: 500, // Short window for tests
+        });
+    });
+
+    afterEach(() => {
+        guard.stop();
+    });
+
+    // ── Circuit Breaker ──────────────────────────────────────────────────
+
+    describe('circuit breaker', () => {
+        it('allows calls when circuit is CLOSED', () => {
+            const result = guard.check('sender-1', 'target-1');
+            expect(result.allowed).toBe(true);
+            expect(result.reason).toBeUndefined();
+        });
+
+        it('stays CLOSED after successes', () => {
+            guard.check('sender-1', 'target-1');
+            guard.recordSuccess('target-1');
+            guard.recordSuccess('target-1');
+
+            expect(guard.getCircuitState('target-1')).toBe('CLOSED');
+            const result = guard.check('sender-1', 'target-1');
+            expect(result.allowed).toBe(true);
+        });
+
+        it('opens after failureThreshold failures', () => {
+            // First call allowed (creates breaker)
+            guard.check('sender-1', 'target-1');
+
+            // Record 3 failures (our threshold)
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+
+            expect(guard.getCircuitState('target-1')).toBe('OPEN');
+
+            // Next call should be rejected
+            const result = guard.check('sender-1', 'target-1');
+            expect(result.allowed).toBe(false);
+            expect(result.reason).toBe('CIRCUIT_OPEN');
+            expect(result.retryAfterMs).toBe(50);
+        });
+
+        it('transitions from OPEN to HALF_OPEN after resetTimeout', async () => {
+            guard.check('sender-1', 'target-1');
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+
+            expect(guard.getCircuitState('target-1')).toBe('OPEN');
+
+            // Wait for reset timeout
+            await new Promise((r) => setTimeout(r, 60));
+
+            expect(guard.getCircuitState('target-1')).toBe('HALF_OPEN');
+
+            // Should allow a probe call
+            const result = guard.check('sender-1', 'target-1');
+            expect(result.allowed).toBe(true);
+        });
+
+        it('closes circuit after successThreshold successes in HALF_OPEN', async () => {
+            guard.check('sender-1', 'target-1');
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+
+            // Wait for HALF_OPEN
+            await new Promise((r) => setTimeout(r, 60));
+            expect(guard.getCircuitState('target-1')).toBe('HALF_OPEN');
+
+            // 2 successes needed (our threshold)
+            guard.recordSuccess('target-1');
+            guard.recordSuccess('target-1');
+
+            expect(guard.getCircuitState('target-1')).toBe('CLOSED');
+        });
+
+        it('re-opens on failure in HALF_OPEN state', async () => {
+            guard.check('sender-1', 'target-1');
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+
+            // Wait for HALF_OPEN
+            await new Promise((r) => setTimeout(r, 60));
+            expect(guard.getCircuitState('target-1')).toBe('HALF_OPEN');
+
+            // Failure re-opens
+            guard.recordFailure('target-1');
+            expect(guard.getCircuitState('target-1')).toBe('OPEN');
+
+            // Should be rejected again
+            const result = guard.check('sender-1', 'target-1');
+            expect(result.allowed).toBe(false);
+            expect(result.reason).toBe('CIRCUIT_OPEN');
+        });
+
+        it('tracks circuit breakers per target agent independently', () => {
+            guard.check('sender-1', 'target-1');
+            guard.check('sender-1', 'target-2');
+
+            // Only fail target-1
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+
+            expect(guard.getCircuitState('target-1')).toBe('OPEN');
+            expect(guard.getCircuitState('target-2')).toBe('CLOSED');
+
+            // target-1 blocked, target-2 allowed
+            expect(guard.check('sender-1', 'target-1').allowed).toBe(false);
+            expect(guard.check('sender-1', 'target-2').allowed).toBe(true);
+        });
+
+        it('resets circuit for a specific agent', () => {
+            guard.check('sender-1', 'target-1');
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+
+            expect(guard.getCircuitState('target-1')).toBe('OPEN');
+            guard.resetCircuit('target-1');
+            expect(guard.getCircuitState('target-1')).toBe('CLOSED');
+
+            const result = guard.check('sender-1', 'target-1');
+            expect(result.allowed).toBe(true);
+        });
+
+        it('getCircuitState returns CLOSED for unknown agents', () => {
+            expect(guard.getCircuitState('unknown-agent')).toBe('CLOSED');
+        });
+    });
+
+    // ── Rate Limiting ────────────────────────────────────────────────────
+
+    describe('rate limiting', () => {
+        it('allows messages under the limit', () => {
+            for (let i = 0; i < 5; i++) {
+                const result = guard.check('sender-1', `target-${i}`);
+                expect(result.allowed).toBe(true);
+            }
+        });
+
+        it('blocks messages over the per-agent limit', () => {
+            // 5 messages allowed
+            for (let i = 0; i < 5; i++) {
+                expect(guard.check('sender-1', `target-${i}`).allowed).toBe(true);
+            }
+
+            // 6th message blocked
+            const result = guard.check('sender-1', 'target-5');
+            expect(result.allowed).toBe(false);
+            expect(result.reason).toBe('RATE_LIMITED');
+            expect(result.retryAfterMs).toBeGreaterThan(0);
+        });
+
+        it('tracks different senders independently', () => {
+            // Fill sender-1's bucket
+            for (let i = 0; i < 5; i++) {
+                expect(guard.check('sender-1', `target-${i}`).allowed).toBe(true);
+            }
+            expect(guard.check('sender-1', 'target-extra').allowed).toBe(false);
+
+            // sender-2 should still have capacity
+            expect(guard.check('sender-2', 'target-1').allowed).toBe(true);
+        });
+
+        it('allows messages after window expires', async () => {
+            // Fill the window
+            for (let i = 0; i < 5; i++) {
+                guard.check('sender-1', `target-${i}`);
+            }
+            expect(guard.check('sender-1', 'target-extra').allowed).toBe(false);
+
+            // Wait for window to expire
+            await new Promise((r) => setTimeout(r, 550));
+
+            // Should be allowed again
+            const result = guard.check('sender-1', 'target-1');
+            expect(result.allowed).toBe(true);
+        });
+
+        it('returns retryAfterMs based on oldest request in window', () => {
+            for (let i = 0; i < 5; i++) {
+                guard.check('sender-1', `target-${i}`);
+            }
+
+            const result = guard.check('sender-1', 'target-extra');
+            expect(result.allowed).toBe(false);
+            expect(result.reason).toBe('RATE_LIMITED');
+            // retryAfterMs should be close to the window size
+            expect(result.retryAfterMs!).toBeGreaterThan(0);
+            expect(result.retryAfterMs!).toBeLessThanOrEqual(500);
+        });
+    });
+
+    // ── Combined behavior ────────────────────────────────────────────────
+
+    describe('combined checks', () => {
+        it('circuit breaker takes priority over rate limit', () => {
+            guard.check('sender-1', 'target-1');
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+
+            // Circuit is OPEN; even though rate limit is fine, should get CIRCUIT_OPEN
+            const result = guard.check('sender-1', 'target-1');
+            expect(result.allowed).toBe(false);
+            expect(result.reason).toBe('CIRCUIT_OPEN');
+        });
+
+        it('rate limit checked after circuit breaker passes', () => {
+            // Fill sender-1's rate limit
+            for (let i = 0; i < 5; i++) {
+                guard.check('sender-1', `target-${i}`);
+            }
+
+            // Circuit for target-new is CLOSED, but sender-1 is rate limited
+            const result = guard.check('sender-1', 'target-new');
+            expect(result.allowed).toBe(false);
+            expect(result.reason).toBe('RATE_LIMITED');
+        });
+    });
+
+    // ── Lifecycle ────────────────────────────────────────────────────────
+
+    describe('lifecycle', () => {
+        it('resetAll clears all state', () => {
+            // Create some state
+            guard.check('sender-1', 'target-1');
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+            guard.recordFailure('target-1');
+
+            for (let i = 0; i < 5; i++) {
+                guard.check('sender-2', `target-${i}`);
+            }
+
+            guard.resetAll();
+
+            // Everything should be fresh
+            expect(guard.getCircuitState('target-1')).toBe('CLOSED');
+            expect(guard.check('sender-1', 'target-1').allowed).toBe(true);
+            expect(guard.check('sender-2', 'target-1').allowed).toBe(true);
+        });
+
+        it('stop cleans up sweep timer', () => {
+            guard.stop();
+            // No assertion needed — just confirm no error
+        });
+    });
+});
+
+describe('MessagingGuard config', () => {
+    it('uses defaults when no config provided', () => {
+        const guard = new MessagingGuard();
+        // Just verify it creates without error
+        const result = guard.check('a', 'b');
+        expect(result.allowed).toBe(true);
+        guard.stop();
+    });
+
+    it('accepts partial config overrides', () => {
+        const guard = new MessagingGuard({ failureThreshold: 1 });
+        guard.check('sender', 'target');
+        guard.recordFailure('target');
+        expect(guard.getCircuitState('target')).toBe('OPEN');
+        guard.stop();
+    });
+});

--- a/server/algochat/messaging-guard.ts
+++ b/server/algochat/messaging-guard.ts
@@ -1,0 +1,294 @@
+/**
+ * Messaging guard: circuit breaker + per-agent rate limiting for agent-to-agent calls.
+ *
+ * Protects against cascading failures by tracking per-agent outbound call health
+ * (circuit breaker) and prevents message flooding via per-agent sliding-window
+ * rate limiting.
+ *
+ * Configuration via environment variables:
+ * - AGENT_CB_FAILURE_THRESHOLD: failures before opening circuit (default: 5)
+ * - AGENT_CB_RESET_TIMEOUT_MS: cooldown before half-open probe (default: 30000)
+ * - AGENT_CB_SUCCESS_THRESHOLD: successes in half-open to close (default: 2)
+ * - AGENT_RATE_LIMIT_PER_MIN: max messages per agent per minute (default: 10)
+ */
+
+import { CircuitBreaker, CircuitOpenError, type CircuitState } from '../lib/resilience';
+import { createLogger } from '../lib/logger';
+import { circuitBreakerTransitions, agentRateLimitRejections } from '../observability/metrics';
+
+const log = createLogger('MessagingGuard');
+
+// ── Configuration ────────────────────────────────────────────────────────
+
+export interface MessagingGuardConfig {
+    /** Failures before opening the circuit. Default: 5 */
+    failureThreshold: number;
+    /** Cooldown (ms) before transitioning OPEN → HALF_OPEN. Default: 30000 */
+    resetTimeoutMs: number;
+    /** Successes needed in HALF_OPEN to close the circuit. Default: 2 */
+    successThreshold: number;
+    /** Max messages per agent per sliding window. Default: 10 */
+    rateLimitPerWindow: number;
+    /** Sliding window size in ms. Default: 60000 (1 minute) */
+    rateLimitWindowMs: number;
+}
+
+export function loadMessagingGuardConfig(): MessagingGuardConfig {
+    const failureThreshold = parseInt(process.env.AGENT_CB_FAILURE_THRESHOLD ?? '5', 10);
+    const resetTimeoutMs = parseInt(process.env.AGENT_CB_RESET_TIMEOUT_MS ?? '30000', 10);
+    const successThreshold = parseInt(process.env.AGENT_CB_SUCCESS_THRESHOLD ?? '2', 10);
+    const rateLimitPerWindow = parseInt(process.env.AGENT_RATE_LIMIT_PER_MIN ?? '10', 10);
+
+    return {
+        failureThreshold: Number.isFinite(failureThreshold) && failureThreshold > 0 ? failureThreshold : 5,
+        resetTimeoutMs: Number.isFinite(resetTimeoutMs) && resetTimeoutMs > 0 ? resetTimeoutMs : 30_000,
+        successThreshold: Number.isFinite(successThreshold) && successThreshold > 0 ? successThreshold : 2,
+        rateLimitPerWindow: Number.isFinite(rateLimitPerWindow) && rateLimitPerWindow > 0 ? rateLimitPerWindow : 10,
+        rateLimitWindowMs: 60_000,
+    };
+}
+
+// ── Guard result ─────────────────────────────────────────────────────────
+
+export type GuardRejectionReason = 'CIRCUIT_OPEN' | 'RATE_LIMITED';
+
+export interface GuardResult {
+    allowed: boolean;
+    reason?: GuardRejectionReason;
+    retryAfterMs?: number;
+}
+
+// ── MessagingGuard ───────────────────────────────────────────────────────
+
+/**
+ * Combined circuit breaker + per-agent rate limiter for agent messaging.
+ *
+ * Circuit breakers are keyed by target agent ID — if calls to a specific agent
+ * consistently fail, the circuit opens and further calls are rejected until
+ * the cooldown period elapses and a half-open probe succeeds.
+ *
+ * Rate limiting is keyed by sender agent ID — no single agent can send more
+ * than `rateLimitPerWindow` messages within the sliding window.
+ */
+export class MessagingGuard {
+    private readonly config: MessagingGuardConfig;
+
+    /** Per-target-agent circuit breakers. */
+    private readonly breakers = new Map<string, CircuitBreaker>();
+
+    /** Per-sender-agent sliding window timestamps. */
+    private readonly senderWindows = new Map<string, number[]>();
+
+    /** Track previous state per breaker for transition logging. */
+    private readonly previousStates = new Map<string, CircuitState>();
+
+    private sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+    constructor(config?: Partial<MessagingGuardConfig>) {
+        const defaults = loadMessagingGuardConfig();
+        this.config = { ...defaults, ...config };
+
+        // Sweep stale rate-limit entries every 5 minutes
+        this.sweepTimer = setInterval(() => this.sweep(), 5 * 60_000);
+        if (this.sweepTimer && typeof this.sweepTimer === 'object' && 'unref' in this.sweepTimer) {
+            (this.sweepTimer as NodeJS.Timeout).unref();
+        }
+    }
+
+    /**
+     * Check whether a message from `fromAgentId` to `toAgentId` is allowed.
+     *
+     * Checks are performed in order:
+     * 1. Circuit breaker for the target agent (is the agent healthy?)
+     * 2. Rate limit for the sender agent (is the sender flooding?)
+     */
+    check(fromAgentId: string, toAgentId: string): GuardResult {
+        // 1. Circuit breaker check
+        const breaker = this.getOrCreateBreaker(toAgentId);
+        const prevState = this.previousStates.get(toAgentId) ?? 'CLOSED';
+        const currentState = breaker.getState();
+
+        // Log state transitions
+        if (currentState !== prevState) {
+            this.logTransition(toAgentId, prevState, currentState);
+            this.previousStates.set(toAgentId, currentState);
+        }
+
+        if (currentState === 'OPEN') {
+            log.warn('Circuit breaker OPEN — rejecting call', {
+                toAgentId,
+                fromAgentId,
+            });
+            agentRateLimitRejections.inc({ reason: 'circuit_open', agent_id: toAgentId });
+            return {
+                allowed: false,
+                reason: 'CIRCUIT_OPEN',
+                retryAfterMs: this.config.resetTimeoutMs,
+            };
+        }
+
+        // 2. Rate limit check
+        const rateLimitResult = this.checkRateLimit(fromAgentId);
+        if (!rateLimitResult.allowed) {
+            log.warn('Agent rate limit exceeded', {
+                fromAgentId,
+                toAgentId,
+                retryAfterMs: rateLimitResult.retryAfterMs,
+            });
+            agentRateLimitRejections.inc({ reason: 'rate_limited', agent_id: fromAgentId });
+            return rateLimitResult;
+        }
+
+        // Record the send timestamp for rate limiting
+        this.recordSend(fromAgentId);
+
+        return { allowed: true };
+    }
+
+    /**
+     * Record a successful call to the target agent.
+     * Should be called after a message is successfully delivered/processed.
+     */
+    recordSuccess(toAgentId: string): void {
+        const breaker = this.breakers.get(toAgentId);
+        if (!breaker) return;
+
+        const prevState = breaker.getState();
+        breaker.recordSuccess();
+
+        const newState = breaker.getState();
+        if (newState !== prevState) {
+            this.logTransition(toAgentId, prevState, newState);
+            this.previousStates.set(toAgentId, newState);
+        }
+    }
+
+    /**
+     * Record a failed call to the target agent.
+     * Should be called when a message delivery or processing fails.
+     */
+    recordFailure(toAgentId: string): void {
+        const breaker = this.getOrCreateBreaker(toAgentId);
+        const prevState = breaker.getState();
+        breaker.recordFailure();
+
+        const newState = breaker.getState();
+        if (newState !== prevState) {
+            this.logTransition(toAgentId, prevState, newState);
+            this.previousStates.set(toAgentId, newState);
+        }
+    }
+
+    /** Get the circuit breaker state for a target agent. */
+    getCircuitState(toAgentId: string): CircuitState {
+        const breaker = this.breakers.get(toAgentId);
+        if (!breaker) return 'CLOSED';
+        return breaker.getState();
+    }
+
+    /** Reset the circuit breaker for a specific target agent. */
+    resetCircuit(toAgentId: string): void {
+        const breaker = this.breakers.get(toAgentId);
+        if (breaker) {
+            breaker.reset();
+            this.previousStates.set(toAgentId, 'CLOSED');
+            log.info('Circuit breaker manually reset', { toAgentId });
+        }
+    }
+
+    /** Reset all circuit breakers and rate limit windows. */
+    resetAll(): void {
+        this.breakers.clear();
+        this.senderWindows.clear();
+        this.previousStates.clear();
+    }
+
+    /** Stop the periodic sweep timer. */
+    stop(): void {
+        if (this.sweepTimer) {
+            clearInterval(this.sweepTimer);
+            this.sweepTimer = null;
+        }
+    }
+
+    // ── Internal ─────────────────────────────────────────────────────────
+
+    private getOrCreateBreaker(toAgentId: string): CircuitBreaker {
+        let breaker = this.breakers.get(toAgentId);
+        if (!breaker) {
+            breaker = new CircuitBreaker({
+                failureThreshold: this.config.failureThreshold,
+                resetTimeoutMs: this.config.resetTimeoutMs,
+                successThreshold: this.config.successThreshold,
+            });
+            this.breakers.set(toAgentId, breaker);
+            this.previousStates.set(toAgentId, 'CLOSED');
+        }
+        return breaker;
+    }
+
+    private checkRateLimit(fromAgentId: string): GuardResult {
+        const now = Date.now();
+        const windowStart = now - this.config.rateLimitWindowMs;
+
+        let timestamps = this.senderWindows.get(fromAgentId);
+        if (!timestamps) {
+            return { allowed: true };
+        }
+
+        // Prune expired timestamps
+        const firstValid = timestamps.findIndex((t) => t > windowStart);
+        if (firstValid > 0) {
+            timestamps.splice(0, firstValid);
+        } else if (firstValid === -1) {
+            timestamps.length = 0;
+        }
+
+        if (timestamps.length >= this.config.rateLimitPerWindow) {
+            const oldestInWindow = timestamps[0];
+            const retryAfterMs = (oldestInWindow + this.config.rateLimitWindowMs) - now;
+            return {
+                allowed: false,
+                reason: 'RATE_LIMITED',
+                retryAfterMs: Math.max(retryAfterMs, 1),
+            };
+        }
+
+        return { allowed: true };
+    }
+
+    private recordSend(fromAgentId: string): void {
+        let timestamps = this.senderWindows.get(fromAgentId);
+        if (!timestamps) {
+            timestamps = [];
+            this.senderWindows.set(fromAgentId, timestamps);
+        }
+        timestamps.push(Date.now());
+    }
+
+    private logTransition(agentId: string, from: CircuitState, to: CircuitState): void {
+        const level = to === 'OPEN' ? 'warn' : 'info';
+        log[level](`Circuit breaker transition: ${from} → ${to}`, { agentId });
+        circuitBreakerTransitions.inc({ from_state: from, to_state: to, agent_id: agentId });
+    }
+
+    private sweep(): void {
+        const now = Date.now();
+        const windowStart = now - this.config.rateLimitWindowMs;
+        let swept = 0;
+
+        for (const [key, timestamps] of this.senderWindows) {
+            const hasRecent = timestamps.some((t) => t > windowStart);
+            if (!hasRecent) {
+                this.senderWindows.delete(key);
+                swept++;
+            }
+        }
+
+        if (swept > 0) {
+            log.debug('Swept stale agent rate-limit entries', { swept, remaining: this.senderWindows.size });
+        }
+    }
+}
+
+export { CircuitOpenError };

--- a/server/lib/resilience.ts
+++ b/server/lib/resilience.ts
@@ -127,15 +127,16 @@ export class CircuitBreaker {
 
         try {
             const result = await fn();
-            this.onSuccess();
+            this.recordSuccess();
             return result;
         } catch (err) {
-            this.onFailure();
+            this.recordFailure();
             throw err;
         }
     }
 
-    private onSuccess(): void {
+    /** Record a successful operation (used by execute() or externally). */
+    recordSuccess(): void {
         if (this.state === 'HALF_OPEN') {
             this.successCount++;
             if (this.successCount >= this.successThreshold) {
@@ -149,7 +150,8 @@ export class CircuitBreaker {
         }
     }
 
-    private onFailure(): void {
+    /** Record a failed operation (used by execute() or externally). */
+    recordFailure(): void {
         this.failureCount++;
         this.lastFailureTime = Date.now();
 

--- a/server/observability/metrics.ts
+++ b/server/observability/metrics.ts
@@ -254,6 +254,18 @@ export const activeSessions = new Gauge(
     'Number of currently active sessions',
 );
 
+export const circuitBreakerTransitions = new Counter(
+    'circuit_breaker_transitions_total',
+    'Circuit breaker state transitions for agent messaging',
+    ['from_state', 'to_state', 'agent_id'],
+);
+
+export const agentRateLimitRejections = new Counter(
+    'agent_rate_limit_rejections_total',
+    'Agent messaging rejections by circuit breaker or rate limiter',
+    ['reason', 'agent_id'],
+);
+
 // ─── Registry ────────────────────────────────────────────────────────────
 
 const allMetrics = [
@@ -264,6 +276,8 @@ const allMetrics = [
     agentMessagesTotal,
     creditsConsumedTotal,
     activeSessions,
+    circuitBreakerTransitions,
+    agentRateLimitRejections,
 ];
 
 /**

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -155,7 +155,9 @@ export type MessageErrorCode =
     | 'CHAIN_ERROR'           // On-chain transaction failed
     | 'EMPTY_RESPONSE'        // Agent session produced no response
     | 'RESPONSE_SEND_FAILED'  // On-chain response delivery failed
-    | 'WORK_TASK_ERROR';      // Work task creation failed
+    | 'WORK_TASK_ERROR'       // Work task creation failed
+    | 'CIRCUIT_OPEN'          // Circuit breaker open for target agent
+    | 'RATE_LIMITED';         // Per-agent rate limit exceeded
 
 /** Current message protocol version for forward compatibility. */
 export const MESSAGE_PROTOCOL_VERSION = 1;


### PR DESCRIPTION
## Summary
- Adds `MessagingGuard` combining per-target-agent **circuit breaker** and per-sender-agent **sliding-window rate limiter** for agent-to-agent messaging
- Circuit breaker tracks failures per target agent — opens after 5 failures (configurable), blocks calls for 30s cooldown, then probes with half-open state requiring 2 successes to close
- Rate limiter enforces 10 messages/min per sender agent (configurable) using sliding window
- Integrated into `AgentMessenger.invoke()` — rejected messages get `CIRCUIT_OPEN` or `RATE_LIMITED` error codes and are recorded in message history
- Prometheus metrics for state transitions and rejections
- 20 new tests, all 2248 existing tests pass

## Files changed
| File | Change |
|------|--------|
| `server/algochat/messaging-guard.ts` | **New** — MessagingGuard class |
| `server/__tests__/messaging-guard.test.ts` | **New** — 20 tests |
| `server/algochat/agent-messenger.ts` | Guard integration in `invoke()` + success/failure tracking |
| `server/lib/resilience.ts` | Expose `recordSuccess()`/`recordFailure()` on CircuitBreaker |
| `server/observability/metrics.ts` | Two new counters |
| `shared/types.ts` | `CIRCUIT_OPEN` and `RATE_LIMITED` error codes |

## Configuration (env vars)
| Variable | Default | Description |
|----------|---------|-------------|
| `AGENT_CB_FAILURE_THRESHOLD` | 5 | Failures before opening circuit |
| `AGENT_CB_RESET_TIMEOUT_MS` | 30000 | Cooldown before half-open probe |
| `AGENT_CB_SUCCESS_THRESHOLD` | 2 | Successes in half-open to close |
| `AGENT_RATE_LIMIT_PER_MIN` | 10 | Max messages per sender per minute |

## Test plan
- [x] All circuit breaker state transitions tested (CLOSED → OPEN → HALF_OPEN → CLOSED, HALF_OPEN → OPEN)
- [x] Per-agent rate limiting: under/over limit, independent senders, window expiry
- [x] Combined behavior: circuit breaker priority, rate limit after breaker passes
- [x] Lifecycle: resetAll, stop, manual reset
- [x] All 2248 existing tests pass

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)