### PR TITLE
Add missing tests and specs for Slack bridge, council discussion, workflows

### DIFF
--- a/server/__tests__/council-discussion.test.ts
+++ b/server/__tests__/council-discussion.test.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import { createAgent } from '../db/agents';
+import { createProject } from '../db/projects';
+import { createSession } from '../db/sessions';
+import { waitForSessions } from '../routes/councils';
+import type { ProcessManager, EventCallback } from '../process/manager';
+
+// ─── Mock ProcessManager with full simulation ───────────────────────────────
+
+function createMockPM() {
+    const subscribers = new Map<string, Set<EventCallback>>();
+    const running = new Set<string>();
+
+    const pm: Pick<ProcessManager, 'subscribe' | 'unsubscribe' | 'isRunning' | 'stopProcess' | 'startProcess' | 'sendMessage'> = {
+        subscribe: (sessionId: string, cb: EventCallback) => {
+            if (!subscribers.has(sessionId)) subscribers.set(sessionId, new Set());
+            subscribers.get(sessionId)!.add(cb);
+        },
+        unsubscribe: (sessionId: string, cb: EventCallback) => {
+            subscribers.get(sessionId)?.delete(cb);
+        },
+        isRunning: (sessionId: string) => running.has(sessionId),
+        stopProcess: mock((sessionId: string) => {
+            running.delete(sessionId);
+        }),
+        startProcess: mock(() => {}),
+        sendMessage: mock(() => true),
+    };
+
+    return {
+        pm: pm as unknown as ProcessManager,
+        markRunning(sessionId: string) {
+            running.add(sessionId);
+        },
+        emitExit(sessionId: string) {
+            running.delete(sessionId);
+            const cbs = subscribers.get(sessionId);
+            if (cbs) {
+                for (const cb of cbs) {
+                    cb(sessionId, { type: 'session_exited', exitCode: 0, duration: 1000 } as any);
+                }
+            }
+        },
+        emitStopped(sessionId: string) {
+            running.delete(sessionId);
+            const cbs = subscribers.get(sessionId);
+            if (cbs) {
+                for (const cb of cbs) {
+                    cb(sessionId, { type: 'session_stopped' } as any);
+                }
+            }
+        },
+        subscribers,
+        running,
+    };
+}
+
+let db: Database;
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+});
+
+afterEach(() => {
+    db.close();
+});
+
+// ─── Parallel Agent Spawning ────────────────────────────────────────────────
+
+describe('Council Discussion: Parallel Agent Spawning', () => {
+    it('spawns multiple sessions and waits for all to complete', async () => {
+        const { pm, markRunning, emitExit } = createMockPM();
+
+        // Simulate 3 agents starting
+        markRunning('session-a');
+        markRunning('session-b');
+        markRunning('session-c');
+
+        const promise = waitForSessions(pm, ['session-a', 'session-b', 'session-c'], 5000);
+
+        // All complete in parallel (different order)
+        emitExit('session-c');
+        emitExit('session-a');
+        emitExit('session-b');
+
+        const result = await promise;
+        expect(result.completed.sort()).toEqual(['session-a', 'session-b', 'session-c']);
+        expect(result.timedOut).toEqual([]);
+    });
+
+    it('no stagger delay — sessions start immediately', async () => {
+        const { pm, markRunning, emitExit } = createMockPM();
+
+        // All sessions start at roughly the same time (no delay between spawns)
+        const startTime = Date.now();
+        const sessionIds = ['s1', 's2', 's3', 's4', 's5'];
+
+        for (const sid of sessionIds) {
+            markRunning(sid);
+        }
+
+        const elapsed = Date.now() - startTime;
+        // Should take < 10ms (no stagger)
+        expect(elapsed).toBeLessThan(50);
+
+        const promise = waitForSessions(pm, sessionIds, 5000);
+
+        for (const sid of sessionIds) {
+            emitExit(sid);
+        }
+
+        const result = await promise;
+        expect(result.completed).toHaveLength(5);
+        expect(result.timedOut).toHaveLength(0);
+    });
+});
+
+// ─── Auto-advance When All Sessions Complete ────────────────────────────────
+
+describe('Council Discussion: Auto-advance', () => {
+    it('resolves when all sessions complete regardless of order', async () => {
+        const { pm, markRunning, emitExit, emitStopped } = createMockPM();
+
+        markRunning('s1');
+        markRunning('s2');
+        markRunning('s3');
+
+        const promise = waitForSessions(pm, ['s1', 's2', 's3'], 5000);
+
+        // Mixed completion types
+        emitExit('s1');
+        emitStopped('s2');
+        emitExit('s3');
+
+        const result = await promise;
+        expect(result.completed.sort()).toEqual(['s1', 's2', 's3']);
+        expect(result.timedOut).toEqual([]);
+    });
+
+    it('resolves immediately if sessions already finished before subscribe', async () => {
+        const { pm } = createMockPM();
+        // Sessions not marked as running → isRunning returns false → immediately complete
+
+        const result = await waitForSessions(pm, ['s1', 's2'], 5000);
+        expect(result.completed.sort()).toEqual(['s1', 's2']);
+        expect(result.timedOut).toEqual([]);
+    });
+});
+
+// ─── Timeout Handling ───────────────────────────────────────────────────────
+
+describe('Council Discussion: Timeout Handling', () => {
+    it('per-round timeout fires for stuck sessions', async () => {
+        const { pm, markRunning } = createMockPM();
+
+        markRunning('stuck-1');
+        markRunning('stuck-2');
+
+        const result = await waitForSessions(pm, ['stuck-1', 'stuck-2'], 100);
+
+        expect(result.completed).toEqual([]);
+        expect(result.timedOut.sort()).toEqual(['stuck-1', 'stuck-2']);
+    });
+
+    it('per-agent timeout does not block completed agents', async () => {
+        const { pm, markRunning, emitExit } = createMockPM();
+
+        markRunning('fast');
+        markRunning('slow');
+
+        const promise = waitForSessions(pm, ['fast', 'slow'], 200);
+
+        // Fast agent completes immediately
+        emitExit('fast');
+
+        // Slow agent never completes — timeout fires
+        const result = await promise;
+        expect(result.completed).toEqual(['fast']);
+        expect(result.timedOut).toEqual(['slow']);
+    });
+
+    it('timeout with no sessions resolves immediately', async () => {
+        const { pm } = createMockPM();
+        const result = await waitForSessions(pm, [], 100);
+        expect(result.completed).toEqual([]);
+        expect(result.timedOut).toEqual([]);
+    });
+});
+
+// ─── Mixed Completed / Timed-Out Sessions ───────────────────────────────────
+
+describe('Council Discussion: Mixed Completion', () => {
+    it('handles mix of completed and timed-out sessions', async () => {
+        const { pm, markRunning, emitExit } = createMockPM();
+
+        markRunning('agent-1');
+        markRunning('agent-2');
+        markRunning('agent-3');
+        markRunning('agent-4');
+
+        const promise = waitForSessions(pm, ['agent-1', 'agent-2', 'agent-3', 'agent-4'], 150);
+
+        // 2 agents complete, 2 timeout
+        emitExit('agent-1');
+        emitExit('agent-3');
+
+        const result = await promise;
+        expect(result.completed.sort()).toEqual(['agent-1', 'agent-3']);
+        expect(result.timedOut.sort()).toEqual(['agent-2', 'agent-4']);
+    });
+
+    it('handles session exiting after another was already marked complete', async () => {
+        const { pm, markRunning, emitExit } = createMockPM();
+
+        markRunning('s1');
+        markRunning('s2');
+        markRunning('s3');
+
+        const promise = waitForSessions(pm, ['s1', 's2', 's3'], 5000);
+
+        // Stagger completions
+        emitExit('s1');
+        await new Promise(r => setTimeout(r, 10));
+        emitExit('s2');
+        await new Promise(r => setTimeout(r, 10));
+        emitExit('s3');
+
+        const result = await promise;
+        expect(result.completed).toHaveLength(3);
+        expect(result.timedOut).toHaveLength(0);
+    });
+});
+
+// ─── Aggregation of Parallel Responses ──────────────────────────────────────
+
+describe('Council Discussion: Response Aggregation', () => {
+    it('creates sessions for each agent in the council', () => {
+        const agent1 = createAgent(db, { name: 'Agent Alpha', model: 'sonnet' });
+        const agent2 = createAgent(db, { name: 'Agent Beta', model: 'sonnet' });
+        const agent3 = createAgent(db, { name: 'Agent Gamma', model: 'sonnet' });
+        const project = createProject(db, { name: 'Test Project', workingDir: '/tmp/test' });
+
+        // Simulate creating discusser sessions (as runDiscussionRounds does)
+        const sessions = [agent1, agent2, agent3].map((agent) => {
+            return createSession(db, {
+                projectId: project.id,
+                agentId: agent.id,
+                name: `Discussion R1: Council - ${agent.name}`,
+                initialPrompt: 'Discuss the topic',
+                councilRole: 'discusser',
+            });
+        });
+
+        expect(sessions).toHaveLength(3);
+        for (const session of sessions) {
+            expect(session.id).toBeTruthy();
+            expect(session.councilRole).toBe('discusser');
+        }
+    });
+
+    it('session messages can be queried for response extraction', () => {
+        const agent = createAgent(db, { name: 'Agent', model: 'sonnet' });
+        const project = createProject(db, { name: 'Project', workingDir: '/tmp/test' });
+
+        const session = createSession(db, {
+            projectId: project.id,
+            agentId: agent.id,
+            name: 'Discussion session',
+            initialPrompt: 'test',
+            councilRole: 'discusser',
+        });
+
+        // Insert a mock assistant message
+        db.query(
+            `INSERT INTO session_messages (session_id, role, content) VALUES (?, 'assistant', ?)`
+        ).run(session.id, 'I believe the answer is 42.');
+
+        const messages = db.query(
+            `SELECT content FROM session_messages WHERE session_id = ? AND role = 'assistant' ORDER BY id DESC LIMIT 1`
+        ).get(session.id) as { content: string } | null;
+
+        expect(messages?.content).toBe('I believe the answer is 42.');
+    });
+});
+
+// ─── Cleanup After Completion ───────────────────────────────────────────────
+
+describe('Council Discussion: Cleanup', () => {
+    it('unsubscribes from all sessions after all complete', async () => {
+        const { pm, subscribers } = createMockPM();
+
+        await waitForSessions(pm, ['s1', 's2', 's3'], 5000);
+
+        for (const [, cbs] of subscribers) {
+            expect(cbs.size).toBe(0);
+        }
+    });
+
+    it('unsubscribes from all sessions after timeout', async () => {
+        const { pm, markRunning, subscribers } = createMockPM();
+
+        markRunning('stuck');
+
+        await waitForSessions(pm, ['stuck'], 50);
+
+        for (const [, cbs] of subscribers) {
+            expect(cbs.size).toBe(0);
+        }
+    });
+
+    it('does not double-count sessions that exit before and after subscribe', async () => {
+        const { pm, markRunning, emitExit } = createMockPM();
+
+        // s1 already exited, s2 will exit during wait
+        markRunning('s2');
+
+        const promise = waitForSessions(pm, ['s1', 's2'], 5000);
+        emitExit('s2');
+
+        const result = await promise;
+        // s1 should appear only once in completed
+        const s1Count = result.completed.filter(id => id === 's1').length;
+        expect(s1Count).toBe(1);
+        expect(result.completed).toHaveLength(2);
+    });
+});
+
+// ─── Large Scale Parallel Sessions ──────────────────────────────────────────
+
+describe('Council Discussion: Scale', () => {
+    it('handles 10 sessions completing in parallel', async () => {
+        const { pm, markRunning, emitExit } = createMockPM();
+
+        const sessionIds = Array.from({ length: 10 }, (_, i) => `s${i}`);
+        for (const sid of sessionIds) {
+            markRunning(sid);
+        }
+
+        const promise = waitForSessions(pm, sessionIds, 5000);
+
+        // Complete all in reverse order
+        for (const sid of [...sessionIds].reverse()) {
+            emitExit(sid);
+        }
+
+        const result = await promise;
+        expect(result.completed).toHaveLength(10);
+        expect(result.timedOut).toHaveLength(0);
+    });
+
+    it('handles many sessions with some timing out', async () => {
+        const { pm, markRunning, emitExit } = createMockPM();
+
+        const sessionIds = Array.from({ length: 8 }, (_, i) => `s${i}`);
+        for (const sid of sessionIds) {
+            markRunning(sid);
+        }
+
+        const promise = waitForSessions(pm, sessionIds, 150);
+
+        // Only first 4 complete
+        for (let i = 0; i < 4; i++) {
+            emitExit(`s${i}`);
+        }
+
+        const result = await promise;
+        expect(result.completed).toHaveLength(4);
+        expect(result.timedOut).toHaveLength(4);
+    });
+});
+
+// ─── Session Stopped vs Exited ──────────────────────────────────────────────
+
+describe('Council Discussion: Event Types', () => {
+    it('treats session_stopped the same as session_exited', async () => {
+        const { pm, markRunning, emitStopped } = createMockPM();
+
+        markRunning('s1');
+        markRunning('s2');
+
+        const promise = waitForSessions(pm, ['s1', 's2'], 5000);
+
+        emitStopped('s1');
+        emitStopped('s2');
+
+        const result = await promise;
+        expect(result.completed.sort()).toEqual(['s1', 's2']);
+        expect(result.timedOut).toEqual([]);
+    });
+
+    it('ignores non-exit event types', async () => {
+        const { pm, markRunning, emitExit, subscribers } = createMockPM();
+
+        markRunning('s1');
+
+        const promise = waitForSessions(pm, ['s1'], 500);
+
+        // Send a non-exit event (should be ignored)
+        const cbs = subscribers.get('s1');
+        if (cbs) {
+            for (const cb of cbs) {
+                cb('s1', { type: 'assistant', message: 'thinking...' } as any);
+            }
+        }
+
+        // Session should still be pending
+        // Now actually exit
+        emitExit('s1');
+
+        const result = await promise;
+        expect(result.completed).toEqual(['s1']);
+        expect(result.timedOut).toEqual([]);
+    });
+});

--- a/server/__tests__/slack-bridge.test.ts
+++ b/server/__tests__/slack-bridge.test.ts
@@ -1,0 +1,1093 @@
+import { test, expect, describe, mock, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import { SlackBridge } from '../slack/bridge';
+import type { SlackBridgeConfig } from '../slack/types';
+import { createAgent } from '../db/agents';
+import { createProject } from '../db/projects';
+
+// ─── Mock ProcessManager ────────────────────────────────────────────────────
+
+function createMockProcessManager() {
+    return {
+        getActiveSessionIds: () => [] as string[],
+        startProcess: mock(() => {}),
+        sendMessage: mock(() => true),
+        subscribe: mock(() => {}),
+        unsubscribe: mock(() => {}),
+        isRunning: mock(() => false),
+    } as unknown as import('../process/manager').ProcessManager;
+}
+
+let db: Database;
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+});
+
+afterEach(() => {
+    db.close();
+});
+
+// ─── Helper: build a signed Slack request ───────────────────────────────────
+
+async function buildSignedRequest(
+    signingSecret: string,
+    body: unknown,
+    timestampOverride?: number,
+): Promise<Request> {
+    const rawBody = JSON.stringify(body);
+    const timestamp = timestampOverride ?? Math.floor(Date.now() / 1000);
+    const sigBasestring = `v0:${timestamp}:${rawBody}`;
+
+    const encoder = new TextEncoder();
+    const key = await crypto.subtle.importKey(
+        'raw',
+        encoder.encode(signingSecret),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign'],
+    );
+    const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(sigBasestring));
+    const hexSig = 'v0=' + Array.from(new Uint8Array(sig))
+        .map(b => b.toString(16).padStart(2, '0'))
+        .join('');
+
+    return new Request('http://localhost/api/slack/events', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'x-slack-request-timestamp': String(timestamp),
+            'x-slack-signature': hexSig,
+        },
+        body: rawBody,
+    });
+}
+
+// ─── Constructor / Config ───────────────────────────────────────────────────
+
+describe('SlackBridge', () => {
+    test('constructor creates bridge', () => {
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test-token',
+            signingSecret: 'test-secret',
+            channelId: 'C12345',
+            allowedUserIds: ['U111'],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        expect(bridge).toBeDefined();
+    });
+
+    test('start and stop', () => {
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test-token',
+            signingSecret: 'test-secret',
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+
+        bridge.start();
+        expect((bridge as any).running).toBe(true);
+
+        bridge.stop();
+        expect((bridge as any).running).toBe(false);
+    });
+
+    test('start is idempotent', () => {
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test-token',
+            signingSecret: 'test-secret',
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+
+        bridge.start();
+        bridge.start(); // second call is no-op
+        expect((bridge as any).running).toBe(true);
+
+        bridge.stop();
+        expect((bridge as any).running).toBe(false);
+    });
+
+    test('stop clears cleanup timer', () => {
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test-token',
+            signingSecret: 'test-secret',
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+
+        bridge.start();
+        expect((bridge as any).processedEventsCleanupTimer).not.toBeNull();
+
+        bridge.stop();
+        expect((bridge as any).processedEventsCleanupTimer).toBeNull();
+    });
+});
+
+// ─── Signature Verification ─────────────────────────────────────────────────
+
+describe('Slack signature verification', () => {
+    const signingSecret = 'my-signing-secret';
+    const config: SlackBridgeConfig = {
+        botToken: 'xoxb-test',
+        signingSecret,
+        channelId: 'C12345',
+        allowedUserIds: [],
+    };
+
+    test('accepts valid signature', async () => {
+        const pm = createMockProcessManager();
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        const body = { type: 'url_verification', challenge: 'test-challenge' };
+        const req = await buildSignedRequest(signingSecret, body);
+
+        const response = await bridge.handleEventRequest(req);
+        expect(response.status).toBe(200);
+
+        const json = await response.json() as { challenge: string };
+        expect(json.challenge).toBe('test-challenge');
+
+        bridge.stop();
+    });
+
+    test('rejects missing signature headers', async () => {
+        const pm = createMockProcessManager();
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        const req = new Request('http://localhost/api/slack/events', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ type: 'url_verification', challenge: 'test' }),
+        });
+
+        const response = await bridge.handleEventRequest(req);
+        expect(response.status).toBe(401);
+
+        bridge.stop();
+    });
+
+    test('rejects invalid signature', async () => {
+        const pm = createMockProcessManager();
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        const timestamp = Math.floor(Date.now() / 1000);
+        const req = new Request('http://localhost/api/slack/events', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-slack-request-timestamp': String(timestamp),
+                'x-slack-signature': 'v0=invalid_signature_here_00000000000000000000000000000000',
+            },
+            body: JSON.stringify({ type: 'url_verification', challenge: 'test' }),
+        });
+
+        const response = await bridge.handleEventRequest(req);
+        expect(response.status).toBe(401);
+
+        bridge.stop();
+    });
+
+    test('rejects replay attacks (timestamp > 5 minutes old)', async () => {
+        const pm = createMockProcessManager();
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        const oldTimestamp = Math.floor(Date.now() / 1000) - 400; // 6+ minutes ago
+        const body = { type: 'url_verification', challenge: 'replay' };
+        const req = await buildSignedRequest(signingSecret, body, oldTimestamp);
+
+        const response = await bridge.handleEventRequest(req);
+        expect(response.status).toBe(401);
+
+        bridge.stop();
+    });
+});
+
+// ─── URL Verification Challenge ─────────────────────────────────────────────
+
+describe('Slack URL verification', () => {
+    test('responds to url_verification with challenge', async () => {
+        const signingSecret = 'challenge-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        const body = {
+            type: 'url_verification',
+            challenge: 'my-challenge-token-xyz',
+        };
+        const req = await buildSignedRequest(signingSecret, body);
+        const response = await bridge.handleEventRequest(req);
+
+        expect(response.status).toBe(200);
+        const json = await response.json() as { challenge: string };
+        expect(json.challenge).toBe('my-challenge-token-xyz');
+
+        bridge.stop();
+    });
+});
+
+// ─── Event Deduplication ────────────────────────────────────────────────────
+
+describe('Slack event deduplication', () => {
+    test('deduplicates events with same channel:ts', async () => {
+        const signingSecret = 'dedup-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        // Seed an agent and project so routeToAgent doesn't fail
+        createAgent(db, { name: 'Test Agent', model: 'sonnet' });
+        createProject(db, { name: 'Test Project', workingDir: '/tmp/test' });
+
+        const event = {
+            type: 'message',
+            user: 'U123',
+            text: 'hello',
+            channel: 'C12345',
+            ts: '1234567890.000100',
+        };
+
+        // First event
+        const body1 = { type: 'event_callback', event };
+        const req1 = await buildSignedRequest(signingSecret, body1);
+        await bridge.handleEventRequest(req1);
+
+        // Small delay to let async handleEvent run
+        await new Promise(r => setTimeout(r, 50));
+
+        // Retry — same event should be deduplicated
+        const req2 = await buildSignedRequest(signingSecret, body1);
+        await bridge.handleEventRequest(req2);
+
+        await new Promise(r => setTimeout(r, 50));
+
+        // Should only have started one process
+        expect(pm.startProcess).toHaveBeenCalledTimes(1);
+
+        bridge.stop();
+    });
+});
+
+// ─── Bot Message Filtering ──────────────────────────────────────────────────
+
+describe('Slack bot message filtering', () => {
+    test('ignores messages with bot_id', async () => {
+        const signingSecret = 'bot-filter-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        const body = {
+            type: 'event_callback',
+            event: {
+                type: 'message',
+                user: 'U123',
+                text: 'bot message',
+                channel: 'C12345',
+                ts: '1234567890.000200',
+                bot_id: 'B_BOT_123',
+            },
+        };
+        const req = await buildSignedRequest(signingSecret, body);
+        await bridge.handleEventRequest(req);
+
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(pm.startProcess).not.toHaveBeenCalled();
+
+        bridge.stop();
+    });
+
+    test('ignores messages with subtype', async () => {
+        const signingSecret = 'subtype-filter-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        const body = {
+            type: 'event_callback',
+            event: {
+                type: 'message',
+                user: 'U123',
+                text: 'channel join',
+                channel: 'C12345',
+                ts: '1234567890.000300',
+                subtype: 'channel_join',
+            },
+        };
+        const req = await buildSignedRequest(signingSecret, body);
+        await bridge.handleEventRequest(req);
+
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(pm.startProcess).not.toHaveBeenCalled();
+
+        bridge.stop();
+    });
+});
+
+// ─── Channel Filtering ──────────────────────────────────────────────────────
+
+describe('Slack channel filtering', () => {
+    test('ignores messages from other channels', async () => {
+        const signingSecret = 'channel-filter-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C_MY_CHANNEL',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        const body = {
+            type: 'event_callback',
+            event: {
+                type: 'message',
+                user: 'U123',
+                text: 'wrong channel',
+                channel: 'C_OTHER_CHANNEL',
+                ts: '1234567890.000400',
+            },
+        };
+        const req = await buildSignedRequest(signingSecret, body);
+        await bridge.handleEventRequest(req);
+
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(pm.startProcess).not.toHaveBeenCalled();
+
+        bridge.stop();
+    });
+});
+
+// ─── User Authorization ─────────────────────────────────────────────────────
+
+describe('Slack user authorization', () => {
+    test('rejects unauthorized users', async () => {
+        const signingSecret = 'auth-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: ['U_ALLOWED_1'],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        // Mock sendMessage to capture what was sent
+        const sentMessages: string[] = [];
+        (bridge as any).sendMessage = mock(async (_ch: string, text: string) => {
+            sentMessages.push(text);
+        });
+
+        const body = {
+            type: 'event_callback',
+            event: {
+                type: 'message',
+                user: 'U_UNAUTHORIZED',
+                text: 'hello',
+                channel: 'C12345',
+                ts: '1234567890.000500',
+            },
+        };
+        const req = await buildSignedRequest(signingSecret, body);
+        await bridge.handleEventRequest(req);
+
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(sentMessages).toContain('Unauthorized.');
+        expect(pm.startProcess).not.toHaveBeenCalled();
+
+        bridge.stop();
+    });
+
+    test('allows authorized users', async () => {
+        const signingSecret = 'auth-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: ['U_ALLOWED_1'],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        createAgent(db, { name: 'Test Agent', model: 'sonnet' });
+        createProject(db, { name: 'Test Project', workingDir: '/tmp/test' });
+
+        const body = {
+            type: 'event_callback',
+            event: {
+                type: 'message',
+                user: 'U_ALLOWED_1',
+                text: 'hello from allowed user',
+                channel: 'C12345',
+                ts: '1234567890.000600',
+            },
+        };
+        const req = await buildSignedRequest(signingSecret, body);
+        await bridge.handleEventRequest(req);
+
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(pm.startProcess).toHaveBeenCalledTimes(1);
+
+        bridge.stop();
+    });
+
+    test('allows all users when allowedUserIds is empty', async () => {
+        const signingSecret = 'auth-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: [], // empty = allow all
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        createAgent(db, { name: 'Test Agent', model: 'sonnet' });
+        createProject(db, { name: 'Test Project', workingDir: '/tmp/test' });
+
+        const body = {
+            type: 'event_callback',
+            event: {
+                type: 'message',
+                user: 'U_ANY_USER',
+                text: 'hello',
+                channel: 'C12345',
+                ts: '1234567890.000700',
+            },
+        };
+        const req = await buildSignedRequest(signingSecret, body);
+        await bridge.handleEventRequest(req);
+
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(pm.startProcess).toHaveBeenCalledTimes(1);
+
+        bridge.stop();
+    });
+});
+
+// ─── Rate Limiting ──────────────────────────────────────────────────────────
+
+describe('Slack rate limiting', () => {
+    test('rate limits after 10 messages per 60s', async () => {
+        const signingSecret = 'rate-limit-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        createAgent(db, { name: 'Test Agent', model: 'sonnet' });
+        createProject(db, { name: 'Test Project', workingDir: '/tmp/test' });
+
+        const sentMessages: string[] = [];
+        (bridge as any).sendMessage = mock(async (_ch: string, text: string) => {
+            sentMessages.push(text);
+        });
+
+        // Send 10 messages (should all be allowed)
+        for (let i = 0; i < 10; i++) {
+            const body = {
+                type: 'event_callback',
+                event: {
+                    type: 'message',
+                    user: 'U_RATE_TEST',
+                    text: `message ${i}`,
+                    channel: 'C12345',
+                    ts: `1234567890.${String(800 + i).padStart(6, '0')}`,
+                },
+            };
+            const req = await buildSignedRequest(signingSecret, body);
+            await bridge.handleEventRequest(req);
+            await new Promise(r => setTimeout(r, 10));
+        }
+
+        // 11th message should be rate limited
+        const body = {
+            type: 'event_callback',
+            event: {
+                type: 'message',
+                user: 'U_RATE_TEST',
+                text: 'message 10',
+                channel: 'C12345',
+                ts: '1234567890.000810',
+            },
+        };
+        const req = await buildSignedRequest(signingSecret, body);
+        await bridge.handleEventRequest(req);
+
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(sentMessages.some(m => m.includes('Rate limit'))).toBe(true);
+
+        bridge.stop();
+    });
+
+    test('rate limit is per-user', () => {
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret: 'test',
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+
+        // Fill user1's rate limit
+        for (let i = 0; i < 10; i++) {
+            expect((bridge as any).checkRateLimit('user1')).toBe(true);
+        }
+        expect((bridge as any).checkRateLimit('user1')).toBe(false);
+
+        // user2 should still have capacity
+        expect((bridge as any).checkRateLimit('user2')).toBe(true);
+    });
+});
+
+// ─── Message Chunking ───────────────────────────────────────────────────────
+
+describe('Slack message chunking', () => {
+    test('sends short messages as single chunk', async () => {
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret: 'test',
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+
+        const fetchCalls: { body: string }[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async (_url: string, opts: RequestInit) => {
+            fetchCalls.push({ body: opts.body as string });
+            return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            await bridge.sendMessage('C12345', 'Hello');
+            expect(fetchCalls).toHaveLength(1);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test('splits messages longer than 4000 chars', async () => {
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret: 'test',
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+
+        const fetchCalls: { body: string }[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async (_url: string, opts: RequestInit) => {
+            fetchCalls.push({ body: opts.body as string });
+            return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            const longText = 'x'.repeat(5000);
+            await bridge.sendMessage('C12345', longText);
+            expect(fetchCalls).toHaveLength(2);
+
+            // First chunk should be 4000 chars
+            const firstBody = JSON.parse(fetchCalls[0].body);
+            expect(firstBody.text).toHaveLength(4000);
+
+            // Second chunk should be the remainder
+            const secondBody = JSON.parse(fetchCalls[1].body);
+            expect(secondBody.text).toHaveLength(1000);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test('sendMessage at exactly 4000 chars sends single chunk', async () => {
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret: 'test',
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+
+        const fetchCalls: unknown[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async () => {
+            fetchCalls.push(1);
+            return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            await bridge.sendMessage('C12345', 'x'.repeat(4000));
+            expect(fetchCalls).toHaveLength(1);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+});
+
+// ─── Thread Support ─────────────────────────────────────────────────────────
+
+describe('Slack thread support', () => {
+    test('sendMessage includes thread_ts when provided', async () => {
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret: 'test',
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+
+        const fetchBodies: Record<string, unknown>[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async (_url: string, opts: RequestInit) => {
+            fetchBodies.push(JSON.parse(opts.body as string));
+            return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            await bridge.sendMessage('C12345', 'threaded reply', '1234567890.000100');
+            expect(fetchBodies).toHaveLength(1);
+            expect(fetchBodies[0].thread_ts).toBe('1234567890.000100');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test('sendMessage omits thread_ts when not provided', async () => {
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret: 'test',
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+
+        const fetchBodies: Record<string, unknown>[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async (_url: string, opts: RequestInit) => {
+            fetchBodies.push(JSON.parse(opts.body as string));
+            return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            await bridge.sendMessage('C12345', 'no thread');
+            expect(fetchBodies).toHaveLength(1);
+            expect(fetchBodies[0].thread_ts).toBeUndefined();
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+});
+
+// ─── app_mention Event ──────────────────────────────────────────────────────
+
+describe('Slack app_mention events', () => {
+    test('handles app_mention events', async () => {
+        const signingSecret = 'mention-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        createAgent(db, { name: 'Test Agent', model: 'sonnet' });
+        createProject(db, { name: 'Test Project', workingDir: '/tmp/test' });
+
+        const body = {
+            type: 'event_callback',
+            event: {
+                type: 'app_mention',
+                user: 'U123',
+                text: '<@BBOT> what is the weather?',
+                channel: 'C12345',
+                ts: '1234567890.000900',
+            },
+        };
+        const req = await buildSignedRequest(signingSecret, body);
+        await bridge.handleEventRequest(req);
+
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(pm.startProcess).toHaveBeenCalledTimes(1);
+
+        bridge.stop();
+    });
+});
+
+// ─── Slash Commands ─────────────────────────────────────────────────────────
+
+describe('Slack slash commands', () => {
+    test('/status reports current session', async () => {
+        const signingSecret = 'cmd-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        const sentMessages: string[] = [];
+        (bridge as any).sendMessage = mock(async (_ch: string, text: string) => {
+            sentMessages.push(text);
+        });
+
+        const body = {
+            type: 'event_callback',
+            event: {
+                type: 'message',
+                user: 'U_CMD',
+                text: '/status',
+                channel: 'C12345',
+                ts: '1234567890.001000',
+            },
+        };
+        const req = await buildSignedRequest(signingSecret, body);
+        await bridge.handleEventRequest(req);
+
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(sentMessages.some(m => m.includes('session'))).toBe(true);
+        expect(pm.startProcess).not.toHaveBeenCalled();
+
+        bridge.stop();
+    });
+
+    test('/new clears session mapping', async () => {
+        const signingSecret = 'cmd-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        // Set a session for the user
+        (bridge as any).userSessions.set('U_CMD', 'old-session-id');
+
+        const sentMessages: string[] = [];
+        (bridge as any).sendMessage = mock(async (_ch: string, text: string) => {
+            sentMessages.push(text);
+        });
+
+        const body = {
+            type: 'event_callback',
+            event: {
+                type: 'message',
+                user: 'U_CMD',
+                text: '/new',
+                channel: 'C12345',
+                ts: '1234567890.001100',
+            },
+        };
+        const req = await buildSignedRequest(signingSecret, body);
+        await bridge.handleEventRequest(req);
+
+        await new Promise(r => setTimeout(r, 50));
+
+        expect((bridge as any).userSessions.has('U_CMD')).toBe(false);
+        expect(sentMessages.some(m => m.includes('cleared'))).toBe(true);
+
+        bridge.stop();
+    });
+});
+
+// ─── Session Routing ────────────────────────────────────────────────────────
+
+describe('Slack session routing', () => {
+    test('creates session with source slack', async () => {
+        const signingSecret = 'routing-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        createAgent(db, { name: 'Test Agent', model: 'sonnet' });
+        createProject(db, { name: 'Test Project', workingDir: '/tmp/test' });
+
+        // Mock sendMessage to avoid actual API calls
+        (bridge as any).sendMessage = mock(async () => {});
+
+        const body = {
+            type: 'event_callback',
+            event: {
+                type: 'message',
+                user: 'U_ROUTE',
+                text: 'hello there',
+                channel: 'C12345',
+                ts: '1234567890.001200',
+            },
+        };
+        const req = await buildSignedRequest(signingSecret, body);
+        await bridge.handleEventRequest(req);
+
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(pm.startProcess).toHaveBeenCalledTimes(1);
+        // Verify user session was created
+        expect((bridge as any).userSessions.has('U_ROUTE')).toBe(true);
+
+        bridge.stop();
+    });
+
+    test('reuses existing session for same user', async () => {
+        const signingSecret = 'routing-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        createAgent(db, { name: 'Test Agent', model: 'sonnet' });
+        createProject(db, { name: 'Test Project', workingDir: '/tmp/test' });
+
+        (bridge as any).sendMessage = mock(async () => {});
+
+        // First message — creates session
+        const body1 = {
+            type: 'event_callback',
+            event: {
+                type: 'message',
+                user: 'U_REUSE',
+                text: 'first message',
+                channel: 'C12345',
+                ts: '1234567890.001300',
+            },
+        };
+        const req1 = await buildSignedRequest(signingSecret, body1);
+        await bridge.handleEventRequest(req1);
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(pm.startProcess).toHaveBeenCalledTimes(1);
+
+        // Second message — should reuse session via sendMessage
+        const body2 = {
+            type: 'event_callback',
+            event: {
+                type: 'message',
+                user: 'U_REUSE',
+                text: 'second message',
+                channel: 'C12345',
+                ts: '1234567890.001400',
+            },
+        };
+        const req2 = await buildSignedRequest(signingSecret, body2);
+        await bridge.handleEventRequest(req2);
+        await new Promise(r => setTimeout(r, 50));
+
+        // sendMessage on processManager should have been called for the reuse path
+        expect(pm.sendMessage).toHaveBeenCalled();
+
+        bridge.stop();
+    });
+
+    test('sends error when no agents configured', async () => {
+        const signingSecret = 'noagent-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        const sentMessages: string[] = [];
+        (bridge as any).sendMessage = mock(async (_ch: string, text: string) => {
+            sentMessages.push(text);
+        });
+
+        const body = {
+            type: 'event_callback',
+            event: {
+                type: 'message',
+                user: 'U_NOAGENT',
+                text: 'hello',
+                channel: 'C12345',
+                ts: '1234567890.001500',
+            },
+        };
+        const req = await buildSignedRequest(signingSecret, body);
+        await bridge.handleEventRequest(req);
+
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(sentMessages.some(m => m.includes('No agents configured'))).toBe(true);
+
+        bridge.stop();
+    });
+});
+
+// ─── Not Running ────────────────────────────────────────────────────────────
+
+describe('Slack bridge not running', () => {
+    test('ignores events when not started', async () => {
+        const signingSecret = 'stopped-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        // Note: NOT started
+
+        const body = {
+            type: 'event_callback',
+            event: {
+                type: 'message',
+                user: 'U123',
+                text: 'hello',
+                channel: 'C12345',
+                ts: '1234567890.001600',
+            },
+        };
+        const req = await buildSignedRequest(signingSecret, body);
+        // handleEventRequest still processes the HTTP request (returns 200)
+        // but handleEvent silently returns early because running=false
+        const response = await bridge.handleEventRequest(req);
+        expect(response.status).toBe(200);
+
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(pm.startProcess).not.toHaveBeenCalled();
+    });
+});
+
+// ─── Invalid JSON ───────────────────────────────────────────────────────────
+
+describe('Slack invalid request body', () => {
+    test('returns 400 for invalid JSON', async () => {
+        const signingSecret = 'json-secret';
+        const pm = createMockProcessManager();
+        const config: SlackBridgeConfig = {
+            botToken: 'xoxb-test',
+            signingSecret,
+            channelId: 'C12345',
+            allowedUserIds: [],
+        };
+        const bridge = new SlackBridge(db, pm, config);
+        bridge.start();
+
+        // Build a signed request with the raw invalid body
+        const rawBody = 'not-json';
+        const timestamp = Math.floor(Date.now() / 1000);
+        const sigBasestring = `v0:${timestamp}:${rawBody}`;
+
+        const encoder = new TextEncoder();
+        const key = await crypto.subtle.importKey(
+            'raw',
+            encoder.encode(signingSecret),
+            { name: 'HMAC', hash: 'SHA-256' },
+            false,
+            ['sign'],
+        );
+        const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(sigBasestring));
+        const hexSig = 'v0=' + Array.from(new Uint8Array(sig))
+            .map(b => b.toString(16).padStart(2, '0'))
+            .join('');
+
+        const req = new Request('http://localhost/api/slack/events', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-slack-request-timestamp': String(timestamp),
+                'x-slack-signature': hexSig,
+            },
+            body: rawBody,
+        });
+
+        // Note: the verifySignature reads the body via req.clone(), then handleEventRequest
+        // reads it again via req.json(). Since we pass valid signature but invalid JSON,
+        // the signature check passes but JSON parse fails.
+        // However, verifySignature uses req.clone() and then req.json() reads the original.
+        // The signature verification will consume the clone. Let me trace through:
+        // 1. verifySignature(req.clone()) — reads clone's body as text → valid sig → true
+        // 2. body = await req.json() — tries to parse "not-json" → throws → 400
+        const response = await bridge.handleEventRequest(req);
+        expect(response.status).toBe(400);
+
+        bridge.stop();
+    });
+});

--- a/specs/algochat/messaging-guard.spec.md
+++ b/specs/algochat/messaging-guard.spec.md
@@ -1,0 +1,165 @@
+---
+module: messaging-guard
+version: 1
+status: active
+files:
+  - server/algochat/messaging-guard.ts
+db_tables: []
+depends_on:
+  - specs/algochat/bridge.spec.md
+---
+
+# MessagingGuard
+
+## Purpose
+
+Combined circuit breaker and per-agent rate limiter for agent-to-agent messaging. Protects against cascading failures by tracking per-target-agent outbound call health (circuit breaker pattern) and prevents message flooding via per-sender-agent sliding-window rate limiting.
+
+## Public API
+
+### Exported Classes
+
+| Class | Description |
+|-------|-------------|
+| `MessagingGuard` | Combined circuit breaker + per-agent rate limiter |
+
+#### MessagingGuard Constructor
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `config` | `Partial<MessagingGuardConfig>` | Optional overrides; defaults loaded from env vars |
+
+#### MessagingGuard Methods
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `check` | `(fromAgentId: string, toAgentId: string)` | `GuardResult` | Check if a message is allowed; records send timestamp if allowed |
+| `recordSuccess` | `(toAgentId: string)` | `void` | Record a successful call to the target agent |
+| `recordFailure` | `(toAgentId: string)` | `void` | Record a failed call to the target agent |
+| `getCircuitState` | `(toAgentId: string)` | `CircuitState` | Get current circuit state for a target agent |
+| `resetCircuit` | `(toAgentId: string)` | `void` | Manually reset the circuit breaker for a target agent |
+| `resetAll` | `()` | `void` | Reset all circuit breakers and rate limit windows |
+| `stop` | `()` | `void` | Stop the periodic sweep timer |
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+| `MessagingGuardConfig` | `{ failureThreshold, resetTimeoutMs, successThreshold, rateLimitPerWindow, rateLimitWindowMs }` |
+| `GuardResult` | `{ allowed: boolean; reason?: GuardRejectionReason; retryAfterMs?: number }` |
+| `GuardRejectionReason` | `'CIRCUIT_OPEN' \| 'RATE_LIMITED'` |
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `loadMessagingGuardConfig` | `()` | `MessagingGuardConfig` | Load config from env vars with defaults |
+
+## Invariants
+
+1. **Check order**: Circuit breaker is checked first, then rate limit. If the circuit is OPEN, the rate limit is not checked
+2. **Per-target-agent circuit breakers**: Each target agent has an independent circuit breaker. Failures to one agent do not affect others
+3. **Circuit breaker state machine**:
+   - **CLOSED** (normal): All calls allowed. Transitions to OPEN after `failureThreshold` consecutive failures
+   - **OPEN** (tripped): All calls rejected with `CIRCUIT_OPEN`. Transitions to HALF_OPEN after `resetTimeoutMs` elapses
+   - **HALF_OPEN** (probing): Allows one probe call. Transitions to CLOSED after `successThreshold` consecutive successes, or back to OPEN on any failure
+4. **Per-sender-agent rate limiting**: Each sender agent has an independent sliding window of message timestamps. No single agent can send more than `rateLimitPerWindow` messages within the window
+5. **Sliding window pruning**: Expired timestamps are pruned on every `check()` call for the sender
+6. **Send recording**: When `check()` returns `allowed: true`, the current timestamp is recorded in the sender's window. This happens inside `check()`, not externally
+7. **retryAfterMs**: When rate limited, `retryAfterMs` is calculated from the oldest request in the window to tell the caller when capacity will free up
+8. **State transition logging**: All circuit breaker state transitions are logged with the agent ID
+9. **Metrics emission**: State transitions emit `circuitBreakerTransitions` metric; rejections emit `agentRateLimitRejections` metric
+10. **Periodic sweep**: Stale rate-limit entries (senders with no recent messages) are swept every 5 minutes. The sweep timer is unref'd to not prevent process exit
+11. **Config defaults**: `failureThreshold=5`, `resetTimeoutMs=30000`, `successThreshold=2`, `rateLimitPerWindow=10`, `rateLimitWindowMs=60000`
+12. **Robust config parsing**: Invalid or non-positive env var values fall back to defaults
+
+## Behavioral Examples
+
+### Scenario: Normal operation (CLOSED circuit)
+
+- **Given** a fresh MessagingGuard
+- **When** agent "sender-1" sends a message to agent "target-1"
+- **Then** `check("sender-1", "target-1")` returns `{ allowed: true }`
+
+### Scenario: Circuit opens after failures
+
+- **Given** `failureThreshold` is 5
+- **When** 5 consecutive failures are recorded for "target-1"
+- **Then** the circuit transitions CLOSED -> OPEN
+- **And** `check("any-sender", "target-1")` returns `{ allowed: false, reason: 'CIRCUIT_OPEN', retryAfterMs: resetTimeoutMs }`
+
+### Scenario: Circuit half-opens after cooldown
+
+- **Given** the circuit for "target-1" is OPEN
+- **When** `resetTimeoutMs` elapses
+- **Then** the circuit transitions OPEN -> HALF_OPEN
+- **And** one probe call is allowed
+
+### Scenario: Circuit closes after successful probes
+
+- **Given** the circuit for "target-1" is HALF_OPEN and `successThreshold` is 2
+- **When** 2 consecutive successes are recorded
+- **Then** the circuit transitions HALF_OPEN -> CLOSED
+
+### Scenario: Circuit re-opens on probe failure
+
+- **Given** the circuit for "target-1" is HALF_OPEN
+- **When** a failure is recorded
+- **Then** the circuit transitions HALF_OPEN -> OPEN
+
+### Scenario: Rate limit exceeded
+
+- **Given** `rateLimitPerWindow` is 10 and `rateLimitWindowMs` is 60000
+- **When** agent "sender-1" sends 10 messages within 60 seconds
+- **Then** the 11th message returns `{ allowed: false, reason: 'RATE_LIMITED', retryAfterMs: N }`
+
+### Scenario: Rate limit window expires
+
+- **Given** agent "sender-1" hit the rate limit
+- **When** the oldest message in the window expires (60 seconds pass)
+- **Then** new messages are allowed again
+
+### Scenario: Circuit breaker takes priority
+
+- **Given** the circuit for "target-1" is OPEN and "sender-1" has rate limit capacity
+- **When** `check("sender-1", "target-1")` is called
+- **Then** returns `{ allowed: false, reason: 'CIRCUIT_OPEN' }` (rate limit not checked)
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Unknown target agent | Returns `CLOSED` state (no breaker created yet) |
+| `resetCircuit` for unknown agent | No-op (breaker not found) |
+| Invalid env var values | Falls back to defaults |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| `server/lib/resilience.ts` | `CircuitBreaker` class, `CircuitOpenError`, `CircuitState` type |
+| `server/lib/logger.ts` | `createLogger` |
+| `server/observability/metrics.ts` | `circuitBreakerTransitions`, `agentRateLimitRejections` counters |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| `server/algochat/agent-messenger.ts` | `check()`, `recordSuccess()`, `recordFailure()` before/after sending messages |
+
+## Configuration
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `AGENT_CB_FAILURE_THRESHOLD` | `5` | Failures before opening circuit |
+| `AGENT_CB_RESET_TIMEOUT_MS` | `30000` | Cooldown (ms) before OPEN -> HALF_OPEN |
+| `AGENT_CB_SUCCESS_THRESHOLD` | `2` | Successes in HALF_OPEN to close circuit |
+| `AGENT_RATE_LIMIT_PER_MIN` | `10` | Max messages per agent per sliding window |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-21 | corvid-agent | Initial spec |

--- a/specs/notifications/service.spec.md
+++ b/specs/notifications/service.spec.md
@@ -1,0 +1,197 @@
+---
+module: notification-service
+version: 1
+status: active
+files:
+  - server/notifications/service.ts
+  - server/notifications/types.ts
+  - server/notifications/channels/websocket.ts
+  - server/notifications/channels/discord.ts
+  - server/notifications/channels/telegram.ts
+  - server/notifications/channels/github.ts
+  - server/notifications/channels/algochat.ts
+  - server/notifications/channels/whatsapp.ts
+  - server/notifications/channels/signal.ts
+  - server/notifications/channels/slack.ts
+db_tables:
+  - owner_notifications
+  - notification_deliveries
+  - notification_channels
+depends_on:
+  - specs/db/schema.spec.md
+---
+
+# Notification Service
+
+## Purpose
+
+Multi-channel notification service that persists notifications to the database and dispatches them to configured channels. Supports 8 channel types, per-agent channel configuration, delivery tracking, and automatic retry of failed deliveries. Ensures notifications are never lost — they are always persisted before dispatch is attempted.
+
+## Public API
+
+### Exported Classes
+
+| Class | Description |
+|-------|-------------|
+| `NotificationService` | Manages notification persistence, multi-channel dispatch, and retry of failed deliveries |
+
+#### NotificationService Constructor
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `db` | `Database` | SQLite database handle |
+
+#### NotificationService Methods
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `start` | `()` | `void` | Start the retry timer (60s interval); idempotent |
+| `stop` | `()` | `void` | Stop the retry timer |
+| `setAgentMessenger` | `(messenger: AgentMessenger)` | `void` | Set the messenger for AlgoChat channel dispatch |
+| `setBroadcast` | `(fn: (message: unknown) => void)` | `void` | Set the WebSocket broadcast function |
+| `notify` | `(params: { agentId, sessionId?, title?, message, level })` | `Promise<{ notificationId, channels }>` | Create and dispatch a notification |
+
+### Exported Types (from types.ts)
+
+| Type | Description |
+|------|-------------|
+| `NotificationPayload` | `{ notificationId, agentId, sessionId, title, message, level, timestamp }` |
+| `ChannelSendResult` | `{ success: boolean; error?: string; externalRef?: string }` |
+
+## Invariants
+
+1. **Persist-first guarantee**: Notifications are always persisted to `owner_notifications` before any dispatch attempt. Even if all channel sends fail, the notification record exists
+2. **WebSocket always dispatched**: If a broadcast function is set, every notification is sent via WebSocket regardless of channel configuration
+3. **Per-agent channel configuration**: Each agent has independently configured channels via `notification_channels`. Only enabled channels are dispatched to
+4. **Delivery tracking**: Each channel dispatch creates a `notification_deliveries` record that tracks status (`pending` → `sent` or `failed`), attempts, errors, and external references
+5. **Async dispatch**: Channel dispatches are fire-and-forget (`.then()/.catch()`) to avoid blocking the notification creation response
+6. **Retry mechanism**: Failed deliveries are retried every 60 seconds, up to 3 attempts maximum. The retry query joins `notification_deliveries`, `owner_notifications`, and `notification_channels` to reconstruct the full dispatch context
+7. **Idempotent start**: Calling `start()` when the retry timer is already running is a no-op
+8. **Channel-specific configuration**: Each channel type reads config from its `notification_channels.config` JSON, with fallback to environment variables
+
+## Behavioral Examples
+
+### Scenario: Notification dispatched to multiple channels
+
+- **Given** agent "A1" has Discord and Telegram channels configured and enabled
+- **When** `notify({ agentId: "A1", message: "Build passed", level: "info" })` is called
+- **Then** the notification is persisted, sent via WebSocket, and dispatched to both Discord and Telegram
+
+### Scenario: Channel dispatch failure
+
+- **Given** agent "A1" has a Telegram channel configured but the bot token is invalid
+- **When** a notification is dispatched to Telegram
+- **Then** the delivery record is updated to `failed` with the error message, and the retry timer will attempt redelivery
+
+### Scenario: Retry of failed delivery
+
+- **Given** a Telegram delivery failed with 1 attempt
+- **When** the retry timer fires (60 seconds)
+- **Then** the service queries for failed deliveries with `attempts < 3`, reconstructs the payload, and retries the dispatch
+
+### Scenario: Max retries exhausted
+
+- **Given** a delivery has failed 3 times
+- **When** the retry timer fires
+- **Then** the delivery is not retried (filtered out by `attempts < 3` query)
+
+### Scenario: No channels configured
+
+- **Given** agent "A1" has no notification channels configured
+- **When** a notification is created
+- **Then** the notification is persisted and sent via WebSocket only
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Discord webhook URL missing | Delivery fails with `"No Discord webhook URL configured"` |
+| Telegram bot token or chat ID missing | Delivery fails with `"Telegram botToken and chatId required"` |
+| GitHub repo not configured | Delivery fails with `"No GitHub repo configured"` |
+| AlgoChat address missing | Delivery fails with `"No AlgoChat toAddress configured"` |
+| AlgoChat messenger not available | Delivery fails with `"AgentMessenger not available"` |
+| WhatsApp credentials missing | Delivery fails with `"WhatsApp phoneNumberId and accessToken required"` |
+| WhatsApp recipient missing | Delivery fails with `"WhatsApp recipientPhone required"` |
+| Signal credentials missing | Delivery fails with `"Signal senderNumber and recipientNumber required"` |
+| Slack credentials missing | Delivery fails with `"Slack botToken and channel required"` |
+| Unknown channel type | Delivery fails with `"Unknown channel type: {type}"` |
+| Channel dispatch throws | Error caught, delivery updated to `failed`, logged as warning |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| `server/db/notifications.ts` | `createNotification`, `createDelivery`, `updateDeliveryStatus`, `listChannelsForAgent`, `listFailedDeliveries` |
+| `server/notifications/channels/*.ts` | `sendWebSocket`, `sendDiscord`, `sendTelegram`, `sendGitHub`, `sendAlgoChat`, `sendWhatsApp`, `sendSignal`, `sendSlack` |
+| `server/algochat/agent-messenger.ts` | `AgentMessenger` for AlgoChat channel |
+| `server/lib/logger.ts` | `createLogger` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| `server/index.ts` | Lifecycle: construction, `start()`, `stop()`, `setAgentMessenger()`, `setBroadcast()` |
+| `server/routes/notifications.ts` | `notify()` via API endpoints |
+| `server/mcp/tool-handlers.ts` | `notify()` via MCP tools |
+
+## Database Tables
+
+### owner_notifications
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | TEXT | PRIMARY KEY | UUID |
+| agent_id | TEXT | NOT NULL, FK → agents | The agent that triggered the notification |
+| session_id | TEXT | | Optional session context |
+| title | TEXT | | Optional notification title |
+| message | TEXT | NOT NULL | Notification message body |
+| level | TEXT | NOT NULL | Severity: info, warn, error, success |
+| created_at | TEXT | DEFAULT datetime('now') | When the notification was created |
+
+### notification_deliveries
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | INTEGER | PRIMARY KEY AUTOINCREMENT | Delivery ID |
+| notification_id | TEXT | NOT NULL, FK → owner_notifications | Parent notification |
+| channel_type | TEXT | NOT NULL | Channel type (discord, telegram, etc.) |
+| status | TEXT | DEFAULT 'pending' | pending, sent, or failed |
+| attempts | INTEGER | DEFAULT 0 | Number of delivery attempts |
+| last_attempt_at | TEXT | | Timestamp of last attempt |
+| error | TEXT | | Error message if failed |
+| external_ref | TEXT | | External reference (message ID, etc.) |
+| created_at | TEXT | DEFAULT datetime('now') | When the delivery was created |
+
+### notification_channels
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | TEXT | PRIMARY KEY | UUID |
+| agent_id | TEXT | NOT NULL, FK → agents | The agent this channel belongs to |
+| channel_type | TEXT | NOT NULL | Channel type |
+| config | TEXT | NOT NULL | JSON configuration for the channel |
+| enabled | INTEGER | DEFAULT 1 | Whether the channel is active |
+| created_at | TEXT | DEFAULT datetime('now') | When created |
+| updated_at | TEXT | DEFAULT datetime('now') | Last modified |
+| | | UNIQUE(agent_id, channel_type) | One channel per type per agent |
+
+## Configuration
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `DISCORD_WEBHOOK_URL` | (optional) | Fallback Discord webhook URL if not in channel config |
+| `TELEGRAM_BOT_TOKEN` | (optional) | Fallback Telegram bot token |
+| `TELEGRAM_CHAT_ID` | (optional) | Fallback Telegram chat ID |
+| `NOTIFICATION_GITHUB_REPO` | (optional) | Fallback GitHub repo for issue notifications |
+| `WHATSAPP_ACCESS_TOKEN` | (optional) | Fallback WhatsApp access token |
+| `SIGNAL_API_URL` | `http://localhost:8080` | Signal API URL |
+| `SIGNAL_SENDER_NUMBER` | (optional) | Fallback Signal sender number |
+| `SLACK_BOT_TOKEN` | (optional) | Fallback Slack bot token |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-21 | corvid-agent | Initial spec |

--- a/specs/slack/bridge.spec.md
+++ b/specs/slack/bridge.spec.md
@@ -1,0 +1,173 @@
+---
+module: slack-bridge
+version: 1
+status: active
+files:
+  - server/slack/bridge.ts
+  - server/slack/types.ts
+db_tables:
+  - sessions
+  - session_messages
+depends_on:
+  - specs/process/process-manager.spec.md
+  - specs/db/sessions.spec.md
+---
+
+# Slack Bridge
+
+## Purpose
+
+Bidirectional Slack bridge using the Events API (webhook-based). Receives messages via POST `/api/slack/events`, verifies request signatures, routes messages to agent sessions, and responds via the Slack Web API (`chat.postMessage`). Supports per-user rate limiting, user authorization, session management, event deduplication, thread-based conversations, and message chunking.
+
+## Public API
+
+### Exported Classes
+
+| Class | Description |
+|-------|-------------|
+| `SlackBridge` | Manages Slack Events API webhook handling, signature verification, and message routing |
+
+#### SlackBridge Constructor
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `db` | `Database` | SQLite database handle |
+| `processManager` | `ProcessManager` | For starting sessions and subscribing to events |
+| `config` | `SlackBridgeConfig` | Bot token, signing secret, channel ID, allowed user IDs |
+
+#### SlackBridge Methods
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `start` | `()` | `void` | Mark bridge as running, start event cleanup timer; idempotent |
+| `stop` | `()` | `void` | Mark bridge as stopped, clear cleanup timer |
+| `handleEventRequest` | `(req: Request)` | `Promise<Response>` | Handle an incoming Slack Events API HTTP request |
+| `sendMessage` | `(channelId: string, content: string, threadTs?: string)` | `Promise<void>` | Send a message to a Slack channel via Web API; auto-chunks at 4000 characters |
+
+### Exported Types (from types.ts)
+
+| Type | Description |
+|------|-------------|
+| `SlackBridgeConfig` | `{ botToken: string; signingSecret: string; channelId: string; allowedUserIds: string[] }` |
+| `SlackEventPayload` | `{ token: string; type: 'url_verification' \| 'event_callback'; challenge?: string; event?: SlackEvent }` |
+| `SlackEvent` | Base event with optional `type`, `user`, `text`, `channel`, `ts`, `thread_ts`, `bot_id`, `subtype` |
+| `SlackMessageEvent` | Extends `SlackEvent` with required `type: 'message' \| 'app_mention'`, `user`, `text`, `channel`, `ts` |
+
+## Invariants
+
+1. **Signature verification**: Every incoming request is verified using HMAC SHA-256 with the signing secret. The signature base string is `v0:{timestamp}:{rawBody}`. Requests with missing or invalid signatures receive HTTP 401
+2. **Replay protection**: Requests with timestamps more than 5 minutes (300 seconds) from current time are rejected
+3. **Timing-safe comparison**: Signature comparison uses a constant-time byte-by-byte XOR to prevent timing attacks
+4. **URL verification**: Requests with `type: 'url_verification'` are responded to with the `challenge` value (required for Slack Events API setup)
+5. **Async event processing**: Event callbacks are processed asynchronously to respond within Slack's 3-second requirement. The HTTP response is sent immediately with `{ ok: true }`
+6. **Bot message filtering**: Messages with a `bot_id` field or any `subtype` are silently ignored to prevent echo loops
+7. **Event deduplication**: Events are tracked by `{channel}:{ts}` key. Duplicate events (Slack retries) are silently ignored. The dedup set is cleared every 5 minutes to prevent memory growth
+8. **Channel filter**: If `config.channelId` is set, only messages from that channel are processed. Messages from other channels are silently ignored
+9. **User authorization**: If `config.allowedUserIds` is non-empty, only those user IDs can interact. Unauthorized users receive `"Unauthorized."` reply in thread
+10. **Per-user rate limiting**: Each user is limited to 10 messages per 60-second sliding window. Rate-limited users receive an explicit message
+11. **Session-per-user mapping**: Each Slack user ID maps to at most one active session. Stored in-memory (`userSessions` Map)
+12. **Session reuse and restart**: Reuses active sessions; creates new ones when stopped/error; restarts process if `sendMessage` returns false (process not running)
+13. **Response debouncing**: Session events are buffered for 1500ms before being sent to Slack, to coalesce streamed output into a single message
+14. **Message chunking**: Slack has a 4000-character block text limit. Long responses are split at that boundary
+15. **Thread support**: Responses are sent in threads using `thread_ts` (either the message's `thread_ts` or its `ts`)
+16. **Agent selection**: Uses the first agent from `listAgents` with its default project, falling back to the first project
+17. **Slash commands**: `/status` reports the current session ID, `/new` clears the user's session mapping
+18. **Event types**: Only `message` and `app_mention` events are processed; all others are silently ignored
+19. **Idempotent start**: Calling `start()` when already running is a no-op
+
+## Behavioral Examples
+
+### Scenario: URL verification handshake
+
+- **Given** a Slack app configured with the Events API URL
+- **When** Slack sends a `url_verification` request with a challenge token
+- **Then** the bridge responds with HTTP 200 and `{ challenge: "<token>" }`
+
+### Scenario: First message from authorized user
+
+- **Given** a running Slack bridge with an agent and project configured
+- **When** user "U123" (in `allowedUserIds`) sends "Hello" in the configured channel
+- **Then** a new session is created with source `slack`, the process is started, and responses are forwarded back as threaded Slack messages
+
+### Scenario: app_mention triggers session
+
+- **Given** a running Slack bridge
+- **When** a user mentions the bot with `<@BOT_ID> what is the weather?`
+- **Then** the `app_mention` event is handled identically to a `message` event, routing to an agent session
+
+### Scenario: Duplicate event from Slack retry
+
+- **Given** event with `channel: "C12345"` and `ts: "1234567890.000100"` was already processed
+- **When** Slack retries the same event
+- **Then** the event is silently ignored (dedup key matches)
+
+### Scenario: Rate limit exceeded
+
+- **Given** user "U123" has sent 10 messages in the last 60 seconds
+- **When** the 11th message arrives
+- **Then** the bridge replies with a rate limit message in the thread and does not route to the agent
+
+### Scenario: Long response chunked
+
+- **Given** an agent produces a 5000-character response
+- **When** the response is flushed
+- **Then** two Slack messages are sent: one with 4000 characters and one with 1000 characters
+
+### Scenario: Replay attack rejected
+
+- **Given** a valid Slack request signature
+- **When** the timestamp is more than 5 minutes old
+- **Then** the request is rejected with HTTP 401
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Missing signature headers | Returns HTTP 401 `{ error: 'Invalid signature' }` |
+| Invalid signature | Returns HTTP 401 `{ error: 'Invalid signature' }` |
+| Timestamp > 5 minutes old | Returns HTTP 401 (replay protection) |
+| Invalid JSON body | Returns HTTP 400 `{ error: 'Invalid JSON' }` |
+| Bot message received | Silently ignored |
+| Message with subtype | Silently ignored |
+| Message from wrong channel | Silently ignored |
+| Unauthorized user | Replies `"Unauthorized."` in thread |
+| Rate limit exceeded | Replies with rate limit message in thread |
+| No agents configured | Replies `"No agents configured. Create an agent first."` in thread |
+| No projects configured | Replies `"No projects configured."` in thread |
+| Session expired and send fails | Replies `"Session expired. Send another message to start a new one."` in thread |
+| Slack Web API send fails | Logs error with status and truncated response body |
+| Slack API returns `ok: false` | Logs error with Slack error code |
+| Bridge not running | Events are silently ignored (early return in `handleEvent`) |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| `server/process/manager.ts` | `ProcessManager` -- startProcess, sendMessage, subscribe |
+| `server/db/agents.ts` | `listAgents` |
+| `server/db/sessions.ts` | `createSession`, `getSession` |
+| `server/db/projects.ts` | `listProjects` |
+| `server/lib/logger.ts` | `createLogger` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| `server/index.ts` | Lifecycle: construction, `start()`, `stop()`, route registration |
+
+## Configuration
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `SLACK_BOT_TOKEN` | (required) | Slack bot OAuth token (`xoxb-...`) |
+| `SLACK_SIGNING_SECRET` | (required) | Slack app signing secret for request verification |
+| `SLACK_CHANNEL_ID` | (required) | Slack channel ID to listen on |
+| `SLACK_ALLOWED_USERS` | `""` | Comma-separated list of allowed Slack user IDs; empty = allow all |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-21 | corvid-agent | Initial spec |


### PR DESCRIPTION
## Summary
- **+58 new tests** (2,248 → 2,306) across 3 new test files and 1 enhanced file
- **+3 new specs** (26 → 29) for previously undocumented modules
- All `tsc`, `bun test`, and `spec:check` pass cleanly

## New Test Files
- `server/__tests__/slack-bridge.test.ts` — 31 tests: HMAC SHA-256 signature verification, replay protection, event deduplication, bot/subtype filtering, channel filtering, user authorization, rate limiting (10/60s), message chunking (4000 char), thread support, app_mention events, slash commands, session routing
- `server/__tests__/council-discussion.test.ts` — 18 tests: parallel session spawning, auto-advance on completion, per-round/per-agent timeout handling, mixed completed/timed-out sessions, response aggregation, cleanup/unsubscribe, scale (10 sessions)
- `server/__tests__/workflows.test.ts` — +10 tests: parallel node graph structure, conditional branching (true/false edges), data passing via `prev.output`, join node semantics (ALL predecessors), delay node metadata, failure propagation in parallel branches

## New Specs
- `specs/slack/bridge.spec.md` — 19 invariants, 7 behavioral examples, 14 error cases
- `specs/notifications/service.spec.md` — 8 invariants, 5 behavioral examples, 3 DB table schemas
- `specs/algochat/messaging-guard.spec.md` — 12 invariants, 8 behavioral examples, circuit breaker state machine

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 2,306 tests pass across 111 files
- [x] `bun run spec:check` — 29 specs pass, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)