### PR TITLE
fix: add timeout-minutes to CI and Docker workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: Build & Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -65,6 +66,7 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: build
     # E2E tests require a running server and may need Claude API for some tests.
     # Tests that need external services are skipped gracefully in CI.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,6 +23,7 @@ jobs:
   docker:
     name: Build & Push Docker Image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Summary
- Adds `timeout-minutes: 15` to CI build and E2E jobs
- Adds `timeout-minutes: 30` to Docker publish job
- Prevents hung jobs (like the Windows build stuck for 3h+ and Docker build stuck for 52m+) from consuming GitHub Actions minutes indefinitely

## Test plan
- [ ] Verify CI runs complete or timeout within the specified limits
- [ ] Verify Docker publish completes within 30 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)