### PR TITLE
fix: pin Dockerfile to bun:1.3.8 to match lockfile

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Build Angular client ────────────────────────────────
-FROM oven/bun:1 AS client-build
+FROM oven/bun:1.3.8 AS client-build
 WORKDIR /app/client
 
 # Install client dependencies
@@ -14,7 +14,7 @@ COPY client/ .
 RUN bun run build
 
 # ── Stage 2: Production image ───────────────────────────────────
-FROM oven/bun:1 AS production
+FROM oven/bun:1.3.8 AS production
 WORKDIR /app
 
 # Install server dependencies only


### PR DESCRIPTION
## Summary
- Pins both Dockerfile stages from `oven/bun:1` (floating) to `oven/bun:1.3.8`
- `oven/bun:1` floated to 1.3.9 which changed the lockfile format, causing `--frozen-lockfile` to fail in Docker builds

## Test plan
- [ ] Docker publish workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)