### PR TITLE
feat: add GitHub Activity dashboard page

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -138,6 +138,13 @@ export const routes: Routes = [
             import('./features/analytics/analytics.component').then((m) => m.AnalyticsComponent),
     },
     {
+        path: 'github-activity',
+        loadComponent: () =>
+            import('./features/github-activity/github-activity.component').then(
+                (m) => m.GitHubActivityComponent,
+            ),
+    },
+    {
         path: 'logs',
         loadComponent: () =>
             import('./features/logs/system-logs.component').then((m) => m.SystemLogsComponent),

--- a/client/src/app/core/models/github-activity.model.ts
+++ b/client/src/app/core/models/github-activity.model.ts
@@ -1,0 +1,56 @@
+export interface GitHubEvent {
+    id: string;
+    type: string;
+    repo: string;
+    actor: string;
+    action?: string;
+    title?: string;
+    number?: number;
+    url?: string;
+    ref?: string;
+    commits?: number;
+    createdAt: string;
+}
+
+export interface GitHubPR {
+    repo: string;
+    number: number;
+    title: string;
+    author: string;
+    state: string;
+    draft: boolean;
+    url: string;
+    labels: string[];
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface GitHubIssue {
+    repo: string;
+    number: number;
+    title: string;
+    author: string;
+    labels: string[];
+    url: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface GitHubRun {
+    id: number;
+    repo: string;
+    name: string;
+    branch: string;
+    status: string;
+    conclusion: string;
+    url: string;
+    createdAt: string;
+}
+
+export interface ActivitySummary {
+    openPRs: number;
+    openIssues: number;
+    recentCommits: number;
+    ciPassRate: number;
+    lastUpdated: string;
+}

--- a/client/src/app/core/services/github-activity.service.ts
+++ b/client/src/app/core/services/github-activity.service.ts
@@ -1,0 +1,81 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { ApiService } from './api.service';
+import type {
+    GitHubEvent,
+    GitHubPR,
+    GitHubIssue,
+    GitHubRun,
+    ActivitySummary,
+} from '../models/github-activity.model';
+
+@Injectable({ providedIn: 'root' })
+export class GitHubActivityService {
+    private readonly api = inject(ApiService);
+
+    readonly events = signal<GitHubEvent[]>([]);
+    readonly prs = signal<GitHubPR[]>([]);
+    readonly issues = signal<GitHubIssue[]>([]);
+    readonly runs = signal<GitHubRun[]>([]);
+    readonly summary = signal<ActivitySummary | null>(null);
+    readonly loading = signal(false);
+
+    async loadEvents(owner: string, repo: string, limit = 30): Promise<void> {
+        const res = await firstValueFrom(
+            this.api.get<{ events: GitHubEvent[] }>(
+                `/github-activity/events?owner=${owner}&repo=${repo}&limit=${limit}`,
+            ),
+        );
+        this.events.set(res.events);
+    }
+
+    async loadPRs(owner: string, repo: string): Promise<void> {
+        const res = await firstValueFrom(
+            this.api.get<{ prs: GitHubPR[] }>(
+                `/github-activity/prs?owner=${owner}&repo=${repo}`,
+            ),
+        );
+        this.prs.set(res.prs);
+    }
+
+    async loadIssues(owner: string, repo: string): Promise<void> {
+        const res = await firstValueFrom(
+            this.api.get<{ issues: GitHubIssue[] }>(
+                `/github-activity/issues?owner=${owner}&repo=${repo}`,
+            ),
+        );
+        this.issues.set(res.issues);
+    }
+
+    async loadRuns(owner: string, repo: string): Promise<void> {
+        const res = await firstValueFrom(
+            this.api.get<{ runs: GitHubRun[] }>(
+                `/github-activity/runs?owner=${owner}&repo=${repo}`,
+            ),
+        );
+        this.runs.set(res.runs);
+    }
+
+    async loadSummary(owner: string, repo: string): Promise<void> {
+        const res = await firstValueFrom(
+            this.api.get<ActivitySummary>(
+                `/github-activity/summary?owner=${owner}&repo=${repo}`,
+            ),
+        );
+        this.summary.set(res);
+    }
+
+    async loadAll(owner: string, repo: string): Promise<void> {
+        this.loading.set(true);
+        try {
+            await Promise.all([
+                this.loadEvents(owner, repo),
+                this.loadPRs(owner, repo),
+                this.loadIssues(owner, repo),
+                this.loadSummary(owner, repo),
+            ]);
+        } finally {
+            this.loading.set(false);
+        }
+    }
+}

--- a/client/src/app/features/github-activity/github-activity.component.ts
+++ b/client/src/app/features/github-activity/github-activity.component.ts
@@ -1,0 +1,434 @@
+import { Component, ChangeDetectionStrategy, inject, OnInit, signal } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { GitHubActivityService } from '../../core/services/github-activity.service';
+
+type Tab = 'events' | 'prs' | 'issues' | 'ci';
+
+@Component({
+    selector: 'app-github-activity',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [DatePipe, FormsModule],
+    template: `
+        <div class="gh">
+            <div class="gh__header">
+                <h2>GitHub Activity</h2>
+                <div class="gh__repo-input">
+                    <input
+                        [(ngModel)]="ownerInput"
+                        placeholder="owner"
+                        class="gh__input gh__input--small"
+                        (keydown.enter)="refresh()" />
+                    <span class="gh__slash">/</span>
+                    <input
+                        [(ngModel)]="repoInput"
+                        placeholder="repo"
+                        class="gh__input"
+                        (keydown.enter)="refresh()" />
+                    <button class="gh__btn" (click)="refresh()">Load</button>
+                </div>
+            </div>
+
+            @if (svc.loading()) {
+                <p class="gh__loading">Loading activity data...</p>
+            } @else if (svc.summary()) {
+                <div class="gh__cards">
+                    <div class="gh__card">
+                        <span class="gh__card-label">Open PRs</span>
+                        <span class="gh__card-value gh__card-value--cyan">{{ svc.summary()!.openPRs }}</span>
+                    </div>
+                    <div class="gh__card">
+                        <span class="gh__card-label">Open Issues</span>
+                        <span class="gh__card-value gh__card-value--yellow">{{ svc.summary()!.openIssues }}</span>
+                    </div>
+                    <div class="gh__card">
+                        <span class="gh__card-label">Recent Commits</span>
+                        <span class="gh__card-value">{{ svc.summary()!.recentCommits }}</span>
+                    </div>
+                    <div class="gh__card">
+                        <span class="gh__card-label">CI Pass Rate</span>
+                        <span class="gh__card-value" [class.gh__card-value--green]="svc.summary()!.ciPassRate >= 80"
+                              [class.gh__card-value--red]="svc.summary()!.ciPassRate < 80 && svc.summary()!.ciPassRate > 0">
+                            {{ svc.summary()!.ciPassRate }}%
+                        </span>
+                    </div>
+                </div>
+            }
+
+            <div class="gh__tabs">
+                <button class="gh__tab" [class.gh__tab--active]="activeTab() === 'events'" (click)="activeTab.set('events')">Events</button>
+                <button class="gh__tab" [class.gh__tab--active]="activeTab() === 'prs'" (click)="activeTab.set('prs')">Pull Requests</button>
+                <button class="gh__tab" [class.gh__tab--active]="activeTab() === 'issues'" (click)="activeTab.set('issues')">Issues</button>
+                <button class="gh__tab" [class.gh__tab--active]="activeTab() === 'ci'" (click)="switchToCi()">CI Runs</button>
+            </div>
+
+            <div class="gh__content">
+                @switch (activeTab()) {
+                    @case ('events') {
+                        @if (svc.events().length === 0) {
+                            <p class="gh__empty">No recent events</p>
+                        } @else {
+                            <ul class="gh__list">
+                                @for (event of svc.events(); track event.id) {
+                                    <li class="gh__item">
+                                        <span class="gh__event-type" [attr.data-type]="event.type">{{ eventLabel(event.type) }}</span>
+                                        <span class="gh__event-actor">{{ event.actor }}</span>
+                                        @if (event.type === 'PushEvent') {
+                                            <span class="gh__event-detail">pushed {{ event.commits }} commit{{ event.commits === 1 ? '' : 's' }} to {{ event.ref }}</span>
+                                        } @else if (event.title) {
+                                            <span class="gh__event-detail">
+                                                {{ event.action }}
+                                                @if (event.url) {
+                                                    <a [href]="event.url" target="_blank" rel="noopener">#{{ event.number }} {{ event.title }}</a>
+                                                } @else {
+                                                    #{{ event.number }} {{ event.title }}
+                                                }
+                                            </span>
+                                        } @else {
+                                            <span class="gh__event-detail">{{ event.action ?? event.type }}</span>
+                                        }
+                                        <span class="gh__time">{{ event.createdAt | date:'short' }}</span>
+                                    </li>
+                                }
+                            </ul>
+                        }
+                    }
+                    @case ('prs') {
+                        @if (svc.prs().length === 0) {
+                            <p class="gh__empty">No open pull requests</p>
+                        } @else {
+                            <ul class="gh__list">
+                                @for (pr of svc.prs(); track pr.number) {
+                                    <li class="gh__item">
+                                        <a [href]="pr.url" target="_blank" rel="noopener" class="gh__pr-title">
+                                            #{{ pr.number }} {{ pr.title }}
+                                        </a>
+                                        <span class="gh__meta">
+                                            by {{ pr.author }}
+                                            @if (pr.draft) { <span class="gh__badge gh__badge--draft">draft</span> }
+                                            @for (label of pr.labels; track label) {
+                                                <span class="gh__badge">{{ label }}</span>
+                                            }
+                                        </span>
+                                        <span class="gh__time">{{ pr.updatedAt | date:'short' }}</span>
+                                    </li>
+                                }
+                            </ul>
+                        }
+                    }
+                    @case ('issues') {
+                        @if (svc.issues().length === 0) {
+                            <p class="gh__empty">No open issues</p>
+                        } @else {
+                            <ul class="gh__list">
+                                @for (issue of svc.issues(); track issue.number) {
+                                    <li class="gh__item">
+                                        <a [href]="issue.url" target="_blank" rel="noopener" class="gh__pr-title">
+                                            #{{ issue.number }} {{ issue.title }}
+                                        </a>
+                                        <span class="gh__meta">
+                                            by {{ issue.author }}
+                                            @for (label of issue.labels; track label) {
+                                                <span class="gh__badge">{{ label }}</span>
+                                            }
+                                        </span>
+                                        <span class="gh__time">{{ issue.updatedAt | date:'short' }}</span>
+                                    </li>
+                                }
+                            </ul>
+                        }
+                    }
+                    @case ('ci') {
+                        @if (ciLoading()) {
+                            <p class="gh__loading">Loading CI runs...</p>
+                        } @else if (svc.runs().length === 0) {
+                            <p class="gh__empty">No recent CI runs</p>
+                        } @else {
+                            <ul class="gh__list">
+                                @for (run of svc.runs(); track run.id) {
+                                    <li class="gh__item">
+                                        <span class="gh__ci-status" [attr.data-conclusion]="run.conclusion || run.status">
+                                            {{ run.conclusion || run.status }}
+                                        </span>
+                                        <a [href]="run.url" target="_blank" rel="noopener" class="gh__pr-title">
+                                            {{ run.name }}
+                                        </a>
+                                        <span class="gh__meta">{{ run.branch }}</span>
+                                        <span class="gh__time">{{ run.createdAt | date:'short' }}</span>
+                                    </li>
+                                }
+                            </ul>
+                        }
+                    }
+                }
+            </div>
+        </div>
+    `,
+    styles: `
+        .gh { padding: 1.5rem; max-width: 900px; }
+        .gh__header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+        }
+        .gh__header h2 { margin: 0; color: var(--text-primary); }
+        .gh__repo-input {
+            display: flex;
+            align-items: center;
+            gap: 0.25rem;
+        }
+        .gh__slash { color: var(--text-tertiary); font-size: 1.1rem; }
+        .gh__input {
+            background: var(--bg-surface);
+            border: 1px solid var(--border);
+            color: var(--text-primary);
+            padding: 0.4rem 0.6rem;
+            border-radius: 4px;
+            font-size: 0.85rem;
+            width: 140px;
+        }
+        .gh__input--small { width: 100px; }
+        .gh__input:focus { outline: 1px solid var(--accent-cyan); border-color: var(--accent-cyan); }
+        .gh__btn {
+            background: var(--accent-cyan);
+            color: var(--bg-base);
+            border: none;
+            padding: 0.4rem 0.8rem;
+            border-radius: 4px;
+            font-size: 0.85rem;
+            cursor: pointer;
+            font-weight: 600;
+            margin-left: 0.5rem;
+        }
+        .gh__btn:hover { opacity: 0.85; }
+        .gh__loading, .gh__empty {
+            color: var(--text-secondary);
+            padding: 2rem;
+            text-align: center;
+        }
+
+        /* Summary cards */
+        .gh__cards {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 0.75rem;
+            margin-bottom: 1.5rem;
+        }
+        .gh__card {
+            background: var(--bg-surface);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 1rem;
+            text-align: center;
+        }
+        .gh__card-label {
+            display: block;
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--text-tertiary);
+            margin-bottom: 0.4rem;
+        }
+        .gh__card-value {
+            font-size: 1.6rem;
+            font-weight: 700;
+            color: var(--text-primary);
+        }
+        .gh__card-value--cyan { color: var(--accent-cyan); }
+        .gh__card-value--yellow { color: var(--accent-yellow, #fbbf24); }
+        .gh__card-value--green { color: var(--accent-green); }
+        .gh__card-value--red { color: var(--accent-red); }
+
+        /* Tabs */
+        .gh__tabs {
+            display: flex;
+            gap: 0;
+            border-bottom: 1px solid var(--border);
+            margin-bottom: 1rem;
+        }
+        .gh__tab {
+            background: none;
+            border: none;
+            border-bottom: 2px solid transparent;
+            color: var(--text-secondary);
+            padding: 0.6rem 1rem;
+            font-size: 0.85rem;
+            cursor: pointer;
+            transition: color 0.15s, border-color 0.15s;
+        }
+        .gh__tab:hover { color: var(--text-primary); }
+        .gh__tab--active {
+            color: var(--accent-cyan);
+            border-bottom-color: var(--accent-cyan);
+        }
+
+        /* List items */
+        .gh__list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+        .gh__item {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            padding: 0.6rem 0.75rem;
+            border-bottom: 1px solid var(--border);
+            font-size: 0.85rem;
+            flex-wrap: wrap;
+        }
+        .gh__item:last-child { border-bottom: none; }
+
+        /* Event type badges */
+        .gh__event-type {
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            padding: 0.15rem 0.4rem;
+            border-radius: 3px;
+            background: var(--bg-raised);
+            color: var(--text-secondary);
+            min-width: 60px;
+            text-align: center;
+            flex-shrink: 0;
+        }
+        .gh__event-type[data-type="PushEvent"] { color: var(--accent-green); }
+        .gh__event-type[data-type="PullRequestEvent"] { color: var(--accent-cyan); }
+        .gh__event-type[data-type="IssuesEvent"] { color: var(--accent-yellow, #fbbf24); }
+        .gh__event-type[data-type="ReleaseEvent"] { color: var(--accent-magenta, #c084fc); }
+        .gh__event-type[data-type="CreateEvent"] { color: var(--accent-green); }
+        .gh__event-type[data-type="DeleteEvent"] { color: var(--accent-red); }
+
+        .gh__event-actor {
+            color: var(--accent-cyan);
+            font-weight: 500;
+            flex-shrink: 0;
+        }
+        .gh__event-detail {
+            color: var(--text-secondary);
+            flex: 1;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .gh__event-detail a {
+            color: var(--text-primary);
+            text-decoration: none;
+        }
+        .gh__event-detail a:hover { text-decoration: underline; }
+
+        .gh__pr-title {
+            color: var(--text-primary);
+            text-decoration: none;
+            flex: 1;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .gh__pr-title:hover { text-decoration: underline; color: var(--accent-cyan); }
+
+        .gh__meta {
+            color: var(--text-tertiary);
+            font-size: 0.8rem;
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+            flex-shrink: 0;
+        }
+        .gh__badge {
+            font-size: 0.65rem;
+            padding: 0.1rem 0.35rem;
+            border-radius: 3px;
+            background: var(--bg-raised);
+            color: var(--text-secondary);
+            border: 1px solid var(--border);
+        }
+        .gh__badge--draft { color: var(--accent-yellow, #fbbf24); border-color: var(--accent-yellow, #fbbf24); }
+
+        .gh__time {
+            color: var(--text-tertiary);
+            font-size: 0.75rem;
+            flex-shrink: 0;
+            margin-left: auto;
+        }
+
+        /* CI status */
+        .gh__ci-status {
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            padding: 0.15rem 0.5rem;
+            border-radius: 3px;
+            min-width: 70px;
+            text-align: center;
+            flex-shrink: 0;
+        }
+        .gh__ci-status[data-conclusion="success"] { color: var(--accent-green); background: rgba(34,197,94,0.1); }
+        .gh__ci-status[data-conclusion="failure"] { color: var(--accent-red); background: rgba(239,68,68,0.1); }
+        .gh__ci-status[data-conclusion="cancelled"] { color: var(--text-tertiary); background: var(--bg-raised); }
+        .gh__ci-status[data-conclusion="in_progress"] { color: var(--accent-cyan); background: rgba(0,229,255,0.1); }
+        .gh__ci-status[data-conclusion="queued"] { color: var(--accent-yellow, #fbbf24); background: rgba(251,191,36,0.1); }
+
+        @media (max-width: 600px) {
+            .gh { padding: 1rem; }
+            .gh__header { flex-direction: column; align-items: flex-start; }
+            .gh__cards { grid-template-columns: repeat(2, 1fr); }
+            .gh__item { font-size: 0.8rem; gap: 0.5rem; }
+        }
+    `,
+})
+export class GitHubActivityComponent implements OnInit {
+    protected readonly svc = inject(GitHubActivityService);
+
+    ownerInput = 'CorvidLabs';
+    repoInput = 'corvid-agent';
+    readonly activeTab = signal<Tab>('events');
+    readonly ciLoading = signal(false);
+
+    ngOnInit(): void {
+        this.refresh();
+    }
+
+    refresh(): void {
+        const owner = this.ownerInput.trim();
+        const repo = this.repoInput.trim();
+        if (!owner || !repo) return;
+        this.svc.loadAll(owner, repo);
+    }
+
+    async switchToCi(): Promise<void> {
+        this.activeTab.set('ci');
+        const owner = this.ownerInput.trim();
+        const repo = this.repoInput.trim();
+        if (!owner || !repo) return;
+        this.ciLoading.set(true);
+        try {
+            await this.svc.loadRuns(owner, repo);
+        } finally {
+            this.ciLoading.set(false);
+        }
+    }
+
+    eventLabel(type: string): string {
+        const labels: Record<string, string> = {
+            PushEvent: 'Push',
+            PullRequestEvent: 'PR',
+            IssuesEvent: 'Issue',
+            ReleaseEvent: 'Release',
+            CreateEvent: 'Create',
+            DeleteEvent: 'Delete',
+            WatchEvent: 'Star',
+            ForkEvent: 'Fork',
+            IssueCommentEvent: 'Comment',
+            PullRequestReviewEvent: 'Review',
+            PullRequestReviewCommentEvent: 'Review',
+        };
+        return labels[type] ?? type.replace('Event', '');
+    }
+}

--- a/client/src/app/shared/components/sidebar.component.ts
+++ b/client/src/app/shared/components/sidebar.component.ts
@@ -145,6 +145,12 @@ import { filter, Subscription } from 'rxjs';
                     </a>
                 </li>
                 <li>
+                    <a class="sidebar__link" routerLink="/github-activity" routerLinkActive="sidebar__link--active" title="GitHub Activity">
+                        <span class="sidebar__label">GitHub</span>
+                        <span class="sidebar__abbr">Gh</span>
+                    </a>
+                </li>
+                <li>
                     <a class="sidebar__link" routerLink="/logs" routerLinkActive="sidebar__link--active" title="Logs">
                         <span class="sidebar__label">Logs</span>
                         <span class="sidebar__abbr">L</span>

--- a/server/github/activity.ts
+++ b/server/github/activity.ts
@@ -1,0 +1,323 @@
+/**
+ * GitHub Activity API client.
+ *
+ * Fetches events, PRs, issues, and CI runs via `gh` CLI using
+ * repo-specific endpoints (not search API) to avoid rate limits.
+ * Uses in-memory caching (2-minute TTL).
+ */
+
+import { buildSafeGhEnv } from '../lib/env';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('GitHubActivity');
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface GitHubEvent {
+    id: string;
+    type: string;
+    repo: string;
+    actor: string;
+    action?: string;
+    title?: string;
+    number?: number;
+    url?: string;
+    ref?: string;
+    commits?: number;
+    createdAt: string;
+}
+
+export interface GitHubPR {
+    repo: string;
+    number: number;
+    title: string;
+    author: string;
+    state: string;
+    draft: boolean;
+    url: string;
+    labels: string[];
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface GitHubIssue {
+    repo: string;
+    number: number;
+    title: string;
+    author: string;
+    labels: string[];
+    url: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface GitHubRun {
+    id: number;
+    repo: string;
+    name: string;
+    branch: string;
+    status: string;
+    conclusion: string;
+    url: string;
+    createdAt: string;
+}
+
+export interface ActivitySummary {
+    openPRs: number;
+    openIssues: number;
+    recentCommits: number;
+    ciPassRate: number;
+    lastUpdated: string;
+}
+
+// ── Cache ────────────────────────────────────────────────────────────
+
+const CACHE_TTL_MS = 2 * 60 * 1000; // 2 minutes
+
+interface CacheEntry<T> {
+    data: T;
+    expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry<unknown>>();
+
+function getCached<T>(key: string): T | null {
+    const entry = cache.get(key);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+        cache.delete(key);
+        return null;
+    }
+    return entry.data as T;
+}
+
+function setCache<T>(key: string, data: T): void {
+    cache.set(key, { data, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+// ── gh CLI runner ────────────────────────────────────────────────────
+
+async function runGh(args: string[]): Promise<{ ok: boolean; stdout: string }> {
+    try {
+        const proc = Bun.spawn(['gh', ...args], {
+            env: buildSafeGhEnv(),
+            stdout: 'pipe',
+            stderr: 'pipe',
+        });
+        const stdout = await new Response(proc.stdout).text();
+        const exitCode = await proc.exited;
+        if (exitCode !== 0) {
+            const stderr = await new Response(proc.stderr).text();
+            log.warn('gh command failed', { args: args.join(' '), exitCode, stderr: stderr.slice(0, 200) });
+            return { ok: false, stdout: '' };
+        }
+        return { ok: true, stdout };
+    } catch (err) {
+        log.error('gh spawn error', { error: err instanceof Error ? err.message : String(err) });
+        return { ok: false, stdout: '' };
+    }
+}
+
+// ── Fetch functions (repo-specific) ──────────────────────────────────
+
+export async function fetchRecentEvents(owner: string, repo: string, perPage = 30): Promise<GitHubEvent[]> {
+    const cacheKey = `events:${owner}/${repo}:${perPage}`;
+    const cached = getCached<GitHubEvent[]>(cacheKey);
+    if (cached) return cached;
+
+    const { ok, stdout } = await runGh([
+        'api', `/repos/${owner}/${repo}/events`,
+        '-f', `per_page=${perPage}`,
+    ]);
+    if (!ok) return [];
+
+    try {
+        const raw = JSON.parse(stdout) as Array<Record<string, unknown>>;
+        const events: GitHubEvent[] = raw.map((e) => {
+            const payload = e.payload as Record<string, unknown> | undefined;
+            const actor = (e.actor as Record<string, string>)?.login ?? '';
+            const type = String(e.type ?? '');
+
+            const event: GitHubEvent = {
+                id: String(e.id),
+                type,
+                repo: `${owner}/${repo}`,
+                actor,
+                createdAt: String(e.created_at),
+            };
+
+            if (payload) {
+                event.action = payload.action as string | undefined;
+
+                if (type === 'PushEvent') {
+                    event.ref = (payload.ref as string)?.replace('refs/heads/', '');
+                    event.commits = (payload.commits as unknown[])?.length ?? 0;
+                }
+
+                const prOrIssue = (payload.pull_request ?? payload.issue) as Record<string, unknown> | undefined;
+                if (prOrIssue) {
+                    event.title = prOrIssue.title as string;
+                    event.number = prOrIssue.number as number;
+                    event.url = prOrIssue.html_url as string;
+                }
+
+                if (type === 'ReleaseEvent') {
+                    const release = payload.release as Record<string, unknown> | undefined;
+                    if (release) {
+                        event.title = release.tag_name as string;
+                        event.url = release.html_url as string;
+                    }
+                }
+            }
+
+            return event;
+        });
+
+        setCache(cacheKey, events);
+        return events;
+    } catch {
+        log.warn('Failed to parse events response');
+        return [];
+    }
+}
+
+export async function fetchOpenPRs(owner: string, repo: string): Promise<GitHubPR[]> {
+    const cacheKey = `prs:${owner}/${repo}`;
+    const cached = getCached<GitHubPR[]>(cacheKey);
+    if (cached) return cached;
+
+    const { ok, stdout } = await runGh([
+        'api', `/repos/${owner}/${repo}/pulls`,
+        '-f', 'state=open',
+        '-f', 'sort=updated',
+        '-f', 'per_page=30',
+    ]);
+    if (!ok) return [];
+
+    try {
+        const items = JSON.parse(stdout) as Array<Record<string, unknown>>;
+        const prs: GitHubPR[] = items.map((item) => ({
+            repo: `${owner}/${repo}`,
+            number: item.number as number,
+            title: String(item.title),
+            author: (item.user as Record<string, string>)?.login ?? '',
+            state: String(item.state),
+            draft: Boolean(item.draft),
+            url: String(item.html_url),
+            labels: ((item.labels as Array<Record<string, string>>) ?? []).map((l) => l.name),
+            createdAt: String(item.created_at),
+            updatedAt: String(item.updated_at),
+        }));
+
+        setCache(cacheKey, prs);
+        return prs;
+    } catch {
+        log.warn('Failed to parse PRs response');
+        return [];
+    }
+}
+
+export async function fetchOpenIssues(owner: string, repo: string): Promise<GitHubIssue[]> {
+    const cacheKey = `issues:${owner}/${repo}`;
+    const cached = getCached<GitHubIssue[]>(cacheKey);
+    if (cached) return cached;
+
+    const { ok, stdout } = await runGh([
+        'api', `/repos/${owner}/${repo}/issues`,
+        '-f', 'state=open',
+        '-f', 'sort=updated',
+        '-f', 'per_page=30',
+    ]);
+    if (!ok) return [];
+
+    try {
+        const items = JSON.parse(stdout) as Array<Record<string, unknown>>;
+        // GitHub issues API includes PRs — filter them out
+        const issues: GitHubIssue[] = items
+            .filter((item) => !(item.pull_request))
+            .map((item) => ({
+                repo: `${owner}/${repo}`,
+                number: item.number as number,
+                title: String(item.title),
+                author: (item.user as Record<string, string>)?.login ?? '',
+                labels: ((item.labels as Array<Record<string, string>>) ?? []).map((l) => l.name),
+                url: String(item.html_url),
+                createdAt: String(item.created_at),
+                updatedAt: String(item.updated_at),
+            }));
+
+        setCache(cacheKey, issues);
+        return issues;
+    } catch {
+        log.warn('Failed to parse issues response');
+        return [];
+    }
+}
+
+export async function fetchRecentRuns(owner: string, repo: string): Promise<GitHubRun[]> {
+    const cacheKey = `runs:${owner}/${repo}`;
+    const cached = getCached<GitHubRun[]>(cacheKey);
+    if (cached) return cached;
+
+    const { ok, stdout } = await runGh([
+        'api', `/repos/${owner}/${repo}/actions/runs`,
+        '-f', 'per_page=10',
+        '--jq', '.workflow_runs',
+    ]);
+    if (!ok) return [];
+
+    try {
+        const items = JSON.parse(stdout) as Array<Record<string, unknown>>;
+        const runs: GitHubRun[] = items.map((item) => ({
+            id: item.id as number,
+            repo: `${owner}/${repo}`,
+            name: String(item.name),
+            branch: String(item.head_branch),
+            status: String(item.status),
+            conclusion: String(item.conclusion ?? ''),
+            url: String(item.html_url),
+            createdAt: String(item.created_at),
+        }));
+
+        setCache(cacheKey, runs);
+        return runs;
+    } catch {
+        log.warn('Failed to parse runs response');
+        return [];
+    }
+}
+
+export async function fetchActivitySummary(owner: string, repo: string): Promise<ActivitySummary> {
+    const cacheKey = `summary:${owner}/${repo}`;
+    const cached = getCached<ActivitySummary>(cacheKey);
+    if (cached) return cached;
+
+    const [events, prs, issues, runs] = await Promise.all([
+        fetchRecentEvents(owner, repo, 30),
+        fetchOpenPRs(owner, repo),
+        fetchOpenIssues(owner, repo),
+        fetchRecentRuns(owner, repo),
+    ]);
+
+    const recentCommits = events
+        .filter((e) => e.type === 'PushEvent')
+        .reduce((sum, e) => sum + (e.commits ?? 0), 0);
+
+    // CI pass rate from recent completed runs
+    const completedRuns = runs.filter((r) => r.status === 'completed');
+    const passedRuns = completedRuns.filter((r) => r.conclusion === 'success');
+    const ciPassRate = completedRuns.length > 0
+        ? Math.round((passedRuns.length / completedRuns.length) * 100)
+        : 0;
+
+    const summary: ActivitySummary = {
+        openPRs: prs.length,
+        openIssues: issues.length,
+        recentCommits,
+        ciPassRate,
+        lastUpdated: new Date().toISOString(),
+    };
+
+    setCache(cacheKey, summary);
+    return summary;
+}

--- a/server/routes/github-activity.ts
+++ b/server/routes/github-activity.ts
@@ -1,0 +1,89 @@
+/**
+ * GitHub Activity API routes.
+ *
+ * All endpoints require `owner` and `repo` query params (e.g. owner=CorvidLabs&repo=corvid-agent).
+ *
+ * GET /api/github-activity/events?owner={owner}&repo={repo}&limit={n}
+ * GET /api/github-activity/prs?owner={owner}&repo={repo}
+ * GET /api/github-activity/issues?owner={owner}&repo={repo}
+ * GET /api/github-activity/runs?owner={owner}&repo={repo}
+ * GET /api/github-activity/summary?owner={owner}&repo={repo}
+ */
+
+import { json, badRequest, handleRouteError } from '../lib/response';
+import {
+    fetchRecentEvents,
+    fetchOpenPRs,
+    fetchOpenIssues,
+    fetchRecentRuns,
+    fetchActivitySummary,
+} from '../github/activity';
+
+export function handleGitHubActivityRoutes(req: Request, url: URL): Response | Promise<Response> | null {
+    if (!url.pathname.startsWith('/api/github-activity/')) return null;
+    if (req.method !== 'GET') return null;
+
+    const owner = url.searchParams.get('owner');
+    const repo = url.searchParams.get('repo');
+    if (!owner || !repo) return badRequest('owner and repo query parameters are required');
+
+    const subpath = url.pathname.slice('/api/github-activity/'.length);
+
+    if (subpath === 'events') {
+        return (async () => {
+            try {
+                const limit = Number(url.searchParams.get('limit') ?? 30);
+                const events = await fetchRecentEvents(owner, repo, limit);
+                return json({ events });
+            } catch (err) {
+                return handleRouteError(err);
+            }
+        })();
+    }
+
+    if (subpath === 'prs') {
+        return (async () => {
+            try {
+                const prs = await fetchOpenPRs(owner, repo);
+                return json({ prs });
+            } catch (err) {
+                return handleRouteError(err);
+            }
+        })();
+    }
+
+    if (subpath === 'issues') {
+        return (async () => {
+            try {
+                const issues = await fetchOpenIssues(owner, repo);
+                return json({ issues });
+            } catch (err) {
+                return handleRouteError(err);
+            }
+        })();
+    }
+
+    if (subpath === 'runs') {
+        return (async () => {
+            try {
+                const runs = await fetchRecentRuns(owner, repo);
+                return json({ runs });
+            } catch (err) {
+                return handleRouteError(err);
+            }
+        })();
+    }
+
+    if (subpath === 'summary') {
+        return (async () => {
+            try {
+                const summary = await fetchActivitySummary(owner, repo);
+                return json(summary);
+            } catch (err) {
+                return handleRouteError(err);
+            }
+        })();
+    }
+
+    return null;
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -12,6 +12,7 @@ import { handleSettingsRoutes } from './settings';
 import { handleScheduleRoutes } from './schedules';
 import { handleWebhookRoutes } from './webhooks';
 import { handleMentionPollingRoutes } from './mention-polling';
+import { handleGitHubActivityRoutes } from './github-activity';
 import { handleWorkflowRoutes } from './workflows';
 import { handleSandboxRoutes } from './sandbox';
 import { handleMarketplaceRoutes } from './marketplace';
@@ -269,6 +270,10 @@ async function handleRoutes(
     // Mention polling routes (local-first GitHub @mention detection)
     const pollingResponse = handleMentionPollingRoutes(req, url, db, mentionPollingService ?? null);
     if (pollingResponse) return pollingResponse;
+
+    // GitHub activity routes (repo events, PRs, issues, CI runs)
+    const ghActivityResponse = handleGitHubActivityRoutes(req, url);
+    if (ghActivityResponse) return ghActivityResponse;
 
     // Workflow routes (graph-based orchestration)
     const workflowResponse = handleWorkflowRoutes(req, url, db, workflowService ?? null);


### PR DESCRIPTION
## Summary
- Adds a GitHub Activity page to the dashboard with live repo stats
- Shows recent events, open PRs, open issues, and CI workflow runs
- Uses repo-specific GitHub API endpoints (not search API) to avoid rate limits
- Server-side caching with 2-minute TTL
- Defaults to `CorvidLabs/corvid-agent`, configurable via owner/repo inputs
- Summary cards: open PRs, open issues, recent commits, CI pass rate

## Files
- `server/github/activity.ts` — GitHub API client via `gh` CLI
- `server/routes/github-activity.ts` — 5 API endpoints
- `server/routes/index.ts` — route registration
- `client/src/app/core/models/github-activity.model.ts` — TypeScript interfaces
- `client/src/app/core/services/github-activity.service.ts` — Angular service
- `client/src/app/features/github-activity/github-activity.component.ts` — Dashboard page
- `client/src/app/app.routes.ts` — route registration
- `client/src/app/shared/components/sidebar.component.ts` — sidebar nav link

## Test plan
- [x] tsc passes
- [x] All 2306 unit tests pass
- [ ] Navigate to GitHub Activity page in dashboard
- [ ] Verify events, PRs, issues, CI tabs populate for CorvidLabs/corvid-agent
- [ ] Verify summary stats display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)