### PR TITLE
fix: replace SQL string interpolation with parameterized queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:e2e:ui": "npx playwright test --config=playwright.config.js --ui",
     "build:client": "cd client && bun run build",
     "dev:client": "cd client && bun run start",
-    "spec:check": "bun scripts/spec-check.ts"
+    "spec:check": "bun scripts/spec-check.ts",
+    "lint:sql": "bash scripts/check-sql-injection.sh"
   },
   "optionalDependencies": {
     "@corvidlabs/ts-algochat": "^0.3.0"

--- a/scripts/check-sql-injection.sh
+++ b/scripts/check-sql-injection.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Detect potential SQL injection via string interpolation in database queries.
+# Run: bash scripts/check-sql-injection.sh
+# Exit code 0 = clean, 1 = potential issues found.
+#
+# Scans for template-literal interpolation (${...}) inside strings that contain
+# SQL keywords, excluding known-safe patterns (dynamic field lists built from
+# hardcoded arrays, PRAGMA with validated identifiers, etc.).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+EXIT=0
+
+# Patterns that indicate SQL keywords combined with interpolation.
+# We look for backtick template strings containing both a SQL keyword and ${…}.
+HITS=$(grep -rn --include='*.ts' -E '(db\.(query|exec|run|prepare)|\.query)\s*\(\s*`[^`]*(SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|PRAGMA)[^`]*\$\{' "$ROOT/server" || true)
+
+if [ -z "$HITS" ]; then
+    echo "No SQL string interpolation found."
+    exit 0
+fi
+
+# Filter out known-safe patterns:
+#   - Dynamic field lists like ${fields.join(', ')} — fields are built from hardcoded arrays
+#   - Dynamic WHERE clause assembly like ${where} or ${conditions.join(...)}
+#   - Dynamic placeholder generation like ${placeholders}
+#   - PRAGMA with validated identifiers (preceded by SAFE_SQL_IDENTIFIER check)
+# Also exclude PRAGMA table_info — doesn't support placeholders; validated by SAFE_SQL_IDENTIFIER.
+FILTERED=$(echo "$HITS" | grep -v -E '\$\{(fields|sets|where|conditions|placeholders|orderClause|limitClause|offsetClause)\b' | grep -v 'PRAGMA table_info' || true)
+
+if [ -z "$FILTERED" ]; then
+    echo "No SQL string interpolation found (safe dynamic patterns excluded)."
+    exit 0
+fi
+
+echo "Potential SQL string interpolation detected:"
+echo "$FILTERED"
+echo ""
+echo "If this is intentional and safe, add identifier validation (allowlist regex)"
+echo "before the interpolation point, or refactor to use parameterized queries (?)."
+EXIT=1
+
+exit $EXIT


### PR DESCRIPTION
## Summary

- Add `SAFE_SQL_IDENTIFIER` allowlist validation to `hasColumn()` in `schema.ts` before PRAGMA table_info interpolation (PRAGMA doesn't support `?` placeholders, so identifier validation is the defense)
- Replace `db.exec()` with `db.query().run()` using `?` parameterized placeholders for schema_version INSERT/UPDATE statements
- Add `scripts/check-sql-injection.sh` lint script to detect future SQL string interpolation in server code
- Add `lint:sql` npm script for easy invocation via `bun run lint:sql`

## Audit Findings

Full audit of 20+ database files found the codebase is generally well-protected:
- Dynamic UPDATE SET clauses (`${fields.join(', ')}`) are safe — field names are hardcoded, values use `?` placeholders
- Dynamic WHERE construction is safe — conditions are hardcoded templates with `?` placeholders
- `validateTenantOwnership` in `db-filter.ts` already validates identifiers against an allowlist
- **Fixed:** `hasColumn()` PRAGMA used unvalidated table name interpolation
- **Fixed:** `runMigrations()` used `SCHEMA_VERSION` interpolation instead of parameterized queries

## Test plan

- [x] All 2334 tests pass (0 failures)
- [x] `bun run lint:sql` passes cleanly
- [ ] Verify migrations still work correctly on fresh database

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)