### PR TITLE
feat: add developer setup script and improve onboarding docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,61 +1,232 @@
 # Contributing to CorvidAgent
 
-Thanks for your interest in contributing to CorvidAgent! This document covers the basics for getting started.
+Thanks for your interest in contributing to CorvidAgent! This document covers everything you need to get started.
 
-## Getting Started
+## Quick Setup
+
+The fastest way to get a development environment running:
+
+```bash
+git clone https://github.com/CorvidLabs/corvid-agent.git
+cd corvid-agent
+bash scripts/dev-setup.sh
+```
+
+The setup script checks prerequisites, copies `.env.example`, installs dependencies, builds the client, and verifies the server starts. Run with `--skip-prompts` for non-interactive mode.
+
+### Manual Setup
 
 1. **Fork the repo** and clone your fork
-2. **Install dependencies**: `bun install`
-3. **Copy the env template**: `cp .env.example .env`
-4. **Fill in required values** in `.env` (see below)
-5. **Start the dev server**: `bun run dev`
+2. **Install Bun** (>= 1.3.0): `curl -fsSL https://bun.sh/install | bash`
+3. **Install dependencies**: `bun install`
+4. **Copy the env template**: `cp .env.example .env`
+5. **Fill in required values** in `.env` (see below)
+6. **Build the client**: `bun run build:client`
+7. **Start the dev server**: `bun run dev`
 
 ### Required Environment Variables
 
 At minimum you need:
-- `ALGOCHAT_MNEMONIC` — 25-word Algorand mnemonic for the agent's wallet
-- `ANTHROPIC_API_KEY` — for agent sessions (optional if you're only working on non-agent features)
+- `ANTHROPIC_API_KEY` — for Claude agent sessions (optional if using Ollama-only mode)
 
-See `.env.example` for the full list of configuration options.
+Optional but recommended:
+- `GH_TOKEN` — for GitHub integration (PRs, issues, webhooks)
+- `ALGOCHAT_MNEMONIC` — 25-word Algorand mnemonic for on-chain identity
+
+For 100% local mode with no cloud dependencies, set `ENABLED_PROVIDERS=ollama` and ensure Ollama is running locally.
+
+See `.env.example` for the full list of 50+ configuration options with descriptions.
+
+## Architecture Overview
+
+```
+                    +--------------------------+
+                    |   Angular 21 Dashboard   |
+                    |  (signals, standalone)   |
+                    +------------+-------------+
+                                 |
+                            HTTP / WebSocket
+                                 |
++--------------------------------+--------------------------------+
+|                     Bun Server (port 3000)                      |
+|                                                                 |
+|  +----------+  +----------+  +-----------+  +----------------+  |
+|  | Process  |  | Council  |  | Scheduler |  | Work Tasks     |  |
+|  | Manager  |  | Engine   |  | Service   |  | (git worktree) |  |
+|  +----------+  +----------+  +-----------+  +----------------+  |
+|  | Telegram |  | Discord  |  | Voice     |  | Personas       |  |
+|  | Bridge   |  | Bridge   |  | TTS / STT |  | + Skills       |  |
+|  +----------+  +----------+  +-----------+  +----------------+  |
+|                                                                 |
+|  +-----------------------------------------------------------+  |
+|  |                    SQLite (bun:sqlite)                     |  |
+|  |  52 migrations | FTS5 search | WAL mode | foreign keys    |  |
+|  +-----------------------------------------------------------+  |
++-----------------------------------------------------------------+
+```
+
+### Key Concepts
+
+- **Agents** — AI entities with configurable models, permissions, personas, and skill bundles
+- **Sessions** — Conversations between a user and an agent, streamed via WebSocket
+- **Councils** — Multi-agent deliberation with a chairman that synthesizes responses
+- **Work Tasks** — Self-improvement pipeline: branch, code, validate (type-check + tests), PR
+- **Workflows** — DAG-based multi-step orchestration with suspend/resume
+- **Schedules** — Cron/interval automation with optional approval gates
+- **AlgoChat** — On-chain encrypted messaging via Algorand
+- **Bridges** — Bidirectional Telegram, Discord, and Slack integrations
+
+### Project Structure
+
+```
+server/           Bun HTTP + WebSocket server
+  algochat/       On-chain messaging (bridge, wallet, directory)
+  ast/            Tree-sitter AST parser for code understanding
+  billing/        Usage metering and Stripe billing
+  db/             SQLite schema (52 migrations) and query modules
+  discord/        Bidirectional Discord bridge (raw WebSocket)
+  github/         GitHub API operations (PRs, issues, reviews)
+  lib/            Shared utilities (logger, crypto, validation, dedup)
+  mcp/            MCP tool server and 36 corvid_* tool handlers
+  middleware/     Auth, CORS, rate limiting, startup validation
+  process/        Agent lifecycle (SDK + Ollama, persona/skill injection)
+  routes/         REST API route handlers (28 modules)
+  scheduler/      Cron/interval execution engine
+  telegram/       Bidirectional Telegram bridge (long-polling, voice)
+  voice/          TTS (OpenAI) and STT (Whisper) with caching
+  work/           Work task service (worktree, branch, validate, PR)
+  workflow/       Graph-based DAG workflow orchestration
+  ws/             WebSocket handlers with pub/sub
+client/           Angular 21 SPA (standalone components, signals)
+shared/           TypeScript types shared between server and client
+e2e/              Playwright end-to-end tests (30 spec files)
+deploy/           Docker, docker-compose, systemd, launchd, nginx, caddy
+packages/         Workspace packages (env, result utilities)
+scripts/          Developer tooling and automation scripts
+specs/            Module specification documents (33 specs)
+```
+
+### Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Runtime | Bun (server, package manager, test runner) |
+| Language | TypeScript (strict mode) |
+| Frontend | Angular 21 (standalone components, signals) |
+| Database | SQLite via bun:sqlite (WAL, FTS5) |
+| Agent SDK | Claude Agent SDK + Ollama |
+| Validation | Zod (runtime schema validation) |
+| Blockchain | Algorand (AlgoChat, wallets) |
+| Observability | OpenTelemetry (tracing + Prometheus metrics) |
+
+### Database
+
+SQLite with embedded migrations in `server/db/schema.ts`. The database is auto-created and migrated on first server start — no separate migration step needed. The current schema version is 52 with 47+ tables.
+
+Key patterns:
+- All queries use parameterized statements (no string interpolation)
+- WAL mode for concurrent reads
+- FTS5 full-text search for memory queries
+- Foreign keys enforced
 
 ## Development
 
+### Common Commands
+
 ```bash
-# Run the server in watch mode
+# Start the server in watch mode (auto-restarts on file changes)
 bun run dev
 
-# Run tests
+# Run all server unit tests
 bun test
 
-# Run e2e tests (requires Playwright)
+# Run a specific test file
+bun test server/__tests__/db.test.ts
+
+# Run E2E tests (requires Playwright: npx playwright install)
 bun run test:e2e
+
+# Run E2E tests in UI mode (interactive)
+bun run test:e2e:ui
 
 # Build the Angular client
 bun run build:client
+
+# Run Angular client dev server (separate terminal)
+bun run dev:client
+
+# Run Angular component tests
+cd client && npx vitest run
+
+# Type-check the entire project
+bunx tsc --noEmit --skipLibCheck
+
+# Validate module specs
+bun run spec:check
+
+# Check for SQL injection patterns
+bun run lint:sql
 ```
 
-## Project Structure
+### Development Workflow
 
+1. **Start the server**: `bun run dev` — starts on `http://localhost:3000` with file watching
+2. **Make changes** — the server restarts automatically on save
+3. **Test your changes** — run the relevant tests (see Testing section)
+4. **Type-check before committing**: `bunx tsc --noEmit --skipLibCheck`
+
+### Code Patterns
+
+- **Logging**: Use `createLogger('module-name')` from `server/lib/logger.ts` — never `console.log`
+- **Validation**: Use Zod schemas for request/response validation
+- **Error handling**: Always catch and log errors with context
+- **Database queries**: Use parameterized queries only — run `bun run lint:sql` to check
+- **Route handlers**: Follow existing patterns in `server/routes/`
+- **Types**: Shared types go in `shared/`, server-only types stay in `server/`
+
+## Testing
+
+### Unit Tests (1757+)
+
+```bash
+bun test                              # Run all tests (~30s)
+bun test server/__tests__/db.test.ts  # Run a specific file
+bun test --watch                      # Watch mode
 ```
-server/           # Bun HTTP server, routes, and core logic
-  algochat/       # On-chain messaging bridge
-  db/             # SQLite database access layer (47 migrations)
-  discord/        # Bidirectional Discord bridge (raw WebSocket)
-  lib/            # Shared utilities (logger, crypto, validation)
-  mcp/            # MCP tool server
-  middleware/     # HTTP/WS auth, CORS, startup security checks
-  process/        # Agent lifecycle (SDK + Ollama, persona/skill injection)
-  routes/         # REST API route handlers (26 modules)
-  selftest/       # Self-test service
-  telegram/       # Bidirectional Telegram bridge (long-polling, voice)
-  voice/          # TTS (OpenAI) and STT (Whisper) with caching
-  work/           # Work task service (branch, agent, validate, PR)
-  ws/             # WebSocket handler
-client/           # Angular 21 mobile-first UI
-shared/           # Types and constants shared between server and client
-e2e/              # Playwright end-to-end tests
-deploy/           # Deployment configs (Docker, systemd, launchd)
+
+Tests live in `server/__tests__/` (119 test files) and cover API routes, authentication, billing, database, bridges (Discord/Telegram/Slack), GitHub tools, MCP handlers, scheduling, workflows, and more.
+
+### E2E Tests (348)
+
+```bash
+npx playwright install                # One-time: install browsers
+bun run test:e2e                      # Run all E2E tests
+bun run test:e2e:ui                   # Interactive UI mode
 ```
+
+E2E tests are in `e2e/` (30 spec files) and cover 198/202 testable API endpoints plus all Angular UI routes. The test config starts a dev server on port 3001 automatically.
+
+### Client Tests
+
+```bash
+cd client && npx vitest run           # Run Angular component tests (~2s)
+cd client && npx vitest               # Watch mode
+```
+
+### Module Spec Validation
+
+```bash
+bun run spec:check                    # Validate 33 module specs in specs/
+```
+
+Checks YAML frontmatter, required sections, API surface coverage, file existence, and dependency graph integrity.
+
+### Writing Tests
+
+- Place server tests in `server/__tests__/`
+- Use Bun's built-in test runner (`describe`, `it`, `expect`)
+- Mock external dependencies (APIs, file system) rather than making real calls
+- Follow existing test patterns for consistency
 
 ## Making Changes
 
@@ -75,6 +246,7 @@ deploy/           # Deployment configs (Docker, systemd, launchd)
 
 Write clear, concise commit messages:
 - Use imperative mood: "Add feature" not "Added feature"
+- Prefix with type: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`
 - Keep the first line under 70 characters
 - Add detail in the body if the change is non-trivial
 
@@ -86,6 +258,7 @@ Write clear, concise commit messages:
    ```bash
    bunx tsc --noEmit --skipLibCheck   # type-check
    bun test                           # unit tests
+   bun run lint:sql                   # SQL injection check
    ```
 4. Open a PR with:
    - A short title describing the change

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Built with [Bun](https://bun.sh), [Angular 21](https://angular.dev), [SQLite](ht
 ```bash
 git clone https://github.com/CorvidLabs/corvid-agent.git
 cd corvid-agent
+bash scripts/dev-setup.sh    # guided setup: prerequisites, env, deps, build
+bun run dev
+```
+
+Or manually:
+
+```bash
 bun install
 cp .env.example .env   # add your ANTHROPIC_API_KEY
 bun run build:client

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# dev-setup.sh — Developer environment setup for corvid-agent
+#
+# Checks prerequisites, copies .env.example, installs dependencies,
+# builds the client, and verifies the server starts.
+#
+# Usage:
+#   bash scripts/dev-setup.sh
+#   bash scripts/dev-setup.sh --skip-prompts   # non-interactive mode
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKIP_PROMPTS=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --skip-prompts) SKIP_PROMPTS=true ;;
+        -h|--help)
+            echo "Usage: bash scripts/dev-setup.sh [--skip-prompts]"
+            echo ""
+            echo "Options:"
+            echo "  --skip-prompts   Run non-interactively (use defaults, don't prompt for env vars)"
+            echo "  -h, --help       Show this help message"
+            exit 0
+            ;;
+        *) echo "Unknown option: $arg"; exit 1 ;;
+    esac
+done
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+info()  { echo -e "${GREEN}[ok]${NC} $1"; }
+warn()  { echo -e "${YELLOW}[warn]${NC} $1"; }
+fail()  { echo -e "${RED}[error]${NC} $1"; exit 1; }
+step()  { echo -e "\n${BOLD}==> $1${NC}"; }
+
+# ─── Step 1: Check prerequisites ────────────────────────────────────────────
+
+step "Checking prerequisites"
+
+# Git
+if command -v git &>/dev/null; then
+    info "git $(git --version | cut -d' ' -f3)"
+else
+    fail "git is not installed. Install it from https://git-scm.com"
+fi
+
+# Bun (required)
+if command -v bun &>/dev/null; then
+    BUN_VERSION=$(bun --version)
+    # Check minimum version (1.3.0)
+    BUN_MAJOR=$(echo "$BUN_VERSION" | cut -d. -f1)
+    BUN_MINOR=$(echo "$BUN_VERSION" | cut -d. -f2)
+    if [[ "$BUN_MAJOR" -lt 1 ]] || { [[ "$BUN_MAJOR" -eq 1 ]] && [[ "$BUN_MINOR" -lt 3 ]]; }; then
+        fail "Bun >= 1.3.0 is required (found $BUN_VERSION). Update: curl -fsSL https://bun.sh/install | bash"
+    fi
+    info "bun $BUN_VERSION"
+else
+    fail "Bun is not installed. Install it: curl -fsSL https://bun.sh/install | bash"
+fi
+
+# Node.js (optional, needed for Angular CLI / Playwright)
+if command -v node &>/dev/null; then
+    info "node $(node --version)"
+else
+    warn "Node.js not found. It's needed for Angular CLI (client build) and Playwright (E2E tests)."
+    warn "Install from https://nodejs.org or use: bun install -g node"
+fi
+
+# ─── Step 2: Environment setup ──────────────────────────────────────────────
+
+step "Setting up environment"
+
+cd "$PROJECT_DIR"
+
+if [[ -f .env ]]; then
+    info ".env already exists — skipping copy"
+else
+    cp .env.example .env
+    info "Copied .env.example to .env"
+
+    if [[ "$SKIP_PROMPTS" == false ]]; then
+        echo ""
+        echo "Let's configure the essential environment variables."
+        echo "Press Enter to skip any prompt and use the default."
+        echo ""
+
+        # Anthropic API Key
+        read -rp "ANTHROPIC_API_KEY (for Claude agent sessions, or leave blank for Ollama-only mode): " ANTHROPIC_KEY
+        if [[ -n "$ANTHROPIC_KEY" ]]; then
+            if [[ "$(uname)" == "Darwin" ]]; then
+                sed -i '' "s|^# ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=$ANTHROPIC_KEY|" .env
+            else
+                sed -i "s|^# ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=$ANTHROPIC_KEY|" .env
+            fi
+            info "Set ANTHROPIC_API_KEY"
+        else
+            warn "No ANTHROPIC_API_KEY set — system will default to Ollama-only mode"
+        fi
+
+        # GitHub Token
+        read -rp "GH_TOKEN (for GitHub integration — PRs, issues, webhooks): " GH_TOKEN_VAL
+        if [[ -n "$GH_TOKEN_VAL" ]]; then
+            if [[ "$(uname)" == "Darwin" ]]; then
+                sed -i '' "s|^# GH_TOKEN=.*|GH_TOKEN=$GH_TOKEN_VAL|" .env
+            else
+                sed -i "s|^# GH_TOKEN=.*|GH_TOKEN=$GH_TOKEN_VAL|" .env
+            fi
+            info "Set GH_TOKEN"
+        fi
+
+        # Ollama
+        read -rp "OLLAMA_HOST (default: http://localhost:11434): " OLLAMA_VAL
+        if [[ -n "$OLLAMA_VAL" ]]; then
+            if [[ "$(uname)" == "Darwin" ]]; then
+                sed -i '' "s|^# OLLAMA_HOST=.*|OLLAMA_HOST=$OLLAMA_VAL|" .env
+            else
+                sed -i "s|^# OLLAMA_HOST=.*|OLLAMA_HOST=$OLLAMA_VAL|" .env
+            fi
+            info "Set OLLAMA_HOST=$OLLAMA_VAL"
+        fi
+    else
+        info "Skipping env prompts (--skip-prompts)"
+    fi
+fi
+
+# ─── Step 3: Install dependencies ───────────────────────────────────────────
+
+step "Installing dependencies"
+
+bun install
+info "Dependencies installed"
+
+# ─── Step 4: Build the Angular client ────────────────────────────────────────
+
+step "Building Angular client"
+
+if bun run build:client; then
+    info "Client built successfully"
+else
+    warn "Client build failed — you can retry with: bun run build:client"
+    warn "The server will still run but the dashboard UI won't be available."
+fi
+
+# ─── Step 5: Verify the server starts ────────────────────────────────────────
+
+step "Verifying server startup"
+
+# Start the server in the background, wait for the health endpoint, then kill it
+SERVER_PID=""
+cleanup() {
+    if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+bun server/index.ts &>/dev/null &
+SERVER_PID=$!
+
+HEALTHY=false
+for i in $(seq 1 15); do
+    if curl -sf http://localhost:3000/api/health &>/dev/null; then
+        HEALTHY=true
+        break
+    fi
+    sleep 1
+done
+
+kill "$SERVER_PID" 2>/dev/null || true
+wait "$SERVER_PID" 2>/dev/null || true
+SERVER_PID=""
+
+if [[ "$HEALTHY" == true ]]; then
+    info "Server started and responded to health check"
+else
+    warn "Server did not respond within 15 seconds."
+    warn "This may be normal if you haven't configured all required env vars yet."
+    warn "Try starting manually: bun run dev"
+fi
+
+# ─── Done ────────────────────────────────────────────────────────────────────
+
+step "Setup complete!"
+
+echo ""
+echo "Next steps:"
+echo "  1. Review and edit .env with your API keys"
+echo "  2. Start the dev server:  bun run dev"
+echo "  3. Open the dashboard:    http://localhost:3000"
+echo "  4. Run tests:             bun test"
+echo ""
+echo "See CONTRIBUTING.md for development workflow and guidelines."
+echo ""


### PR DESCRIPTION
## Summary

Closes #248

- **`scripts/dev-setup.sh`** — Guided developer setup script that checks prerequisites (bun >= 1.3, git, node), copies `.env.example` with interactive prompts for key env vars, installs dependencies, builds the Angular client, and verifies the server starts via health check. Supports `--skip-prompts` for CI/non-interactive use. Works on macOS and Linux.
- **`CONTRIBUTING.md`** — Expanded from 110 to 233 lines with architecture overview (diagram + key concepts), full project structure, tech stack table, database overview, comprehensive testing guide (unit, E2E, client, spec validation), development workflow, and code patterns.
- **`README.md`** — Updated Quick Start to reference the setup script as the primary onboarding path.

Note: `.env.example` already existed with comprehensive documentation of all 50+ environment variables, so no changes were needed there.

## Test plan

- [ ] Run `bash scripts/dev-setup.sh --skip-prompts` on a fresh clone — should complete without errors
- [ ] Run `bash scripts/dev-setup.sh` interactively — should prompt for API keys and write them to `.env`
- [ ] Verify `scripts/dev-setup.sh --help` shows usage info
- [ ] Review CONTRIBUTING.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)