### PR TITLE
feat: add database migration system for schema changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: TypeScript check
         run: bunx tsc --noEmit --skipLibCheck
 
+      - name: Run database migrations
+        run: bun run migrate:up
+
       - name: Unit tests
         run: bun test
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     "test:e2e:ui": "npx playwright test --config=playwright.config.js --ui",
     "build:client": "cd client && bun run build",
     "dev:client": "cd client && bun run start",
+    "migrate": "bun server/db/migrate-cli.ts",
+    "migrate:up": "bun server/db/migrate-cli.ts up",
+    "migrate:down": "bun server/db/migrate-cli.ts down",
+    "migrate:status": "bun server/db/migrate-cli.ts status",
+    "migrate:create": "bun server/db/migrate-create.ts",
     "spec:check": "bun scripts/spec-check.ts",
     "lint:sql": "bash scripts/check-sql-injection.sh"
   },

--- a/server/__tests__/migrate.test.ts
+++ b/server/__tests__/migrate.test.ts
@@ -1,0 +1,308 @@
+import { test, expect, beforeEach, afterEach, describe } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+    migrateUp,
+    migrateDown,
+    migrationStatus,
+    getCurrentVersion,
+    discoverMigrations,
+} from '../db/migrate';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+let db: Database;
+let tempDir: string;
+
+function makeMigrationDir(): string {
+    tempDir = mkdtempSync(join(tmpdir(), 'migrate-test-'));
+    return tempDir;
+}
+
+function writeMigration(dir: string, filename: string, upSql: string, downSql: string): void {
+    const content = `
+import { Database } from 'bun:sqlite';
+export function up(db: Database): void { db.exec(${JSON.stringify(upSql)}); }
+export function down(db: Database): void { db.exec(${JSON.stringify(downSql)}); }
+`;
+    writeFileSync(join(dir, filename), content);
+}
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+});
+
+afterEach(() => {
+    db.close();
+    if (tempDir) {
+        try { rmSync(tempDir, { recursive: true }); } catch {}
+    }
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('getCurrentVersion', () => {
+    test('returns 0 for fresh database', () => {
+        expect(getCurrentVersion(db)).toBe(0);
+    });
+
+    test('creates schema_version table', () => {
+        getCurrentVersion(db);
+        const tables = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_version'").all();
+        expect(tables).toHaveLength(1);
+    });
+});
+
+describe('discoverMigrations', () => {
+    test('returns empty for non-existent directory', () => {
+        expect(discoverMigrations('/nonexistent')).toEqual([]);
+    });
+
+    test('discovers migration files in correct order', () => {
+        const dir = makeMigrationDir();
+        writeMigration(dir, '002_add_users.ts', 'SELECT 1', 'SELECT 1');
+        writeMigration(dir, '001_baseline.ts', 'SELECT 1', 'SELECT 1');
+        writeMigration(dir, '003_add_posts.ts', 'SELECT 1', 'SELECT 1');
+
+        const entries = discoverMigrations(dir);
+        expect(entries).toHaveLength(3);
+        expect(entries[0].version).toBe(1);
+        expect(entries[0].name).toBe('baseline');
+        expect(entries[1].version).toBe(2);
+        expect(entries[1].name).toBe('add users');
+        expect(entries[2].version).toBe(3);
+        expect(entries[2].name).toBe('add posts');
+    });
+
+    test('ignores non-migration files', () => {
+        const dir = makeMigrationDir();
+        writeMigration(dir, '001_baseline.ts', 'SELECT 1', 'SELECT 1');
+        writeFileSync(join(dir, 'README.md'), '# Migrations');
+        writeFileSync(join(dir, 'helper.ts'), 'export const x = 1;');
+
+        const entries = discoverMigrations(dir);
+        expect(entries).toHaveLength(1);
+    });
+});
+
+describe('migrateUp', () => {
+    test('applies all pending migrations', async () => {
+        const dir = makeMigrationDir();
+        writeMigration(
+            dir,
+            '001_create_users.ts',
+            'CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)',
+            'DROP TABLE users',
+        );
+        writeMigration(
+            dir,
+            '002_create_posts.ts',
+            'CREATE TABLE posts (id INTEGER PRIMARY KEY, user_id INTEGER, title TEXT)',
+            'DROP TABLE posts',
+        );
+
+        const result = await migrateUp(db, undefined, dir);
+        expect(result.applied).toBe(2);
+        expect(result.to).toBe(2);
+        expect(getCurrentVersion(db)).toBe(2);
+
+        // Verify tables exist
+        const tables = db.query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as { name: string }[];
+        const tableNames = tables.map((t) => t.name);
+        expect(tableNames).toContain('users');
+        expect(tableNames).toContain('posts');
+    });
+
+    test('applies migrations up to target version', async () => {
+        const dir = makeMigrationDir();
+        writeMigration(dir, '001_create_users.ts', 'CREATE TABLE users (id INTEGER PRIMARY KEY)', 'DROP TABLE users');
+        writeMigration(dir, '002_create_posts.ts', 'CREATE TABLE posts (id INTEGER PRIMARY KEY)', 'DROP TABLE posts');
+        writeMigration(dir, '003_create_tags.ts', 'CREATE TABLE tags (id INTEGER PRIMARY KEY)', 'DROP TABLE tags');
+
+        const result = await migrateUp(db, 2, dir);
+        expect(result.applied).toBe(2);
+        expect(result.to).toBe(2);
+
+        const tables = db.query("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[];
+        const tableNames = tables.map((t) => t.name);
+        expect(tableNames).toContain('users');
+        expect(tableNames).toContain('posts');
+        expect(tableNames).not.toContain('tags');
+    });
+
+    test('skips already-applied migrations', async () => {
+        const dir = makeMigrationDir();
+        writeMigration(dir, '001_create_users.ts', 'CREATE TABLE users (id INTEGER PRIMARY KEY)', 'DROP TABLE users');
+        writeMigration(dir, '002_create_posts.ts', 'CREATE TABLE posts (id INTEGER PRIMARY KEY)', 'DROP TABLE posts');
+
+        await migrateUp(db, 1, dir);
+        expect(getCurrentVersion(db)).toBe(1);
+
+        const result = await migrateUp(db, undefined, dir);
+        expect(result.applied).toBe(1);
+        expect(result.to).toBe(2);
+    });
+
+    test('returns 0 applied when already up to date', async () => {
+        const dir = makeMigrationDir();
+        writeMigration(dir, '001_create_users.ts', 'CREATE TABLE users (id INTEGER PRIMARY KEY)', 'DROP TABLE users');
+
+        await migrateUp(db, undefined, dir);
+        const result = await migrateUp(db, undefined, dir);
+        expect(result.applied).toBe(0);
+        expect(result.to).toBe(1);
+    });
+
+    test('rolls back on failure (transaction safety)', async () => {
+        const dir = makeMigrationDir();
+        writeMigration(dir, '001_create_users.ts', 'CREATE TABLE users (id INTEGER PRIMARY KEY)', 'DROP TABLE users');
+        writeMigration(dir, '002_bad_migration.ts', 'INVALID SQL STATEMENT', 'SELECT 1');
+
+        await migrateUp(db, 1, dir);
+
+        try {
+            await migrateUp(db, undefined, dir);
+        } catch {
+            // Expected to fail
+        }
+
+        // Version should still be 1 (failed migration didn't commit)
+        expect(getCurrentVersion(db)).toBe(1);
+    });
+});
+
+describe('migrateDown', () => {
+    test('reverts the most recent migration', async () => {
+        const dir = makeMigrationDir();
+        writeMigration(dir, '001_create_users.ts', 'CREATE TABLE users (id INTEGER PRIMARY KEY)', 'DROP TABLE IF EXISTS users');
+        writeMigration(dir, '002_create_posts.ts', 'CREATE TABLE posts (id INTEGER PRIMARY KEY)', 'DROP TABLE IF EXISTS posts');
+
+        await migrateUp(db, undefined, dir);
+        expect(getCurrentVersion(db)).toBe(2);
+
+        const result = await migrateDown(db, undefined, dir);
+        expect(result.reverted).toBe(1);
+        expect(result.to).toBe(1);
+        expect(getCurrentVersion(db)).toBe(1);
+
+        // posts table should be gone, users should remain
+        const tables = db.query("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[];
+        const tableNames = tables.map((t) => t.name);
+        expect(tableNames).not.toContain('posts');
+        expect(tableNames).toContain('users');
+    });
+
+    test('reverts down to target version', async () => {
+        const dir = makeMigrationDir();
+        writeMigration(dir, '001_create_users.ts', 'CREATE TABLE users (id INTEGER PRIMARY KEY)', 'DROP TABLE IF EXISTS users');
+        writeMigration(dir, '002_create_posts.ts', 'CREATE TABLE posts (id INTEGER PRIMARY KEY)', 'DROP TABLE IF EXISTS posts');
+        writeMigration(dir, '003_create_tags.ts', 'CREATE TABLE tags (id INTEGER PRIMARY KEY)', 'DROP TABLE IF EXISTS tags');
+
+        await migrateUp(db, undefined, dir);
+        expect(getCurrentVersion(db)).toBe(3);
+
+        const result = await migrateDown(db, 1, dir);
+        expect(result.reverted).toBe(2);
+        expect(result.to).toBe(1);
+        expect(getCurrentVersion(db)).toBe(1);
+    });
+
+    test('returns 0 reverted when at version 0', async () => {
+        const result = await migrateDown(db, undefined, '/nonexistent');
+        expect(result.reverted).toBe(0);
+        expect(result.to).toBe(0);
+    });
+});
+
+describe('migrationStatus', () => {
+    test('shows all migrations with applied status', async () => {
+        const dir = makeMigrationDir();
+        writeMigration(dir, '001_create_users.ts', 'CREATE TABLE users (id INTEGER PRIMARY KEY)', 'DROP TABLE users');
+        writeMigration(dir, '002_create_posts.ts', 'CREATE TABLE posts (id INTEGER PRIMARY KEY)', 'DROP TABLE posts');
+        writeMigration(dir, '003_create_tags.ts', 'CREATE TABLE tags (id INTEGER PRIMARY KEY)', 'DROP TABLE tags');
+
+        await migrateUp(db, 2, dir);
+
+        const statuses = migrationStatus(db, dir);
+        expect(statuses).toHaveLength(3);
+        expect(statuses[0]).toEqual({ version: 1, name: 'create users', applied: true });
+        expect(statuses[1]).toEqual({ version: 2, name: 'create posts', applied: true });
+        expect(statuses[2]).toEqual({ version: 3, name: 'create tags', applied: false });
+    });
+});
+
+describe('baseline migration (001_baseline.ts)', () => {
+    test('creates full schema from scratch', async () => {
+        const result = await migrateUp(db);
+        expect(result.applied).toBeGreaterThan(0);
+
+        // Spot-check key tables exist
+        const tables = db.query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as { name: string }[];
+        const tableNames = tables.map((t) => t.name);
+
+        expect(tableNames).toContain('projects');
+        expect(tableNames).toContain('agents');
+        expect(tableNames).toContain('sessions');
+        expect(tableNames).toContain('session_messages');
+        expect(tableNames).toContain('agent_messages');
+        expect(tableNames).toContain('councils');
+        expect(tableNames).toContain('work_tasks');
+        expect(tableNames).toContain('agent_memories');
+        expect(tableNames).toContain('credit_ledger');
+        expect(tableNames).toContain('workflows');
+        expect(tableNames).toContain('audit_log');
+        expect(tableNames).toContain('skill_bundles');
+        expect(tableNames).toContain('mcp_server_configs');
+    });
+
+    test('produces same schema as legacy runMigrations', async () => {
+        // Run file-based migration on db1
+        const db1 = new Database(':memory:');
+        db1.exec('PRAGMA foreign_keys = ON');
+        await migrateUp(db1);
+
+        // Run legacy migration on db2
+        const db2 = new Database(':memory:');
+        db2.exec('PRAGMA foreign_keys = ON');
+        const { runMigrations } = await import('../db/schema');
+        runMigrations(db2);
+
+        // Compare table lists
+        const getTables = (d: Database) =>
+            (d.query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as { name: string }[])
+                .map((t) => t.name)
+                .filter((n) => n !== 'schema_version');
+        const tables1 = getTables(db1);
+        const tables2 = getTables(db2);
+        expect(tables1).toEqual(tables2);
+
+        // Compare columns for each table
+        for (const table of tables1) {
+            const getCols = (d: Database) =>
+                (d.query(`PRAGMA table_info(${table})`).all() as { name: string; type: string }[])
+                    .map((c) => `${c.name}:${c.type}`)
+                    .sort();
+            expect(getCols(db1)).toEqual(getCols(db2));
+        }
+
+        db1.close();
+        db2.close();
+    });
+
+    test('baseline down drops all tables', async () => {
+        await migrateUp(db);
+
+        const tablesBefore = db.query("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[];
+        expect(tablesBefore.length).toBeGreaterThan(5);
+
+        await migrateDown(db, 0);
+
+        const tablesAfter = db.query("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[];
+        // sqlite_sequence is an internal SQLite table for AUTOINCREMENT tracking
+        const remaining = tablesAfter.map((t) => t.name).filter((n) => n !== 'schema_version' && n !== 'sqlite_sequence');
+        expect(remaining).toEqual([]);
+    });
+});

--- a/server/db/migrate-cli.ts
+++ b/server/db/migrate-cli.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env bun
+/**
+ * Database migration CLI.
+ *
+ * Usage:
+ *   bun run migrate up              Apply all pending migrations
+ *   bun run migrate up --to 55      Apply migrations up to version 55
+ *   bun run migrate down            Revert the most recent migration
+ *   bun run migrate down --to 52    Revert down to version 52
+ *   bun run migrate status          Show migration status
+ */
+
+import { Database } from 'bun:sqlite';
+import { existsSync } from 'node:fs';
+import { migrateUp, migrateDown, migrationStatus, getCurrentVersion } from './migrate';
+
+const DB_PATH = process.env.DB_PATH ?? 'corvid-agent.db';
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+function getFlag(name: string): string | undefined {
+    const idx = args.indexOf(`--${name}`);
+    if (idx === -1 || idx + 1 >= args.length) return undefined;
+    return args[idx + 1];
+}
+
+function printUsage(): void {
+    console.log(`
+Database Migration CLI
+
+Usage:
+  bun run migrate up              Apply all pending migrations
+  bun run migrate up --to <ver>   Apply migrations up to version
+  bun run migrate down            Revert the most recent migration
+  bun run migrate down --to <ver> Revert down to version
+  bun run migrate status          Show migration status
+
+Environment:
+  DB_PATH                         Database file path (default: corvid-agent.db)
+`);
+}
+
+async function main(): Promise<void> {
+    if (!command || command === '--help' || command === '-h') {
+        printUsage();
+        return;
+    }
+
+    const isNew = !existsSync(DB_PATH);
+    const db = new Database(DB_PATH, { create: true });
+    db.exec('PRAGMA journal_mode = WAL');
+    db.exec('PRAGMA busy_timeout = 5000');
+    db.exec('PRAGMA foreign_keys = ON');
+
+    try {
+        switch (command) {
+            case 'up': {
+                const to = getFlag('to');
+                const target = to ? parseInt(to, 10) : undefined;
+                const before = getCurrentVersion(db);
+                console.log(`Current schema version: ${before}`);
+
+                const { applied, to: newVersion } = await migrateUp(db, target);
+                if (applied === 0) {
+                    console.log('Already up to date.');
+                } else {
+                    console.log(`Applied ${applied} migration(s). Schema version: ${before} -> ${newVersion}`);
+                }
+                break;
+            }
+
+            case 'down': {
+                const to = getFlag('to');
+                const target = to ? parseInt(to, 10) : undefined;
+                const before = getCurrentVersion(db);
+                console.log(`Current schema version: ${before}`);
+
+                if (before === 0) {
+                    console.log('No migrations to revert.');
+                    break;
+                }
+
+                const { reverted, to: newVersion } = await migrateDown(db, target);
+                if (reverted === 0) {
+                    console.log('Nothing to revert.');
+                } else {
+                    console.log(`Reverted ${reverted} migration(s). Schema version: ${before} -> ${newVersion}`);
+                }
+                break;
+            }
+
+            case 'status': {
+                const current = getCurrentVersion(db);
+                const statuses = migrationStatus(db);
+
+                console.log(`Schema version: ${current}`);
+                if (isNew) {
+                    console.log('(new database — no migrations applied yet)\n');
+                }
+                console.log('');
+
+                if (statuses.length === 0) {
+                    console.log('No migration files found.');
+                    break;
+                }
+
+                const maxNameLen = Math.max(...statuses.map((s) => s.name.length));
+                console.log(
+                    `${'Ver'.padStart(4)}  ${'Name'.padEnd(maxNameLen)}  Status`,
+                );
+                console.log(`${'─'.repeat(4)}  ${'─'.repeat(maxNameLen)}  ${'─'.repeat(10)}`);
+
+                for (const s of statuses) {
+                    const marker = s.applied ? '  applied' : '  pending';
+                    console.log(
+                        `${String(s.version).padStart(4)}  ${s.name.padEnd(maxNameLen)}${marker}`,
+                    );
+                }
+
+                const pending = statuses.filter((s) => !s.applied);
+                if (pending.length > 0) {
+                    console.log(`\n${pending.length} pending migration(s).`);
+                } else {
+                    console.log('\nAll migrations applied.');
+                }
+                break;
+            }
+
+            default:
+                console.error(`Unknown command: ${command}`);
+                printUsage();
+                process.exit(1);
+        }
+    } finally {
+        db.close();
+    }
+}
+
+main().catch((err) => {
+    console.error('Migration error:', err instanceof Error ? err.message : String(err));
+    process.exit(1);
+});

--- a/server/db/migrate-create.ts
+++ b/server/db/migrate-create.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+/**
+ * Create a new migration file.
+ *
+ * Usage:
+ *   bun run migrate:create add_user_preferences
+ *
+ * Creates: server/db/migrations/NNN_add_user_preferences.ts
+ */
+
+import { resolve } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { discoverMigrations } from './migrate';
+
+const MIGRATION_DIR = resolve(import.meta.dir, 'migrations');
+
+const name = process.argv[2];
+if (!name) {
+    console.error('Usage: bun run migrate:create <name>');
+    console.error('  e.g. bun run migrate:create add_user_preferences');
+    process.exit(1);
+}
+
+// Validate name
+if (!/^[a-z][a-z0-9_]*$/.test(name)) {
+    console.error('Migration name must be lowercase alphanumeric with underscores (e.g. add_user_preferences)');
+    process.exit(1);
+}
+
+// Determine next version number
+const existing = discoverMigrations();
+const lastVersion = existing.length > 0 ? existing[existing.length - 1].version : 0;
+const nextVersion = lastVersion + 1;
+const paddedVersion = String(nextVersion).padStart(3, '0');
+const filename = `${paddedVersion}_${name}.ts`;
+const filepath = resolve(MIGRATION_DIR, filename);
+
+const template = `import { Database } from 'bun:sqlite';
+
+export function up(db: Database): void {
+    // TODO: Add your migration SQL here
+    // db.exec(\`CREATE TABLE IF NOT EXISTS ...\`);
+}
+
+export function down(db: Database): void {
+    // TODO: Revert the migration
+    // db.exec(\`DROP TABLE IF EXISTS ...\`);
+}
+`;
+
+writeFileSync(filepath, template);
+console.log(`Created: server/db/migrations/${filename}`);

--- a/server/db/migrate.ts
+++ b/server/db/migrate.ts
@@ -1,0 +1,186 @@
+/**
+ * File-based database migration system.
+ *
+ * Migrations live in server/db/migrations/ as TypeScript files.
+ * Each migration exports:
+ *   - up(db: Database): void   — apply the migration
+ *   - down(db: Database): void — revert the migration
+ *
+ * The schema_version table (single-row, version INTEGER) remains the
+ * source of truth for the current schema version, preserving compatibility
+ * with the legacy inline migration system that shipped versions 1–52.
+ */
+
+import { Database } from 'bun:sqlite';
+import { readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface MigrationModule {
+    up: (db: Database) => void;
+    down: (db: Database) => void;
+}
+
+export interface MigrationEntry {
+    version: number;
+    name: string;
+    filename: string;
+}
+
+export interface MigrationStatus {
+    version: number;
+    name: string;
+    applied: boolean;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const MIGRATION_DIR = resolve(import.meta.dir, 'migrations');
+
+/** Filename pattern: NNN_description.ts  (e.g. 001_baseline.ts) */
+const MIGRATION_RE = /^(\d{3})_(.+)\.ts$/;
+
+/** Discover all migration files sorted by version. */
+export function discoverMigrations(dir: string = MIGRATION_DIR): MigrationEntry[] {
+    let files: string[];
+    try {
+        files = readdirSync(dir).sort();
+    } catch {
+        return [];
+    }
+
+    const entries: MigrationEntry[] = [];
+    for (const f of files) {
+        const m = MIGRATION_RE.exec(f);
+        if (!m) continue;
+        entries.push({
+            version: parseInt(m[1], 10),
+            name: m[2].replace(/_/g, ' '),
+            filename: f,
+        });
+    }
+    return entries;
+}
+
+/** Load a migration module by filename. */
+async function loadMigration(filename: string, dir: string = MIGRATION_DIR): Promise<MigrationModule> {
+    const mod = await import(join(dir, filename));
+    if (typeof mod.up !== 'function' || typeof mod.down !== 'function') {
+        throw new Error(`Migration ${filename} must export up(db) and down(db) functions`);
+    }
+    return mod as MigrationModule;
+}
+
+/** Ensure the schema_version table exists and return the current version. */
+export function getCurrentVersion(db: Database): number {
+    db.exec('CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)');
+    const row = db.query('SELECT version FROM schema_version LIMIT 1').get() as
+        | { version: number }
+        | null;
+    return row?.version ?? 0;
+}
+
+function setVersion(db: Database, version: number, currentVersion: number): void {
+    if (currentVersion === 0) {
+        db.query('INSERT INTO schema_version (version) VALUES (?)').run(version);
+    } else {
+        db.query('UPDATE schema_version SET version = ?').run(version);
+    }
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Apply all pending migrations (or up to `target` version).
+ * Returns the number of migrations applied.
+ */
+export async function migrateUp(
+    db: Database,
+    target?: number,
+    dir?: string,
+): Promise<{ applied: number; to: number }> {
+    const current = getCurrentVersion(db);
+    const migrations = discoverMigrations(dir);
+    const pending = migrations.filter(
+        (m) => m.version > current && (target === undefined || m.version <= target),
+    );
+
+    if (pending.length === 0) {
+        return { applied: 0, to: current };
+    }
+
+    let lastVersion = current;
+    for (const entry of pending) {
+        const mod = await loadMigration(entry.filename, dir);
+        db.transaction(() => {
+            mod.up(db);
+            setVersion(db, entry.version, lastVersion);
+        })();
+        lastVersion = entry.version;
+    }
+
+    return { applied: pending.length, to: lastVersion };
+}
+
+/**
+ * Revert the most recent migration (or down to `target` version).
+ * Returns the number of migrations reverted.
+ */
+export async function migrateDown(
+    db: Database,
+    target?: number,
+    dir?: string,
+): Promise<{ reverted: number; to: number }> {
+    const current = getCurrentVersion(db);
+    if (current === 0) return { reverted: 0, to: 0 };
+
+    const migrations = discoverMigrations(dir);
+    const effectiveTarget = target ?? current - 1;
+
+    // Migrations to revert, in reverse order
+    const toRevert = migrations
+        .filter((m) => m.version <= current && m.version > effectiveTarget)
+        .reverse();
+
+    if (toRevert.length === 0) {
+        return { reverted: 0, to: current };
+    }
+
+    let lastVersion = current;
+    for (const entry of toRevert) {
+        const mod = await loadMigration(entry.filename, dir);
+        const newVersion = entry.version - 1;
+        db.transaction(() => {
+            mod.down(db);
+            setVersion(db, newVersion, lastVersion);
+        })();
+        lastVersion = newVersion;
+    }
+
+    return { reverted: toRevert.length, to: lastVersion };
+}
+
+/**
+ * Return the status of all known migrations.
+ */
+export function migrationStatus(db: Database, dir?: string): MigrationStatus[] {
+    const current = getCurrentVersion(db);
+    const migrations = discoverMigrations(dir);
+    return migrations.map((m) => ({
+        version: m.version,
+        name: m.name,
+        applied: m.version <= current,
+    }));
+}
+
+/**
+ * Run all pending migrations. Drop-in replacement for the legacy
+ * runMigrations() — called from connection.ts on startup.
+ */
+export async function runPendingMigrations(db: Database): Promise<void> {
+    const { applied } = await migrateUp(db);
+    if (applied > 0) {
+        console.log(`[migrate] Applied ${applied} migration(s)`);
+    }
+}

--- a/server/db/migrations/001_baseline.ts
+++ b/server/db/migrations/001_baseline.ts
@@ -1,0 +1,976 @@
+/**
+ * Baseline migration — captures the full schema from legacy versions 1–52.
+ *
+ * For existing databases already at version 52, this migration is a no-op
+ * (the runner skips it because getCurrentVersion() returns 52 which maps
+ * to file-based version 52, and this file is version 1 which is <= 52).
+ *
+ * However, the file-based migration system uses its OWN version numbering
+ * starting at 53+. This baseline exists at version 001 (file naming) but
+ * represents schema version 52. The migration runner bridges the gap:
+ * - Legacy DBs at version 52 skip this file (already applied).
+ * - Fresh DBs run this to get to version 52's schema in one shot.
+ *
+ * Version 52 is the "bridge version" — the last legacy version and the
+ * starting point for file-based migrations.
+ */
+
+import { Database } from 'bun:sqlite';
+
+const SAFE_SQL_IDENTIFIER = /^[a-z_][a-z0-9_]*$/i;
+
+function hasColumn(db: Database, table: string, column: string): boolean {
+    if (!SAFE_SQL_IDENTIFIER.test(table)) {
+        throw new Error(`hasColumn: invalid table name '${table}'`);
+    }
+    const cols = db.query(`PRAGMA table_info(${table})`).all() as { name: string }[];
+    return cols.some((c) => c.name === column);
+}
+
+function safeAlter(db: Database, sql: string): void {
+    const match = sql.match(/ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(\w+)/i);
+    if (match && hasColumn(db, match[1], match[2])) return;
+    db.exec(sql);
+}
+
+/**
+ * All SQL statements from legacy migrations 1–52, applied in order.
+ * This creates the full schema for a brand-new database.
+ */
+export function up(db: Database): void {
+    // ── v1: Core tables ─────────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS projects (
+        id          TEXT PRIMARY KEY,
+        name        TEXT NOT NULL,
+        description TEXT DEFAULT '',
+        working_dir TEXT NOT NULL,
+        claude_md   TEXT DEFAULT '',
+        env_vars    TEXT DEFAULT '{}',
+        created_at  TEXT DEFAULT (datetime('now')),
+        updated_at  TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE TABLE IF NOT EXISTS agents (
+        id                TEXT PRIMARY KEY,
+        name              TEXT NOT NULL,
+        description       TEXT DEFAULT '',
+        system_prompt     TEXT DEFAULT '',
+        append_prompt     TEXT DEFAULT '',
+        model             TEXT DEFAULT '',
+        allowed_tools     TEXT DEFAULT '',
+        disallowed_tools  TEXT DEFAULT '',
+        permission_mode   TEXT DEFAULT 'default',
+        max_budget_usd    REAL DEFAULT NULL,
+        algochat_enabled  INTEGER DEFAULT 0,
+        algochat_auto     INTEGER DEFAULT 0,
+        custom_flags      TEXT DEFAULT '{}',
+        created_at        TEXT DEFAULT (datetime('now')),
+        updated_at        TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE TABLE IF NOT EXISTS sessions (
+        id              TEXT PRIMARY KEY,
+        project_id      TEXT REFERENCES projects(id),
+        agent_id        TEXT REFERENCES agents(id),
+        name            TEXT DEFAULT '',
+        status          TEXT DEFAULT 'idle',
+        source          TEXT DEFAULT 'web',
+        initial_prompt  TEXT DEFAULT '',
+        pid             INTEGER DEFAULT NULL,
+        total_cost_usd  REAL DEFAULT 0,
+        total_algo_spent REAL DEFAULT 0,
+        total_turns     INTEGER DEFAULT 0,
+        council_launch_id TEXT DEFAULT NULL,
+        council_role    TEXT DEFAULT NULL,
+        work_dir        TEXT DEFAULT NULL,
+        credits_consumed REAL DEFAULT 0,
+        created_at      TEXT DEFAULT (datetime('now')),
+        updated_at      TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE TABLE IF NOT EXISTS session_messages (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id  TEXT NOT NULL REFERENCES sessions(id),
+        role        TEXT NOT NULL,
+        content     TEXT NOT NULL,
+        cost_usd    REAL DEFAULT 0,
+        timestamp   TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE TABLE IF NOT EXISTS algochat_conversations (
+        id                TEXT PRIMARY KEY,
+        participant_addr  TEXT NOT NULL,
+        agent_id          TEXT REFERENCES agents(id),
+        session_id        TEXT REFERENCES sessions(id),
+        last_round        INTEGER DEFAULT 0,
+        created_at        TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_agent ON sessions(agent_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_session_messages_session ON session_messages(session_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_algochat_participant ON algochat_conversations(participant_addr)`);
+
+    // ── v2: PSK state (created as v23 network-aware version directly) ───
+    db.exec(`CREATE TABLE IF NOT EXISTS algochat_psk_state (
+        address           TEXT NOT NULL,
+        network           TEXT NOT NULL DEFAULT 'testnet',
+        initial_psk       BLOB NOT NULL,
+        label             TEXT DEFAULT '',
+        send_counter      INTEGER DEFAULT 0,
+        peer_last_counter INTEGER DEFAULT 0,
+        seen_counters     TEXT DEFAULT '[]',
+        last_round        INTEGER DEFAULT 0,
+        created_at        TEXT DEFAULT (datetime('now')),
+        updated_at        TEXT DEFAULT (datetime('now')),
+        PRIMARY KEY (address, network)
+    )`);
+
+    // ── v3: Agent wallet columns ────────────────────────────────────────
+    safeAlter(db, `ALTER TABLE agents ADD COLUMN wallet_address TEXT DEFAULT NULL`);
+    safeAlter(db, `ALTER TABLE agents ADD COLUMN wallet_mnemonic_encrypted TEXT DEFAULT NULL`);
+    safeAlter(db, `ALTER TABLE agents ADD COLUMN wallet_funded_algo REAL DEFAULT 0`);
+
+    // ── v4: Agent messages ──────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS agent_messages (
+        id              TEXT PRIMARY KEY,
+        from_agent_id   TEXT NOT NULL,
+        to_agent_id     TEXT NOT NULL,
+        content         TEXT NOT NULL,
+        payment_micro   INTEGER DEFAULT 0,
+        txid            TEXT DEFAULT NULL,
+        status          TEXT DEFAULT 'pending',
+        response        TEXT DEFAULT NULL,
+        response_txid   TEXT DEFAULT NULL,
+        session_id      TEXT DEFAULT NULL,
+        created_at      TEXT DEFAULT (datetime('now')),
+        completed_at    TEXT DEFAULT NULL
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_messages_to ON agent_messages(to_agent_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_messages_status ON agent_messages(status)`);
+
+    // ── v5: Councils ────────────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS councils (
+        id                TEXT PRIMARY KEY,
+        name              TEXT NOT NULL,
+        description       TEXT DEFAULT '',
+        chairman_agent_id TEXT DEFAULT NULL REFERENCES agents(id),
+        created_at        TEXT DEFAULT (datetime('now')),
+        updated_at        TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE TABLE IF NOT EXISTS council_members (
+        council_id  TEXT NOT NULL REFERENCES councils(id) ON DELETE CASCADE,
+        agent_id    TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+        sort_order  INTEGER DEFAULT 0,
+        PRIMARY KEY (council_id, agent_id)
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_council_members_council ON council_members(council_id)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS council_launches (
+        id          TEXT PRIMARY KEY,
+        council_id  TEXT NOT NULL REFERENCES councils(id),
+        project_id  TEXT NOT NULL REFERENCES projects(id),
+        prompt      TEXT NOT NULL,
+        stage       TEXT DEFAULT 'responding',
+        synthesis   TEXT DEFAULT NULL,
+        created_at  TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_council_launches_council ON council_launches(council_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_council_launch ON sessions(council_launch_id)`);
+
+    // ── v6: Council launch logs ─────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS council_launch_logs (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        launch_id   TEXT NOT NULL REFERENCES council_launches(id) ON DELETE CASCADE,
+        level       TEXT DEFAULT 'info',
+        message     TEXT NOT NULL,
+        detail      TEXT DEFAULT NULL,
+        created_at  TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_council_launch_logs_launch ON council_launch_logs(launch_id)`);
+
+    // ── v7: Agent default project ───────────────────────────────────────
+    safeAlter(db, `ALTER TABLE agents ADD COLUMN default_project_id TEXT DEFAULT NULL`);
+
+    // ── v8: Work tasks ──────────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS work_tasks (
+        id              TEXT PRIMARY KEY,
+        agent_id        TEXT NOT NULL REFERENCES agents(id),
+        project_id      TEXT NOT NULL REFERENCES projects(id),
+        session_id      TEXT DEFAULT NULL,
+        source          TEXT DEFAULT 'web',
+        source_id       TEXT DEFAULT NULL,
+        requester_info  TEXT DEFAULT '{}',
+        description     TEXT NOT NULL,
+        branch_name     TEXT DEFAULT NULL,
+        status          TEXT DEFAULT 'pending',
+        pr_url          TEXT DEFAULT NULL,
+        summary         TEXT DEFAULT NULL,
+        error           TEXT DEFAULT NULL,
+        created_at      TEXT DEFAULT (datetime('now')),
+        completed_at    TEXT DEFAULT NULL
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_work_tasks_agent ON work_tasks(agent_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_work_tasks_status ON work_tasks(status)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_work_tasks_session ON work_tasks(session_id)`);
+
+    // ── v9: Council discussions ──────────────────────────────────────────
+    safeAlter(db, `ALTER TABLE councils ADD COLUMN discussion_rounds INTEGER DEFAULT 2`);
+    safeAlter(db, `ALTER TABLE council_launches ADD COLUMN current_discussion_round INTEGER DEFAULT 0`);
+    safeAlter(db, `ALTER TABLE council_launches ADD COLUMN total_discussion_rounds INTEGER DEFAULT 0`);
+    db.exec(`CREATE TABLE IF NOT EXISTS council_discussion_messages (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        launch_id   TEXT NOT NULL REFERENCES council_launches(id) ON DELETE CASCADE,
+        agent_id    TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+        agent_name  TEXT NOT NULL,
+        round       INTEGER NOT NULL,
+        content     TEXT NOT NULL,
+        txid        TEXT DEFAULT NULL,
+        session_id  TEXT DEFAULT NULL,
+        created_at  TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_cdm_launch ON council_discussion_messages(launch_id)`);
+
+    // ── v10: Agent memories ─────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS agent_memories (
+        id          TEXT PRIMARY KEY,
+        agent_id    TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+        key         TEXT NOT NULL,
+        content     TEXT NOT NULL,
+        txid        TEXT DEFAULT NULL,
+        created_at  TEXT DEFAULT (datetime('now')),
+        updated_at  TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_memories_agent_key ON agent_memories(agent_id, key)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_memories_agent ON agent_memories(agent_id)`);
+
+    // ── v12: Agent message threads ──────────────────────────────────────
+    safeAlter(db, `ALTER TABLE agent_messages ADD COLUMN thread_id TEXT DEFAULT NULL`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_messages_thread ON agent_messages(thread_id)`);
+
+    // ── v13: Daily spending ─────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS daily_spending (
+        date         TEXT PRIMARY KEY,
+        algo_micro   INTEGER DEFAULT 0,
+        api_cost_usd REAL DEFAULT 0.0
+    )`);
+
+    // ── v14: Escalation queue ───────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS escalation_queue (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id  TEXT NOT NULL,
+        tool_name   TEXT NOT NULL,
+        tool_input  TEXT NOT NULL DEFAULT '{}',
+        status      TEXT DEFAULT 'pending',
+        created_at  TEXT DEFAULT (datetime('now')),
+        resolved_at TEXT DEFAULT NULL
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_escalation_queue_status ON escalation_queue(status)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_escalation_queue_session ON escalation_queue(session_id)`);
+
+    // ── v16: AlgoChat messages ──────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS algochat_messages (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        participant TEXT NOT NULL,
+        content     TEXT NOT NULL,
+        direction   TEXT NOT NULL DEFAULT 'inbound',
+        fee         INTEGER DEFAULT 0,
+        created_at  TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_algochat_messages_created ON algochat_messages(created_at)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_algochat_messages_participant ON algochat_messages(participant)`);
+
+    // ── v17: Work task iteration tracking ───────────────────────────────
+    safeAlter(db, `ALTER TABLE work_tasks ADD COLUMN original_branch TEXT DEFAULT NULL`);
+    safeAlter(db, `ALTER TABLE work_tasks ADD COLUMN iteration_count INTEGER DEFAULT 0`);
+
+    // ── v18: Worktree support ───────────────────────────────────────────
+    safeAlter(db, `ALTER TABLE work_tasks ADD COLUMN worktree_dir TEXT DEFAULT NULL`);
+
+    // ── v19: AlgoChat allowlist ─────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS algochat_allowlist (
+        address    TEXT PRIMARY KEY,
+        label      TEXT DEFAULT '',
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`);
+
+    // ── v20: Credit system ──────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS credit_ledger (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        wallet_address  TEXT NOT NULL,
+        credits         INTEGER NOT NULL DEFAULT 0,
+        reserved        INTEGER NOT NULL DEFAULT 0,
+        total_purchased INTEGER NOT NULL DEFAULT 0,
+        total_consumed  INTEGER NOT NULL DEFAULT 0,
+        created_at      TEXT DEFAULT (datetime('now')),
+        updated_at      TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_credit_ledger_wallet ON credit_ledger(wallet_address)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS credit_transactions (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        wallet_address  TEXT NOT NULL,
+        type            TEXT NOT NULL,
+        amount          INTEGER NOT NULL,
+        balance_after   INTEGER NOT NULL,
+        reference       TEXT DEFAULT NULL,
+        txid            TEXT DEFAULT NULL,
+        session_id      TEXT DEFAULT NULL,
+        created_at      TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_credit_txn_wallet ON credit_transactions(wallet_address)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_credit_txn_type ON credit_transactions(type)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_credit_txn_session ON credit_transactions(session_id)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS credit_config (
+        key         TEXT PRIMARY KEY,
+        value       TEXT NOT NULL,
+        updated_at  TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`INSERT OR IGNORE INTO credit_config (key, value) VALUES ('credits_per_algo', '1000')`);
+    db.exec(`INSERT OR IGNORE INTO credit_config (key, value) VALUES ('low_credit_threshold', '50')`);
+    db.exec(`INSERT OR IGNORE INTO credit_config (key, value) VALUES ('reserve_per_group_message', '10')`);
+    db.exec(`INSERT OR IGNORE INTO credit_config (key, value) VALUES ('credits_per_turn', '1')`);
+    db.exec(`INSERT OR IGNORE INTO credit_config (key, value) VALUES ('credits_per_agent_message', '5')`);
+    db.exec(`INSERT OR IGNORE INTO credit_config (key, value) VALUES ('free_credits_on_first_message', '100')`);
+
+    // ── v21: MCP tool permissions ───────────────────────────────────────
+    safeAlter(db, `ALTER TABLE agents ADD COLUMN mcp_tool_permissions TEXT DEFAULT NULL`);
+
+    // ── v22: Council launch chat session ────────────────────────────────
+    safeAlter(db, `ALTER TABLE council_launches ADD COLUMN chat_session_id TEXT DEFAULT NULL`);
+
+    // ── v24: Agent schedules ────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS agent_schedules (
+        id                  TEXT PRIMARY KEY,
+        agent_id            TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+        name                TEXT NOT NULL,
+        description         TEXT DEFAULT '',
+        cron_expression     TEXT DEFAULT NULL,
+        interval_ms         INTEGER DEFAULT NULL,
+        actions             TEXT NOT NULL DEFAULT '[]',
+        approval_policy     TEXT DEFAULT 'owner_approve',
+        status              TEXT DEFAULT 'active',
+        max_executions      INTEGER DEFAULT NULL,
+        execution_count     INTEGER DEFAULT 0,
+        max_budget_per_run  REAL DEFAULT NULL,
+        last_run_at         TEXT DEFAULT NULL,
+        next_run_at         TEXT DEFAULT NULL,
+        created_at          TEXT DEFAULT (datetime('now')),
+        updated_at          TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_schedules_agent ON agent_schedules(agent_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_schedules_status ON agent_schedules(status)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_schedules_next_run ON agent_schedules(next_run_at)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS schedule_executions (
+        id              TEXT PRIMARY KEY,
+        schedule_id     TEXT NOT NULL REFERENCES agent_schedules(id) ON DELETE CASCADE,
+        agent_id        TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+        status          TEXT DEFAULT 'running',
+        action_type     TEXT NOT NULL,
+        action_input    TEXT DEFAULT '{}',
+        result          TEXT DEFAULT NULL,
+        session_id      TEXT DEFAULT NULL,
+        work_task_id    TEXT DEFAULT NULL,
+        cost_usd        REAL DEFAULT 0,
+        started_at      TEXT DEFAULT (datetime('now')),
+        completed_at    TEXT DEFAULT NULL
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_schedule_executions_schedule ON schedule_executions(schedule_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_schedule_executions_status ON schedule_executions(status)`);
+
+    // ── v25: Schedule execution config snapshot ─────────────────────────
+    safeAlter(db, `ALTER TABLE schedule_executions ADD COLUMN config_snapshot TEXT DEFAULT NULL`);
+
+    // ── v26: LLM provider metadata ──────────────────────────────────────
+    safeAlter(db, `ALTER TABLE agents ADD COLUMN provider TEXT DEFAULT ''`);
+    safeAlter(db, `ALTER TABLE agent_messages ADD COLUMN provider TEXT DEFAULT ''`);
+    safeAlter(db, `ALTER TABLE agent_messages ADD COLUMN model TEXT DEFAULT ''`);
+    safeAlter(db, `ALTER TABLE algochat_messages ADD COLUMN provider TEXT DEFAULT ''`);
+    safeAlter(db, `ALTER TABLE algochat_messages ADD COLUMN model TEXT DEFAULT ''`);
+
+    // ── v27: Schedule notification address ──────────────────────────────
+    safeAlter(db, `ALTER TABLE agent_schedules ADD COLUMN notify_address TEXT DEFAULT NULL`);
+
+    // ── v28: Memory sync status ─────────────────────────────────────────
+    safeAlter(db, `ALTER TABLE agent_memories ADD COLUMN status TEXT DEFAULT 'confirmed'`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_memories_status ON agent_memories(status)`);
+
+    // ── v29: Agent memories FTS ─────────────────────────────────────────
+    db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS agent_memories_fts USING fts5(
+        key, content, content=agent_memories, content_rowid=rowid
+    )`);
+    // Populate FTS from existing rows (safe for empty table on fresh DB)
+    db.exec(`INSERT INTO agent_memories_fts(rowid, key, content)
+        SELECT rowid, key, content FROM agent_memories`);
+    db.exec(`CREATE TRIGGER IF NOT EXISTS agent_memories_ai AFTER INSERT ON agent_memories BEGIN
+        INSERT INTO agent_memories_fts(rowid, key, content) VALUES (new.rowid, new.key, new.content);
+    END`);
+    db.exec(`CREATE TRIGGER IF NOT EXISTS agent_memories_ad AFTER DELETE ON agent_memories BEGIN
+        INSERT INTO agent_memories_fts(agent_memories_fts, rowid, key, content) VALUES ('delete', old.rowid, old.key, old.content);
+    END`);
+    db.exec(`CREATE TRIGGER IF NOT EXISTS agent_memories_au AFTER UPDATE ON agent_memories BEGIN
+        INSERT INTO agent_memories_fts(agent_memories_fts, rowid, key, content) VALUES ('delete', old.rowid, old.key, old.content);
+        INSERT INTO agent_memories_fts(rowid, key, content) VALUES (new.rowid, new.key, new.content);
+    END`);
+
+    // ── v30: PSK contacts ───────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS psk_contacts (
+        id              TEXT PRIMARY KEY,
+        nickname        TEXT NOT NULL,
+        network         TEXT NOT NULL,
+        initial_psk     BLOB NOT NULL,
+        mobile_address  TEXT DEFAULT NULL,
+        active          INTEGER DEFAULT 1,
+        created_at      TEXT DEFAULT (datetime('now')),
+        updated_at      TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_psk_contacts_network ON psk_contacts(network)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_psk_contacts_active ON psk_contacts(active, network)`);
+
+    // ── v31: Webhook registrations & deliveries ─────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS webhook_registrations (
+        id                TEXT PRIMARY KEY,
+        agent_id          TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+        repo              TEXT NOT NULL,
+        events            TEXT NOT NULL DEFAULT '[]',
+        mention_username  TEXT NOT NULL,
+        project_id        TEXT NOT NULL REFERENCES projects(id),
+        status            TEXT DEFAULT 'active',
+        trigger_count     INTEGER DEFAULT 0,
+        created_at        TEXT DEFAULT (datetime('now')),
+        updated_at        TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_webhook_registrations_repo ON webhook_registrations(repo)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_webhook_registrations_status ON webhook_registrations(status)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_webhook_registrations_agent ON webhook_registrations(agent_id)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS webhook_deliveries (
+        id                TEXT PRIMARY KEY,
+        registration_id   TEXT NOT NULL REFERENCES webhook_registrations(id) ON DELETE CASCADE,
+        event             TEXT NOT NULL,
+        action            TEXT NOT NULL DEFAULT '',
+        repo              TEXT NOT NULL,
+        sender            TEXT NOT NULL,
+        body              TEXT DEFAULT '',
+        html_url          TEXT DEFAULT '',
+        session_id        TEXT DEFAULT NULL,
+        work_task_id      TEXT DEFAULT NULL,
+        status            TEXT DEFAULT 'processing',
+        result            TEXT DEFAULT NULL,
+        created_at        TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_registration ON webhook_deliveries(registration_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_status ON webhook_deliveries(status)`);
+
+    // ── v32: Mention polling ────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS mention_polling_configs (
+        id                TEXT PRIMARY KEY,
+        agent_id          TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+        repo              TEXT NOT NULL,
+        mention_username  TEXT NOT NULL,
+        project_id        TEXT NOT NULL REFERENCES projects(id),
+        interval_seconds  INTEGER NOT NULL DEFAULT 60,
+        status            TEXT DEFAULT 'active',
+        trigger_count     INTEGER DEFAULT 0,
+        last_poll_at      TEXT DEFAULT NULL,
+        last_seen_id      TEXT DEFAULT NULL,
+        event_filter      TEXT NOT NULL DEFAULT '[]',
+        allowed_users     TEXT NOT NULL DEFAULT '[]',
+        created_at        TEXT DEFAULT (datetime('now')),
+        updated_at        TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_mention_polling_configs_agent ON mention_polling_configs(agent_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_mention_polling_configs_status ON mention_polling_configs(status)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_mention_polling_configs_repo ON mention_polling_configs(repo)`);
+
+    // ── v33: Processed mention IDs ──────────────────────────────────────
+    safeAlter(db, `ALTER TABLE mention_polling_configs ADD COLUMN processed_ids TEXT NOT NULL DEFAULT '[]'`);
+
+    // ── v34: Workflows ──────────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS workflows (
+        id                  TEXT PRIMARY KEY,
+        agent_id            TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+        name                TEXT NOT NULL,
+        description         TEXT DEFAULT '',
+        nodes               TEXT NOT NULL DEFAULT '[]',
+        edges               TEXT NOT NULL DEFAULT '[]',
+        status              TEXT DEFAULT 'draft',
+        default_project_id  TEXT DEFAULT NULL,
+        max_concurrency     INTEGER DEFAULT 2,
+        created_at          TEXT DEFAULT (datetime('now')),
+        updated_at          TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_workflows_agent ON workflows(agent_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_workflows_status ON workflows(status)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS workflow_runs (
+        id                  TEXT PRIMARY KEY,
+        workflow_id         TEXT NOT NULL REFERENCES workflows(id) ON DELETE CASCADE,
+        agent_id            TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+        status              TEXT DEFAULT 'running',
+        input               TEXT DEFAULT '{}',
+        output              TEXT DEFAULT NULL,
+        workflow_snapshot    TEXT NOT NULL DEFAULT '{}',
+        current_node_ids    TEXT DEFAULT '[]',
+        error               TEXT DEFAULT NULL,
+        started_at          TEXT DEFAULT (datetime('now')),
+        completed_at        TEXT DEFAULT NULL
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_workflow_runs_workflow ON workflow_runs(workflow_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_workflow_runs_status ON workflow_runs(status)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS workflow_node_runs (
+        id              TEXT PRIMARY KEY,
+        run_id          TEXT NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+        node_id         TEXT NOT NULL,
+        node_type       TEXT NOT NULL,
+        status          TEXT DEFAULT 'pending',
+        input           TEXT DEFAULT '{}',
+        output          TEXT DEFAULT NULL,
+        session_id      TEXT DEFAULT NULL,
+        work_task_id    TEXT DEFAULT NULL,
+        error           TEXT DEFAULT NULL,
+        started_at      TEXT DEFAULT NULL,
+        completed_at    TEXT DEFAULT NULL
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_workflow_node_runs_run ON workflow_node_runs(run_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_workflow_node_runs_status ON workflow_node_runs(status)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_workflow_node_runs_session ON workflow_node_runs(session_id)`);
+
+    // ── v35: Audit log ──────────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS audit_log (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp   TEXT NOT NULL DEFAULT (datetime('now')),
+        action      TEXT NOT NULL,
+        actor       TEXT NOT NULL,
+        resource_type TEXT NOT NULL,
+        resource_id TEXT,
+        detail      TEXT,
+        trace_id    TEXT,
+        ip_address  TEXT
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_audit_log_action ON audit_log(action)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp ON audit_log(timestamp)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_audit_log_trace_id ON audit_log(trace_id)`);
+
+    // ── v36: Owner questions ────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS owner_questions (
+        id           TEXT PRIMARY KEY,
+        session_id   TEXT NOT NULL,
+        agent_id     TEXT NOT NULL,
+        question     TEXT NOT NULL,
+        options      TEXT DEFAULT NULL,
+        context      TEXT DEFAULT NULL,
+        status       TEXT DEFAULT 'pending',
+        answer       TEXT DEFAULT NULL,
+        timeout_ms   INTEGER DEFAULT 120000,
+        created_at   TEXT DEFAULT (datetime('now')),
+        resolved_at  TEXT DEFAULT NULL
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_owner_questions_session ON owner_questions(session_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_owner_questions_agent ON owner_questions(agent_id)`);
+
+    // ── v37: Notifications ──────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS notification_channels (
+        id           TEXT PRIMARY KEY,
+        agent_id     TEXT NOT NULL,
+        channel_type TEXT NOT NULL,
+        config       TEXT NOT NULL DEFAULT '{}',
+        enabled      INTEGER NOT NULL DEFAULT 1,
+        created_at   TEXT DEFAULT (datetime('now')),
+        updated_at   TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_channels_agent_type
+        ON notification_channels(agent_id, channel_type)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS owner_notifications (
+        id         TEXT PRIMARY KEY,
+        agent_id   TEXT NOT NULL,
+        session_id TEXT DEFAULT NULL,
+        title      TEXT DEFAULT NULL,
+        message    TEXT NOT NULL,
+        level      TEXT NOT NULL DEFAULT 'info',
+        created_at TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_owner_notifications_agent ON owner_notifications(agent_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_owner_notifications_created ON owner_notifications(created_at)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS notification_deliveries (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        notification_id TEXT NOT NULL REFERENCES owner_notifications(id) ON DELETE CASCADE,
+        channel_type    TEXT NOT NULL,
+        status          TEXT NOT NULL DEFAULT 'pending',
+        attempts        INTEGER NOT NULL DEFAULT 0,
+        last_attempt_at TEXT DEFAULT NULL,
+        error           TEXT DEFAULT NULL,
+        external_ref    TEXT DEFAULT NULL,
+        created_at      TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_notification_deliveries_notification ON notification_deliveries(notification_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_notification_deliveries_status ON notification_deliveries(status)`);
+
+    // ── v38: Question dispatches ────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS owner_question_dispatches (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        question_id     TEXT NOT NULL,
+        channel_type    TEXT NOT NULL,
+        external_ref    TEXT,
+        status          TEXT NOT NULL DEFAULT 'sent',
+        created_at      TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_question_dispatches_question ON owner_question_dispatches(question_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_question_dispatches_status ON owner_question_dispatches(status)`);
+
+    // ── v39: Plugins ────────────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS plugins (
+        name TEXT PRIMARY KEY,
+        package_name TEXT NOT NULL,
+        version TEXT NOT NULL,
+        description TEXT DEFAULT '',
+        author TEXT DEFAULT '',
+        capabilities TEXT NOT NULL DEFAULT '[]',
+        status TEXT DEFAULT 'active',
+        loaded_at TEXT DEFAULT (datetime('now')),
+        config TEXT DEFAULT '{}'
+    )`);
+    db.exec(`CREATE TABLE IF NOT EXISTS plugin_capabilities (
+        plugin_name TEXT NOT NULL REFERENCES plugins(name) ON DELETE CASCADE,
+        capability TEXT NOT NULL,
+        granted INTEGER DEFAULT 0,
+        granted_at TEXT DEFAULT NULL,
+        PRIMARY KEY (plugin_name, capability)
+    )`);
+
+    // ── v40: Sandbox configs ────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS sandbox_configs (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL UNIQUE,
+        image TEXT DEFAULT 'corvid-agent-sandbox:latest',
+        cpu_limit REAL DEFAULT 1.0,
+        memory_limit_mb INTEGER DEFAULT 512,
+        network_policy TEXT DEFAULT 'restricted',
+        timeout_seconds INTEGER DEFAULT 600,
+        read_only_mounts TEXT DEFAULT '[]',
+        work_dir TEXT DEFAULT NULL,
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+    )`);
+
+    // ── v41: Marketplace ────────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS marketplace_listings (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        description TEXT NOT NULL,
+        long_description TEXT DEFAULT '',
+        category TEXT NOT NULL,
+        tags TEXT DEFAULT '[]',
+        pricing_model TEXT DEFAULT 'free',
+        price_credits INTEGER DEFAULT 0,
+        instance_url TEXT DEFAULT NULL,
+        status TEXT DEFAULT 'draft',
+        use_count INTEGER DEFAULT 0,
+        avg_rating REAL DEFAULT 0,
+        review_count INTEGER DEFAULT 0,
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_marketplace_listings_agent ON marketplace_listings(agent_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_marketplace_listings_status ON marketplace_listings(status)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_marketplace_listings_category ON marketplace_listings(category)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS marketplace_reviews (
+        id TEXT PRIMARY KEY,
+        listing_id TEXT NOT NULL,
+        reviewer_agent_id TEXT DEFAULT NULL,
+        reviewer_address TEXT DEFAULT NULL,
+        rating INTEGER NOT NULL,
+        comment TEXT DEFAULT '',
+        created_at TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_marketplace_reviews_listing ON marketplace_reviews(listing_id)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS federated_instances (
+        url TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        last_sync_at TEXT DEFAULT NULL,
+        listing_count INTEGER DEFAULT 0,
+        status TEXT DEFAULT 'active'
+    )`);
+
+    // ── v42: Reputation ─────────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS agent_reputation (
+        agent_id TEXT PRIMARY KEY,
+        overall_score INTEGER DEFAULT 0,
+        trust_level TEXT DEFAULT 'untrusted',
+        task_completion INTEGER DEFAULT 0,
+        peer_rating INTEGER DEFAULT 0,
+        credit_pattern INTEGER DEFAULT 0,
+        security_compliance INTEGER DEFAULT 0,
+        activity_level INTEGER DEFAULT 0,
+        attestation_hash TEXT DEFAULT NULL,
+        computed_at TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE TABLE IF NOT EXISTS reputation_events (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        score_impact REAL DEFAULT 0,
+        metadata TEXT DEFAULT '{}',
+        created_at TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_reputation_events_agent ON reputation_events(agent_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_reputation_events_type ON reputation_events(event_type)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS reputation_attestations (
+        agent_id TEXT NOT NULL,
+        hash TEXT NOT NULL,
+        payload TEXT NOT NULL,
+        txid TEXT DEFAULT NULL,
+        published_at TEXT DEFAULT NULL,
+        created_at TEXT DEFAULT (datetime('now')),
+        PRIMARY KEY (agent_id, hash)
+    )`);
+
+    // ── v43: Multi-tenancy ──────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS tenants (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        slug TEXT UNIQUE NOT NULL,
+        owner_email TEXT NOT NULL,
+        stripe_customer_id TEXT DEFAULT NULL,
+        plan TEXT DEFAULT 'free',
+        max_agents INTEGER DEFAULT 3,
+        max_concurrent_sessions INTEGER DEFAULT 2,
+        sandbox_enabled INTEGER DEFAULT 0,
+        status TEXT DEFAULT 'active',
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE TABLE IF NOT EXISTS api_keys (
+        key_hash TEXT PRIMARY KEY,
+        tenant_id TEXT NOT NULL,
+        label TEXT DEFAULT 'default',
+        created_at TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_api_keys_tenant ON api_keys(tenant_id)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS subscriptions (
+        id TEXT PRIMARY KEY,
+        tenant_id TEXT NOT NULL,
+        stripe_subscription_id TEXT NOT NULL,
+        plan TEXT NOT NULL,
+        status TEXT DEFAULT 'active',
+        current_period_start TEXT NOT NULL,
+        current_period_end TEXT NOT NULL,
+        cancel_at_period_end INTEGER DEFAULT 0,
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_subscriptions_tenant ON subscriptions(tenant_id)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS usage_records (
+        id TEXT PRIMARY KEY,
+        tenant_id TEXT NOT NULL,
+        credits_used INTEGER DEFAULT 0,
+        api_calls INTEGER DEFAULT 0,
+        session_count INTEGER DEFAULT 0,
+        storage_mb REAL DEFAULT 0,
+        period_start TEXT NOT NULL,
+        period_end TEXT NOT NULL,
+        reported INTEGER DEFAULT 0,
+        created_at TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_usage_records_tenant ON usage_records(tenant_id)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS invoices (
+        id TEXT PRIMARY KEY,
+        tenant_id TEXT NOT NULL,
+        stripe_invoice_id TEXT NOT NULL,
+        amount_cents INTEGER NOT NULL,
+        currency TEXT DEFAULT 'usd',
+        status TEXT DEFAULT 'open',
+        period_start TEXT NOT NULL,
+        period_end TEXT NOT NULL,
+        paid_at TEXT DEFAULT NULL,
+        created_at TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_invoices_tenant ON invoices(tenant_id)`);
+
+    // ── v44: Health snapshots + memory archival ─────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS health_snapshots (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        project_id TEXT NOT NULL,
+        tsc_error_count INTEGER DEFAULT 0,
+        tsc_passed INTEGER DEFAULT 0,
+        tests_passed INTEGER DEFAULT 0,
+        test_failure_count INTEGER DEFAULT 0,
+        todo_count INTEGER DEFAULT 0,
+        fixme_count INTEGER DEFAULT 0,
+        hack_count INTEGER DEFAULT 0,
+        large_file_count INTEGER DEFAULT 0,
+        outdated_dep_count INTEGER DEFAULT 0,
+        collected_at TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_health_snap_agent ON health_snapshots(agent_id, project_id)`);
+    safeAlter(db, `ALTER TABLE agent_memories ADD COLUMN archived INTEGER NOT NULL DEFAULT 0`);
+
+    // ── v45: Agent personas ─────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS agent_personas (
+        agent_id TEXT PRIMARY KEY REFERENCES agents(id) ON DELETE CASCADE,
+        archetype TEXT DEFAULT 'custom',
+        traits TEXT NOT NULL DEFAULT '[]',
+        voice_guidelines TEXT DEFAULT '',
+        background TEXT DEFAULT '',
+        example_messages TEXT DEFAULT '[]',
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+    )`);
+
+    // ── v46: Skill bundles ──────────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS skill_bundles (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        description TEXT DEFAULT '',
+        tools TEXT NOT NULL DEFAULT '[]',
+        prompt_additions TEXT DEFAULT '',
+        preset INTEGER DEFAULT 0,
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE TABLE IF NOT EXISTS agent_skills (
+        agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+        bundle_id TEXT NOT NULL REFERENCES skill_bundles(id) ON DELETE CASCADE,
+        sort_order INTEGER DEFAULT 0,
+        PRIMARY KEY (agent_id, bundle_id)
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_skills_agent ON agent_skills(agent_id)`);
+    // Preset skill bundles
+    db.exec(`INSERT OR IGNORE INTO skill_bundles (id, name, description, tools, prompt_additions, preset) VALUES
+        ('preset-code-reviewer', 'Code Reviewer', 'Review pull requests and provide feedback', '["corvid_github_list_prs","corvid_github_review_pr","corvid_github_get_pr_diff","corvid_github_comment_on_pr"]', 'You are an expert code reviewer. Focus on code quality, security, performance, and maintainability. Provide specific, actionable feedback.', 1)`);
+    db.exec(`INSERT OR IGNORE INTO skill_bundles (id, name, description, tools, prompt_additions, preset) VALUES
+        ('preset-devops', 'DevOps', 'Infrastructure and deployment automation', '["corvid_create_work_task","corvid_github_create_pr","corvid_github_fork_repo"]', 'You specialize in DevOps practices. Focus on CI/CD, infrastructure-as-code, monitoring, and deployment automation.', 1)`);
+    db.exec(`INSERT OR IGNORE INTO skill_bundles (id, name, description, tools, prompt_additions, preset) VALUES
+        ('preset-researcher', 'Researcher', 'Deep research and information gathering', '["corvid_web_search","corvid_deep_research","corvid_save_memory","corvid_recall_memory"]', 'You are a thorough researcher. Gather comprehensive information, cross-reference sources, and synthesize findings into clear summaries.', 1)`);
+    db.exec(`INSERT OR IGNORE INTO skill_bundles (id, name, description, tools, prompt_additions, preset) VALUES
+        ('preset-communicator', 'Communicator', 'Inter-agent and external communication', '["corvid_send_message","corvid_list_agents","corvid_discover_agent","corvid_invoke_remote_agent"]', 'You excel at communication and coordination. Draft clear messages, manage conversations, and facilitate collaboration between agents.', 1)`);
+    db.exec(`INSERT OR IGNORE INTO skill_bundles (id, name, description, tools, prompt_additions, preset) VALUES
+        ('preset-analyst', 'Analyst', 'Code analysis and health monitoring', '["corvid_check_health_trends","corvid_check_reputation","corvid_github_repo_info","corvid_github_list_issues"]', 'You are a data-driven analyst. Examine metrics, identify trends, and provide actionable insights from codebase health and project data.', 1)`);
+
+    // ── v47: Voice support ──────────────────────────────────────────────
+    safeAlter(db, `ALTER TABLE agents ADD COLUMN voice_enabled INTEGER DEFAULT 0`);
+    safeAlter(db, `ALTER TABLE agents ADD COLUMN voice_preset TEXT DEFAULT 'alloy'`);
+    db.exec(`CREATE TABLE IF NOT EXISTS voice_cache (
+        id TEXT PRIMARY KEY,
+        text_hash TEXT NOT NULL,
+        voice_preset TEXT NOT NULL,
+        audio_data BLOB NOT NULL,
+        format TEXT DEFAULT 'mp3',
+        duration_ms INTEGER DEFAULT 0,
+        created_at TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_voice_cache_hash ON voice_cache(text_hash, voice_preset)`);
+
+    // ── v49: MCP server configs ─────────────────────────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS mcp_server_configs (
+        id          TEXT PRIMARY KEY,
+        agent_id    TEXT DEFAULT NULL REFERENCES agents(id) ON DELETE CASCADE,
+        name        TEXT NOT NULL,
+        command     TEXT NOT NULL,
+        args        TEXT NOT NULL DEFAULT '[]',
+        env_vars    TEXT NOT NULL DEFAULT '{}',
+        cwd         TEXT DEFAULT NULL,
+        enabled     INTEGER NOT NULL DEFAULT 1,
+        created_at  TEXT DEFAULT (datetime('now')),
+        updated_at  TEXT DEFAULT (datetime('now'))
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_mcp_server_configs_agent ON mcp_server_configs(agent_id)`);
+
+    // ── v50: Question dispatch answered_at ──────────────────────────────
+    safeAlter(db, `ALTER TABLE owner_question_dispatches ADD COLUMN answered_at TEXT DEFAULT NULL`);
+
+    // ── v51: Project skills + more preset bundles ───────────────────────
+    db.exec(`CREATE TABLE IF NOT EXISTS project_skills (
+        project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        bundle_id  TEXT NOT NULL REFERENCES skill_bundles(id) ON DELETE CASCADE,
+        sort_order INTEGER DEFAULT 0,
+        created_at TEXT DEFAULT (datetime('now')),
+        PRIMARY KEY (project_id, bundle_id)
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_project_skills_project ON project_skills(project_id)`);
+    db.exec(`INSERT OR IGNORE INTO skill_bundles (id, name, description, tools, prompt_additions, preset) VALUES
+        ('preset-coder', 'Coder', 'Read, write, and edit code with command execution', '["read_file","write_file","edit_file","run_command","list_files","search_files"]', 'You are an expert coder. Read files to understand context before making changes. Use edit_file for targeted modifications and write_file only for new files. Always verify changes by reading the result. Run commands to test and validate your work.', 1)`);
+    db.exec(`INSERT OR IGNORE INTO skill_bundles (id, name, description, tools, prompt_additions, preset) VALUES
+        ('preset-github-ops', 'GitHub Ops', 'GitHub PR and issue management', '["corvid_github_list_prs","corvid_github_get_pr_diff","corvid_github_review_pr","corvid_github_comment_on_pr","corvid_github_create_pr","corvid_github_create_issue","corvid_github_list_issues","corvid_github_repo_info"]', 'You specialize in GitHub operations. Review PRs thoroughly by reading diffs before commenting. When creating issues or PRs, write clear titles and descriptions. Check existing issues before creating duplicates.', 1)`);
+    db.exec(`INSERT OR IGNORE INTO skill_bundles (id, name, description, tools, prompt_additions, preset) VALUES
+        ('preset-full-stack', 'Full Stack', 'Code, GitHub, tasks, and web search combined', '["read_file","write_file","edit_file","run_command","list_files","search_files","corvid_github_list_prs","corvid_github_get_pr_diff","corvid_github_review_pr","corvid_github_comment_on_pr","corvid_github_create_pr","corvid_github_create_issue","corvid_github_list_issues","corvid_create_work_task","corvid_web_search"]', 'You are a full-stack developer agent. You can read and edit code, run commands, manage GitHub PRs and issues, and create work tasks. Approach problems methodically: understand the codebase first, make targeted changes, test your work, then create PRs or report findings.', 1)`);
+    db.exec(`INSERT OR IGNORE INTO skill_bundles (id, name, description, tools, prompt_additions, preset) VALUES
+        ('preset-memory-manager', 'Memory Manager', 'Knowledge and memory management with research', '["corvid_save_memory","corvid_recall_memory","corvid_web_search","corvid_deep_research"]', 'You manage knowledge and memory. Save important findings, decisions, and context using structured keys. Recall relevant memories before starting new work. Use web search and deep research to fill knowledge gaps.', 1)`);
+
+    // ── v52: Fire-and-forget messaging ──────────────────────────────────
+    safeAlter(db, `ALTER TABLE agent_messages ADD COLUMN fire_and_forget INTEGER DEFAULT 0`);
+    safeAlter(db, `ALTER TABLE agent_messages ADD COLUMN message_version INTEGER DEFAULT 1`);
+    safeAlter(db, `ALTER TABLE agent_messages ADD COLUMN error_code TEXT DEFAULT NULL`);
+}
+
+/**
+ * Drop all tables created by the baseline migration.
+ * This completely destroys the database schema — use with extreme caution.
+ */
+export function down(db: Database): void {
+    // Drop triggers first (FTS sync)
+    db.exec(`DROP TRIGGER IF EXISTS agent_memories_ai`);
+    db.exec(`DROP TRIGGER IF EXISTS agent_memories_ad`);
+    db.exec(`DROP TRIGGER IF EXISTS agent_memories_au`);
+
+    // Drop FTS virtual table
+    db.exec(`DROP TABLE IF EXISTS agent_memories_fts`);
+
+    // Drop tables in reverse dependency order
+    const tables = [
+        'project_skills',
+        'agent_skills',
+        'skill_bundles',
+        'voice_cache',
+        'agent_personas',
+        'health_snapshots',
+        'invoices',
+        'usage_records',
+        'subscriptions',
+        'api_keys',
+        'tenants',
+        'reputation_attestations',
+        'reputation_events',
+        'agent_reputation',
+        'federated_instances',
+        'marketplace_reviews',
+        'marketplace_listings',
+        'sandbox_configs',
+        'plugin_capabilities',
+        'plugins',
+        'owner_question_dispatches',
+        'notification_deliveries',
+        'owner_notifications',
+        'notification_channels',
+        'owner_questions',
+        'audit_log',
+        'workflow_node_runs',
+        'workflow_runs',
+        'workflows',
+        'mention_polling_configs',
+        'webhook_deliveries',
+        'webhook_registrations',
+        'psk_contacts',
+        'agent_memories',
+        'schedule_executions',
+        'agent_schedules',
+        'credit_config',
+        'credit_transactions',
+        'credit_ledger',
+        'algochat_allowlist',
+        'algochat_messages',
+        'daily_spending',
+        'escalation_queue',
+        'mcp_server_configs',
+        'council_discussion_messages',
+        'council_launch_logs',
+        'work_tasks',
+        'council_launches',
+        'council_members',
+        'councils',
+        'agent_messages',
+        'algochat_psk_state',
+        'algochat_conversations',
+        'session_messages',
+        'sessions',
+        'agents',
+        'projects',
+    ];
+
+    for (const table of tables) {
+        db.exec(`DROP TABLE IF EXISTS ${table}`);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a file-based database migration system with versioned migration files, CLI commands, and server startup integration
- Baseline migration (001) captures the full existing schema (v1-52) so fresh databases can be bootstrapped via the new system
- Future schema changes go in `server/db/migrations/` as individual TypeScript files with `up()` and `down()` functions

## Changes

### New files
- **`server/db/migrate.ts`** — Core migration runner with `migrateUp()`, `migrateDown()`, `migrationStatus()`, and discovery logic
- **`server/db/migrate-cli.ts`** — CLI entry point: `bun run migrate up/down/status`
- **`server/db/migrate-create.ts`** — Helper: `bun run migrate:create <name>` generates a new migration file
- **`server/db/migrations/001_baseline.ts`** — Baseline migration reproducing the complete v1-52 schema with full rollback support
- **`server/__tests__/migrate.test.ts`** — 17 tests covering discovery, up, down, rollback, status, and schema parity with legacy system

### Modified files
- **`server/db/connection.ts`** — Added `initDb()` for async file-based migrations after legacy sync init
- **`server/index.ts`** — Calls `initDb()` on startup for v53+ migrations
- **`package.json`** — Added `migrate`, `migrate:up`, `migrate:down`, `migrate:status`, `migrate:create` scripts
- **`.github/workflows/ci.yml`** — Runs `migrate:up` before unit tests

## Design

The system is additive — the legacy inline migrations in `schema.ts` continue to handle v1-52 synchronously. File-based migrations handle v53+ asynchronously. Both share the `schema_version` table. This means:

- **Zero breaking changes** — existing `runMigrations()` callers (including tests) work unchanged
- **Backward compatible** — databases at v52 skip the baseline migration automatically
- **Reversible** — every migration has a `down()` function for rollback
- **Fresh DB support** — new databases can use either the legacy or file-based path

## Test plan

- [x] 17 new migration tests pass (discovery, up, down, target versions, rollback on failure, status, baseline schema parity)
- [x] All 40 existing DB tests pass unchanged
- [x] Full test suite (2633 tests) passes
- [x] `bun run migrate:status` shows correct state
- [x] `bun run migrate:create` generates valid migration template
- [x] TypeScript passes with no new errors

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)