### PR TITLE
chore: bump version references to 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.12.0] - 2026-02-25
+## [0.13.0] - 2026-02-25
 
 ### Added
 - **Centralized DedupService** — unified deduplication with TTL expiry, LRU eviction, and SQLite persistence; replaces scattered per-feature dedup logic (#254)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.12.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.13.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: corvid-agent
 description: Agent orchestration platform with MCP tools, AlgoChat messaging, and on-chain wallet integration
 type: application
-version: 0.12.0
-appVersion: "0.12.0"
+version: 0.13.0
+appVersion: "0.13.0"
 keywords:
   - ai
   - agent

--- a/scripts/demo.md
+++ b/scripts/demo.md
@@ -1,4 +1,4 @@
-# corvid-agent v0.12.0 Demo Script
+# corvid-agent v0.13.0 Demo Script
 
 Structured walkthrough for demonstrating the full corvid-agent platform.
 

--- a/server/openapi/generator.ts
+++ b/server/openapi/generator.ts
@@ -264,7 +264,7 @@ export function generateOpenApiSpec(options: GeneratorOptions = {}): OpenApiSpec
         openapi: '3.0.3',
         info: {
             title: 'Corvid Agent API',
-            version: '0.12.0',
+            version: '0.13.0',
             description: 'AI agent framework with on-chain identity and messaging via AlgoChat on Algorand. Provides multi-agent orchestration, GitHub automation, workflow pipelines, and an agent marketplace.',
             license: {
                 name: 'MIT',


### PR DESCRIPTION
## Summary
- Update all stale `0.12.0` version references to `0.13.0` across 6 files: CHANGELOG.md, README.md, scripts/demo.md, deploy/helm/Chart.yaml, server/openapi/generator.ts

## Test plan
- [ ] `bunx tsc --noEmit --skipLibCheck` passes
- [ ] `bun test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)