### PR TITLE
Replace `as any` casts in routes-mcp-api.test.ts

### DIFF
--- a/server/__tests__/routes-mcp-api.test.ts
+++ b/server/__tests__/routes-mcp-api.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { runMigrations } from '../db/schema';
 import { handleMcpApiRoutes } from '../routes/mcp-api';
+import type { McpApiDeps } from '../routes/mcp-api';
+import type { AgentMessenger } from '../algochat/agent-messenger';
+import type { AgentDirectory } from '../algochat/agent-directory';
+import type { AgentWalletService } from '../algochat/agent-wallet';
 
 let db: Database;
 
@@ -13,6 +17,20 @@ function fakeReq(method: string, path: string, body?: unknown): { req: Request; 
         opts.headers = { 'Content-Type': 'application/json' };
     }
     return { req: new Request(url.toString(), opts), url };
+}
+
+/** Create a typed McpApiDeps with stub services. Pass partial overrides for specific methods. */
+function makeMockDeps(overrides?: {
+    agentMessenger?: Partial<AgentMessenger>;
+    agentDirectory?: Partial<AgentDirectory>;
+    agentWalletService?: Partial<AgentWalletService>;
+}): McpApiDeps {
+    return {
+        db,
+        agentMessenger: (overrides?.agentMessenger ?? {}) as unknown as AgentMessenger,
+        agentDirectory: (overrides?.agentDirectory ?? {}) as unknown as AgentDirectory,
+        agentWalletService: (overrides?.agentWalletService ?? {}) as unknown as AgentWalletService,
+    };
 }
 
 beforeAll(() => {
@@ -37,38 +55,23 @@ describe('MCP API Routes', () => {
     });
 
     it('returns null for non-mcp paths with deps provided', () => {
-        const deps = {
-            db,
-            agentMessenger: {} as any,
-            agentDirectory: {} as any,
-            agentWalletService: {} as any,
-        };
+        const deps = makeMockDeps();
         const { req, url } = fakeReq('GET', '/api/other');
         const res = handleMcpApiRoutes(req, url, deps);
         expect(res).toBeNull();
     });
 
     it('returns null for unknown /api/mcp/ sub-paths', () => {
-        const deps = {
-            db,
-            agentMessenger: {} as any,
-            agentDirectory: {} as any,
-            agentWalletService: {} as any,
-        };
+        const deps = makeMockDeps();
         const { req, url } = fakeReq('GET', '/api/mcp/unknown-endpoint');
         const res = handleMcpApiRoutes(req, url, deps);
         expect(res).toBeNull();
     });
 
     it('GET /api/mcp/list-agents returns 400 without agentId', async () => {
-        const deps = {
-            db,
-            agentMessenger: {} as any,
-            agentDirectory: {
-                getRegisteredAgents: () => [],
-            } as any,
-            agentWalletService: {} as any,
-        };
+        const deps = makeMockDeps({
+            agentDirectory: { listAvailable: async () => [] },
+        });
         const { req, url } = fakeReq('GET', '/api/mcp/list-agents');
         const res = await handleMcpApiRoutes(req, url, deps);
         expect(res).not.toBeNull();
@@ -78,14 +81,11 @@ describe('MCP API Routes', () => {
     });
 
     it('POST /api/mcp/send-message with valid deps but missing body fields returns error', async () => {
-        const deps = {
-            db,
+        const deps = makeMockDeps({
             agentMessenger: {
                 sendMessage: async () => ({ content: [{ type: 'text', text: 'ok' }], isError: false }),
-            } as any,
-            agentDirectory: {} as any,
-            agentWalletService: {} as any,
-        };
+            } as Partial<AgentMessenger>,
+        });
         const { req, url } = fakeReq('POST', '/api/mcp/send-message', {});
         const res = await handleMcpApiRoutes(req, url, deps);
         expect(res).not.toBeNull();
@@ -94,12 +94,7 @@ describe('MCP API Routes', () => {
     });
 
     it('POST /api/mcp/save-memory with missing fields returns error', async () => {
-        const deps = {
-            db,
-            agentMessenger: {} as any,
-            agentDirectory: {} as any,
-            agentWalletService: {} as any,
-        };
+        const deps = makeMockDeps();
         const { req, url } = fakeReq('POST', '/api/mcp/save-memory', {});
         const res = await handleMcpApiRoutes(req, url, deps);
         expect(res).not.toBeNull();
@@ -107,12 +102,7 @@ describe('MCP API Routes', () => {
     });
 
     it('POST /api/mcp/recall-memory with missing fields returns error', async () => {
-        const deps = {
-            db,
-            agentMessenger: {} as any,
-            agentDirectory: {} as any,
-            agentWalletService: {} as any,
-        };
+        const deps = makeMockDeps();
         const { req, url } = fakeReq('POST', '/api/mcp/recall-memory', {});
         const res = await handleMcpApiRoutes(req, url, deps);
         expect(res).not.toBeNull();

--- a/server/routes/mcp-api.ts
+++ b/server/routes/mcp-api.ts
@@ -14,7 +14,7 @@ function extractResultText(result: CallToolResult): string {
     return '';
 }
 
-interface McpApiDeps {
+export interface McpApiDeps {
     db: Database;
     agentMessenger: AgentMessenger;
     agentDirectory: AgentDirectory;


### PR DESCRIPTION
## Summary
- Exported `McpApiDeps` interface from `server/routes/mcp-api.ts`
- Created a typed `makeMockDeps()` factory function using `Partial<T>` overrides for `AgentMessenger`, `AgentDirectory`, and `AgentWalletService`
- Replaced all 18 `as any` casts in test bodies with the shared factory; `as unknown as T` casts are consolidated in the single factory function

## Verification
- `bun test server/__tests__/routes-mcp-api.test.ts` — 8/8 pass
- `bunx tsc --noEmit --skipLibCheck` — zero errors
- Zero `as any` remaining in the test file

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)