### PR TITLE
fix: allow org-only names in mention polling repo validation

### DIFF
--- a/server/__tests__/mention-polling.test.ts
+++ b/server/__tests__/mention-polling.test.ts
@@ -714,7 +714,7 @@ describe('Mention Polling Routes', () => {
             const service = createPollingService();
             const { req, url } = fakeReq('POST', '/api/mention-polling', {
                 agentId,
-                repo: 'invalid-repo-format',
+                repo: 'owner/middle/extra',
                 mentionUsername: 'bot',
             });
 

--- a/server/__tests__/routes-mention-polling-routes.test.ts
+++ b/server/__tests__/routes-mention-polling-routes.test.ts
@@ -62,7 +62,7 @@ describe('Mention Polling Routes', () => {
     it('POST /api/mention-polling rejects invalid repo format', async () => {
         const { req, url } = fakeReq('POST', '/api/mention-polling', {
             agentId,
-            repo: 'invalid-repo-no-slash',
+            repo: 'owner/middle/extra',
             mentionUsername: 'bot',
         });
         const res = await handleMentionPollingRoutes(req, url, db, null);

--- a/server/lib/validation.ts
+++ b/server/lib/validation.ts
@@ -360,7 +360,7 @@ const PollingEventFilterSchema = z.enum([
 
 export const CreateMentionPollingSchema = z.object({
     agentId: z.string().min(1, 'agentId is required'),
-    repo: z.string().min(1, 'repo is required (format: owner/name)').regex(/^[^/]+\/[^/]+$/, 'repo must be in owner/name format'),
+    repo: z.string().min(1, 'repo is required').regex(/^[^/]+(?:\/[^/]+)?$/, 'repo must be owner/name or org name'),
     mentionUsername: z.string().min(1, 'mentionUsername is required'),
     projectId: z.string().min(1).optional(),
     intervalSeconds: z.number().int().min(30, 'Minimum polling interval is 30 seconds').max(3600, 'Maximum polling interval is 1 hour').optional(),


### PR DESCRIPTION
## Summary
- Relaxed `CreateMentionPollingSchema` repo regex from `owner/name` only to also accept org-only names like `CorvidLabs`, `0xLeif`, `corvid-agent`
- The polling service's `repoQualifier()` already handles org-only names (maps to `org:NAME`), but the API schema rejected creating/updating them
- Updated tests to use truly invalid formats (`owner/middle/extra`) instead of org-only names

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — 2906 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)