### PR TITLE
test: add comprehensive unit tests for AlgoChat CommandHandler (100 tests)

### DIFF
--- a/server/__tests__/algochat-command-handler.test.ts
+++ b/server/__tests__/algochat-command-handler.test.ts
@@ -81,14 +81,19 @@ function createMockResponseFormatter(): ResponseFormatter & { lastResponse: { pa
     return formatter;
 }
 
-function createMockContext(overrides: Partial<CommandHandlerContext> = {}): CommandHandlerContext {
+interface MockContextOptions {
+    defaultAgentId?: string | null;
+    defaultProjectId?: string;
+    extendResult?: boolean;
+}
+
+function createMockContext(overrides: MockContextOptions = {}): CommandHandlerContext {
     return {
         findAgentForNewConversation: mock(() => overrides.defaultAgentId ?? 'agent-1') as () => string | null,
         getDefaultProjectId: mock(() => overrides.defaultProjectId ?? 'proj-1') as () => string,
         extendSession: mock((_sessionId: string, _minutes: number) =>
             overrides.extendResult ?? true
         ) as (sessionId: string, minutes: number) => boolean,
-        ...overrides,
     };
 }
 


### PR DESCRIPTION
## Summary
- Adds **100 unit tests** for `server/algochat/command-handler.ts`, bringing this critical module from 0% to comprehensive test coverage
- Tests all 14 slash commands (`/help`, `/status`, `/stop`, `/agent`, `/queue`, `/approve`, `/deny`, `/mode`, `/credits`, `/history`, `/work`, `/council`, `/extend`, `/schedule`)
- Covers `isOwner` authorization logic, privilege enforcement for all privileged commands, response routing (on-chain vs local), dependency injection, and edge cases

## Test plan
- [x] All 100 new tests pass (`bun test server/__tests__/algochat-command-handler.test.ts`)
- [x] Full test suite passes (3006 tests across 135 files)
- [x] Uses in-memory SQLite DB with real schema migrations for DB-backed commands
- [x] Lightweight mocks for ProcessManager, ResponseFormatter, and CommandHandlerContext

🤖 Generated with [Claude Code](https://claude.com/claude-code)