### PR TITLE
test: add unit tests for AlgoChat DiscoveryService and ResponseFormatter (74 tests)

### DIFF
--- a/server/__tests__/algochat-discovery-service.test.ts
+++ b/server/__tests__/algochat-discovery-service.test.ts
@@ -32,7 +32,6 @@ import { createProject } from '../db/projects';
 const MY_ADDR = 'MY_CHAT_ACCOUNT_ADDR';
 const SENDER_A = 'SENDER_ADDR_AAAA';
 const SENDER_B = 'SENDER_ADDR_BBBB';
-const SENDER_C = 'SENDER_ADDR_CCCC';
 const OWNER_ADDR = 'OWNER_ADDR_ABC123';
 
 // ── Mock factories ────────────────────────────────────────────────────────
@@ -684,7 +683,7 @@ describe('DiscoveryService', () => {
             await new Promise((r) => setTimeout(r, 5200));
 
             // Approval manager was checked
-            expect(approvalMgr.hasPendingRequests.mock.calls.length).toBeGreaterThanOrEqual(1);
+            expect((approvalMgr.hasPendingRequests as ReturnType<typeof mock>).mock.calls.length).toBeGreaterThanOrEqual(1);
 
             discovery.stopFastPolling();
         }, 10_000);


### PR DESCRIPTION
## Summary
- Adds 37 unit tests for `DiscoveryService` covering conversation seeding, indexer-based sender discovery, polling lifecycle, agent wallet caching with TTL, agent resolution, and project fallback
- Adds 37 unit tests for `ResponseFormatter` covering PSK routing with byte-limited chunking, on-chain transactor delegation, per-agent wallet selection, spending limit enforcement, event callbacks, DB persistence, and dead-letter logging
- Uses in-memory SQLite with real schema migrations and lightweight mocks following existing conventions from `algochat-command-handler.test.ts`

Closes #299

## Test plan
- [x] All 74 tests pass (`bun test server/__tests__/algochat-discovery-service.test.ts server/__tests__/algochat-response-formatter.test.ts`)
- [ ] CI passes on branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)