### PR TITLE
test: add comprehensive unit tests for AlgoChat MessageRouter (79 tests)

### DIFF
--- a/server/__tests__/algochat-message-router.test.ts
+++ b/server/__tests__/algochat-message-router.test.ts
@@ -37,6 +37,7 @@ import type { AgentDirectory } from '../algochat/agent-directory';
 import type { ApprovalManager } from '../process/approval-manager';
 import type { OwnerQuestionManager } from '../process/owner-question-manager';
 import type { ClaudeStreamEvent } from '../process/types';
+import type { SessionMessage } from '../channels/types';
 
 // ── Test constants ────────────────────────────────────────────────────────
 
@@ -543,7 +544,7 @@ describe('handleIncomingMessage', () => {
     describe('ChannelAdapter message handler notification', () => {
         test('notifies registered message handlers for authorized messages', async () => {
             (ch.isOwner as ReturnType<typeof mock>).mockReturnValue(true);
-            const handler = mock(() => {});
+            const handler = mock((_msg: SessionMessage) => {});
             router.onMessage(handler);
 
             await router.handleIncomingMessage(OWNER_ADDR, 'Hello', 1000, 100);
@@ -1000,7 +1001,7 @@ describe('setupSessionNotifications', () => {
         callback('some-session', {
             type: 'message',
             content: 'Hello',
-        } as ClaudeStreamEvent);
+        } as unknown as ClaudeStreamEvent);
 
         expect(rf.calls.length).toBe(0);
     });


### PR DESCRIPTION
## Summary
- Add 79 unit tests for `server/algochat/message-router.ts` covering the full incoming message routing pipeline
- Tests cover: trace ID extraction, device name envelope parsing, group chunk safety guard, approval/question response routing, agent-to-agent filtering, owner authorization, command dispatch, session creation/resumption, local chat flow, session notifications, and edge cases
- Uses in-memory SQLite with real schema migrations and lightweight typed mocks matching existing codebase conventions

## Test plan
- [x] All 79 tests pass locally with `bun test server/__tests__/algochat-message-router.test.ts`
- [x] No changes to production code
- [ ] CI passes

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)