### PR TITLE
Implements client and API key authentication

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -14,13 +14,59 @@ import { SidebarComponent } from './shared/components/sidebar.component';
 import { ToastContainerComponent } from './shared/components/toast-container.component';
 import { WebSocketService } from './core/services/websocket.service';
 import { SessionService } from './core/services/session.service';
+import { environment } from '../environments/environment';
 
 @Component({
     selector: 'app-root',
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [RouterOutlet, HeaderComponent, SidebarComponent, ToastContainerComponent],
     template: `
-        <div class="app-layout">
+        @if (!isAuthenticated) {
+            <div class="auth-overlay" role="dialog" aria-modal="true" aria-label="Authentication required">
+                <div class="auth-card">
+                    <div class="auth-header">
+                        <div class="auth-logo">🐦‍⬛</div>
+                        <h1>corvid-agent</h1>
+                        <p class="auth-subtitle">Authentication required</p>
+                    </div>
+                    <div class="auth-body">
+                        <p class="auth-description">
+                            Access is protected by an API key. Append <code>?apiKey=</code> to the URL,
+                            or enter your key below.
+                        </p>
+                        <div class="auth-url-example">
+                            <span class="auth-url-base">{{ origin }}/?apiKey=</span><span class="auth-url-key">YOUR_API_KEY</span>
+                        </div>
+                        <div class="auth-form">
+                            <input
+                                class="auth-input"
+                                type="password"
+                                placeholder="Enter API key…"
+                                autocomplete="current-password"
+                                [value]="apiKeyInput()"
+                                (input)="apiKeyInput.set($any($event.target).value)"
+                                (keydown.enter)="submitApiKey()"
+                            />
+                            <button
+                                class="auth-btn"
+                                [disabled]="!apiKeyInput().trim()"
+                                (click)="submitApiKey()"
+                            >
+                                Authenticate
+                            </button>
+                        </div>
+                        <div class="auth-hint">
+                            <strong>Where is my API key?</strong><br>
+                            Set <code>API_KEY</code> in <code>deploy/.env</code> before starting
+                            the container. Generate one with:
+                            <code>openssl rand -base64 32</code>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        }
+
+        <div class="app-layout" [attr.inert]="isAuthenticated ? null : ''">
             <app-header
                 [sidebarOpen]="sidebarOpen()"
                 (hamburgerClick)="toggleSidebar()" />
@@ -39,6 +85,147 @@ import { SessionService } from './core/services/session.service';
         <app-toast-container />
     `,
     styles: `
+        /* ── Auth overlay ── */
+        .auth-overlay {
+            position: fixed;
+            inset: 0;
+            z-index: 9999;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(0, 0, 0, 0.75);
+            backdrop-filter: blur(6px);
+            padding: 1.5rem;
+        }
+
+        .auth-card {
+            width: 100%;
+            max-width: 460px;
+            background: var(--bg-surface);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            overflow: hidden;
+        }
+
+        .auth-header {
+            padding: 2rem 2rem 1.5rem;
+            text-align: center;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .auth-logo {
+            font-size: 2.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .auth-header h1 {
+            margin: 0 0 0.25rem;
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+
+        .auth-subtitle {
+            margin: 0;
+            font-size: 0.875rem;
+            color: var(--text-secondary);
+        }
+
+        .auth-body {
+            padding: 1.75rem 2rem 2rem;
+            display: flex;
+            flex-direction: column;
+            gap: 1.25rem;
+        }
+
+        .auth-description {
+            margin: 0;
+            font-size: 0.875rem;
+            color: var(--text-secondary);
+            line-height: 1.5;
+        }
+
+        .auth-url-example {
+            padding: 0.75rem 1rem;
+            background: var(--bg-deep);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            font-family: monospace;
+            font-size: 0.8rem;
+            word-break: break-all;
+            color: var(--text-secondary);
+        }
+
+        .auth-url-key {
+            color: var(--accent-cyan);
+            font-weight: 600;
+        }
+
+        .auth-form {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .auth-input {
+            flex: 1;
+            padding: 0.625rem 0.875rem;
+            background: var(--bg-deep);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            color: var(--text-primary);
+            font-size: 0.875rem;
+            font-family: inherit;
+            outline: none;
+            transition: border-color 0.15s;
+        }
+
+        .auth-input:focus {
+            border-color: var(--accent-cyan);
+        }
+
+        .auth-btn {
+            padding: 0.625rem 1.25rem;
+            background: var(--accent-cyan, #00e5ff);
+            color: #000;
+            border: none;
+            border-radius: 6px;
+            font-size: 0.875rem;
+            font-weight: 600;
+            font-family: inherit;
+            cursor: pointer;
+            white-space: nowrap;
+            transition: opacity 0.15s;
+        }
+
+        .auth-btn:disabled {
+            opacity: 0.35;
+            cursor: not-allowed;
+        }
+
+        .auth-btn:not(:disabled):hover {
+            opacity: 0.8;
+        }
+
+        .auth-hint {
+            padding: 0.875rem 1rem;
+            background: var(--bg-deep);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            font-size: 0.8rem;
+            color: var(--text-secondary);
+            line-height: 1.6;
+        }
+
+        code {
+            font-family: monospace;
+            background: rgba(0, 229, 255, 0.08);
+            color: var(--accent-cyan);
+            padding: 0.1em 0.35em;
+            border-radius: 3px;
+            font-size: 0.85em;
+        }
+
+        /* ── App layout ── */
         .app-layout {
             display: flex;
             flex-direction: column;
@@ -74,17 +261,22 @@ export class App implements OnInit, OnDestroy, AfterViewInit {
     protected readonly wsService = inject(WebSocketService);
     private readonly sessionService = inject(SessionService);
 
+    protected readonly isAuthenticated = !!environment.apiKey;
+    protected readonly origin = typeof window !== 'undefined' ? window.location.origin : '';
+    protected readonly apiKeyInput = signal('');
     protected readonly sidebarOpen = signal(false);
 
     private readonly sidebarComponent = viewChild(SidebarComponent);
 
     ngOnInit(): void {
+        // Skip all background connections when unauthenticated — prevents 401 toast spam
+        if (!this.isAuthenticated) return;
         this.wsService.connect();
         this.sessionService.init();
     }
 
     ngAfterViewInit(): void {
-        // Supply the hamburger button ref to sidebar for focus management
+        if (!this.isAuthenticated) return;
         setTimeout(() => {
             const btn = document.querySelector('.header__hamburger') as HTMLElement;
             if (btn) {
@@ -107,5 +299,11 @@ export class App implements OnInit, OnDestroy, AfterViewInit {
         } else {
             sidebar.openSidebar();
         }
+    }
+
+    protected submitApiKey(): void {
+        const key = this.apiKeyInput().trim();
+        if (!key) return;
+        window.location.href = `/?apiKey=${encodeURIComponent(key)}`;
     }
 }

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,61 @@
+# =============================================================================
+# corvid-agent Docker — Environment Configuration
+# Copy to: cp deploy/.env.example deploy/.env
+# Edit with your values, then: cd deploy && docker compose up -d
+# =============================================================================
+
+# --- AI Providers ------------------------------------------------------------
+
+# Anthropic API key (get at: https://console.anthropic.com/settings/keys)
+# Required if ENABLED_PROVIDERS includes "anthropic"
+ANTHROPIC_API_KEY=sk-ant-
+
+# Which providers to enable (comma-separated: anthropic, ollama)
+# Use "ollama" only for fully local operation (no Anthropic key needed)
+ENABLED_PROVIDERS=anthropic,ollama
+
+# --- API Authentication [REQUIRED when BIND_HOST=0.0.0.0] -------------------
+# Generate with: openssl rand -base64 32
+API_KEY=
+
+# --- Ollama (local models) ---------------------------------------------------
+# Ollama running on the Docker host. Defaults to host.docker.internal:11434.
+# On macOS Docker Desktop this resolves automatically. Leave blank for default.
+# OLLAMA_HOST=http://host.docker.internal:11434
+
+# --- Algorand / AlgoChat -----------------------------------------------------
+# 25-word mnemonic for the corvid-agent main wallet.
+# TIP: Generate BEFORE first run: algokit generate mnemonic
+# If left blank, a new wallet is auto-generated on localnet but lost on restart.
+# ALGOCHAT_MNEMONIC=word1 word2 ... word25
+
+# Network: localnet | testnet | mainnet (default: localnet)
+# ALGORAND_NETWORK=localnet
+
+# Algorand addresses authorized to send privileged commands to the agent
+# ALGOCHAT_OWNER_ADDRESSES=ADDR1,ADDR2
+
+# --- Optional Integrations ---------------------------------------------------
+
+# GitHub (for work tasks, PR creation, mention polling)
+# GH_TOKEN=ghp_...
+
+# Telegram bridge (bidirectional — chat with agents from Telegram)
+# TELEGRAM_BOT_TOKEN=
+# TELEGRAM_CHAT_ID=
+
+# Discord bridge
+# DISCORD_BOT_TOKEN=
+# DISCORD_CHANNEL_ID=
+
+# Voice TTS/STT (OpenAI, separate from Anthropic)
+# OPENAI_API_KEY=sk-...
+
+# Admin API key (for /metrics and audit-log endpoints)
+# ADMIN_API_KEY=
+
+# Web search (for corvid_web_search MCP tool)
+# BRAVE_SEARCH_API_KEY=
+
+# --- Logging -----------------------------------------------------------------
+# LOG_LEVEL=info

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -36,9 +36,14 @@ ENV BIND_HOST=0.0.0.0
 ENV LOG_LEVEL=info
 ENV NODE_ENV=production
 
+# Install Claude Code CLI — lets agents authenticate via `claude login` instead
+# of requiring ANTHROPIC_API_KEY. Credentials survive restarts but not `docker compose down`.
+RUN BUN_INSTALL=/usr/local bun add --global @anthropic-ai/claude-code
+
 # Run as non-root user (oven/bun:1 is Debian-slim — use native commands)
-RUN groupadd --system corvid && useradd --system --gid corvid corvid
-RUN chown -R corvid:corvid /app
+# -m creates /home/corvid so `claude login` can store credentials there
+RUN groupadd --system corvid && useradd --system -m --gid corvid corvid
+RUN mkdir -p /app/data && chown -R corvid:corvid /app
 USER corvid
 
 EXPOSE 3000

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,103 +1,192 @@
 # Deployment Configs
 
-Optional configs for running CorvidAgent as a production service. For local development, just use `bun run dev`.
+Production and local-service deployment configs. For local development use `bun run dev` instead.
 
 ## Files
 
 | File | Purpose |
 |------|---------|
-| `Dockerfile` | Multi-stage Docker build (Angular client + Bun server) |
-| `docker-compose.yml` | Docker Compose orchestration with health checks |
+| `Dockerfile` | Multi-stage build (Angular client + Bun server) |
+| `docker-compose.yml` | corvid-agent service (connects to Algorand localnet on the host) |
+| `.env.example` | Environment variable template — copy to `.env` before running |
 | `daemon.sh` | Cross-platform daemon installer (auto-detects launchd/systemd) |
-| `corvid-agent.service` | systemd unit file (Linux) with security hardening |
+| `corvid-agent.service` | systemd unit (Linux) with security hardening |
 | `com.corvidlabs.corvid-agent.plist` | macOS launchd plist |
-| `corvid-agent.newsyslog.conf` | macOS log rotation |
-| `caddy/Caddyfile` | Caddy reverse proxy with auto-TLS |
+| `caddy/Caddyfile` | Caddy reverse proxy (auto-TLS) |
 | `nginx/corvid-agent.conf` | nginx reverse proxy with rate limiting |
 
-## Quick Start
+## Docker Quick Start
 
-### Docker (simplest)
+### Prerequisites
+
+- Docker Desktop (macOS/Windows) or Docker Engine + Compose v2 (Linux)
+- An Anthropic API key from https://console.anthropic.com/settings/keys
+- Ollama installed on the host if using local models: https://ollama.com
+- Algorand localnet running separately (e.g. AlgoKit sandbox or another Docker container)
+
+### 1. Configure environment
 
 ```bash
-cp .env.example .env   # add your API keys
+cp deploy/.env.example deploy/.env
+```
+
+Edit `deploy/.env`. Required fields:
+- `API_KEY` — any strong random string (`openssl rand -base64 32`)
+
+For Claude models, choose one:
+- **Option A — Anthropic API key**: set `ANTHROPIC_API_KEY` (from console.anthropic.com)
+- **Option B — Claude Code login**: leave `ANTHROPIC_API_KEY` blank; after starting the container run `docker exec -it corvid-agent claude login` (see below)
+- **Option C — Ollama only**: set `ENABLED_PROVIDERS=ollama`, no API key needed
+
+Optional but recommended before first run:
+- `ALGOCHAT_MNEMONIC` — 25-word Algorand mnemonic (see "Algorand wallet" below)
+
+### 2. Start corvid-agent
+
+```bash
 cd deploy
 docker compose up -d
 ```
 
-### Running Inside Containers (with Algorand localnet)
+First run builds the app image — allow ~1 minute.
 
-When corvid-agent runs inside Docker, `localhost` resolves to the container — not the host where AlgoKit localnet is running. You need to tell the container how to reach the host's localnet services.
-
-**Docker Desktop (macOS / Windows)** — `host.docker.internal` works automatically:
+### 3. Open the dashboard
 
 ```bash
-# In your .env or docker-compose override:
-LOCALNET_ALGOD_URL=http://host.docker.internal:4001
-LOCALNET_KMD_URL=http://host.docker.internal:4002
-LOCALNET_INDEXER_URL=http://host.docker.internal:8980
+docker compose ps          # Should show "healthy"
+docker compose logs -f corvid-agent
 ```
 
-**Linux Docker** — add the host gateway mapping (already included in `docker-compose.yml`):
+Open the dashboard and authenticate (choose one):
 
-```yaml
-extra_hosts:
-  - "host.docker.internal:host-gateway"
+**Option A — URL parameter (bookmark-friendly):**
 ```
+http://localhost:3000/?apiKey=YOUR_API_KEY
+```
+The key is read on load, stripped from the URL, and held in memory for the session.
+Closing the tab or refreshing without the `?apiKey=` parameter requires re-authenticating.
 
-Then set the same `LOCALNET_*` env vars as above.
+**Option B — in-app form:**
+Open `http://localhost:3000` — a login overlay appears. Enter the key and click **Authenticate**.
+This navigates to the URL form above automatically.
 
-**Steps:**
+> The dashboard shows a full-screen overlay and disables the sidebar/navbar until authenticated.
+> No API calls are made before you log in, so there are no error notifications.
 
-1. Start AlgoKit localnet on the **host** machine:
-   ```bash
-   algokit localnet start
-   ```
-2. Set the `LOCALNET_*` env vars in your `.env` (or pass them via `docker-compose.yml`).
-3. Start the container:
-   ```bash
-   cd deploy && docker compose up -d
-   ```
-4. The health check (`/api/health`) confirms connectivity.
+## Algorand Localnet
 
-> **Tip:** Running `./setup.sh` inside a container auto-detects the environment and sets the `LOCALNET_*` overrides for you. It also warns that AlgoKit localnet must run on the host (Docker-in-Docker is not supported by the setup script).
+Algorand localnet runs in its own Docker container (or via AlgoKit) on the host machine.
+corvid-agent reaches it via `host.docker.internal` which resolves to the host on both
+macOS Docker Desktop and Linux (the `extra_hosts` mapping in `docker-compose.yml` handles Linux).
 
-### Daemon (bare metal)
+Default ports (override via `.env` if your localnet uses different ports):
+
+| Service | Default URL | Override env var |
+|---------|-------------|-----------------|
+| algod | `http://host.docker.internal:4001` | `LOCALNET_ALGOD_URL` |
+| KMD | `http://host.docker.internal:4002` | `LOCALNET_KMD_URL` |
+| indexer | `http://host.docker.internal:8980` | `LOCALNET_INDEXER_URL` |
+
+## Claude Code Login (no API key)
+
+The Docker image includes the `claude` CLI. If you have a Claude Pro/Max subscription and don't want to manage a separate API key:
 
 ```bash
-# Auto-detects macOS (launchd) or Linux (systemd)
-./deploy/daemon.sh install
+docker compose up -d
+docker exec -it corvid-agent claude login
+```
+
+Follow the prompts — it will print a URL to open in your host browser. After you authorise in the browser, paste the code back into the terminal. Credentials are stored in `/home/corvid/.claude/` inside the container and survive `docker compose restart` but are lost on `docker compose down`. Just run `claude login` again after a fresh start.
+
+> **Note**: `ANTHROPIC_API_KEY` takes precedence if set. Leave it blank (or remove it) in `.env` to use CLI auth.
+
+> **Limitation**: A small number of server-side features (council synthesis, work-task internal completions) call the Anthropic SDK directly and still need `ANTHROPIC_API_KEY`. Core agent chat and all MCP tools work without it.
+
+## Algorand Wallet Setup
+
+On localnet with no `ALGOCHAT_MNEMONIC` set, a new wallet is generated each restart and auto-funded (100 ALGO) from the KMD dispenser. The wallet is not persisted between container replacements (only restarts).
+
+**Recommended**: generate a mnemonic before first run and set it in `.env`:
+
+```bash
+# Using algokit (install from https://github.com/algorandfoundation/algokit-cli):
+algokit generate mnemonic
+
+# Then in deploy/.env:
+ALGOCHAT_MNEMONIC=word1 word2 ... word25
+```
+
+The wallet address and 100 ALGO funding happen automatically on localnet. For mainnet, fund the address manually.
+
+## Using Ollama Models
+
+1. Install Ollama: https://ollama.com and start it on your host machine
+2. Pull a model: `ollama pull qwen3:8b`
+3. In `deploy/.env`:
+   ```
+   ENABLED_PROVIDERS=anthropic,ollama
+   ```
+   `OLLAMA_HOST` defaults to `http://host.docker.internal:11434` which works on macOS Docker Desktop.
+   On Linux, `host.docker.internal` is mapped via `extra_hosts` in the compose file.
+4. When creating agents in the UI, set the model to e.g. `qwen3:8b`, `llama3.1:8b`, etc.
+
+For fully local operation (no Anthropic key):
+```
+ENABLED_PROVIDERS=ollama
+```
+
+## Data Volumes
+
+All persistent data is in a named Docker volume:
+
+| Volume | Contents |
+|--------|----------|
+| `corvid-data` → `/app/data` | SQLite DB (`corvid-agent.db`) + wallet keystore |
+
+Inspect:
+```bash
+docker run --rm -v deploy_corvid-data:/data alpine ls -la /data
+```
+
+## Stopping / Cleanup
+
+```bash
+docker compose down              # Stop, keep volume
+docker compose down -v           # Stop + delete all data (DESTRUCTIVE)
+docker compose restart corvid-agent
+```
+
+## Daemon (Bare Metal)
+
+```bash
+./deploy/daemon.sh install   # macOS → launchd, Linux → systemd
 ./deploy/daemon.sh status
 ./deploy/daemon.sh logs
+./deploy/daemon.sh uninstall
 ```
 
-### Reverse Proxy (production TLS)
+## Production TLS
 
-For production, bind the server to localhost and terminate TLS at the proxy:
+Set `BIND_HOST=127.0.0.1` and front with a reverse proxy:
 
-1. Set `BIND_HOST=127.0.0.1` in your `.env` or docker-compose override
-2. Choose your proxy:
-
-**Caddy** (auto-TLS via Let's Encrypt):
+**Caddy** (auto-TLS):
 ```bash
-# Edit deploy/caddy/Caddyfile — replace "yourdomain.com" with your domain
+# Edit deploy/caddy/Caddyfile — replace "yourdomain.com"
 sudo cp deploy/caddy/Caddyfile /etc/caddy/Caddyfile
 sudo systemctl restart caddy
 ```
 
-**nginx** (manual TLS via certbot):
+**nginx** (manual TLS):
 ```bash
-# Edit deploy/nginx/corvid-agent.conf — replace "yourdomain.com"
 sudo cp deploy/nginx/corvid-agent.conf /etc/nginx/sites-available/
 sudo ln -s /etc/nginx/sites-available/corvid-agent.conf /etc/nginx/sites-enabled/
 sudo certbot --nginx -d yourdomain.com
 sudo nginx -t && sudo systemctl reload nginx
 ```
 
-## Security Notes
+## Notes
 
+- **Volume rename**: `db-data` → `corvid-data`. Existing `db-data` volume data won't transfer automatically.
 - The systemd unit runs with `NoNewPrivileges`, `ProtectSystem=strict`, and `PrivateTmp`
-- Secrets go in `/etc/corvid-agent/env` (mode 600, root-owned) on Linux
 - Docker runs as non-root user `corvid` inside the container
 - nginx config includes rate limiting (30 req/s, burst 50) with health check exemption
-- Both proxy configs add `X-Content-Type-Options`, `X-Frame-Options`, and `Referrer-Policy` headers

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   corvid-agent:
+    container_name: corvid-agent
     build:
       context: ..
       dockerfile: deploy/Dockerfile
@@ -8,30 +9,48 @@ services:
     ports:
       - "${PORT:-3000}:3000"
     volumes:
-      - db-data:/app/data
+      - corvid-data:/app/data
     environment:
       - PORT=3000
-      # WARNING: 0.0.0.0 exposes the API on ALL network interfaces.
-      # In production, use a reverse proxy (nginx/caddy) with TLS and
-      # restrict BIND_HOST to 127.0.0.1 or a private network interface.
       - BIND_HOST=0.0.0.0
       - LOG_LEVEL=${LOG_LEVEL:-info}
-      - ALGOCHAT_MNEMONIC=${ALGOCHAT_MNEMONIC:-}
+      # Persistent paths inside the named volume
+      - DB_PATH=/app/data/corvid-agent.db
+      - WALLET_KEYSTORE_PATH=/app/data/wallet-keystore.json
+      # API authentication — set in deploy/.env before starting
+      - API_KEY=${API_KEY:-}
+      # AI Providers
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - ENABLED_PROVIDERS=${ENABLED_PROVIDERS:-anthropic,ollama}
+      # Ollama on the Docker host machine
+      - OLLAMA_HOST=${OLLAMA_HOST:-http://host.docker.internal:11434}
+      # Algorand / AlgoChat
       - ALGORAND_NETWORK=${ALGORAND_NETWORK:-localnet}
+      - ALGOCHAT_MNEMONIC=${ALGOCHAT_MNEMONIC:-}
       - ALGOCHAT_SYNC_INTERVAL=${ALGOCHAT_SYNC_INTERVAL:-30000}
       - ALGOCHAT_DEFAULT_AGENT_ID=${ALGOCHAT_DEFAULT_AGENT_ID:-}
       - ALGOCHAT_PSK_URI=${ALGOCHAT_PSK_URI:-}
+      - ALGOCHAT_OWNER_ADDRESSES=${ALGOCHAT_OWNER_ADDRESSES:-}
       - AGENT_TIMEOUT_MS=${AGENT_TIMEOUT_MS:-1800000}
-      - LOCALNET_ALGOD_URL=${LOCALNET_ALGOD_URL:-}
-      - LOCALNET_KMD_URL=${LOCALNET_KMD_URL:-}
-      - LOCALNET_INDEXER_URL=${LOCALNET_INDEXER_URL:-}
+      # Algorand localnet running on the Docker host machine (separate container or algokit).
+      # host.docker.internal resolves to the host on macOS/Windows Docker Desktop and Linux
+      # (via extra_hosts above). Override these if your localnet uses different ports.
+      - LOCALNET_ALGOD_URL=${LOCALNET_ALGOD_URL:-http://host.docker.internal:4001}
+      - LOCALNET_KMD_URL=${LOCALNET_KMD_URL:-http://host.docker.internal:4002}
+      - LOCALNET_INDEXER_URL=${LOCALNET_INDEXER_URL:-http://host.docker.internal:8980}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "bun", "-e", "const r = await fetch('http://localhost:3000/health/ready'); process.exit(r.ok ? 0 : 1)"]
+      test:
+        [
+          "CMD",
+          "bun",
+          "-e",
+          "const r = await fetch('http://localhost:3000/health/ready'); process.exit(r.ok ? 0 : 1)",
+        ]
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 10s
+      start_period: 15s
 
 volumes:
-  db-data:
+  corvid-data:

--- a/server/db/connection.ts
+++ b/server/db/connection.ts
@@ -26,7 +26,7 @@ function setDbFilePermissions(path: string): void {
  * ensure the v1–52 schema is present. Call `await initDb()` early
  * in your startup to also apply any newer file-based migrations.
  */
-export function getDb(path: string = 'corvid-agent.db'): Database {
+export function getDb(path: string = process.env.DB_PATH ?? 'corvid-agent.db'): Database {
     if (db) return db;
 
     db = new Database(path, { create: true });

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -161,6 +161,13 @@ export async function handleRequest(
         }
     }
 
+    // Only apply auth and guards to API/A2A paths.
+    // Any other path (Angular SPA routes, static assets) falls through to
+    // the static file handler in server/index.ts — no auth required there.
+    if (!url.pathname.startsWith('/api/') && !url.pathname.startsWith('/a2a/')) {
+        return null;
+    }
+
     // Build request context and apply declarative guard chain
     const context = createRequestContext(url.searchParams.get('wallet') || undefined);
 


### PR DESCRIPTION
## Summary

- Updates Docker deployment structure/documentation
- Add authentication to routes
- Addded configuration for claude CLI inside docker container

Introduces an authentication overlay in the client that prompts for an API key, which can be provided via a URL parameter or an input form. Enforces API key authentication on server-side `/api/` and `/a2a/` routes, while allowing unauthenticated access to client-side assets.

Expands Docker deployment configuration with new environment variables for API key, Anthropic, Ollama, and Algorand settings. Adds support for Claude Code CLI login within the Docker container, providing an alternative to direct `ANTHROPIC_API_KEY`.

Updates the `Dockerfile` to create a home directory for the `corvid` user, enabling persistent Claude CLI credentials. Refactors `docker-compose.yml` for clarity, consistent volume naming (`corvid-data`), and enhanced health checks. The database path is now configurable via an environment variable.

Completely rewrites `deploy/README.md` to provide comprehensive setup and usage instructions for the new authentication and deployment options.

## Checklist
- [x] `bun test` passes
- [x] No secrets committed
- [x] Structured logging used (no `console.log`)
