### PR TITLE
test: add unit tests for response helpers and safe env builder

### DIFF
--- a/server/__tests__/env.test.ts
+++ b/server/__tests__/env.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { buildSafeGhEnv } from '../lib/env';
+
+describe('buildSafeGhEnv', () => {
+    const originalEnv = { ...process.env };
+
+    afterEach(() => {
+        // Restore env to original state
+        for (const key of Object.keys(process.env)) {
+            if (!(key in originalEnv)) {
+                delete process.env[key];
+            }
+        }
+        Object.assign(process.env, originalEnv);
+    });
+
+    it('includes PATH when present', () => {
+        const env = buildSafeGhEnv();
+        if (process.env.PATH) {
+            expect(env.PATH).toBe(process.env.PATH);
+        }
+    });
+
+    it('includes HOME when present', () => {
+        const env = buildSafeGhEnv();
+        if (process.env.HOME) {
+            expect(env.HOME).toBe(process.env.HOME);
+        }
+    });
+
+    it('includes GH_TOKEN when set', () => {
+        process.env.GH_TOKEN = 'ghp_test123';
+        const env = buildSafeGhEnv();
+        expect(env.GH_TOKEN).toBe('ghp_test123');
+    });
+
+    it('includes GITHUB_TOKEN when set', () => {
+        process.env.GITHUB_TOKEN = 'ghp_another';
+        const env = buildSafeGhEnv();
+        expect(env.GITHUB_TOKEN).toBe('ghp_another');
+    });
+
+    it('does NOT include ANTHROPIC_API_KEY', () => {
+        process.env.ANTHROPIC_API_KEY = 'sk-ant-secret';
+        const env = buildSafeGhEnv();
+        expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    });
+
+    it('does NOT include ALGORAND_MNEMONIC', () => {
+        process.env.ALGORAND_MNEMONIC = 'abandon abandon abandon';
+        const env = buildSafeGhEnv();
+        expect(env.ALGORAND_MNEMONIC).toBeUndefined();
+    });
+
+    it('does NOT include API_KEY', () => {
+        process.env.API_KEY = 'secret-api-key';
+        const env = buildSafeGhEnv();
+        expect(env.API_KEY).toBeUndefined();
+    });
+
+    it('does NOT include DATABASE_URL', () => {
+        process.env.DATABASE_URL = 'postgres://secret';
+        const env = buildSafeGhEnv();
+        expect(env.DATABASE_URL).toBeUndefined();
+    });
+
+    it('omits undefined env vars from the result', () => {
+        delete process.env.COMSPEC; // Windows-only, likely not set on macOS
+        const env = buildSafeGhEnv();
+        expect('COMSPEC' in env).toBe(false);
+    });
+
+    it('includes git author env vars when set', () => {
+        process.env.GIT_AUTHOR_NAME = 'corvid-agent';
+        process.env.GIT_AUTHOR_EMAIL = 'agent@corvid.dev';
+        const env = buildSafeGhEnv();
+        expect(env.GIT_AUTHOR_NAME).toBe('corvid-agent');
+        expect(env.GIT_AUTHOR_EMAIL).toBe('agent@corvid.dev');
+    });
+
+    it('returns only string values', () => {
+        const env = buildSafeGhEnv();
+        for (const [key, val] of Object.entries(env)) {
+            expect(typeof key).toBe('string');
+            expect(typeof val).toBe('string');
+        }
+    });
+});

--- a/server/__tests__/response.test.ts
+++ b/server/__tests__/response.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'bun:test';
+import {
+    json,
+    badRequest,
+    notFound,
+    unavailable,
+    serverError,
+    errorMessage,
+    safeNumParam,
+    handleRouteError,
+} from '../lib/response';
+import {
+    ValidationError,
+    NotFoundError,
+    RateLimitError,
+    ExternalServiceError,
+} from '../lib/errors';
+
+// --- json() -----------------------------------------------------------------
+
+describe('json', () => {
+    it('returns 200 by default', async () => {
+        const res = json({ ok: true });
+        expect(res.status).toBe(200);
+        expect(res.headers.get('Content-Type')).toBe('application/json');
+        expect(await res.json()).toEqual({ ok: true });
+    });
+
+    it('accepts a custom status code', () => {
+        const res = json({ created: true }, 201);
+        expect(res.status).toBe(201);
+    });
+
+    it('serializes arrays', async () => {
+        const res = json([1, 2, 3]);
+        expect(await res.json()).toEqual([1, 2, 3]);
+    });
+
+    it('serializes null', async () => {
+        const res = json(null);
+        expect(await res.json()).toBeNull();
+    });
+
+    it('serializes strings', async () => {
+        const res = json('hello');
+        expect(await res.text()).toBe('"hello"');
+    });
+});
+
+// --- convenience responses --------------------------------------------------
+
+describe('badRequest', () => {
+    it('returns 400 with error message', async () => {
+        const res = badRequest('missing field');
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toBe('missing field');
+    });
+});
+
+describe('notFound', () => {
+    it('returns 404 with error message', async () => {
+        const res = notFound('Session not found');
+        expect(res.status).toBe(404);
+        const body = await res.json();
+        expect(body.error).toBe('Session not found');
+    });
+});
+
+describe('unavailable', () => {
+    it('returns 503 with error message', async () => {
+        const res = unavailable('service down');
+        expect(res.status).toBe(503);
+        const body = await res.json();
+        expect(body.error).toBe('service down');
+    });
+});
+
+// --- serverError() ----------------------------------------------------------
+
+describe('serverError', () => {
+    it('returns 500 with generic message', async () => {
+        const res = serverError(new Error('secret details'));
+        expect(res.status).toBe(500);
+        const body = await res.json();
+        expect(body.error).toBe('Internal server error');
+        expect(body.timestamp).toBeTruthy();
+        // Must NOT leak error details
+        expect(JSON.stringify(body)).not.toContain('secret details');
+    });
+
+    it('handles non-Error thrown values', async () => {
+        const res = serverError('string error');
+        expect(res.status).toBe(500);
+        const body = await res.json();
+        expect(body.error).toBe('Internal server error');
+    });
+
+    it('includes an ISO timestamp', async () => {
+        const res = serverError(new Error('test'));
+        const body = await res.json();
+        // Validate ISO 8601 format
+        expect(new Date(body.timestamp).toISOString()).toBe(body.timestamp);
+    });
+});
+
+// --- errorMessage() ---------------------------------------------------------
+
+describe('errorMessage', () => {
+    it('extracts message from Error', () => {
+        expect(errorMessage(new Error('test'))).toBe('test');
+    });
+
+    it('converts non-Error to string', () => {
+        expect(errorMessage('oops')).toBe('oops');
+        expect(errorMessage(42)).toBe('42');
+        expect(errorMessage(null)).toBe('null');
+    });
+});
+
+// --- safeNumParam() ---------------------------------------------------------
+
+describe('safeNumParam', () => {
+    it('returns parsed number for valid strings', () => {
+        expect(safeNumParam('42', 10)).toBe(42);
+        expect(safeNumParam('0', 10)).toBe(0);
+        expect(safeNumParam('-5', 10)).toBe(-5);
+        expect(safeNumParam('3.14', 10)).toBeCloseTo(3.14);
+    });
+
+    it('returns default for null', () => {
+        expect(safeNumParam(null, 10)).toBe(10);
+    });
+
+    it('returns default for NaN strings', () => {
+        expect(safeNumParam('abc', 10)).toBe(10);
+    });
+
+    it('treats empty string as 0 (Number("") === 0)', () => {
+        expect(safeNumParam('', 10)).toBe(0);
+    });
+});
+
+// --- handleRouteError() -----------------------------------------------------
+
+describe('handleRouteError', () => {
+    it('maps ValidationError to 400', async () => {
+        const res = handleRouteError(new ValidationError('bad input'));
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toBe('bad input');
+        expect(body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('maps NotFoundError to 404', async () => {
+        const res = handleRouteError(new NotFoundError('Agent', 'xyz'));
+        expect(res.status).toBe(404);
+        const body = await res.json();
+        expect(body.error).toBe('Agent xyz not found');
+        expect(body.code).toBe('NOT_FOUND');
+    });
+
+    it('maps RateLimitError to 429 with retryAfter', async () => {
+        const res = handleRouteError(new RateLimitError('slow down', { retryAfter: 15 }));
+        expect(res.status).toBe(429);
+        const body = await res.json();
+        expect(body.error).toBe('slow down');
+        expect(body.code).toBe('RATE_LIMITED');
+        expect(body.retryAfter).toBe(15);
+    });
+
+    it('maps RateLimitError without retryAfter', async () => {
+        const res = handleRouteError(new RateLimitError());
+        expect(res.status).toBe(429);
+        const body = await res.json();
+        expect(body.retryAfter).toBeUndefined();
+    });
+
+    it('maps ExternalServiceError to 502', async () => {
+        const res = handleRouteError(new ExternalServiceError('Algo', 'timeout'));
+        expect(res.status).toBe(502);
+        const body = await res.json();
+        expect(body.code).toBe('EXTERNAL_SERVICE_ERROR');
+    });
+
+    it('falls back to 500 for unknown errors', async () => {
+        const res = handleRouteError(new Error('random'));
+        expect(res.status).toBe(500);
+        const body = await res.json();
+        expect(body.error).toBe('Internal server error');
+        expect(body.code).toBeUndefined();
+    });
+
+    it('falls back to 500 for non-Error values', async () => {
+        const res = handleRouteError('string thrown');
+        expect(res.status).toBe(500);
+    });
+});


### PR DESCRIPTION
## Summary

- Add unit tests for `server/lib/response.ts` — 24 tests covering all exported functions: `json`, `badRequest`, `notFound`, `unavailable`, `serverError`, `errorMessage`, `safeNumParam`, `handleRouteError`
- Add unit tests for `server/lib/env.ts` — 11 tests verifying the `buildSafeGhEnv` allowlist correctly includes safe vars (PATH, HOME, GH_TOKEN, git config) and excludes secrets (ANTHROPIC_API_KEY, ALGORAND_MNEMONIC, API_KEY, DATABASE_URL)

These are foundational modules used across every route handler and subprocess spawn. Previously had 0% test coverage.

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` passes (3,775 tests, 0 failures)
- [x] `bun run spec:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)