### PR TITLE
docs: add VISION.md manifesto and reposition documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 # corvid-agent
 
-Agent orchestration platform — manages Claude agent sessions with MCP tools, AlgoChat messaging, on-chain wallet integration, bidirectional Telegram/Discord bridges, persona system, skill bundles, and voice TTS/STT.
+Decentralized development agent platform built on Algorand — spawns, orchestrates, and monitors AI agents that do real software engineering work with on-chain identity, encrypted inter-agent communication, and structured multi-agent deliberation.
+
+See [VISION.md](VISION.md) for the full project manifesto: positioning, architecture, competitive landscape, technical principles, and long-term direction. VISION.md is the canonical source of truth for project identity.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@
 
 # corvid-agent
 
-Agent orchestration platform for running, managing, and governing autonomous AI agents. Talk to your agents from Telegram and Discord, give them unique personalities, equip them with composable skill bundles, and add voice interaction — all on top of cryptographic identities, credit balances, multi-agent governance, graph workflows, and self-improving code pipelines.
+**Decentralized development agent platform built on Algorand.**
+
+Spawns, orchestrates, and monitors AI agents that do real software engineering work — picking up tasks, writing code, creating branches, validating changes, opening PRs, and deliberating with other agents about decisions. The key differentiator: agents have **verifiable on-chain identities**, communicate through **encrypted cryptographic channels**, and can form **decentralized networks** where trust is established through blockchain.
+
+See [VISION.md](VISION.md) for the full manifesto on positioning, architecture, competitive landscape, and long-term direction.
 
 Built with [Bun](https://bun.sh), [Angular 21](https://angular.dev), [SQLite](https://bun.sh/docs/api/sqlite), [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk), and [Algorand](https://algorand.co).
 
@@ -36,233 +40,69 @@ bun run dev
 
 Server starts at `http://localhost:3000`. See `.env.example` for all configuration options.
 
-### Minimum `.env`
-
-```bash
-ANTHROPIC_API_KEY=sk-ant-...          # Required — Claude agent sessions
-ALGOCHAT_MNEMONIC=your 25 words ...   # Optional — on-chain identity & messaging
-OLLAMA_HOST=http://localhost:11434    # Optional — local model inference
-```
-
-### Optional: Enable Messaging Bridges
-
-```bash
-# Telegram — talk to agents from your phone
-TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
-TELEGRAM_CHAT_ID=123456789
-TELEGRAM_ALLOWED_USER_IDS=111222333   # comma-separated, empty = allow all
-
-# Discord — talk to agents from Discord
-DISCORD_BOT_TOKEN=your-bot-token
-DISCORD_CHANNEL_ID=channel-id
-
-# Slack — talk to agents from Slack channels
-SLACK_BOT_TOKEN=xoxb-your-bot-token
-SLACK_CHANNEL_ID=C0123456789
-SLACK_SIGNING_SECRET=your-signing-secret
-
-# Voice — TTS/STT for Telegram voice notes and audio responses
-OPENAI_API_KEY=sk-...
-```
-
----
-
-## Core Capabilities
-
-### Agent Sessions
-- Spawn and manage Claude or Ollama agent sessions with configurable system prompts, tool permissions, and budgets
-- Real-time streaming via WebSocket with terminal-style UI
-- Tool approval workflows for sensitive operations
-- Automatic context management with turn-based resets
-
-### Bidirectional Telegram Bridge
-- Talk to agents directly from Telegram with long-polling integration
-- Voice note support: send a voice message, agent transcribes via Whisper STT and responds
-- Voice responses: agents with voice enabled reply with audio (OpenAI TTS) plus text
-- Per-user sessions with `/start`, `/status`, `/new` commands
-- Authorization via `TELEGRAM_ALLOWED_USER_IDS`
-
-### Bidirectional Discord Bridge
-- Talk to agents from any Discord channel via raw WebSocket gateway (no discord.js dependency)
-- Auto-reconnect with exponential backoff, heartbeat, and session resume
-- Per-user sessions with `/status` and `/new` commands
-- Messages over 2000 characters automatically chunked
-
-### Slack Integration
-- Talk to agents from Slack channels with bidirectional message bridge
-- Notification delivery for schedule approvals, work task results, and agent questions
-- Question routing: `corvid_ask_owner` questions appear in Slack with response buttons
-- Implements the ChannelAdapter interface for consistent bridge behavior
-
-### Character/Persona System
-- Give each agent a distinct personality with archetype, traits, background, and voice guidelines
-- Example messages to set communication tone and style
-- Persona is injected into the system prompt for both Claude SDK and Ollama sessions
-- API: `GET/PUT/DELETE /api/agents/{id}/persona`
-
-### Skill Bundles
-- Composable packages of tools + prompt additions that can be assigned to agents
-- 5 built-in presets: Code Reviewer, DevOps, Researcher, Communicator, Analyst
-- Create custom bundles and assign multiple to a single agent
-- Tools from bundles are merged with the agent's base permissions at session start
-- API: `/api/skill-bundles` (CRUD), `/api/agents/{id}/skills` (assign/unassign)
-
-### Voice Support (TTS/STT)
-- Text-to-speech via OpenAI TTS API (`tts-1` model) with 6 voice presets (alloy, echo, fable, onyx, nova, shimmer)
-- Speech-to-text via OpenAI Whisper API for transcribing voice messages
-- Intelligent caching: synthesized audio is stored in SQLite by text hash + voice preset
-- Per-agent voice configuration: `voiceEnabled` and `voicePreset` fields on the agent model
-
-### Multi-Agent Councils
-- Structured deliberation with multiple agents and a chairman
-- Pipeline: responding → discussing (N rounds) → reviewing → synthesizing
-- Chairman synthesizes a final decision from independent agent responses
-
-### Self-Improvement Pipeline
-- Agents call `corvid_create_work_task` to propose code changes
-- Automatic git worktree, branch creation, and PR submission
-- Validation loop: TypeScript type-check + test suite (up to 3 iterations)
-- Protected file enforcement prevents agents from modifying critical code
-
-### Graph Workflow Orchestration
-- DAG-based multi-step workflows with suspend/resume
-- Node types: agent session, work task, condition, delay, transform, parallel fork/join
-
-### Scheduling & Automation
-- Cron and interval-based task scheduling with configurable approval policies
-- Actions: agent chat, work tasks, council launches, GitHub operations, inter-agent messaging
-- GitHub webhook-driven automation with `@mention` triggers
-
-### On-Chain Identity (AlgoChat)
-- Algorand-backed agent wallets with AES-256-GCM encryption at rest
-- X25519 PSK encrypted messaging channels
-- Owner commands: `/stop`, `/approve`, `/deny`, `/mode`, `/work`, `/council`
-- Credit system with ALGO-based purchasing
-
-### Multi-Channel Notifications
-- Delivery via Discord, Telegram, GitHub Issues, and AlgoChat
-- Blocking `corvid_ask_owner` for two-way agent-to-owner questions
-- First-response-wins across all configured channels
-
-### Cloud Model Routing
-- Ollama cloud model support with `-cloud` suffix routing to remote instances
-- Local proxy handles authentication forwarding for remote Ollama hosts
-- Merged local + remote model listings in the dashboard
-
-### Model Exam System
-- 18 test cases across 6 categories: coding, context, tools, algochat, council, instruction
-- Per-category scoring with aggregate scorecard for evaluating model capabilities
-- Integrated into the dashboard and API at `/api/exam`
-
-### Mention Polling
-- GitHub `@mention` polling for automated issue and PR responses
-- Configurable per-agent poll intervals with centralized deduplication
-- Filters by event type (issue comments, issues, PR review comments)
-
-### Centralized Deduplication
-- Bounded LRU caches with configurable TTL per namespace
-- Replaces per-module Map/Set patterns to prevent unbounded memory growth
-- Optional SQLite persistence for crash recovery
-- Used across polling, messaging, AlgoChat bridge, and Slack bridge
-
-### AST Code Understanding
-- Tree-sitter parser for TypeScript, JavaScript, Python, Go, Rust, and more
-- Extracts functions, classes, imports, and call graphs for smarter work tasks
-- `corvid_code_symbols` and `corvid_find_references` tools for agent use
-
-### Observability
-- OpenTelemetry tracing with OTLP HTTP export
-- Prometheus metrics endpoint
-- Immutable audit log with trace context propagation
-
 ---
 
 ## Architecture
 
 ```
-                    +--------------------------+
-                    |   Angular 21 Dashboard   |
-                    |  (signals, standalone)   |
-                    +------------+-------------+
-                                 |
-                            HTTP / WebSocket
-                                 |
-+--------------------------------+--------------------------------+
-|                     Bun Server (port 3000)                      |
-|                                                                 |
-|  +----------+  +----------+  +-----------+  +----------------+  |
-|  | Process  |  | Council  |  | Scheduler |  | Work Tasks     |  |
-|  | Manager  |  | Engine   |  | Service   |  | (git worktree) |  |
-|  +----------+  +----------+  +-----------+  +----------------+  |
-|  | Telegram |  | Discord  |  | Voice     |  | Personas       |  |
-|  | Bridge   |  | Bridge   |  | TTS / STT |  | + Skills       |  |
-|  +----------+  +----------+  +-----------+  +----------------+  |
-|  | Workflow |  | A2A      |  | Marketplace |  | Sandbox       |  |
-|  | Engine   |  | Protocol |  | + Plugins   |  | (containers)  |  |
-|  +----------+  +----------+  +-------------+  +---------------+  |
-|  | Mention  |  | Exam     |  | Improvement |  | Notifications |  |
-|  | Polling  |  | System   |  | Pipeline    |  | (multi-chan)  |  |
-|  +----------+  +----------+  +-------------+  +---------------+  |
-|  | Reputation |  | Tenants |  | Observability (OTEL)          |  |
-|  | + Trust    |  | + Billing|  | Tracing + Metrics + Audit    |  |
-|  +------------+  +---------+  +-------------------------------+  |
-|       |              |              |                |           |
-|  +----+-----+  +----+-----+  +-----+-----+  +------+--------+  |
-|  | Claude   |  | Ollama   |  | AlgoChat  |  | GitHub API    |  |
-|  | Agent SDK|  | (local)  |  | (Algorand)|  | (webhooks)    |  |
-|  +----------+  +----------+  +-----------+  +---------------+  |
-|                                                                 |
-|  +-----------------------------------------------------------+  |
-|  |                    SQLite (bun:sqlite)                     |  |
-|  |  47 migrations | FTS5 search | WAL mode | foreign keys    |  |
-|  +-----------------------------------------------------------+  |
-+-----------------------------------------------------------------+
++--------------------------------------------------+
+|              AGENT RUNTIME                        |
+|  Claude SDK · Ollama · MCP Tools (36+)            |
+|  Council Deliberation · Self-Improvement Pipeline |
+|  Memory · AST Code Analysis · Model Exams         |
++--------------------------------------------------+
+|              TRUST LAYER (Algorand)               |
+|  On-Chain Identity · AlgoChat (encrypted P2P)     |
+|  Agent Directory · Transaction Audit Trail        |
++--------------------------------------------------+
+|              INTERFACE LAYER                      |
+|  Angular Web UI · Discord · Telegram              |
+|  GitHub Integration · REST + WebSocket API        |
+|  Google A2A Protocol                              |
++--------------------------------------------------+
 ```
 
-### Directory Structure
+### What Agents Do
 
-```
-server/          Bun HTTP + WebSocket server
-  a2a/           Google A2A protocol inbound task handling and agent card
-  algochat/      On-chain messaging (bridge, wallet, directory, messenger)
-  ast/           Tree-sitter AST parser for code understanding
-  billing/       Usage metering and billing
-  db/            SQLite schema (47 migrations) and query modules
-  discord/       Bidirectional Discord bridge (raw WebSocket gateway)
-  docs/          OpenAPI generator, MCP tool docs, route registry
-  exam/          Model exam system with 18 test cases across 6 categories
-  github/        GitHub API operations (PRs, issues, reviews)
-  improvement/   Self-improvement pipeline and health metrics
-  lib/           Shared utilities (logger, crypto, validation, web search, dedup)
-  marketplace/   Agent marketplace — publish, discover, consume services
-  mcp/           MCP tool server and 36 corvid_* tool handlers
-  memory/        Structured memory with vector embeddings
-  middleware/    Auth, CORS, rate limiting, startup validation
-  notifications/ Multi-channel notification delivery (Discord, Telegram, GitHub, AlgoChat)
-  observability/ OpenTelemetry tracing, Prometheus metrics
-  plugins/       Plugin SDK and dynamic tool registration
-  polling/       GitHub mention polling for @mention-driven automation
-  process/       Agent lifecycle (SDK + Ollama, approval, event bus, persona/skill injection)
-  providers/     Multi-model cost-aware routing
-  public/        Static assets served by the HTTP server
-  reputation/    Reputation and trust scoring
-  routes/        REST API routes (28 route modules)
-  sandbox/       Container sandboxing for isolated execution
-  scheduler/     Cron/interval execution engine
-  selftest/      Self-test and validation utilities
-  slack/         Bidirectional Slack bridge (channel adapter, notifications, questions)
-  telegram/      Bidirectional Telegram bridge (long-polling, voice)
-  tenant/        Multi-tenant isolation and access control
-  voice/         TTS (OpenAI) and STT (Whisper) with caching
-  webhooks/      GitHub webhook and mention polling
-  work/          Work task service (worktree, branch, validate, PR)
-  workflow/      Graph-based DAG workflow orchestration engine
-  ws/            WebSocket handlers with pub/sub
-client/          Angular 21 SPA (standalone components, signals)
-shared/          TypeScript types shared between server and client
-deploy/          Docker, docker-compose, systemd, launchd, nginx, caddy, Helm
-e2e/             Playwright end-to-end tests (30 spec files, 348 tests)
-```
+1. **Scheduled runs** trigger multiple times per day
+2. Agent reviews its **work queue**, creates feature branches, implements changes using **MCP tools**
+3. Runs **validation** (TypeScript, tests, build) — iterates up to N times on failure
+4. Opens **pull requests** with descriptions, or flags for human review
+5. For complex decisions, **convenes a council** of specialist agents
+6. Results communicated via Discord, Telegram, GitHub, and AlgoChat
+
+### What Makes It Different
+
+- **On-chain identity** — every agent gets an Algorand wallet as its cryptographically verifiable identity
+- **Encrypted inter-agent messaging** — AlgoChat provides P2P communication across network boundaries
+- **Structured multi-agent deliberation** — council voting with recorded reasoning
+- **Self-improvement pipeline** — agents propose changes to their own codebase via PRs
+- **Blockchain audit trail** — immutable record of all inter-agent actions
+
+---
+
+## Core Capabilities
+
+| Category | Details |
+|---|---|
+| **Agent Sessions** | Claude SDK + Ollama, configurable prompts/tools/budgets, real-time WebSocket streaming |
+| **Work Tasks** | Git worktree isolation, branch/validate/PR pipeline, up to 3 iteration attempts |
+| **Council Deliberation** | Multi-agent structured discussion, voting rounds, chairman synthesis |
+| **Self-Improvement** | Agents call `corvid_create_work_task` to propose codebase changes autonomously |
+| **AlgoChat** | On-chain encrypted messaging (PSK + X25519), wallet identity, slash commands |
+| **Telegram Bridge** | Bidirectional long-polling, voice notes (Whisper STT), voice responses (OpenAI TTS) |
+| **Discord Bridge** | Raw WebSocket gateway (no discord.js), auto-reconnect, heartbeat |
+| **Slack Integration** | Bidirectional bridge, notification delivery, question routing with response buttons |
+| **Personas & Skills** | Archetype/trait system for agent personality, composable skill bundles for capabilities |
+| **Graph Workflows** | DAG-based multi-step orchestration with suspend/resume |
+| **Scheduling** | Cron/interval automation with configurable approval policies |
+| **AST Analysis** | Tree-sitter parsing for TypeScript, JavaScript, Python, Go, Rust and more |
+| **Model Exams** | 18 test cases across 6 categories for validating agent capabilities |
+| **Memory** | Structured memory with vector embeddings, FTS5 search |
+| **Voice** | OpenAI TTS (6 presets) + Whisper STT with intelligent caching |
+| **Notifications** | Multi-channel delivery: Discord, Telegram, GitHub Issues, AlgoChat |
+| **A2A Protocol** | Google Agent-to-Agent interop (inbound tasks, agent card) |
+| **Observability** | OpenTelemetry tracing, Prometheus metrics, immutable audit logging |
 
 ---
 
@@ -284,44 +124,54 @@ Extensible tool system via [Model Context Protocol](https://github.com/modelcont
 | **Code** | `corvid_code_symbols` (AST symbols), `corvid_find_references` (cross-file refs) |
 | **Session** | `corvid_extend_timeout` |
 
-Tools are permission-scoped per agent via skill bundles and agent-level allowlists. Scheduler-blocked enforcement prevents unintended side effects from automated runs.
+Tools are permission-scoped per agent via skill bundles and agent-level allowlists.
 
 ---
 
-## API
+## Project Structure
 
-~55 REST endpoints and a WebSocket interface across 28 route modules:
-
-| Group | Endpoints | Description |
-|-------|----------|-------------|
-| Agents | `GET/POST/PUT/DELETE /api/agents` | Agent CRUD with model, voice, and permission config |
-| Personas | `GET/PUT/DELETE /api/agents/:id/persona` | Character system — archetype, traits, voice style |
-| Skills | `/api/skill-bundles`, `/api/agents/:id/skills` | Composable tool + prompt bundles |
-| Sessions | `GET/POST/PUT/DELETE /api/sessions` | Session lifecycle and message history |
-| Councils | `/api/councils`, `/api/councils/:id/launch` | Multi-agent deliberation with stage tracking |
-| Workflows | `/api/workflows` | DAG orchestration with suspend/resume |
-| Schedules | `/api/schedules` | Cron/interval automation with approval |
-| Work Tasks | `/api/work-tasks` | Self-improvement task tracking |
-| Marketplace | `/api/marketplace` | Agent service listings, reviews, federation |
-| Webhooks | `/api/webhooks`, `POST /webhooks/github` | GitHub event-driven automation |
-| Mention Polling | `/api/mention-polling` | GitHub @mention polling configuration |
-| Reputation | `/api/reputation` | Trust scores, events, attestations |
-| Billing | `/api/billing` | Subscriptions, usage metering, invoices |
-| Sandbox | `/api/sandbox` | Container policies and allocation |
-| Analytics | `/api/analytics` | Cost, token, and session statistics |
-| Audit | `/api/audit` | Immutable audit log queries |
-| Exam | `/api/exam` | Model examination and capability scoring |
-| MCP API | `/api/mcp` | Model Context Protocol endpoints |
-| MCP Servers | `/api/mcp-servers` | External MCP server configuration |
-| Ollama | `/api/ollama` | Ollama provider management and model pulls |
-| Plugins | `/api/plugins` | Plugin registry and capability management |
-| Allowlist | `/api/allowlist` | Address allowlist management |
-| Auth Flow | `/api/auth` | Device authorization for CLI login |
-| Settings | `/api/settings` | Application settings and operational mode |
-| System Logs | `/api/system-logs` | System log queries and credit history |
-| Health | `GET /api/health` | Health check (public, no auth) |
-| A2A | `/.well-known/agent-card.json` | Google A2A protocol Agent Card |
-| WebSocket | `WS /ws` | Real-time streaming and event subscriptions |
+```
+server/           Bun HTTP + WebSocket server
+  a2a/            Google A2A protocol (inbound tasks, agent card)
+  algochat/       On-chain messaging (bridge, wallet, directory, messenger)
+  ast/            Tree-sitter AST parser for code understanding
+  billing/        Usage metering and billing
+  db/             SQLite schema (47 migrations) and query modules
+  discord/        Bidirectional Discord bridge (raw WebSocket gateway)
+  docs/           OpenAPI generator, MCP tool docs, route registry
+  exam/           Model exam system (18 tests, 6 categories)
+  github/         GitHub API operations (PRs, issues, reviews)
+  improvement/    Self-improvement pipeline and health metrics
+  lib/            Shared utilities (logger, crypto, validation, web search, dedup)
+  marketplace/    Agent marketplace (publish, discover, consume services)
+  mcp/            MCP tool server and 36 corvid_* tool handlers
+  memory/         Structured memory with vector embeddings
+  middleware/     Auth, CORS, rate limiting, startup validation
+  notifications/  Multi-channel delivery (Discord, Telegram, GitHub, AlgoChat)
+  observability/  Metrics and health monitoring
+  plugins/        Plugin SDK and dynamic tool registration
+  polling/        GitHub mention polling for @mention-driven automation
+  process/        Agent lifecycle (SDK + Ollama, approval, persona/skill injection)
+  providers/      Multi-model cost-aware routing
+  public/         Static assets served by the HTTP server
+  reputation/     Reputation and trust scoring
+  routes/         REST API routes (28 route modules)
+  sandbox/        Container sandboxing for isolated execution
+  scheduler/      Cron/interval execution engine
+  selftest/       Self-test and validation utilities
+  slack/          Bidirectional Slack bridge (channel adapter, notifications)
+  telegram/       Bidirectional Telegram bridge (long-polling, voice)
+  tenant/         Multi-tenant isolation and access control
+  voice/          TTS (OpenAI) and STT (Whisper) with caching
+  webhooks/       GitHub webhook and mention polling
+  work/           Work task service (worktree, branch, validate, PR)
+  workflow/       Graph-based DAG workflow orchestration engine
+  ws/             WebSocket handlers with pub/sub
+client/           Angular 21 SPA (standalone components, signals)
+shared/           TypeScript types shared between server and client
+deploy/           Docker, docker-compose, systemd, launchd, nginx, caddy
+e2e/              Playwright end-to-end tests (30 spec files, 348 tests)
+```
 
 ---
 
@@ -338,57 +188,29 @@ bun run spec:check    # Validate all module specs in specs/
 
 **348 E2E tests** across 30 Playwright spec files covering 198/202 testable API endpoints and all 34 Angular UI routes.
 
-**33 module specs** in `specs/` with automated validation via `bun run spec:check` — checks YAML frontmatter, required sections, API surface coverage (exported symbols vs documented), file existence, database table references, and dependency graph integrity. Runs in CI on every commit.
-
----
-
-## Tech Stack
-
-| Layer | Technology |
-|-------|-----------|
-| Runtime | [Bun](https://bun.sh) — server, package manager, test runner, bundler |
-| Frontend | [Angular 21](https://angular.dev) — standalone components, signals, responsive mobile UI |
-| Database | [SQLite](https://bun.sh/docs/api/sqlite) — WAL mode, FTS5, 47 migrations |
-| Agent SDK | [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) |
-| Local Models | [Ollama](https://ollama.com) — Qwen, Llama, etc. |
-| Voice | [OpenAI TTS/Whisper](https://platform.openai.com/docs/guides/text-to-speech) — 6 voice presets, STT transcription |
-| Blockchain | [Algorand](https://algorand.co) — on-chain identity and messaging |
-| Tools | [MCP SDK](https://github.com/modelcontextprotocol/sdk) |
-| Observability | [OpenTelemetry](https://opentelemetry.io) — tracing, Prometheus metrics |
-| Validation | [Zod](https://zod.dev) — runtime schema validation |
-
----
-
-## Security
-
-- **Authentication** — API key required on non-localhost; WebSocket auth enforced
-- **Encryption** — AES-256-GCM for wallets and memory; X25519 for on-chain messaging
-- **File protection** — agents cannot modify security-critical files (enforced at runtime)
-- **Bash validation** — dangerous commands blocked before execution
-- **Environment isolation** — agent subprocesses receive only safe environment variables
-- **Rate limiting** — per-IP sliding window (600 GET/min, 60 mutation/min)
-- **Spending limits** — daily ALGO cap, per-message cost check, credit gating
-- **Bridge authorization** — Telegram user allowlist, Discord channel restriction
-- **Audit logging** — immutable, insert-only log with trace IDs
-- **Startup validation** — server refuses to start without API key on non-localhost bind
-
-See [SECURITY.md](SECURITY.md) for the full security model and responsible disclosure.
-
----
-
-## Deployment
-
-The `deploy/` directory includes production configurations:
-
-- `Dockerfile` + `docker-compose.yml` — multi-stage build, non-root container
-- `corvid-agent.service` — systemd unit for Linux
-- `com.corvidlabs.corvid-agent.plist` — macOS LaunchAgent
-- `daemon.sh` — cross-platform daemon installer
-- `nginx/` + `caddy/` — reverse proxy with TLS termination
+**33 module specs** in `specs/` with automated validation via `bun run spec:check`.
 
 ---
 
 ## Environment Variables
+
+### Required
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...          # Claude agent sessions
+```
+
+### Optional
+
+```bash
+ALGOCHAT_MNEMONIC=your 25 words ...   # On-chain identity & messaging
+OLLAMA_HOST=http://localhost:11434    # Local model inference
+TELEGRAM_BOT_TOKEN=123456:ABC-DEF... # Telegram bridge
+DISCORD_BOT_TOKEN=your-bot-token     # Discord bridge
+SLACK_BOT_TOKEN=xoxb-your-bot-token  # Slack bridge
+GH_TOKEN=ghp_...                     # GitHub PR creation
+OPENAI_API_KEY=sk-...                # Voice TTS/STT
+```
 
 | Variable | Description | Default |
 |---|---|---|
@@ -416,6 +238,54 @@ See `.env.example` for the full list of 30+ options including wallet encryption,
 
 ---
 
+## Security
+
+- **Authentication** — API key required on non-localhost; WebSocket auth enforced
+- **Encryption** — AES-256-GCM for wallets and memory; X25519 for on-chain messaging
+- **File protection** — agents cannot modify security-critical files (enforced at runtime)
+- **Bash validation** — dangerous commands blocked before execution
+- **Environment isolation** — agent subprocesses receive only safe environment variables
+- **Rate limiting** — per-IP sliding window (600 GET/min, 60 mutation/min)
+- **Spending limits** — daily ALGO cap, per-message cost check, credit gating
+- **Bridge authorization** — Telegram user allowlist, Discord channel restriction
+- **Audit logging** — immutable, insert-only log with trace IDs
+- **Startup validation** — server refuses to start without API key on non-localhost bind
+- **Prompt injection detection** — multi-layer scanner with encoding attack detection
+
+See [SECURITY.md](SECURITY.md) for the full security model and responsible disclosure.
+
+---
+
+## Deployment
+
+The `deploy/` directory includes production configurations:
+
+- `Dockerfile` + `docker-compose.yml` — multi-stage build, non-root container
+- `corvid-agent.service` — systemd unit for Linux
+- `com.corvidlabs.corvid-agent.plist` — macOS LaunchAgent
+- `daemon.sh` — cross-platform daemon installer
+- `run-loop.sh` — auto-restart wrapper with update support
+- `nginx/` + `caddy/` — reverse proxy with TLS termination
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Runtime | [Bun](https://bun.sh) — server, package manager, test runner, bundler |
+| Frontend | [Angular 21](https://angular.dev) — standalone components, signals, responsive mobile UI |
+| Database | [SQLite](https://bun.sh/docs/api/sqlite) — WAL mode, FTS5, 47 migrations |
+| Agent SDK | [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) |
+| Local Models | [Ollama](https://ollama.com) — Qwen, Llama, etc. |
+| Voice | [OpenAI TTS/Whisper](https://platform.openai.com/docs/guides/text-to-speech) — 6 voice presets, STT transcription |
+| Blockchain | [Algorand](https://algorand.co) — on-chain identity and messaging |
+| Tools | [MCP SDK](https://github.com/modelcontextprotocol/sdk) |
+| Observability | [OpenTelemetry](https://opentelemetry.io) — tracing, Prometheus metrics |
+| Validation | [Zod](https://zod.dev) — runtime schema validation |
+
+---
+
 ## Built by corvid-agent
 
 These apps were designed, coded, tested, and deployed autonomously by corvid-agent — no human-written application code. Each is an Angular 21 standalone app hosted on GitHub Pages.
@@ -433,6 +303,16 @@ These apps were designed, coded, tested, and deployed autonomously by corvid-age
 | [quake-tracker](https://corvid-agent.github.io/quake-tracker/) | USGS | Real-time earthquake dashboard with magnitude filtering and seismic analytics |
 | [pd-music](https://corvid-agent.github.io/pd-music/) | MusicBrainz + Internet Archive | Public domain music explorer with streaming and curated collections |
 | [pixel-forge](https://corvid-agent.github.io/pixel-forge/) | Canvas API | Pixel art editor with drawing tools, palette presets, and gallery |
+
+---
+
+## Key Files
+
+- [`CLAUDE.md`](CLAUDE.md) — Agent instructions for working on this repo
+- [`VISION.md`](VISION.md) — Project manifesto and long-term direction
+- [`.env.example`](.env.example) — All configuration options with descriptions
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — Development setup and guidelines
+- [`SECURITY.md`](SECURITY.md) — Responsible disclosure policy
 
 ---
 

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,306 @@
+# corvid-agent
+
+## The Decentralized Development Agent Platform
+
+**Corvid Labs — 2026**
+
+---
+
+## What This Is
+
+corvid-agent is a **decentralized development agent platform** built on Algorand. It spawns, orchestrates, and monitors AI agents that do real software engineering work — picking up tasks, writing code, creating branches, validating changes, opening PRs, and deliberating with other agents about decisions.
+
+It is **not** a personal life automation tool. It does not send your emails, control your smart home, or browse the web on your behalf. Those are solved problems with massive incumbents. corvid-agent solves a different problem: **how do autonomous AI agents trust each other, communicate verifiably, and collaborate on development work across organizational boundaries?**
+
+The answer is on-chain identity, cryptographic messaging, and structured multi-agent deliberation — all native to the platform, not bolted on.
+
+---
+
+## What This Is Not
+
+corvid-agent is not trying to be OpenClaw, Devin, or Copilot Workspace.
+
+**OpenClaw** is a personal AI butler. It connects to your messaging apps and automates your digital life. It's model-agnostic, channel-heavy, and consumer-facing. It went viral because everyone can picture what they'd use it for.
+
+**Devin / Copilot Workspace** are cloud-hosted coding agents tied to specific platforms. They're powerful but centralized, proprietary, and isolated to single-user sessions.
+
+**corvid-agent** is none of these. It is:
+
+- A **self-hosted** agent runtime you own and operate
+- Purpose-built for **development workflows** (code, review, test, deploy)
+- The only agent platform with **native on-chain identity and communication**
+- Designed for agents that **talk to each other** across trust boundaries
+- Part of the broader **Corvid Labs ecosystem** on Algorand
+
+The key differentiator is not that agents can write code — everyone does that now. It's that agents have **verifiable identities**, can **communicate through cryptographic channels**, and can **form decentralized networks** where trust is established through blockchain, not through sharing API keys or being on the same server.
+
+---
+
+## Core Thesis
+
+> As AI agents become more autonomous and more prevalent, the fundamental problem shifts from "can an agent do useful work?" to "can I trust this agent, verify its identity, and let it collaborate with agents I don't control?"
+
+Every other agent platform assumes agents operate in isolation on a single user's machine. corvid-agent assumes agents need to **interoperate** — across teams, across organizations, across trust boundaries — and that blockchain is the right substrate for establishing that trust.
+
+This is not a hypothetical future concern. The moment you want Agent A (running on your infrastructure) to delegate a subtask to Agent B (running on someone else's infrastructure), you need answers to:
+
+- **Identity:** How does Agent A know Agent B is who it claims to be?
+- **Communication:** How do they exchange messages without a centralized broker?
+- **Verification:** How does Agent A verify that Agent B actually completed the work?
+- **Accountability:** How do you audit what happened if something goes wrong?
+
+Algorand provides the answers. On-chain wallets give agents verifiable identity. AlgoChat gives them encrypted peer-to-peer messaging. Transaction history gives you an immutable audit trail. Smart contracts can enforce agreements between agents.
+
+---
+
+## Architecture
+
+### The Three Layers
+
+```
++--------------------------------------------------+
+|              AGENT RUNTIME                        |
+|  Claude SDK · Ollama · Model-agnostic             |
+|  MCP Tools · Council Deliberation                 |
+|  Self-Improvement Pipeline · Work Management      |
+|  Memory (vector embeddings) · AST Code Analysis   |
++--------------------------------------------------+
+|              TRUST LAYER (Algorand)               |
+|  On-Chain Identity (wallet per agent)             |
+|  AlgoChat (encrypted P2P messaging)               |
+|  Agent Directory (capability registry)            |
+|  Transaction Audit Trail                          |
+|  Smart Contract Agreements (future)               |
++--------------------------------------------------+
+|              INTERFACE LAYER                      |
+|  Angular Web UI · Discord Bridge                  |
+|  Telegram Bridge · WebSocket API                  |
+|  GitHub Integration · REST API                    |
+|  Google A2A Protocol                              |
++--------------------------------------------------+
+```
+
+### Agent Runtime
+
+The engine that makes agents do useful work:
+
+- **Process Management:** Spawning, monitoring, and managing agent lifecycles with health checks, automatic restart, and resource limits.
+- **Work Management:** Task/ticket system where work items are created, assigned to agents, tracked through stages (todo -> in-progress -> review -> done), and linked to git branches and PRs.
+- **MCP Tool System:** 36+ tools exposed via Model Context Protocol. Agents interact with the codebase, file system, git, GitHub, and external services through a standardized tool interface. New capabilities are added as MCP handlers without modifying the core runtime.
+- **Council Deliberation:** Multi-agent structured discussion and voting. When a decision requires input from multiple agents (architecture choices, code review, prioritization), a council session is created. Agents present positions, vote, and reach consensus through structured rounds.
+- **Self-Improvement Pipeline:** Agents identify improvements to their own codebase, create work items, branch, implement changes, run validation, and open PRs. The platform improves itself.
+- **Memory System:** Structured memory with vector embeddings for long-term context. Agents remember past decisions, project context, and learned patterns across sessions.
+- **AST Code Analysis:** Tree-sitter parsing for deep code understanding, enabling smarter refactoring and context-aware changes.
+- **Model Exam System:** 18 test cases across 6 categories for validating agent capabilities and ensuring quality.
+
+### Trust Layer (Algorand)
+
+What makes corvid-agent fundamentally different from every other agent platform:
+
+- **On-Chain Identity:** Every agent gets an Algorand wallet. This wallet IS the agent's identity — cryptographically verifiable, not dependent on any central authority, portable across instances. When Agent A receives a message from Agent B, it can verify the signature against the blockchain. No trust-on-first-use. No shared secrets. No central identity provider.
+- **AlgoChat:** Encrypted peer-to-peer messaging via Algorand note fields. Supports PSK (pre-shared key) and X25519 key exchange. Messages are on-chain — immutable, timestamped, and auditable. Agents communicate across network boundaries without a centralized message broker.
+- **Agent Directory:** On-chain registry of agent identities, capabilities, and availability. Agents discover other agents by querying the blockchain, verify their identity, and establish communication channels without a central coordinator.
+- **Audit Trail:** Every agent action that touches the blockchain creates an immutable record. No log files that might have been tampered with — just blockchain history.
+
+### Interface Layer
+
+Multiple ways to interact with agents and monitor their work:
+
+- **Web UI (Angular 21):** Real-time dashboard with WebSocket updates. Monitor agent status, review work output, manage tasks, inspect council deliberations.
+- **Discord Bridge:** Bidirectional communication via raw WebSocket gateway. Issue commands, receive notifications, participate in council discussions.
+- **Telegram Bridge:** Talk to agents from your phone. Review PRs, approve work, check status.
+- **GitHub Integration:** Agents create branches, commit code, open PRs, respond to reviews, and close issues. Full participants in the development workflow, not just notification hooks.
+- **Google A2A Protocol:** Inbound task handling and agent card support for interoperability with the broader agent ecosystem.
+- **REST + WebSocket API:** Programmatic access for automation, CI/CD integration, and custom tooling.
+
+---
+
+## What Agents Actually Do
+
+corvid-agent is not a demo. It runs in production on a schedule and ships real work.
+
+### Daily Autonomous Operation
+
+1. **Scheduled runs** trigger multiple times per day.
+2. Agent reviews its **work queue** — tasks tagged for autonomous work.
+3. For each task, the agent:
+   - Creates a **feature branch** from main
+   - Reads relevant code context using **AST parsing** (Tree-sitter)
+   - Implements the change using **MCP tools** (file edit, create, delete)
+   - Runs **validation** (lint, test, build)
+   - If validation passes -> opens a **pull request** with a description of changes
+   - If validation fails -> iterates up to N times, then flags for human review
+4. For complex decisions, the agent **convenes a council** — spawning specialist agents to deliberate before proceeding.
+5. Results are communicated through configured channels (Discord, Telegram, GitHub).
+
+### Autonomous App Development
+
+corvid-agent doesn't just maintain its own codebase. It designs, codes, tests, and deploys complete applications autonomously — no human-written application code. These are Angular 21 standalone apps hosted on GitHub Pages, built entirely by the agent from spec to production.
+
+### Human-in-the-Loop
+
+Agents are autonomous but not unsupervised:
+
+- **Agents propose, humans approve.** PRs require human merge. Deployments require human trigger.
+- **Escalation paths are explicit.** Uncertainty gets flagged, not guessed at.
+- **Council deliberation provides transparency.** Decision reasoning is recorded and reviewable.
+- **On-chain audit trail means nothing is hidden.** Every inter-agent message is verifiable.
+
+---
+
+## The Corvid Labs Ecosystem
+
+corvid-agent is one piece of a larger ecosystem:
+
+```
+Corvid Labs Ecosystem
+|-- Nevermore NFT Collection --- 1,000 lifetime membership tokens on Algorand
+|-- CORVID ASA ---------------- Community token with tiered Discord roles
+|-- Mono ---------------------- iOS productivity app (pro features for NFT holders)
+|-- Corvid Companion ---------- Discord bot (NFT/ASA verification + role management)
+|-- AlgoChat ------------------ Encrypted on-chain messaging protocol (6 languages)
+|-- corvid-agent -------------- Decentralized development agents (this project)
+|-- Swift SDK for Algorand ---- swift-algorand, swift-algokit, swift-mint, swift-arc, etc.
++-- Open Source Utilities ----- swift-qr, swift-retry, swift-env, swift-graph, etc.
+```
+
+### AlgoChat is the Connective Tissue
+
+AlgoChat was built as a standalone encrypted messaging protocol on Algorand with implementations in Swift, TypeScript, Python, Kotlin, Rust, and a web app. In corvid-agent, AlgoChat becomes the **native communication layer for AI agents**.
+
+This means:
+
+- Agents running corvid-agent can message any AlgoChat-compatible endpoint
+- Future Corvid Labs apps (Mono, Discord bot) can receive agent messages natively
+- Third-party developers can build AlgoChat-compatible agents in any of the 6 supported languages
+- The protocol is open and on-chain — no vendor lock-in, no central broker
+
+### NFT Holder Benefits (Future)
+
+As the platform matures, Nevermore NFT holders gain:
+
+- Priority access to hosted agent instances
+- Exclusive agent skills and capabilities
+- Governance voting on platform development priorities
+- Access to the agent marketplace as both consumers and publishers
+
+---
+
+## Competitive Positioning
+
+| Capability | OpenClaw | Devin | Copilot Workspace | corvid-agent |
+|---|---|---|---|---|
+| Primary use case | Life automation | Cloud coding | PR-scoped coding | Dev workflow + inter-agent |
+| Self-hosted | Yes | No | No | Yes |
+| On-chain identity | No | No | No | **Yes** |
+| Agent-to-agent comms | Same machine only | No | No | **Cross-network, encrypted** |
+| Verifiable audit trail | Log files | Proprietary | Git history | **Blockchain** |
+| Multi-agent deliberation | Spawn + merge | No | No | **Structured council voting** |
+| Model support | Any | Proprietary | GPT only | Claude SDK + Ollama |
+| Channel integrations | 10+ | Web only | GitHub only | Web, Discord, Telegram, GitHub |
+| Self-improvement | Community skills | No | No | **Autonomous PR pipeline** |
+| A2A interop | No | No | No | **Google A2A protocol** |
+| Open source | Yes | No | No | Yes (MIT) |
+
+corvid-agent does not compete with OpenClaw on breadth of life automation or community size. The bet is that **agent identity and inter-agent trust** become critical infrastructure as the ecosystem matures, and that being the first platform with native blockchain-backed solutions to these problems creates a durable advantage in the development agent space.
+
+---
+
+## Technical Principles
+
+### 1. Ship Sequentially
+
+One feature at a time. Ship, monitor, fix, then move on. This applies to the agent's own work too — tasks are processed sequentially, not in a parallel frenzy.
+
+### 2. Blockchain is Immutable — Be Careful
+
+On-chain actions can't be undone. Validation gates are enforced before any blockchain interaction. Test on localnet and testnet before mainnet. Always.
+
+### 3. MCP Over Custom Tools
+
+All agent capabilities are exposed through MCP (Model Context Protocol). Portable, testable, composable. No bespoke tool interfaces.
+
+### 4. Security by Default
+
+- Wallet encryption at rest (AES-256)
+- Bearer token auth for all HTTP/WS when exposed beyond localhost
+- Gitleaks integration for secret scanning
+- Rate limiting on all public endpoints
+- CORS enforcement with explicit origin allowlists
+- Startup security checks before any services bind
+
+### 5. Agents Are Workers, Not Wizards
+
+Agents do well-scoped development tasks. They don't have root access to production systems. They propose changes via PRs. They escalate uncertainty. The goal is reliable, auditable work — not impressive demos that collapse under pressure.
+
+### 6. Decentralization is the Endgame
+
+Today, corvid-agent runs as a single instance managing local agents. Tomorrow, multiple instances communicate through AlgoChat, forming a decentralized network of development agents that discover, verify, and collaborate with each other without any central coordinator.
+
+---
+
+## Roadmap
+
+### Shipped (v0.1.0 -> v0.13.0)
+
+- Agent orchestration with Claude SDK
+- Council deliberation with structured voting and follow-up chat
+- AlgoChat on-chain messaging (PSK + X25519)
+- Self-improvement pipeline (branch -> validate -> PR)
+- Angular 21 web UI with real-time WebSocket updates
+- Discord bridge (raw WebSocket gateway, bidirectional)
+- Telegram bridge
+- MCP tool system (36+ corvid_* handlers)
+- GitHub integration (PRs, issues, reviews)
+- Google A2A protocol (inbound task handling, agent card)
+- AST code analysis via Tree-sitter
+- Model exam system (18 tests, 6 categories)
+- Structured memory with vector embeddings
+- SQLite persistence (47 migrations)
+- Billing/metering infrastructure
+- Agent marketplace foundations
+- Notification system (Discord, Telegram, GitHub, AlgoChat)
+- Observability and health metrics
+- Docker, systemd, macOS LaunchAgent deployment configs
+- Nginx + Caddy reverse proxy configs with TLS
+- Playwright end-to-end tests
+- Autonomous app development (Angular apps designed, coded, and deployed by agents)
+
+### Next (v0.14.x)
+
+- **Agent Directory on-chain:** Publish agent capabilities to Algorand for discovery by other agents
+- **Cross-instance messaging:** Two corvid-agent instances communicating via AlgoChat
+- **Model exam expansion:** Broader validation across task types and complexity levels
+- **Marketplace activation:** Publish and consume agent skills/services
+- **Ollama parity:** Full feature parity with Claude SDK for local model inference
+- **Deeper AST understanding:** Smarter refactoring through richer code comprehension
+
+### Later (v0.15.x+)
+
+- **Multi-instance agent networks:** Decentralized mesh of corvid-agent nodes
+- **Smart contract task agreements:** On-chain contracts defining work scope, validation criteria, and completion verification between agents
+- **Agent reputation system:** On-chain track record of reliability, code quality, and task completion rates
+- **NFT-gated agent access:** Nevermore holders get priority access to hosted agent services
+- **Billing activation:** Usage-based pricing for hosted agent instances
+- **Full A2A maturity:** Complete Google Agent-to-Agent protocol support for interop with non-Corvid agents
+
+### Long-term Vision
+
+Development teams run networks of specialized agents that discover each other on-chain, negotiate task assignments through smart contracts, communicate through encrypted channels, and build verifiable track records of their work. No central platform. No vendor lock-in. Just agents, wallets, and code.
+
+---
+
+## Summary
+
+corvid-agent is not another ChatGPT wrapper or a me-too agent framework. It is a bet that the future of AI agents requires **trust infrastructure** — verifiable identity, encrypted communication, and auditable behavior — and that blockchain is the right foundation for that infrastructure.
+
+We build on Algorand because it's fast, cheap, carbon-negative, and has the technical properties we need. We build in the open because the trust problem can't be solved by a proprietary platform. And we build as part of Corvid Labs because this is the logical extension of everything we've been building: an ecosystem where software is community-owned, development is transparent, and the tools do real work.
+
+The agent is already running. It's already shipping code. The question isn't whether autonomous development agents will become normal — they will. The question is whether they'll operate as isolated black boxes on corporate servers, or as verifiable participants in an open, decentralized network.
+
+We're building for the second outcome.
+
+---
+
+*Built with care by Corvid Labs on Algorand.*
+*MIT Licensed. Contributions welcome.*

--- a/docs/algochat.html
+++ b/docs/algochat.html
@@ -31,6 +31,7 @@
         <a href="algochat.html" class="nav__link nav__link--active">AlgoChat</a>
         <a href="https://corvid-agent.github.io/agent-dashboard/" class="nav__link" target="_blank" rel="noopener">Dashboard <span class="ext-icon">&nearr;</span></a>
         <a href="https://corvid-agent.github.io/corvid-agent-chat/" class="nav__link" target="_blank" rel="noopener">Chat <span class="ext-icon">&nearr;</span></a>
+        <a href="https://github.com/CorvidLabs/corvid-agent/blob/main/VISION.md" class="nav__link" target="_blank" rel="noopener">Vision <span class="ext-icon">&nearr;</span></a>
         <a href="https://github.com/CorvidLabs/corvid-agent" class="nav__link" target="_blank" rel="noopener">GitHub <span class="ext-icon">&nearr;</span></a>
       </div>
     </div>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>API &amp; Architecture — CorvidAgent</title>
-  <meta name="description" content="REST API reference, WebSocket protocol, database schema, and system architecture for the CorvidAgent framework.">
+  <meta name="description" content="REST API reference, WebSocket protocol, database schema, and system architecture for the CorvidAgent decentralized development agent platform.">
   <meta name="theme-color" content="#0a0a12">
 
   <meta property="og:title" content="API &amp; Architecture — CorvidAgent">
@@ -31,6 +31,7 @@
         <a href="algochat.html" class="nav__link">AlgoChat</a>
         <a href="https://corvid-agent.github.io/agent-dashboard/" class="nav__link" target="_blank" rel="noopener">Dashboard <span class="ext-icon">&nearr;</span></a>
         <a href="https://corvid-agent.github.io/corvid-agent-chat/" class="nav__link" target="_blank" rel="noopener">Chat <span class="ext-icon">&nearr;</span></a>
+        <a href="https://github.com/CorvidLabs/corvid-agent/blob/main/VISION.md" class="nav__link" target="_blank" rel="noopener">Vision <span class="ext-icon">&nearr;</span></a>
         <a href="https://github.com/CorvidLabs/corvid-agent" class="nav__link" target="_blank" rel="noopener">GitHub <span class="ext-icon">&nearr;</span></a>
       </div>
     </div>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Getting Started — CorvidAgent</title>
-  <meta name="description" content="Set up CorvidAgent in minutes. Prerequisites, installation, configuration, and first steps for the AI agent framework on Algorand.">
+  <meta name="description" content="Set up CorvidAgent in minutes. Prerequisites, installation, configuration, and first steps for the decentralized development agent platform on Algorand.">
   <meta name="theme-color" content="#0a0a12">
 
   <meta property="og:title" content="Getting Started — CorvidAgent">
@@ -31,6 +31,7 @@
         <a href="algochat.html" class="nav__link">AlgoChat</a>
         <a href="https://corvid-agent.github.io/agent-dashboard/" class="nav__link" target="_blank" rel="noopener">Dashboard <span class="ext-icon">&nearr;</span></a>
         <a href="https://corvid-agent.github.io/corvid-agent-chat/" class="nav__link" target="_blank" rel="noopener">Chat <span class="ext-icon">&nearr;</span></a>
+        <a href="https://github.com/CorvidLabs/corvid-agent/blob/main/VISION.md" class="nav__link" target="_blank" rel="noopener">Vision <span class="ext-icon">&nearr;</span></a>
         <a href="https://github.com/CorvidLabs/corvid-agent" class="nav__link" target="_blank" rel="noopener">GitHub <span class="ext-icon">&nearr;</span></a>
       </div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>CorvidAgent — Autonomous AI Agent Orchestration on Algorand</title>
-  <meta name="description" content="Autonomous AI agent orchestration with on-chain identity, multi-agent councils, graph workflows, and self-improving code — powered by Algorand and Claude Agent SDK.">
+  <title>CorvidAgent — Decentralized Development Agent Platform on Algorand</title>
+  <meta name="description" content="Decentralized development agent platform with on-chain identity, encrypted inter-agent communication, multi-agent councils, and self-improving code — built on Algorand.">
   <meta name="theme-color" content="#0a0a12">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="CorvidAgent — Autonomous AI Agent Orchestration">
-  <meta property="og:description" content="Autonomous AI agent orchestration with on-chain identity, multi-agent councils, graph workflows, and self-improving code — powered by Algorand.">
+  <meta property="og:title" content="CorvidAgent — Decentralized Development Agent Platform">
+  <meta property="og:description" content="Decentralized development agent platform with on-chain identity and encrypted inter-agent communication — built on Algorand.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://corvidlabs.github.io/corvid-agent/">
 
@@ -33,6 +33,7 @@
         <a href="algochat.html" class="nav__link">AlgoChat</a>
         <a href="https://corvid-agent.github.io/agent-dashboard/" class="nav__link" target="_blank" rel="noopener">Dashboard <span class="ext-icon">&nearr;</span></a>
         <a href="https://corvid-agent.github.io/corvid-agent-chat/" class="nav__link" target="_blank" rel="noopener">Chat <span class="ext-icon">&nearr;</span></a>
+        <a href="https://github.com/CorvidLabs/corvid-agent/blob/main/VISION.md" class="nav__link" target="_blank" rel="noopener">Vision <span class="ext-icon">&nearr;</span></a>
         <a href="https://github.com/CorvidLabs/corvid-agent" class="nav__link" target="_blank" rel="noopener">GitHub <span class="ext-icon">&nearr;</span></a>
       </div>
     </div>
@@ -41,12 +42,12 @@
   <!-- ═══════════════════ HERO ═══════════════════ -->
   <header class="hero">
     <div class="container">
-      <div class="hero__badge">v0.12.0</div>
+      <div class="hero__badge">v0.13.0</div>
       <h1 class="hero__title">
         <span class="glow-cyan">Corvid</span><span class="glow-magenta">Agent</span>
       </h1>
       <p class="hero__tagline">
-        Autonomous AI agent orchestration with on-chain identity, graph workflows &amp; self-improving code on
+        Decentralized development agent platform with on-chain identity, encrypted inter-agent communication &amp; self-improving code on
         <span class="accent-cyan">Algorand</span>
       </p>
       <div class="hero__actions">
@@ -68,7 +69,10 @@
       <h2 class="section__title">What is CorvidAgent?</h2>
       <div class="explainer">
         <p class="explainer__text">
-          CorvidAgent is an <span class="accent-cyan">open-source autonomous AI agent platform</span> that combines Claude&rsquo;s reasoning with Algorand&rsquo;s on-chain identity. Deploy self-improving agents that can <span class="accent-magenta">write code</span>, <span class="accent-green">coordinate in councils</span>, execute scheduled tasks, and communicate through encrypted on-chain messaging &mdash; all with a verifiable cryptographic identity.
+          CorvidAgent is a <span class="accent-cyan">decentralized development agent platform</span> built on Algorand. It spawns AI agents that do real software engineering &mdash; <span class="accent-magenta">picking up tasks, writing code, creating branches, validating changes, opening PRs</span>, and <span class="accent-green">deliberating with other agents</span> about decisions. The key differentiator: agents have <span class="accent-cyan">verifiable on-chain identities</span>, communicate through <span class="accent-magenta">encrypted cryptographic channels</span>, and can form decentralized networks where trust is established through blockchain.
+        </p>
+        <p class="explainer__text" style="margin-top: 12px; font-size: 9px; opacity: 0.7;">
+          Read the full manifesto in <a href="https://github.com/CorvidLabs/corvid-agent/blob/main/VISION.md" class="accent-cyan">VISION.md</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **VISION.md** (new): Full project manifesto — positioning, core thesis, three-layer architecture, competitive landscape, technical principles, roadmap, and ecosystem overview. Canonical source of truth for project identity.
- **README.md**: Rewritten to lead with "decentralized development agent platform" positioning, links to VISION.md, condensed capabilities into scannable table format. Preserves Quick Start, env vars, testing, deployment, and "Built by corvid-agent" showcase.
- **CLAUDE.md**: Updated description and added VISION.md reference so future agent sessions have context on project direction.
- **docs/ site**: Updated hero tagline, OG meta, "What is" section on index.html. Added Vision nav link across all 4 pages. Bumped version badge to v0.13.0.

Note: GitHub repo description and topics need manual update (bot token lacks admin scope):
- Description: `Decentralized development agent platform with on-chain identity and encrypted inter-agent communication via Algorand`
- Topics to add: `decentralized`, `agent-orchestration`

## Test plan

- [ ] VISION.md renders correctly on GitHub
- [ ] README.md renders correctly (badges, tables, architecture diagram)
- [ ] docs/ site pages load with updated content and Vision nav link
- [ ] `bunx tsc --noEmit --skipLibCheck` passes (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)