### PR TITLE
fix: E2E auth support for API key gates

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -31,6 +31,7 @@ export default defineConfig({
             RATE_LIMIT_GET: '5000',      // Higher read limit for e2e test volume
             RATE_LIMIT_MUTATION: '1000',  // Higher write limit for parallel e2e tests
             ENABLED_PROVIDERS: 'anthropic,ollama', // Prevent auto-restrict to ollama-only in CI
+            API_KEY: 'e2e-test-key',     // Auth key for client-side + server-side auth gates
         },
     },
 });


### PR DESCRIPTION
## Summary
- Adds `API_KEY=e2e-test-key` to Playwright's webServer env so the server has auth configured during E2E runs
- `gotoWithRetry` now appends `?apiKey=` to all browser navigations (needed for client-side auth overlay from #336)
- `fetchWithRetry` injects `Authorization: Bearer` header on all API calls (needed for server-side auth from #336)
- Exports `authedFetch` and `E2E_API_KEY` for tests that use direct `fetch()` — these tests will need to switch from `fetch()` to `authedFetch()` when #336 merges

## Context
PR #336 adds client + API key authentication. The E2E tests currently have no auth awareness, so when #336 merges:
1. The client auth overlay blocks all UI interaction (every Playwright click times out)
2. Server-side API key validation rejects all direct `fetch()` calls

This PR prepares the E2E infrastructure. It's harmless on main today (no `API_KEY` is enforced) and becomes essential once #336 merges.

**Note:** Tests using direct `fetch()` (not the fixture helpers) will still need to be migrated to `authedFetch()` — that can be done in #336 itself or a follow-up.

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — 3796 pass, 0 fail
- [ ] E2E tests pass on CI (no behavior change on main since API_KEY isn't enforced yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)