### PR TITLE
fix: run bun install after auto-update pulls dependency changes

### DIFF
--- a/deploy/run-loop.sh
+++ b/deploy/run-loop.sh
@@ -23,7 +23,12 @@ while true; do
         echo "[run-loop] Server exited cleanly (code 0). Stopping."
         break
     elif [[ $exit_code -eq $RESTART_EXIT_CODE ]]; then
-        echo "[run-loop] Server requested restart after auto-update (code $RESTART_EXIT_CODE). Restarting immediately..."
+        echo "[run-loop] Server requested restart after auto-update (code $RESTART_EXIT_CODE)."
+        # The server runs bun install before exiting, but as a safety net
+        # ensure deps are fresh in case that step was skipped or failed.
+        echo "[run-loop] Running bun install..."
+        bun install --frozen-lockfile 2>/dev/null || bun install
+        echo "[run-loop] Restarting..."
     else
         echo "[run-loop] Server crashed (code $exit_code). Restarting in ${CRASH_COOLDOWN_SECS}s..."
         sleep "$CRASH_COOLDOWN_SECS"


### PR DESCRIPTION
## Summary
- After `git pull`, checks if `bun.lock` or `package.json` changed between the old and new HEAD
- If changed, runs `bun install --frozen-lockfile --ignore-scripts` before exiting for restart
- On install failure, rolls back to the previous commit (`git reset --hard`) to avoid running with mismatched code + deps
- `run-loop.sh` also runs `bun install` as a safety net on code-75 restarts

## Problem
The auto-update loop (`checkForUpdates`) does `git pull --rebase origin main` then `process.exit(75)`, and `run-loop.sh` restarts the server — but `bun install` never runs. If a merged PR changes dependencies (e.g. the MCP SDK data leak fix #338 was a dependency update), the server restarts with stale `node_modules`.

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — 3796 pass, 0 fail
- [ ] Manual: deploy with `run-loop.sh`, merge a PR that bumps a dep, verify `bun install` runs before restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)