### PR TITLE
fix: order wallet messages newest-first

### DIFF
--- a/server/db/algochat-messages.ts
+++ b/server/db/algochat-messages.ts
@@ -192,7 +192,7 @@ export function getWalletMessages(
     ).get(address) as { cnt: number };
 
     const rows = db.query(
-        `SELECT * FROM algochat_messages WHERE participant = ? ORDER BY created_at ASC LIMIT ? OFFSET ?`,
+        `SELECT * FROM algochat_messages WHERE participant = ? ORDER BY created_at DESC LIMIT ? OFFSET ?`,
     ).all(address, limit, offset) as AlgoChatMessageRow[];
 
     return { messages: rows.map(rowToMessage), total: countRow.cnt };


### PR DESCRIPTION
## Summary
- Change `getWalletMessages` query from `ORDER BY created_at ASC` to `DESC` so the wallet viewer shows the most recent messages at the top

## Test plan
- [ ] Open Wallets view, expand a wallet, verify newest messages appear first

🤖 Generated with [Claude Code](https://claude.com/claude-code)