### PR TITLE
fix: scale up base font size for 1080p displays

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -89,6 +89,11 @@ html, body {
     -moz-osx-font-smoothing: grayscale;
 }
 
+/* Scale up for 1080p displays — the 8px base is too small at this resolution */
+@media (max-height: 1200px) and (min-width: 769px) {
+    html { font-size: 10px; }
+}
+
 a {
     color: inherit;
 }


### PR DESCRIPTION
## Summary
- Adds a CSS media query that bumps the root `font-size` from `8px` to `10px` for desktop screens with `max-height: 1200px` (1080p and similar)
- All component sizing uses `rem` units, so this scales everything uniformly — text, spacing, padding, and gaps all increase by 25%
- The `min-width: 769px` guard ensures mobile layouts are unaffected

Closes #351

## Test plan
- [ ] Open the app on a 1080p display (or resize browser to 1920×1080) — text and UI elements should be noticeably larger
- [ ] Open on a 1440p+ display — no change from current behavior
- [ ] Resize browser window vertically past 1200px — should transition smoothly between sizes
- [ ] Mobile layout should remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)