### PR TITLE
fix: security hardening — admin guard, rate limits, prompt scanning

### DIFF
--- a/server/__tests__/guards.test.ts
+++ b/server/__tests__/guards.test.ts
@@ -370,6 +370,15 @@ describe('requiresAdminRole', () => {
         expect(requiresAdminRole('/api/agents')).toBe(false);
         expect(requiresAdminRole('/api/projects')).toBe(false);
     });
+
+    it('returns true for credit grant endpoint', () => {
+        expect(requiresAdminRole('/api/wallets/ABCDEFGH1234567890ABCDEFGH1234567890ABCDEFGH1234567890ABCDEF/credits')).toBe(true);
+    });
+
+    it('returns false for wallet paths that are not credit grants', () => {
+        expect(requiresAdminRole('/api/wallets')).toBe(false);
+        expect(requiresAdminRole('/api/wallets/ABCD1234')).toBe(false);
+    });
 });
 
 // --- createRequestContext ---------------------------------------------------

--- a/server/middleware/endpoint-rate-limit.ts
+++ b/server/middleware/endpoint-rate-limit.ts
@@ -121,6 +121,15 @@ export function loadEndpointRateLimitConfig(): EndpointRateLimitConfig {
                     admin: { max: safeMutation, windowMs: ONE_MINUTE },
                 },
             },
+            // Credit grant is admin-only but gets extra rate limiting as defense-in-depth
+            {
+                pattern: 'POST /api/wallets/*',
+                tiers: {
+                    public: { max: 0, windowMs: ONE_MINUTE },
+                    user: { max: 0, windowMs: ONE_MINUTE },
+                    admin: { max: 5, windowMs: ONE_MINUTE },
+                },
+            },
         ],
         exemptPaths: ['/api/health', '/webhooks/github', '/ws', '/.well-known/agent-card.json'],
     };

--- a/server/middleware/guards.ts
+++ b/server/middleware/guards.ts
@@ -119,5 +119,7 @@ export const ADMIN_PATHS = new Set([
 export function requiresAdminRole(pathname: string): boolean {
     if (ADMIN_PATHS.has(pathname)) return true;
     if (pathname.startsWith('/api/escalation-queue')) return true;
+    // Credit grant endpoint requires admin — prevents any authenticated user from granting themselves credits
+    if (/^\/api\/wallets\/[^/]+\/credits$/.test(pathname)) return true;
     return false;
 }


### PR DESCRIPTION
## Summary

- **#354 (P0)**: Credit grant endpoint (`POST /api/wallets/:address/credits`) now requires `admin` role — prevents any authenticated user from granting themselves unlimited credits
- **#356 (P1)**: Added strict per-endpoint rate limiting on credit grant (max 5 req/min for admin, blocked for user/public) as defense-in-depth
- **#355 (P1)**: Schedule creation and update now scan all prompt/description/message fields through the existing `scanForInjection()` detector, blocking prompts with HIGH/CRITICAL injection confidence

## Test plan

- [x] `requiresAdminRole` returns true for `/api/wallets/:address/credits` pattern
- [x] Injection scanner blocks "ignore all previous instructions" in schedule prompts
- [x] Injection scanner blocks command injection (`;rm -rf /`) in schedule prompts
- [x] Injection scanner blocks system prompt override in schedule updates
- [x] Legitimate prompts still pass through
- [x] All 3,873 tests pass, 0 failures
- [x] `tsc --noEmit` clean
- [x] `spec:check` passes (38/38)

Closes #354, closes #355, closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)