### PR TITLE
fix: restrict system metadata in settings endpoint to admin role

### DIFF
--- a/server/__tests__/guards.test.ts
+++ b/server/__tests__/guards.test.ts
@@ -371,6 +371,10 @@ describe('requiresAdminRole', () => {
         expect(requiresAdminRole('/api/projects')).toBe(false);
     });
 
+    it('returns true for /api/settings/credits', () => {
+        expect(requiresAdminRole('/api/settings/credits')).toBe(true);
+    });
+
     it('returns true for credit grant endpoint', () => {
         expect(requiresAdminRole('/api/wallets/ABCDEFGH1234567890ABCDEFGH1234567890ABCDEFGH1234567890ABCDEF/credits')).toBe(true);
     });

--- a/server/middleware/guards.ts
+++ b/server/middleware/guards.ts
@@ -114,6 +114,7 @@ export const ADMIN_PATHS = new Set([
     '/api/backup',
     '/api/memories/backfill',
     '/api/selftest/run',
+    '/api/settings/credits',
 ]);
 
 export function requiresAdminRole(pathname: string): boolean {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -57,6 +57,7 @@ import {
     applyGuards,
     createRequestContext,
     requiresAdminRole,
+    type RequestContext,
 } from '../middleware/guards';
 import type { SandboxManager } from '../sandbox/manager';
 import type { MarketplaceService } from '../marketplace/service';
@@ -201,7 +202,7 @@ export async function handleRequest(
     }
 
     try {
-        const response = await handleRoutes(req, url, db, processManager, algochatBridge, agentWalletService, agentMessenger, workTaskService, selfTestService, agentDirectory, networkSwitchFn, schedulerService, webhookService, mentionPollingService, workflowService, sandboxManager, marketplace, marketplaceFederation, reputationScorer, reputationAttestation, billing, usageMeter);
+        const response = await handleRoutes(req, url, db, context, processManager, algochatBridge, agentWalletService, agentMessenger, workTaskService, selfTestService, agentDirectory, networkSwitchFn, schedulerService, webhookService, mentionPollingService, workflowService, sandboxManager, marketplace, marketplaceFederation, reputationScorer, reputationAttestation, billing, usageMeter);
         if (response) {
             applyCors(response, req, config);
             if (context.rateLimitHeaders) {
@@ -221,6 +222,7 @@ async function handleRoutes(
     req: Request,
     url: URL,
     db: Database,
+    context: RequestContext,
     processManager: ProcessManager,
     algochatBridge: AlgoChatBridge | null,
     agentWalletService?: AgentWalletService | null,
@@ -273,7 +275,7 @@ async function handleRoutes(
     const systemLogResponse = handleSystemLogRoutes(req, url, db);
     if (systemLogResponse) return systemLogResponse;
 
-    const settingsResponse = await handleSettingsRoutes(req, url, db);
+    const settingsResponse = await handleSettingsRoutes(req, url, db, context);
     if (settingsResponse) return settingsResponse;
 
     const sessionResponse = await handleSessionRoutes(req, url, db, processManager);

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -6,11 +6,12 @@
 import type { Database } from 'bun:sqlite';
 import { json } from '../lib/response';
 import { parseBodyOrThrow, ValidationError, UpdateCreditConfigSchema } from '../lib/validation';
+import type { RequestContext } from '../middleware/guards';
 
-export function handleSettingsRoutes(req: Request, url: URL, db: Database): Response | Promise<Response> | null {
-    // GET /api/settings — all settings
+export function handleSettingsRoutes(req: Request, url: URL, db: Database, context?: RequestContext): Response | Promise<Response> | null {
+    // GET /api/settings — all settings (system metadata is admin-only)
     if (url.pathname === '/api/settings' && req.method === 'GET') {
-        return handleGetSettings(db);
+        return handleGetSettings(db, context?.role === 'admin');
     }
 
     // PUT /api/settings/credits — update credit config
@@ -21,29 +22,32 @@ export function handleSettingsRoutes(req: Request, url: URL, db: Database): Resp
     return null;
 }
 
-function handleGetSettings(db: Database): Response {
-    // Credit configuration
+function handleGetSettings(db: Database, isAdmin: boolean): Response {
+    // Credit configuration (public — users need to know rates)
     const creditRows = db.query(`SELECT key, value FROM credit_config`).all() as { key: string; value: string }[];
     const creditConfig: Record<string, string> = {};
     for (const row of creditRows) {
         creditConfig[row.key] = row.value;
     }
 
-    // System stats
-    const agentCount = (db.query(`SELECT COUNT(*) as c FROM agents`).get() as { c: number }).c;
-    const projectCount = (db.query(`SELECT COUNT(*) as c FROM projects`).get() as { c: number }).c;
-    const sessionCount = (db.query(`SELECT COUNT(*) as c FROM sessions`).get() as { c: number }).c;
-    const schemaVersion = (db.query(`SELECT version FROM schema_version LIMIT 1`).get() as { version: number } | null)?.version ?? 0;
+    const result: Record<string, unknown> = { creditConfig };
 
-    return json({
-        creditConfig,
-        system: {
+    // System stats — admin-only to avoid leaking operational metadata
+    if (isAdmin) {
+        const agentCount = (db.query(`SELECT COUNT(*) as c FROM agents`).get() as { c: number }).c;
+        const projectCount = (db.query(`SELECT COUNT(*) as c FROM projects`).get() as { c: number }).c;
+        const sessionCount = (db.query(`SELECT COUNT(*) as c FROM sessions`).get() as { c: number }).c;
+        const schemaVersion = (db.query(`SELECT version FROM schema_version LIMIT 1`).get() as { version: number } | null)?.version ?? 0;
+
+        result.system = {
             schemaVersion,
             agentCount,
             projectCount,
             sessionCount,
-        },
-    });
+        };
+    }
+
+    return json(result);
 }
 
 async function handleUpdateCreditConfig(req: Request, db: Database): Promise<Response> {


### PR DESCRIPTION
## Summary

Closes #357

- `GET /api/settings` now only returns `creditConfig` for non-admin users; `system` metadata (schemaVersion, agentCount, projectCount, sessionCount) is omitted
- `PUT /api/settings/credits` is now protected by the admin role guard via `ADMIN_PATHS`
- `RequestContext` is threaded through `handleRoutes` → `handleSettingsRoutes` so the handler can check the caller's role
- Frontend uses optional chaining (`settings()?.system?.schemaVersion`) so it gracefully shows nothing for non-admin callers

## Test plan

- [x] Unit tests updated: admin gets full response, non-admin gets `creditConfig` only
- [x] Guards test updated: `/api/settings/credits` now in `requiresAdminRole` coverage
- [x] All 38 tests pass across both test files
- [x] TypeScript compiles clean (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)