### PR TITLE
fix: increase test timeouts for Windows CI flaky failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
         run: bun run migrate:up
 
       - name: Unit tests
-        run: bun test
+        # Windows process spawning and dynamic imports are ~3-5x slower;
+        # use 30s per-test timeout there to avoid flaky failures (default 10s via bunfig).
+        run: bun test ${{ matrix.os == 'windows-latest' && '--timeout 30000' || '' }}
 
       - name: Spec check
         run: bun run spec:check

--- a/server/__tests__/coding-tools.test.ts
+++ b/server/__tests__/coding-tools.test.ts
@@ -223,13 +223,13 @@ describe('run_command', () => {
         const result = await getTool('run_command').handler({ command: 'echo hello' });
         expect(result.isError).toBeUndefined();
         expect(result.text.trim()).toBe('hello');
-    });
+    }, 20_000); // Windows process spawning via sh -c is ~3-5x slower
 
     test('returns exit code on failure', async () => {
         const result = await getTool('run_command').handler({ command: 'exit 42' });
         expect(result.isError).toBe(true);
         expect(result.text).toContain('Exit code 42');
-    });
+    }, 20_000);
 
     test('blocks sudo', async () => {
         const result = await getTool('run_command').handler({ command: 'sudo rm -rf /' });
@@ -258,7 +258,7 @@ describe('run_command', () => {
             const normalizePrivate = (p: string) => p.replace(/^\/private/, '');
             expect(normalizePrivate(output)).toEndWith(normalizePrivate(workDir));
         }
-    });
+    }, 20_000);
 
     test('respects timeout', async () => {
         const isWindows = process.platform === 'win32';

--- a/server/__tests__/providers.test.ts
+++ b/server/__tests__/providers.test.ts
@@ -341,7 +341,7 @@ describe('AnthropicProvider', () => {
         // the SDK check may still pass if env has a key. We just verify it doesn't throw.
         const available = await provider.isAvailable();
         expect(typeof available).toBe('boolean');
-    });
+    }, 20_000); // dynamic SDK import can be slow on Windows CI
 });
 
 // ─── OllamaProvider ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Increase per-test timeout to 30s on `windows-latest` CI via `bun test --timeout 30000`
- Add explicit 20s timeouts on `run_command` tests that spawn processes (sh -c is ~3-5x slower on Windows)
- Add explicit 20s timeout on `AnthropicProvider.isAvailable` test (dynamic SDK import is slow on Windows)

## Root Cause

The default 10s per-test timeout (`bunfig.toml`) is insufficient on Windows where:
1. Process spawning via `sh -c` requires MSYS2/Git Bash and is significantly slower
2. Dynamic `import('@anthropic-ai/sdk')` has higher cold-start overhead
3. Module-level initialization (rate limiter timers, pattern parsing) adds startup cost

This explains the non-deterministic failure pattern — whichever tests happen to hit cold module loads or process spawns first exceed the timeout.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Pass `--timeout 30000` on `windows-latest` |
| `server/__tests__/coding-tools.test.ts` | Add 20s timeouts on 3 process-spawning run_command tests |
| `server/__tests__/providers.test.ts` | Add 20s timeout on `isAvailable` SDK import test |

## Test plan

- [x] All 135 tests pass locally across the 3 modified test files
- [ ] Verify Windows CI passes on this PR
- [ ] Confirm Linux/macOS CI unaffected (no timeout override applied)

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)