### PR TITLE
fix: close cross-tenant session access, SSRF, and tenant filter bypass

### DIFF
--- a/server/__tests__/tenant-billing.test.ts
+++ b/server/__tests__/tenant-billing.test.ts
@@ -217,7 +217,7 @@ describe('Tenant DB Filter', () => {
 
     test('withTenantFilter injects into existing WHERE', () => {
         const result = withTenantFilter("SELECT * FROM agents WHERE status = 'active'", 'tenant-1');
-        expect(result.query).toContain('WHERE tenant_id = ? AND');
+        expect(result.query).toContain("WHERE status = 'active' AND tenant_id = ?");
         expect(result.bindings).toEqual(['tenant-1']);
     });
 

--- a/server/db/work-tasks.ts
+++ b/server/db/work-tasks.ts
@@ -228,7 +228,7 @@ export function cleanupStaleWorkTasks(db: Database): WorkTask[] {
 export function listWorkTasks(db: Database, agentId?: string, tenantId: string = DEFAULT_TENANT_ID): WorkTask[] {
     if (agentId) {
         const { query, bindings } = withTenantFilter('SELECT * FROM work_tasks WHERE agent_id = ? ORDER BY created_at DESC', tenantId);
-        const rows = db.query(query).all(...bindings, agentId) as WorkTaskRow[];
+        const rows = db.query(query).all(agentId, ...bindings) as WorkTaskRow[];
         return rows.map(rowToWorkTask);
     }
 


### PR DESCRIPTION
## Summary
- **Session ownership (#373):** Thread `tenantId` through session update/stop/resume route handlers and add `validateTenantOwnership()` checks to `updateSession()` and `getSessionMessages()`, preventing cross-tenant session access
- **SSRF prevention (#374):** Add `validateUrl()` to A2A client that blocks private IPs (`10.x`, `172.16-31.x`, `192.168.x`, `169.254.x`, `127.x`, `0.x`), localhost, `::1`, and non-HTTP schemes before every outbound fetch in `fetchAgentCard()` and `invokeRemoteAgent()`
- **Tenant filter bypass (#375):** Replace regex-based `WHERE` replacement in `withTenantFilter()` with append-based strategy that correctly handles queries with multiple `WHERE` conditions, preventing data leakage in complex queries

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — 3959 pass, 0 fail
- [x] `bun run spec:check` — 38 specs pass, 0 fail
- [x] New tests: cross-tenant `getSessionMessages` and `updateSession` blocked
- [x] New tests: SSRF rejects localhost, private IPs, non-HTTP schemes; allows public URLs
- [x] New tests: `withTenantFilter` handles existing WHERE, multiple conditions, ORDER BY

🤖 Generated with [Claude Code](https://claude.com/claude-code)