### PR TITLE
fix: block GitHub prompt injection and harden allowlist default

### DIFF
--- a/server/polling/service.ts
+++ b/server/polling/service.ts
@@ -1205,6 +1205,17 @@ export class MentionPollingService {
             return false;
         }
 
+        // Block mentions with HIGH/CRITICAL injection confidence before creating a session
+        const injectionScan = scanGitHubContent(mention.body);
+        if (injectionScan.blocked) {
+            log.warn('Blocked mention: prompt injection detected', {
+                configId: config.id, mentionId: mention.id,
+                sender: mention.sender, confidence: injectionScan.confidence,
+                patterns: injectionScan.matches.map(m => m.pattern),
+            });
+            return false;
+        }
+
         // Always create an agent session — the session is responsible for both
         // replying on GitHub AND deciding whether to create a work task for code
         // changes. This ensures the person who mentioned us always gets a reply.

--- a/server/webhooks/service.ts
+++ b/server/webhooks/service.ts
@@ -231,6 +231,19 @@ export class WebhookService {
                 continue;
             }
 
+            // Block mentions with HIGH/CRITICAL injection confidence
+            const injectionScan = scanGitHubContent(mentionBody);
+            if (injectionScan.blocked) {
+                log.warn('Blocked webhook: prompt injection detected', {
+                    registrationId: reg.id, sender, repo,
+                    confidence: injectionScan.confidence,
+                    patterns: injectionScan.matches.map(m => m.pattern),
+                });
+                skipped++;
+                details.push(`${reg.id}: Blocked — prompt injection detected (${injectionScan.confidence})`);
+                continue;
+            }
+
             // Create delivery record
             const htmlUrl = this.getHtmlUrl(event, payload);
             const delivery = createDelivery(


### PR DESCRIPTION
## Summary

- **Block prompt injection from GitHub mentions/webhooks**: `scanGitHubContent()` already detected HIGH/CRITICAL injection patterns but the `blocked` flag was never checked — sessions were created anyway with just a warning. Now matches Telegram/Discord/AlgoChat behavior by refusing to create sessions for blocked content.
- **Harden GitHub allowlist default**: Empty allowlist previously allowed all users (open mode). Now denies by default — set `GITHUB_ALLOWLIST_OPEN_MODE=true` to opt back in.

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 3995/3995 pass
- [ ] Verify injection-blocked mentions are logged but don't create sessions
- [ ] Verify allowlist deny-by-default works, and `GITHUB_ALLOWLIST_OPEN_MODE=true` re-enables open mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)