### PR TITLE
fix: expand bash protection for find, zsh, env wrappers

### DIFF
--- a/server/process/protected-paths.ts
+++ b/server/process/protected-paths.ts
@@ -30,7 +30,7 @@ export const PROTECTED_SUBSTRINGS = [
 ];
 
 // Shell operators/commands that indicate write/destructive file operations.
-export const BASH_WRITE_OPERATORS = /(?:>>?\s|rm\s|mv\s|cp\s|chmod\s|chown\s|sed\s+-i|tee\s|dd\s|ln\s|curl\s.*-o|wget\s|python[3]?\s+-c|node\s+-e|bun\s+-e|ed\s|perl\s+-|rsync\s|install\s|truncate\s|ruby\s+-[ie]|php\s+-r|command\s+-p\s+\w)/;
+export const BASH_WRITE_OPERATORS = /(?:>>?\s|rm\s|mv\s|cp\s|chmod\s|chown\s|sed\s+-i|tee\s|dd\s|ln\s|curl\s.*-o|wget\s|python[3]?\s+-c|node\s+-e|bun\s+-e|ed\s|perl\s+-|rsync\s|install\s|truncate\s|ruby\s+-[ie]|php\s+-r|command\s+-p\s+\w|find\s.*-(?:delete|exec))/;
 
 export function isProtectedPath(filePath: string): boolean {
     // Normalize to forward slashes for cross-platform matching


### PR DESCRIPTION
## Summary

- Add `find -delete` and `find -exec` to write operator regexes (`EXPANDED_WRITE_OPERATORS` and `BASH_WRITE_OPERATORS`)
- Add `find -delete/-exec` detection in `detectDangerousPatterns()`
- Expand `env` command wrapper bypass list to include `node`, `bun`, `awk`, `bash`, `sh`, `zsh`
- Detect `zsh -c` as shell invocation alongside `bash -c` and `sh -c`
- Fix `\bexec\b` pattern to not false-match `find`'s `-exec` flag (use negative lookbehind)
- Add 10 new unit tests and 7 new integration tests for all bypass vectors

## Bypass vectors closed

| Vector | Before | After |
|--------|--------|-------|
| `find /app -name "*.env" -delete` | Not detected | Blocked |
| `find . -exec rm {} \;` | Matched generic `exec` (misleading) | Matched as `find -exec` specifically |
| `zsh -c "rm .env"` | Not detected | Blocked (shell -c) |
| `env node -e "..."` | Not detected | Blocked (env wrapper) |
| `env bun -e "..."` | Not detected | Blocked (env wrapper) |
| `env bash -c "..."` | Only detected as `bash -c` | Detected (either pattern) |

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` — 0 errors
- [x] `bun test` — 4033 tests pass, 0 failures
- [x] All 90 bash-security + protected-paths tests pass

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)