### PR TITLE
fix: API key expiration/rotation and webhook signature hardening

### DIFF
--- a/server/__tests__/routes-settings.test.ts
+++ b/server/__tests__/routes-settings.test.ts
@@ -3,6 +3,7 @@ import { Database } from 'bun:sqlite';
 import { runMigrations } from '../db/schema';
 import { handleSettingsRoutes } from '../routes/settings';
 import type { RequestContext } from '../middleware/guards';
+import type { AuthConfig } from '../middleware/auth';
 
 let db: Database;
 
@@ -105,5 +106,127 @@ describe('Settings Routes', () => {
         const { req, url } = fakeReq('GET', '/api/other');
         const res = handleSettingsRoutes(req, url, db);
         expect(res).toBeNull();
+    });
+});
+
+describe('API Key Rotation Endpoint', () => {
+    it('POST /api/settings/api-key/rotate rotates the key', async () => {
+        const authConfig: AuthConfig = {
+            apiKey: 'original-key-for-rotation',
+            allowedOrigins: [],
+            bindHost: '0.0.0.0',
+        };
+
+        const { req, url } = fakeReq('POST', '/api/settings/api-key/rotate', {});
+        const res = await handleSettingsRoutes(req, url, db, adminContext(), authConfig);
+        expect(res).not.toBeNull();
+        expect(res!.status).toBe(200);
+        const data = await res!.json();
+        expect(data.ok).toBe(true);
+        expect(data.apiKey).toBeTruthy();
+        expect(data.apiKey).not.toBe('original-key-for-rotation');
+        expect(authConfig.apiKey).toBe(data.apiKey);
+        expect(authConfig.previousApiKey).toBe('original-key-for-rotation');
+    });
+
+    it('POST /api/settings/api-key/rotate with ttlDays sets expiry', async () => {
+        const authConfig: AuthConfig = {
+            apiKey: 'key-to-rotate-with-ttl',
+            allowedOrigins: [],
+            bindHost: '0.0.0.0',
+        };
+
+        const { req, url } = fakeReq('POST', '/api/settings/api-key/rotate', { ttlDays: 30 });
+        const res = await handleSettingsRoutes(req, url, db, adminContext(), authConfig);
+        expect(res).not.toBeNull();
+        expect(res!.status).toBe(200);
+        const data = await res!.json();
+        expect(data.ok).toBe(true);
+        expect(data.expiresAt).toBeTruthy();
+        expect(authConfig.apiKeyExpiresAt).toBeGreaterThan(Date.now());
+    });
+
+    it('POST /api/settings/api-key/rotate returns 400 when no API key configured', async () => {
+        const authConfig: AuthConfig = {
+            apiKey: null,
+            allowedOrigins: [],
+            bindHost: '127.0.0.1',
+        };
+
+        const { req, url } = fakeReq('POST', '/api/settings/api-key/rotate', {});
+        const res = await handleSettingsRoutes(req, url, db, adminContext(), authConfig);
+        expect(res).not.toBeNull();
+        expect(res!.status).toBe(400);
+    });
+
+    it('POST /api/settings/api-key/rotate returns 503 when authConfig is null', async () => {
+        const { req, url } = fakeReq('POST', '/api/settings/api-key/rotate', {});
+        const res = await handleSettingsRoutes(req, url, db, adminContext(), null);
+        expect(res).not.toBeNull();
+        expect(res!.status).toBe(503);
+    });
+});
+
+describe('API Key Status Endpoint', () => {
+    it('GET /api/settings/api-key/status returns status with no expiry', async () => {
+        const authConfig: AuthConfig = {
+            apiKey: 'test-status-key',
+            allowedOrigins: [],
+            bindHost: '0.0.0.0',
+        };
+
+        const { req, url } = fakeReq('GET', '/api/settings/api-key/status');
+        const res = handleSettingsRoutes(req, url, db, adminContext(), authConfig);
+        expect(res).not.toBeNull();
+        const resolved = await Promise.resolve(res!);
+        expect(resolved.status).toBe(200);
+        const data = await resolved.json();
+        expect(data.hasActiveKey).toBe(true);
+        expect(data.expired).toBe(false);
+        expect(data.expiresAt).toBeNull();
+        expect(data.warning).toBeNull();
+    });
+
+    it('GET /api/settings/api-key/status returns warning when key expiring soon', async () => {
+        const authConfig: AuthConfig = {
+            apiKey: 'test-expiring-key',
+            allowedOrigins: [],
+            bindHost: '0.0.0.0',
+            apiKeyExpiresAt: Date.now() + 3 * 24 * 60 * 60 * 1000, // 3 days
+        };
+
+        const { req, url } = fakeReq('GET', '/api/settings/api-key/status');
+        const res = handleSettingsRoutes(req, url, db, adminContext(), authConfig);
+        expect(res).not.toBeNull();
+        const resolved = await Promise.resolve(res!);
+        expect(resolved.status).toBe(200);
+        const data = await resolved.json();
+        expect(data.expired).toBe(false);
+        expect(data.warning).toContain('3 days');
+    });
+
+    it('GET /api/settings/api-key/status returns expired status', async () => {
+        const authConfig: AuthConfig = {
+            apiKey: 'test-expired-key',
+            allowedOrigins: [],
+            bindHost: '0.0.0.0',
+            apiKeyExpiresAt: Date.now() - 1000,
+        };
+
+        const { req, url } = fakeReq('GET', '/api/settings/api-key/status');
+        const res = handleSettingsRoutes(req, url, db, adminContext(), authConfig);
+        expect(res).not.toBeNull();
+        const resolved = await Promise.resolve(res!);
+        expect(resolved.status).toBe(200);
+        const data = await resolved.json();
+        expect(data.expired).toBe(true);
+    });
+
+    it('GET /api/settings/api-key/status returns 503 when authConfig null', async () => {
+        const { req, url } = fakeReq('GET', '/api/settings/api-key/status');
+        const res = handleSettingsRoutes(req, url, db, adminContext(), null);
+        expect(res).not.toBeNull();
+        const resolved = await Promise.resolve(res!);
+        expect(resolved.status).toBe(503);
     });
 });

--- a/server/db/migrations/056_api_key_expiry.ts
+++ b/server/db/migrations/056_api_key_expiry.ts
@@ -1,0 +1,34 @@
+/**
+ * Migration 056: API key expiration and usage tracking.
+ *
+ * Adds expires_at and last_used_at columns to the api_keys table
+ * to support key expiration policies and forced rotation (#380).
+ */
+
+import { Database } from 'bun:sqlite';
+
+const SAFE_SQL_IDENTIFIER = /^[a-z_][a-z0-9_]*$/i;
+
+function hasColumn(db: Database, table: string, column: string): boolean {
+    if (!SAFE_SQL_IDENTIFIER.test(table)) {
+        throw new Error(`hasColumn: invalid table name '${table}'`);
+    }
+    const cols = db.query(`PRAGMA table_info(${table})`).all() as { name: string }[];
+    return cols.some((c) => c.name === column);
+}
+
+function safeAlter(db: Database, sql: string): void {
+    const match = sql.match(/ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(\w+)/i);
+    if (match && hasColumn(db, match[1], match[2])) return;
+    db.exec(sql);
+}
+
+export function up(db: Database): void {
+    safeAlter(db, `ALTER TABLE api_keys ADD COLUMN expires_at TEXT DEFAULT NULL`);
+    safeAlter(db, `ALTER TABLE api_keys ADD COLUMN last_used_at TEXT DEFAULT NULL`);
+}
+
+export function down(_db: Database): void {
+    // SQLite doesn't support DROP COLUMN before 3.35.0;
+    // columns are left in place (harmless with DEFAULT NULL).
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,6 +1,6 @@
 import { Database } from 'bun:sqlite';
 
-const SCHEMA_VERSION = 55;
+const SCHEMA_VERSION = 56;
 
 const MIGRATIONS: Record<number, string[]> = {
     1: [
@@ -1105,6 +1105,12 @@ const MIGRATIONS: Record<number, string[]> = {
             updated_at TEXT DEFAULT (datetime('now')),
             PRIMARY KEY (tenant_id, key_hash)
         )`,
+    ],
+
+    // Migration 56: API key expiration and usage tracking (#380)
+    56: [
+        `ALTER TABLE api_keys ADD COLUMN expires_at TEXT DEFAULT NULL`,
+        `ALTER TABLE api_keys ADD COLUMN last_used_at TEXT DEFAULT NULL`,
     ],
 };
 

--- a/server/discord/bridge.ts
+++ b/server/discord/bridge.ts
@@ -24,6 +24,12 @@ const MAX_MESSAGE_LENGTH = 2000;
 /**
  * Bidirectional Discord bridge using raw WebSocket gateway.
  * No external Discord library dependencies.
+ *
+ * Security note: This bridge authenticates via the Discord Gateway WebSocket API
+ * using a bot token — it does NOT use the HTTP-based Interactions endpoint.
+ * Therefore, Ed25519 request signature validation (X-Signature-Ed25519) is not
+ * applicable here. If Discord Interactions support is added in the future,
+ * Ed25519 verification must be implemented for that endpoint.
  */
 export class DiscordBridge {
     private db: Database;

--- a/server/middleware/guards.ts
+++ b/server/middleware/guards.ts
@@ -207,6 +207,8 @@ export const ADMIN_PATHS = new Set([
     '/api/memories/backfill',
     '/api/selftest/run',
     '/api/settings/credits',
+    '/api/settings/api-key/rotate',
+    '/api/settings/api-key/status',
 ]);
 
 export function requiresAdminRole(pathname: string): boolean {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -292,7 +292,7 @@ async function handleRoutes(
     const systemLogResponse = handleSystemLogRoutes(req, url, db);
     if (systemLogResponse) return systemLogResponse;
 
-    const settingsResponse = await handleSettingsRoutes(req, url, db, context);
+    const settingsResponse = await handleSettingsRoutes(req, url, db, context, getAuthConfig());
     if (settingsResponse) return settingsResponse;
 
     const sessionResponse = await handleSessionRoutes(req, url, db, processManager, context);

--- a/server/slack/bridge.ts
+++ b/server/slack/bridge.ts
@@ -11,6 +11,7 @@ import { createSession, getSession } from '../db/sessions';
 import { listProjects } from '../db/projects';
 import { createLogger } from '../lib/logger';
 import { DedupService } from '../lib/dedup';
+import { timingSafeEqual } from '../middleware/auth';
 
 const log = createLogger('SlackBridge');
 
@@ -129,13 +130,8 @@ export class SlackBridge {
             .map(b => b.toString(16).padStart(2, '0'))
             .join('');
 
-        // Timing-safe comparison
-        if (hexSig.length !== signature.length) return false;
-        let mismatch = 0;
-        for (let i = 0; i < hexSig.length; i++) {
-            mismatch |= hexSig.charCodeAt(i) ^ signature.charCodeAt(i);
-        }
-        return mismatch === 0;
+        // Timing-safe comparison using shared utility
+        return timingSafeEqual(hexSig, signature);
     }
 
     private async handleEvent(event: SlackMessageEvent): Promise<void> {


### PR DESCRIPTION
## Summary
- **#384** — Validates webhook signatures for Discord and Slack bridges. Discord uses Gateway WebSocket API (not HTTP Interactions), so Ed25519 is inapplicable — documented with guard comment. Slack bridge's manual XOR timing-safe loop replaced with shared `timingSafeEqual` utility for consistency.
- **#380** — Adds API key expiration and forced rotation. New `apiKeyExpiresAt` field on `AuthConfig`, `API_KEY_TTL_DAYS` env var, expired key rejection (401), admin endpoints for rotation (`POST /api/settings/api-key/rotate`) and status (`GET /api/settings/api-key/status`), health check integration (degraded <7 days, unhealthy if expired), and migration 056 for `expires_at`/`last_used_at` columns.

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` passes (4056 tests, 23 new)
- [x] `bun run spec:check` passes (38/38 specs)
- [ ] Manual: set `API_KEY_TTL_DAYS=1` and verify key expiry warning in health check
- [ ] Manual: call `POST /api/settings/api-key/rotate` with `{ "ttlDays": 30 }` and verify new key + expiry
- [ ] Manual: verify `GET /api/settings/api-key/status` shows correct expiry info

Closes #384, closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)