### PR TITLE
Security hardening + scheduler improvements

### DIFF
--- a/client/src/app/core/models/schedule.model.ts
+++ b/client/src/app/core/models/schedule.model.ts
@@ -8,9 +8,20 @@ export type ScheduleActionType =
     | 'council_launch'
     | 'send_message'
     | 'github_suggest'
+    | 'codebase_review'
+    | 'dependency_audit'
+    | 'improvement_loop'
+    | 'memory_maintenance'
+    | 'reputation_attestation'
     | 'custom';
 
 export type ScheduleApprovalPolicy = 'auto' | 'owner_approve' | 'council_approve';
+
+export interface ScheduleTriggerEvent {
+    source: 'github_webhook' | 'github_poll';
+    event: string;
+    repo?: string;
+}
 
 export interface ScheduleAction {
     type: ScheduleActionType;
@@ -23,6 +34,8 @@ export interface ScheduleAction {
     maxPrs?: number;
     autoCreatePr?: boolean;
     prompt?: string;
+    maxImprovementTasks?: number;
+    focusArea?: string;
 }
 
 export interface AgentSchedule {
@@ -38,13 +51,14 @@ export interface AgentSchedule {
     maxExecutions: number | null;
     executionCount: number;
     maxBudgetPerRun: number | null;
+    triggerEvents: ScheduleTriggerEvent[] | null;
     lastRunAt: string | null;
     nextRunAt: string | null;
     createdAt: string;
     updatedAt: string;
 }
 
-export type ScheduleExecutionStatus = 'running' | 'completed' | 'failed' | 'awaiting_approval' | 'approved' | 'denied';
+export type ScheduleExecutionStatus = 'running' | 'completed' | 'failed' | 'cancelled' | 'awaiting_approval' | 'approved' | 'denied';
 
 export interface ScheduleExecution {
     id: string;
@@ -71,6 +85,7 @@ export interface CreateScheduleInput {
     approvalPolicy?: ScheduleApprovalPolicy;
     maxExecutions?: number;
     maxBudgetPerRun?: number;
+    triggerEvents?: ScheduleTriggerEvent[];
 }
 
 export interface UpdateScheduleInput {
@@ -83,4 +98,5 @@ export interface UpdateScheduleInput {
     status?: ScheduleStatus;
     maxExecutions?: number;
     maxBudgetPerRun?: number;
+    triggerEvents?: ScheduleTriggerEvent[] | null;
 }

--- a/server/db/migrations/057_schedule_trigger_events.ts
+++ b/server/db/migrations/057_schedule_trigger_events.ts
@@ -1,0 +1,33 @@
+/**
+ * Migration 057: Schedule trigger events.
+ *
+ * Adds trigger_events column to agent_schedules to support
+ * event-based schedule triggers (GitHub webhooks, polling events).
+ */
+
+import { Database } from 'bun:sqlite';
+
+const SAFE_SQL_IDENTIFIER = /^[a-z_][a-z0-9_]*$/i;
+
+function hasColumn(db: Database, table: string, column: string): boolean {
+    if (!SAFE_SQL_IDENTIFIER.test(table)) {
+        throw new Error(`hasColumn: invalid table name '${table}'`);
+    }
+    const cols = db.query(`PRAGMA table_info(${table})`).all() as { name: string }[];
+    return cols.some((c) => c.name === column);
+}
+
+function safeAlter(db: Database, sql: string): void {
+    const match = sql.match(/ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(\w+)/i);
+    if (match && hasColumn(db, match[1], match[2])) return;
+    db.exec(sql);
+}
+
+export function up(db: Database): void {
+    safeAlter(db, `ALTER TABLE agent_schedules ADD COLUMN trigger_events TEXT DEFAULT NULL`);
+}
+
+export function down(_db: Database): void {
+    // SQLite doesn't support DROP COLUMN before 3.35.0;
+    // column is left in place (harmless with DEFAULT NULL).
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -222,6 +222,8 @@ const improvementLoopService = new AutonomousLoopService(
 schedulerService.setImprovementLoopService(improvementLoopService);
 schedulerService.setReputationServices(reputationScorer, reputationAttestation);
 schedulerService.setNotificationService(notificationService);
+webhookService.setSchedulerService(schedulerService);
+mentionPollingService.setSchedulerService(schedulerService);
 
 // Initialize multi-tenant (opt-in via MULTI_TENANT=true)
 const multiTenant = process.env.MULTI_TENANT === 'true';

--- a/server/lib/validation.ts
+++ b/server/lib/validation.ts
@@ -314,6 +314,12 @@ const ScheduleActionSchema = z.object({
     focusArea: z.string().optional(),
 });
 
+const ScheduleTriggerEventSchema = z.object({
+    source: z.enum(['github_webhook', 'github_poll']),
+    event: z.string().min(1),
+    repo: z.string().optional(),
+});
+
 export const CreateScheduleSchema = z.object({
     agentId: z.string().min(1, 'agentId is required'),
     name: z.string().min(1, 'name is required'),
@@ -325,9 +331,10 @@ export const CreateScheduleSchema = z.object({
     maxExecutions: z.number().int().min(1).optional(),
     maxBudgetPerRun: z.number().min(0).optional(),
     notifyAddress: z.string().min(1).optional(),
+    triggerEvents: z.array(ScheduleTriggerEventSchema).optional(),
 }).refine(
-    (d) => d.cronExpression || d.intervalMs,
-    { message: 'Either cronExpression or intervalMs must be provided' },
+    (d) => d.cronExpression || d.intervalMs || (d.triggerEvents && d.triggerEvents.length > 0),
+    { message: 'Either cronExpression, intervalMs, or triggerEvents must be provided' },
 );
 
 export const UpdateScheduleSchema = z.object({
@@ -341,10 +348,16 @@ export const UpdateScheduleSchema = z.object({
     maxExecutions: z.number().int().min(1).optional(),
     maxBudgetPerRun: z.number().min(0).optional(),
     notifyAddress: z.string().min(1).nullable().optional(),
+    triggerEvents: z.array(ScheduleTriggerEventSchema).nullable().optional(),
 });
 
 export const ScheduleApprovalSchema = z.object({
     approved: z.boolean({ message: 'approved (boolean) is required' }),
+});
+
+export const BulkScheduleActionSchema = z.object({
+    action: z.enum(['pause', 'resume', 'delete']),
+    ids: z.array(z.string().min(1)).min(1, 'At least one schedule ID is required').max(50, 'Maximum 50 IDs per bulk action'),
 });
 
 // ─── Webhooks ────────────────────────────────────────────────────────────────

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -362,6 +362,12 @@ export type ScheduleActionType =
 
 export type ScheduleApprovalPolicy = 'auto' | 'owner_approve' | 'council_approve';
 
+export interface ScheduleTriggerEvent {
+    source: 'github_webhook' | 'github_poll';
+    event: string;
+    repo?: string;
+}
+
 export interface ScheduleAction {
     type: ScheduleActionType;
     /** Target repos (for star/fork/review/suggest) */
@@ -409,13 +415,15 @@ export interface AgentSchedule {
     maxBudgetPerRun: number | null;
     /** Algorand address to notify on execution start/complete/fail */
     notifyAddress: string | null;
+    /** Event-based triggers (optional, in addition to or instead of cron/interval) */
+    triggerEvents: ScheduleTriggerEvent[] | null;
     lastRunAt: string | null;
     nextRunAt: string | null;
     createdAt: string;
     updatedAt: string;
 }
 
-export type ScheduleExecutionStatus = 'running' | 'completed' | 'failed' | 'awaiting_approval' | 'approved' | 'denied';
+export type ScheduleExecutionStatus = 'running' | 'completed' | 'failed' | 'cancelled' | 'awaiting_approval' | 'approved' | 'denied';
 
 export interface ScheduleExecution {
     id: string;
@@ -444,6 +452,7 @@ export interface CreateScheduleInput {
     maxExecutions?: number;
     maxBudgetPerRun?: number;
     notifyAddress?: string;
+    triggerEvents?: ScheduleTriggerEvent[];
 }
 
 export interface UpdateScheduleInput {
@@ -457,6 +466,7 @@ export interface UpdateScheduleInput {
     maxExecutions?: number;
     maxBudgetPerRun?: number;
     notifyAddress?: string | null;
+    triggerEvents?: ScheduleTriggerEvent[] | null;
 }
 
 // MARK: - Webhooks (GitHub Event Triggers)


### PR DESCRIPTION
## Summary

- **API key expiration & rotation**: Add `expires_at`/`last_used_at` tracking, key rotation endpoint, expired key rejection in auth middleware (#384, #380)
- **Webhook signature hardening**: HMAC-SHA256 verification for GitHub/Slack/Discord webhooks, replay protection via timestamp validation
- **Scheduler UI sync**: Expose all 12 server action types in the client (was 7), with full parameter forms for each type
- **Execution management**: Filtered execution queries (status/actionType/date/pagination), cancel running executions, bulk pause/resume/delete schedules
- **Event-based triggers**: Schedules can now fire from GitHub webhook/polling events (not just cron/interval), with migration 057 adding `trigger_events` column
- **Schema reconciliation fix**: `reconcileTables()` now applies missing `ALTER TABLE ADD COLUMN` statements and wraps `CREATE INDEX` in try-catch to survive missing columns

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 4080 tests pass
- [x] `bun run spec:check` — 38 specs pass
- [x] Server starts cleanly after schema reconciliation fix
- [ ] Verify schedule creation with new action types in UI
- [ ] Verify execution filtering and cancellation via API
- [ ] Verify event-triggered schedule fires on webhook receipt

🤖 Generated with [Claude Code](https://claude.com/claude-code)