### PR TITLE
fix: add error handling for resumeProcess in session resume route

### DIFF
--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -148,6 +148,10 @@ async function handleResume(
     } catch {
         // Empty body is fine for resume
     }
-    processManager.resumeProcess(session, prompt);
+    try {
+        processManager.resumeProcess(session, prompt);
+    } catch (err) {
+        log.error('Failed to resume process', { sessionId: session.id, error: err instanceof Error ? err.message : String(err) });
+    }
     return json({ ok: true });
 }


### PR DESCRIPTION
## Summary

- Wraps `processManager.resumeProcess()` in try/catch with error logging, matching the existing pattern used for `startProcess()` in the same file
- Prevents errors from being silently lost when the HTTP response has already been queued

Closes #398

## Validation

- `bunx tsc --noEmit --skipLibCheck` passes (no new errors)
- `bun test` passes (4148 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)