### PR TITLE
fix: sort schedule list by cron hour and expand gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,11 @@ coverage/
 blob-report/
 backups/
 git-focus/
+
+# Cloned repos (scheduled tasks may clone these into the working directory)
+arbor/
+emitter/
+signal/
+corvid-agent-chat/
+corvid-reputation/
+client/package-lock.json

--- a/client/src/app/features/schedules/schedule-list.component.ts
+++ b/client/src/app/features/schedules/schedule-list.component.ts
@@ -489,8 +489,8 @@ export class ScheduleListComponent implements OnInit, OnDestroy {
     readonly filteredSchedules = computed(() => {
         const filter = this.activeFilter();
         const all = this.scheduleService.schedules();
-        if (filter === 'all') return all;
-        return all.filter((s) => s.status === filter);
+        const filtered = filter === 'all' ? all : all.filter((s) => s.status === filter);
+        return [...filtered].sort((a, b) => this.cronHour(a.cronExpression) - this.cronHour(b.cronExpression));
     });
 
     async ngOnInit(): Promise<void> {
@@ -692,6 +692,14 @@ export class ScheduleListComponent implements OnInit, OnDestroy {
         } catch {
             this.notifications.error('Failed to resolve approval');
         }
+    }
+
+    private cronHour(expr: string | null | undefined): number {
+        if (!expr) return 99;
+        const parts = expr.trim().split(/\s+/);
+        if (parts.length < 2) return 99;
+        const h = parseInt(parts[1], 10);
+        return isNaN(h) ? 99 : h;
     }
 
     private resetForm(): void {


### PR DESCRIPTION
## Summary
- **Schedule list sorting**: The schedule page displayed schedules in random order because WebSocket `schedule_update` messages prepend updated items to the front of the array, breaking the server-side cron hour sort. Added a `cronHour()` helper and client-side sorting to the `filteredSchedules` computed signal so schedules always display chronologically (midnight first, event-triggered last).
- **Gitignore expansion**: Added cloned repo directories (`arbor/`, `emitter/`, `signal/`, `corvid-agent-chat/`, `corvid-reputation/`) and `client/package-lock.json` to `.gitignore` to prevent scheduled tasks from accidentally tracking them.

## Test plan
- [x] Verify schedule page displays schedules sorted by cron hour (00:00 first)
- [x] Trigger a WebSocket schedule update and confirm sort order is maintained
- [x] Verify event-triggered schedules (no cron) appear at the bottom
- [x] Confirm cloned repo directories are ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)