### PR TITLE
docs: fix stale references and add missing route documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,19 +269,21 @@ server/          Bun HTTP + WebSocket server
   notifications/ Multi-channel notification delivery (Discord, Telegram, GitHub, AlgoChat)
   observability/ OpenTelemetry tracing, Prometheus metrics
   openapi/       OpenAPI spec generator and route registry
+  performance/   Performance metrics collection and regression detection
   plugins/       Plugin SDK and dynamic tool registration
   polling/       GitHub mention polling for @mention-driven automation
   process/       Agent lifecycle (SDK + Ollama, approval, event bus, persona/skill injection)
   providers/     Multi-model cost-aware routing
   public/        Static assets served by the HTTP server
   reputation/    Reputation and trust scoring
-  routes/        REST API routes (30 route modules)
+  routes/        REST API routes (32 route modules)
   sandbox/       Container sandboxing for isolated execution
   scheduler/     Cron/interval execution engine
   selftest/      Self-test and validation utilities
   slack/         Bidirectional Slack bridge (channel adapter, notifications, questions)
   telegram/      Bidirectional Telegram bridge (long-polling, voice)
   tenant/        Multi-tenant isolation and access control
+  usage/         Schedule usage monitoring and anomaly detection
   voice/         TTS (OpenAI) and STT (Whisper) with caching
   webhooks/      GitHub webhook and mention polling
   work/          Work task service (worktree, branch, validate, PR)
@@ -319,7 +321,7 @@ Tools are permission-scoped per agent via skill bundles and agent-level allowlis
 
 ## API
 
-~200 REST endpoints and a WebSocket interface across 30 route modules:
+~200 REST endpoints and a WebSocket interface across 32 route modules:
 
 | Group | Endpoints | Description |
 |-------|----------|-------------|
@@ -350,6 +352,8 @@ Tools are permission-scoped per agent via skill bundles and agent-level allowlis
 | Tenants | `/api/tenants` | Multi-tenant registration and member management |
 | Auth Flow | `/api/auth` | Device authorization for CLI login |
 | Settings | `/api/settings` | Application settings and operational mode |
+| Performance | `/api/performance` | Performance snapshots, trends, and regression detection |
+| Usage | `/api/usage` | Schedule usage monitoring and anomaly detection |
 | System Logs | `/api/system-logs` | System log queries and credit history |
 | Health | `GET /api/health` | Health check (public, no auth) |
 | A2A | `/.well-known/agent-card.json` | Google A2A protocol Agent Card |

--- a/docs/hardening-guide.md
+++ b/docs/hardening-guide.md
@@ -16,7 +16,7 @@
 - [ ] Deploy behind a reverse proxy (Caddy or nginx, see `deploy/`)
 - [ ] Enable TLS (Let's Encrypt via Caddy, or cert-manager in K8s)
 - [ ] Restrict API access to known IP ranges if possible
-- [ ] Use `CORS_ORIGINS` to allowlist specific frontend domains
+- [ ] Use `ALLOWED_ORIGINS` to allowlist specific frontend domains
 - [ ] Do NOT expose port 3578 directly to the internet
 - [ ] Ensure WebSocket connections use WSS (not WS)
 

--- a/specs/notifications/service.spec.md
+++ b/specs/notifications/service.spec.md
@@ -226,7 +226,7 @@ Multi-channel notification service that persists notifications to the database a
 | Module | What is used |
 |--------|-------------|
 | `server/index.ts` | Lifecycle: construction, `start()`, `stop()`, `setAgentMessenger()`, `setBroadcast()` |
-| `server/routes/notifications.ts` | `notify()` via API endpoints |
+| `server/scheduler/service.ts` | `notify()` for schedule execution alerts |
 | `server/mcp/tool-handlers/notifications.ts` | `notify()` via MCP tools |
 
 ## Database Tables


### PR DESCRIPTION
## Summary

API & documentation sync audit found several stale references and undocumented routes. This PR fixes the direct issues; larger items filed as #431.

- **Fix `CORS_ORIGINS` → `ALLOWED_ORIGINS`** in hardening guide — was an actionable misconfiguration that would silently fail for anyone following the guide
- **Add 6 missing route files** to `specs/routes/routes.spec.md` frontmatter: `audit.ts`, `github-allowlist.ts`, `performance.ts`, `slack.ts`, `tenants.ts`, `usage.ts`
- **Add ~30 undocumented endpoints** to routes spec: agent spending, reputation identity, settings API key rotation, schedule trigger/bulk/cancel, plus full sections for GitHub Allowlist, Audit, Performance, Usage, Tenants, and Slack
- **Fix stale reference** in notifications spec: `server/routes/notifications.ts` (doesn't exist) → `server/scheduler/service.ts`
- **Update README**: route count 30→32, add `server/usage/` and `server/performance/` to directory listing, add Performance and Usage to API table

Remaining items tracked in #431: port inconsistency across docs, ADR-001 table names, threat model staleness.

## Test plan

- [x] `bun run spec:check` — 38 specs, 0 failures
- [x] `tsc --noEmit` clean
- [x] Ubuntu and macOS builds passing (4283 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)