### PR TITLE
fix: health collector test timeout and parsing reliability

### DIFF
--- a/server/__tests__/health-collector.test.ts
+++ b/server/__tests__/health-collector.test.ts
@@ -90,11 +90,27 @@ describe('parseTestOutput', () => {
         expect(result.failureCount).toBeGreaterThanOrEqual(1);
     });
 
-    test('captures last 30 lines as summary', () => {
-        const lines = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join('\n');
+    test('captures last 50 lines as summary', () => {
+        const lines = Array.from({ length: 80 }, (_, i) => `line ${i + 1}`).join('\n');
         const result = parseTestOutput(lines, 0);
-        expect(result.summary).toContain('line 50');
-        expect(result.summary).not.toContain('line 10');
+        expect(result.summary).toContain('line 80');
+        expect(result.summary).not.toContain('line 20');
+    });
+
+    test('finds fail count when summary is buried by stderr', () => {
+        // Simulates stdout (test results) + stderr (log output) concatenation
+        const stdout = `bun test v1.0.0\n\n100 pass\n2 fail\n`;
+        const stderr = Array.from({ length: 60 }, (_, i) => `2026-03-02 WARN [Test] log line ${i}`).join('\n');
+        const result = parseTestOutput(stdout + stderr, 1);
+        expect(result.failureCount).toBe(2);
+        expect(result.passed).toBe(false);
+    });
+
+    test('reports passed=false when failureCount > 0 even with exit 0', () => {
+        const output = `bun test v1.0.0\n\n98 pass\n1 fail\n`;
+        const result = parseTestOutput(output, 0);
+        expect(result.passed).toBe(false);
+        expect(result.failureCount).toBe(1);
     });
 });
 

--- a/server/improvement/health-collector.ts
+++ b/server/improvement/health-collector.ts
@@ -11,6 +11,7 @@ import { createLogger } from '../lib/logger';
 const log = createLogger('HealthCollector');
 
 const SPAWN_TIMEOUT_MS = 60_000;
+const TEST_TIMEOUT_MS = 180_000;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -102,15 +103,16 @@ export function parseTscOutput(output: string): TscError[] {
 
 export function parseTestOutput(output: string, exitCode: number): { passed: boolean; summary: string; failureCount: number } {
     const lines = output.split('\n');
-    const last30 = lines.slice(-30).join('\n');
+    const last50 = lines.slice(-50).join('\n');
 
-    // Look for bun test summary lines like "42 pass" / "3 fail"
-    const failMatch = last30.match(/(\d+)\s+fail/i);
+    // Search entire output for bun test summary line (stdout may not be at the end
+    // when stderr is appended after it)
+    const failMatch = output.match(/^\s*(\d+)\s+fail\b/im);
     const failureCount = failMatch ? parseInt(failMatch[1], 10) : 0;
 
     return {
-        passed: exitCode === 0,
-        summary: last30.trim(),
+        passed: exitCode === 0 && failureCount === 0,
+        summary: last50.trim(),
         failureCount: exitCode !== 0 ? Math.max(failureCount, 1) : failureCount,
     };
 }
@@ -244,6 +246,7 @@ export class CodebaseHealthCollector {
         const { stdout, exitCode } = await spawnAndCapture(
             ['bun', 'test'],
             cwd,
+            TEST_TIMEOUT_MS,
         );
         return parseTestOutput(stdout, exitCode);
     }


### PR DESCRIPTION
## Summary
- The test suite takes ~107s but the health collector's spawn timeout was 60s, causing the bun test process to be killed and exit non-zero. This produced a persistent **phantom "1 test failure"** in health metrics (the test_failures trend has been stuck at 1 for multiple cycles).
- `parseTestOutput` only searched the last 30 lines for the fail count, but since stdout and stderr are concatenated, the bun test summary could be buried earlier in the output.
- Added `passed=false` when `failureCount > 0` regardless of exit code, for correctness.

## Changes
- **`server/improvement/health-collector.ts`**: Add `TEST_TIMEOUT_MS = 180_000` for the test runner (3x the test suite duration). Search entire output with anchored regex `^\s*(\d+)\s+fail\b` instead of last-30-lines window. Expand summary from 30 to 50 lines.
- **`server/__tests__/health-collector.test.ts`**: Update summary test, add tests for stderr-buried-fail-count and failureCount-with-zero-exit scenarios.

## Impact
Eliminates the stable `test_failures: 1` false positive in health metrics. The improvement loop will now correctly report 0 test failures when the suite is green.

## Test plan
- [x] `bun test server/__tests__/health-collector.test.ts` — 23 pass, 0 fail
- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)