### PR TITLE
feat: add pull_request event type to mention poller

### DIFF
--- a/server/__tests__/github-searcher.test.ts
+++ b/server/__tests__/github-searcher.test.ts
@@ -647,9 +647,9 @@ describe('GitHubSearcher', () => {
 
             await searcher.fetchMentions(config, () => true);
 
-            // Should make 4 search/issues calls: issue_comment, issues, assigned, PR reviews
+            // Should make 5 search/issues calls: issue_comment, issues, assigned, PR reviews, pull_request
             const searchCalls = capturedArgs.filter(a => a.includes('search/issues'));
-            expect(searchCalls).toHaveLength(4);
+            expect(searchCalls).toHaveLength(5);
         });
 
         test('skips issue_comment search when filtered out', async () => {

--- a/server/lib/validation.ts
+++ b/server/lib/validation.ts
@@ -390,6 +390,7 @@ const PollingEventFilterSchema = z.enum([
     'issue_comment',
     'issues',
     'pull_request_review_comment',
+    'pull_request',
 ]);
 
 export const CreateMentionPollingSchema = z.object({

--- a/server/polling/github-searcher.ts
+++ b/server/polling/github-searcher.ts
@@ -16,7 +16,7 @@ export interface DetectedMention {
     /** Unique identifier (e.g. comment ID or issue number + timestamp) */
     id: string;
     /** Event type */
-    type: 'issue_comment' | 'issues' | 'pull_request_review_comment' | 'assignment';
+    type: 'issue_comment' | 'issues' | 'pull_request_review_comment' | 'pull_request' | 'assignment';
     /** The comment/issue body containing the @mention */
     body: string;
     /** GitHub username of the author */
@@ -93,6 +93,13 @@ export class GitHubSearcher {
                 config.repo, config.mentionUsername, sinceDate,
             );
             mentions.push(...prReviewMentions);
+        }
+
+        if (shouldPollEventType(config, 'pull_request')) {
+            const prMentions = await this.searchPullRequestMentions(
+                config.repo, config.mentionUsername, sinceDate,
+            );
+            mentions.push(...prMentions);
         }
 
         // Sort by creation time descending (newest first)
@@ -308,6 +315,60 @@ export class GitHubSearcher {
             return mentions;
         } catch (err) {
             log.error('Error searching assigned issues', { repo, error: err instanceof Error ? err.message : String(err) });
+            return [];
+        }
+    }
+
+    /**
+     * Search for open PRs that mention, request review from, or are assigned to the user.
+     * This catches PRs (including dependabot) that need attention.
+     */
+    async searchPullRequestMentions(
+        repo: string,
+        username: string,
+        since: string,
+    ): Promise<DetectedMention[]> {
+        try {
+            const sinceDate = since.split('T')[0];
+            // Search for PRs that involve this user (review-requested, mentioned, assigned)
+            const query = `${repoQualifier(repo)} is:pr is:open review-requested:${username} updated:>=${sinceDate}`;
+            const result = await this.runGh([
+                'api', 'search/issues',
+                '-X', 'GET',
+                '-f', `q=${query}`,
+                '-f', 'sort=updated',
+                '-f', 'order=desc',
+                '-f', 'per_page=20',
+            ]);
+
+            if (!result.ok || !result.stdout.trim()) return [];
+
+            const parsed = JSON.parse(result.stdout) as { items?: Array<Record<string, unknown>> };
+            const items = parsed.items ?? [];
+            const mentions: DetectedMention[] = [];
+
+            for (const item of items) {
+                const body = (item.body as string) ?? '';
+                const sender = ((item.user as Record<string, unknown>)?.login as string) ?? '';
+                const htmlUrl = (item.html_url as string) ?? '';
+                const itemRepo = resolveFullRepo(repo, htmlUrl);
+
+                mentions.push({
+                    id: `pr-${itemRepo}-${item.number}`,
+                    type: 'pull_request',
+                    body,
+                    sender,
+                    number: item.number as number,
+                    title: (item.title as string) ?? '',
+                    htmlUrl,
+                    createdAt: (item.created_at as string) ?? '',
+                    isPullRequest: true,
+                });
+            }
+
+            return mentions;
+        } catch (err) {
+            log.error('Error searching PR mentions', { repo, error: err instanceof Error ? err.message : String(err) });
             return [];
         }
     }

--- a/server/polling/service.ts
+++ b/server/polling/service.ts
@@ -852,12 +852,17 @@ export class MentionPollingService {
 
         const contextType = mention.isPullRequest ? 'PR' : 'Issue';
         const isAssignment = mention.type === 'assignment';
+        const isPullRequestReview = mention.type === 'pull_request';
         // corvid_create_work_task only works for the platform's own repo
         const isHomeRepo = repo === 'CorvidLabs/corvid-agent';
 
-        const triggerLabel = isAssignment ? 'assigned to you' : '@mention detected';
+        const triggerLabel = isAssignment ? 'assigned to you'
+            : isPullRequestReview ? 'review requested'
+            : '@mention detected';
         const commentType = mention.type === 'issues' ? 'issue body'
-            : isAssignment ? 'assignment' : 'comment';
+            : isAssignment ? 'assignment'
+            : isPullRequestReview ? 'PR description'
+            : 'comment';
 
         const context = [
             `## GitHub ${contextType} — ${triggerLabel} via polling`,
@@ -902,8 +907,8 @@ export class MentionPollingService {
         ];
 
         // Detect review requests so we can give the model explicit steps
-        const isReviewRequest = mention.isPullRequest &&
-            /\breview\b/i.test(mention.body);
+        const isReviewRequest = isPullRequestReview || (mention.isPullRequest &&
+            /\breview\b/i.test(mention.body));
 
         const reviewSteps = [
             `1. Run this EXACT command to get the diff:\n   \`run_command({"command": "gh pr diff ${mention.number} --repo ${repo}"})\``,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -558,7 +558,7 @@ export interface MentionPollingConfig {
     /** Set of all processed mention IDs to avoid re-triggering */
     processedIds: string[];
     /** Optional: only poll specific event types */
-    eventFilter: ('issue_comment' | 'issues' | 'pull_request_review_comment')[];
+    eventFilter: ('issue_comment' | 'issues' | 'pull_request_review_comment' | 'pull_request')[];
     /** Optional: only respond to mentions from specific users (empty = all users) */
     allowedUsers: string[];
     createdAt: string;


### PR DESCRIPTION
## Summary
- Mention poller now detects PRs where review is requested from the agent (dependabot PRs, review assignments)
- Previously these were only caught by the daily `PR Review — All Repos` schedule at 10:00 UTC
- New `searchPullRequestMentions()` queries `review-requested:username` via GitHub search API
- `pull_request` mentions route to the review prompt path automatically

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 4371 pass, 0 fail
- [x] `bun run spec:check` — 38 specs, 0 failed
- [x] Updated github-searcher test for 5th search call

🤖 Generated with [Claude Code](https://claude.com/claude-code)