### PR TITLE
feat: enforce multi-tenant route isolation (#305)

### DIFF
--- a/server/__tests__/routes-work-tasks.test.ts
+++ b/server/__tests__/routes-work-tasks.test.ts
@@ -57,7 +57,7 @@ describe('Work Task Routes', () => {
         const svc = createMockWorkTaskService();
         const { req, url } = fakeReq('GET', '/api/work-tasks?agentId=agent-1');
         handleWorkTaskRoutes(req, url, svc);
-        expect(svc.listTasks).toHaveBeenCalledWith('agent-1');
+        expect(svc.listTasks).toHaveBeenCalledWith('agent-1', 'default');
     });
 
     it('POST /api/work-tasks rejects empty body', async () => {

--- a/server/__tests__/tenant-isolation.test.ts
+++ b/server/__tests__/tenant-isolation.test.ts
@@ -9,7 +9,13 @@ import { extractTenantId, registerApiKey } from '../tenant/middleware';
 import { createAgent, listAgents, getAgent, updateAgent, deleteAgent } from '../db/agents';
 import { createSession, listSessions, getSession, deleteSession, updateSession, getSessionMessages, addSessionMessage } from '../db/sessions';
 import { createProject, listProjects, getProject } from '../db/projects';
-// work-tasks unused in current tests but kept for future expansion
+import { createWorkTask, listWorkTasks, getWorkTask } from '../db/work-tasks';
+import { listCouncils, getCouncil, createCouncil, updateCouncil, deleteCouncil } from '../db/councils';
+import { listSchedules, getSchedule, createSchedule, updateSchedule, deleteSchedule } from '../db/schedules';
+import { listWorkflows, getWorkflow, createWorkflow, updateWorkflow, deleteWorkflow } from '../db/workflows';
+import { listWebhookRegistrations, getWebhookRegistration, createWebhookRegistration, updateWebhookRegistration, deleteWebhookRegistration } from '../db/webhooks';
+import { listMentionPollingConfigs, getMentionPollingConfig, createMentionPollingConfig, updateMentionPollingConfig, deleteMentionPollingConfig } from '../db/mention-polling';
+import { listMcpServerConfigs, getMcpServerConfig, createMcpServerConfig, updateMcpServerConfig, deleteMcpServerConfig } from '../db/mcp-servers';
 import { tenantGuard, tenantRoleGuard, createRequestContext } from '../middleware/guards';
 import { tenantTopic } from '../ws/handler';
 import { validateUrl } from '../a2a/client';
@@ -765,5 +771,457 @@ describe('tenantTopic', () => {
     test('returns scoped topic for real tenant', () => {
         expect(tenantTopic('council', 'tenant-abc')).toBe('council:tenant-abc');
         expect(tenantTopic('algochat', 'tenant-xyz')).toBe('algochat:tenant-xyz');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-tenant council isolation (#305)
+// ---------------------------------------------------------------------------
+
+describe('Cross-tenant council isolation', () => {
+    const TENANT_A = 'tenant-a';
+    const TENANT_B = 'tenant-b';
+
+    function createTestCouncil(tenantId: string, name: string) {
+        // Councils need agent IDs — create agents in the same tenant
+        const agent = createAgent(db, { name: `Agent for ${name}` }, tenantId);
+        return createCouncil(db, { name, agentIds: [agent.id] }, tenantId);
+    }
+
+    test('Tenant A cannot list Tenant B councils', () => {
+        createTestCouncil(TENANT_A, 'Council A');
+        createTestCouncil(TENANT_B, 'Council B');
+
+        const councilsA = listCouncils(db, TENANT_A);
+        const councilsB = listCouncils(db, TENANT_B);
+
+        expect(councilsA).toHaveLength(1);
+        expect(councilsA[0].name).toBe('Council A');
+        expect(councilsB).toHaveLength(1);
+        expect(councilsB[0].name).toBe('Council B');
+    });
+
+    test('Tenant A cannot get Tenant B council by ID', () => {
+        const councilB = createTestCouncil(TENANT_B, 'Council B');
+
+        expect(getCouncil(db, councilB.id, TENANT_A)).toBeNull();
+        expect(getCouncil(db, councilB.id, TENANT_B)).not.toBeNull();
+    });
+
+    test('Tenant A cannot update Tenant B council', () => {
+        const councilB = createTestCouncil(TENANT_B, 'Council B');
+
+        const result = updateCouncil(db, councilB.id, { name: 'Hacked' }, TENANT_A);
+        expect(result).toBeNull();
+
+        const original = getCouncil(db, councilB.id, TENANT_B);
+        expect(original!.name).toBe('Council B');
+    });
+
+    test('Tenant A cannot delete Tenant B council', () => {
+        const councilB = createTestCouncil(TENANT_B, 'Council B');
+
+        const deleted = deleteCouncil(db, councilB.id, TENANT_A);
+        expect(deleted).toBe(false);
+
+        expect(getCouncil(db, councilB.id, TENANT_B)).not.toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-tenant schedule isolation (#305)
+// ---------------------------------------------------------------------------
+
+describe('Cross-tenant schedule isolation', () => {
+    const TENANT_A = 'tenant-a';
+    const TENANT_B = 'tenant-b';
+
+    function createTestSchedule(tenantId: string, name: string) {
+        const agent = createAgent(db, { name: `Agent for ${name}` }, tenantId);
+        return createSchedule(db, {
+            agentId: agent.id,
+            name,
+            actions: [{ type: 'prompt', prompt: 'test' }],
+            intervalMs: 3600000,
+        } as any, tenantId);
+    }
+
+    test('Tenant A cannot list Tenant B schedules', () => {
+        createTestSchedule(TENANT_A, 'Schedule A');
+        createTestSchedule(TENANT_B, 'Schedule B');
+
+        const schedulesA = listSchedules(db, undefined, TENANT_A);
+        const schedulesB = listSchedules(db, undefined, TENANT_B);
+
+        expect(schedulesA).toHaveLength(1);
+        expect(schedulesA[0].name).toBe('Schedule A');
+        expect(schedulesB).toHaveLength(1);
+        expect(schedulesB[0].name).toBe('Schedule B');
+    });
+
+    test('Tenant A cannot get Tenant B schedule by ID', () => {
+        const scheduleB = createTestSchedule(TENANT_B, 'Schedule B');
+
+        expect(getSchedule(db, scheduleB.id, TENANT_A)).toBeNull();
+        expect(getSchedule(db, scheduleB.id, TENANT_B)).not.toBeNull();
+    });
+
+    test('Tenant A cannot update Tenant B schedule', () => {
+        const scheduleB = createTestSchedule(TENANT_B, 'Schedule B');
+
+        const result = updateSchedule(db, scheduleB.id, { name: 'Hacked' }, TENANT_A);
+        expect(result).toBeNull();
+
+        const original = getSchedule(db, scheduleB.id, TENANT_B);
+        expect(original!.name).toBe('Schedule B');
+    });
+
+    test('Tenant A cannot delete Tenant B schedule', () => {
+        const scheduleB = createTestSchedule(TENANT_B, 'Schedule B');
+
+        const deleted = deleteSchedule(db, scheduleB.id, TENANT_A);
+        expect(deleted).toBe(false);
+
+        expect(getSchedule(db, scheduleB.id, TENANT_B)).not.toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-tenant workflow isolation (#305)
+// ---------------------------------------------------------------------------
+
+describe('Cross-tenant workflow isolation', () => {
+    const TENANT_A = 'tenant-a';
+    const TENANT_B = 'tenant-b';
+
+    function createTestWorkflow(tenantId: string, name: string) {
+        const agent = createAgent(db, { name: `Agent for ${name}` }, tenantId);
+        return createWorkflow(db, {
+            agentId: agent.id,
+            name,
+            nodes: [],
+            edges: [],
+        }, tenantId);
+    }
+
+    test('Tenant A cannot list Tenant B workflows', () => {
+        createTestWorkflow(TENANT_A, 'Workflow A');
+        createTestWorkflow(TENANT_B, 'Workflow B');
+
+        const workflowsA = listWorkflows(db, undefined, TENANT_A);
+        const workflowsB = listWorkflows(db, undefined, TENANT_B);
+
+        expect(workflowsA).toHaveLength(1);
+        expect(workflowsA[0].name).toBe('Workflow A');
+        expect(workflowsB).toHaveLength(1);
+        expect(workflowsB[0].name).toBe('Workflow B');
+    });
+
+    test('Tenant A cannot get Tenant B workflow by ID', () => {
+        const workflowB = createTestWorkflow(TENANT_B, 'Workflow B');
+
+        expect(getWorkflow(db, workflowB.id, TENANT_A)).toBeNull();
+        expect(getWorkflow(db, workflowB.id, TENANT_B)).not.toBeNull();
+    });
+
+    test('Tenant A cannot update Tenant B workflow', () => {
+        const workflowB = createTestWorkflow(TENANT_B, 'Workflow B');
+
+        const result = updateWorkflow(db, workflowB.id, { name: 'Hacked' }, TENANT_A);
+        expect(result).toBeNull();
+
+        const original = getWorkflow(db, workflowB.id, TENANT_B);
+        expect(original!.name).toBe('Workflow B');
+    });
+
+    test('Tenant A cannot delete Tenant B workflow', () => {
+        const workflowB = createTestWorkflow(TENANT_B, 'Workflow B');
+
+        const deleted = deleteWorkflow(db, workflowB.id, TENANT_A);
+        expect(deleted).toBe(false);
+
+        expect(getWorkflow(db, workflowB.id, TENANT_B)).not.toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-tenant webhook isolation (#305)
+// ---------------------------------------------------------------------------
+
+describe('Cross-tenant webhook isolation', () => {
+    const TENANT_A = 'tenant-a';
+    const TENANT_B = 'tenant-b';
+
+    function createTestWebhook(tenantId: string, repo: string) {
+        const agent = createAgent(db, { name: `Agent for ${repo}` }, tenantId);
+        const project = createProject(db, { name: `Project for ${repo}`, workingDir: '/tmp/test' }, tenantId);
+        return createWebhookRegistration(db, {
+            agentId: agent.id,
+            repo,
+            events: ['issue_comment'],
+            mentionUsername: 'testbot',
+            projectId: project.id,
+        } as any, tenantId);
+    }
+
+    test('Tenant A cannot list Tenant B webhooks', () => {
+        createTestWebhook(TENANT_A, 'owner/repo-a');
+        createTestWebhook(TENANT_B, 'owner/repo-b');
+
+        const webhooksA = listWebhookRegistrations(db, undefined, TENANT_A);
+        const webhooksB = listWebhookRegistrations(db, undefined, TENANT_B);
+
+        expect(webhooksA).toHaveLength(1);
+        expect(webhooksA[0].repo).toBe('owner/repo-a');
+        expect(webhooksB).toHaveLength(1);
+        expect(webhooksB[0].repo).toBe('owner/repo-b');
+    });
+
+    test('Tenant A cannot get Tenant B webhook by ID', () => {
+        const webhookB = createTestWebhook(TENANT_B, 'owner/repo-b');
+
+        expect(getWebhookRegistration(db, webhookB.id, TENANT_A)).toBeNull();
+        expect(getWebhookRegistration(db, webhookB.id, TENANT_B)).not.toBeNull();
+    });
+
+    test('Tenant A cannot update Tenant B webhook', () => {
+        const webhookB = createTestWebhook(TENANT_B, 'owner/repo-b');
+
+        const result = updateWebhookRegistration(db, webhookB.id, { mentionUsername: 'hacked' }, TENANT_A);
+        expect(result).toBeNull();
+
+        const original = getWebhookRegistration(db, webhookB.id, TENANT_B);
+        expect(original!.mentionUsername).toBe('testbot');
+    });
+
+    test('Tenant A cannot delete Tenant B webhook', () => {
+        const webhookB = createTestWebhook(TENANT_B, 'owner/repo-b');
+
+        const deleted = deleteWebhookRegistration(db, webhookB.id, TENANT_A);
+        expect(deleted).toBe(false);
+
+        expect(getWebhookRegistration(db, webhookB.id, TENANT_B)).not.toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-tenant mention-polling isolation (#305)
+// ---------------------------------------------------------------------------
+
+describe('Cross-tenant mention-polling isolation', () => {
+    const TENANT_A = 'tenant-a';
+    const TENANT_B = 'tenant-b';
+
+    function createTestPollingConfig(tenantId: string, repo: string) {
+        const agent = createAgent(db, { name: `Agent for ${repo}` }, tenantId);
+        const project = createProject(db, { name: `Project for ${repo}`, workingDir: '/tmp/test' }, tenantId);
+        return createMentionPollingConfig(db, {
+            agentId: agent.id,
+            repo,
+            mentionUsername: 'testbot',
+            projectId: project.id,
+        }, tenantId);
+    }
+
+    test('Tenant A cannot list Tenant B polling configs', () => {
+        createTestPollingConfig(TENANT_A, 'owner/repo-a');
+        createTestPollingConfig(TENANT_B, 'owner/repo-b');
+
+        const configsA = listMentionPollingConfigs(db, undefined, TENANT_A);
+        const configsB = listMentionPollingConfigs(db, undefined, TENANT_B);
+
+        expect(configsA).toHaveLength(1);
+        expect(configsA[0].repo).toBe('owner/repo-a');
+        expect(configsB).toHaveLength(1);
+        expect(configsB[0].repo).toBe('owner/repo-b');
+    });
+
+    test('Tenant A cannot get Tenant B polling config by ID', () => {
+        const configB = createTestPollingConfig(TENANT_B, 'owner/repo-b');
+
+        expect(getMentionPollingConfig(db, configB.id, TENANT_A)).toBeNull();
+        expect(getMentionPollingConfig(db, configB.id, TENANT_B)).not.toBeNull();
+    });
+
+    test('Tenant A cannot update Tenant B polling config', () => {
+        const configB = createTestPollingConfig(TENANT_B, 'owner/repo-b');
+
+        const result = updateMentionPollingConfig(db, configB.id, { mentionUsername: 'hacked' }, TENANT_A);
+        expect(result).toBeNull();
+
+        const original = getMentionPollingConfig(db, configB.id, TENANT_B);
+        expect(original!.mentionUsername).toBe('testbot');
+    });
+
+    test('Tenant A cannot delete Tenant B polling config', () => {
+        const configB = createTestPollingConfig(TENANT_B, 'owner/repo-b');
+
+        const deleted = deleteMentionPollingConfig(db, configB.id, TENANT_A);
+        expect(deleted).toBe(false);
+
+        expect(getMentionPollingConfig(db, configB.id, TENANT_B)).not.toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-tenant MCP server config isolation (#305)
+// ---------------------------------------------------------------------------
+
+describe('Cross-tenant MCP server config isolation', () => {
+    const TENANT_A = 'tenant-a';
+    const TENANT_B = 'tenant-b';
+
+    function createTestMcpConfig(tenantId: string, name: string) {
+        const agent = createAgent(db, { name: `Agent for ${name}` }, tenantId);
+        return createMcpServerConfig(db, {
+            agentId: agent.id,
+            name,
+            command: 'echo',
+            args: [],
+            envVars: {},
+        }, tenantId);
+    }
+
+    test('Tenant A cannot list Tenant B MCP configs', () => {
+        createTestMcpConfig(TENANT_A, 'MCP A');
+        createTestMcpConfig(TENANT_B, 'MCP B');
+
+        const configsA = listMcpServerConfigs(db, undefined, TENANT_A);
+        const configsB = listMcpServerConfigs(db, undefined, TENANT_B);
+
+        expect(configsA).toHaveLength(1);
+        expect(configsA[0].name).toBe('MCP A');
+        expect(configsB).toHaveLength(1);
+        expect(configsB[0].name).toBe('MCP B');
+    });
+
+    test('Tenant A cannot get Tenant B MCP config by ID', () => {
+        const configB = createTestMcpConfig(TENANT_B, 'MCP B');
+
+        expect(getMcpServerConfig(db, configB.id, TENANT_A)).toBeNull();
+        expect(getMcpServerConfig(db, configB.id, TENANT_B)).not.toBeNull();
+    });
+
+    test('Tenant A cannot update Tenant B MCP config', () => {
+        const configB = createTestMcpConfig(TENANT_B, 'MCP B');
+
+        const result = updateMcpServerConfig(db, configB.id, { name: 'Hacked' }, TENANT_A);
+        expect(result).toBeNull();
+
+        const original = getMcpServerConfig(db, configB.id, TENANT_B);
+        expect(original!.name).toBe('MCP B');
+    });
+
+    test('Tenant A cannot delete Tenant B MCP config', () => {
+        const configB = createTestMcpConfig(TENANT_B, 'MCP B');
+
+        const deleted = deleteMcpServerConfig(db, configB.id, TENANT_A);
+        expect(deleted).toBe(false);
+
+        expect(getMcpServerConfig(db, configB.id, TENANT_B)).not.toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-tenant work task isolation (#305)
+// ---------------------------------------------------------------------------
+
+describe('Cross-tenant work task isolation', () => {
+    const TENANT_A = 'tenant-a';
+    const TENANT_B = 'tenant-b';
+
+    function createTestWorkTask(tenantId: string, description: string) {
+        const agent = createAgent(db, { name: `Agent for ${description}` }, tenantId);
+        const project = createProject(db, { name: `Project for ${description}`, workingDir: '/tmp/test' }, tenantId);
+        return createWorkTask(db, {
+            agentId: agent.id,
+            projectId: project.id,
+            description,
+            tenantId,
+        });
+    }
+
+    test('Tenant A cannot list Tenant B work tasks', () => {
+        createTestWorkTask(TENANT_A, 'Task A');
+        createTestWorkTask(TENANT_B, 'Task B');
+
+        const tasksA = listWorkTasks(db, undefined, TENANT_A);
+        const tasksB = listWorkTasks(db, undefined, TENANT_B);
+
+        expect(tasksA).toHaveLength(1);
+        expect(tasksA[0].description).toBe('Task A');
+        expect(tasksB).toHaveLength(1);
+        expect(tasksB[0].description).toBe('Task B');
+    });
+
+    test('Tenant A cannot get Tenant B work task by ID', () => {
+        const taskB = createTestWorkTask(TENANT_B, 'Task B');
+
+        expect(getWorkTask(db, taskB.id, TENANT_A)).toBeNull();
+        expect(getWorkTask(db, taskB.id, TENANT_B)).not.toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-tenant persona access (#305)
+// ---------------------------------------------------------------------------
+
+describe('Cross-tenant persona access via agent ownership', () => {
+    const TENANT_A = 'tenant-a';
+    const TENANT_B = 'tenant-b';
+
+    test('getAgent with wrong tenant returns null (blocks persona CRUD)', () => {
+        const agentB = createAgent(db, { name: 'Agent B' }, TENANT_B);
+
+        // Tenant A trying to access Tenant B's agent
+        expect(getAgent(db, agentB.id, TENANT_A)).toBeNull();
+        // Tenant B can access their own agent
+        expect(getAgent(db, agentB.id, TENANT_B)).not.toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Default tenant backwards compatibility (#305)
+// ---------------------------------------------------------------------------
+
+describe('Default tenant backwards compatibility', () => {
+    test('Resources created without tenant use DEFAULT_TENANT_ID', () => {
+        const agent = createAgent(db, { name: 'Default Agent' });
+        const row = db.query('SELECT tenant_id FROM agents WHERE id = ?').get(agent.id) as { tenant_id: string };
+        expect(row.tenant_id).toBe(DEFAULT_TENANT_ID);
+    });
+
+    test('Default tenant can access resources with DEFAULT_TENANT_ID', () => {
+        const agent = createAgent(db, { name: 'Default Agent' });
+        expect(getAgent(db, agent.id, DEFAULT_TENANT_ID)).not.toBeNull();
+        expect(getAgent(db, agent.id)).not.toBeNull(); // omit param = default
+    });
+
+    test('Newly-scoped tables have tenant_id column', () => {
+        const newlyScoped = [
+            'councils', 'council_launches',
+            'agent_schedules', 'schedule_executions',
+            'workflows', 'workflow_runs',
+            'mention_polling_configs', 'mcp_server_configs', 'webhook_registrations',
+        ];
+        for (const table of newlyScoped) {
+            const cols = db.query(`PRAGMA table_info(${table})`).all() as { name: string }[];
+            const colNames = cols.map((c) => c.name);
+            expect(colNames).toContain('tenant_id');
+        }
+    });
+
+    test('Newly-scoped tables have tenant_id index', () => {
+        const newlyScoped = [
+            'councils', 'council_launches',
+            'agent_schedules', 'schedule_executions',
+            'workflows', 'workflow_runs',
+            'mention_polling_configs', 'mcp_server_configs', 'webhook_registrations',
+        ];
+        for (const table of newlyScoped) {
+            const indexes = db.query(`PRAGMA index_list(${table})`).all() as { name: string }[];
+            const indexNames = indexes.map((i) => i.name);
+            expect(indexNames.some(n => n.includes('tenant'))).toBe(true);
+        }
     });
 });

--- a/server/db/councils.ts
+++ b/server/db/councils.ts
@@ -9,6 +9,8 @@ import type {
     CreateCouncilInput,
     UpdateCouncilInput,
 } from '../../shared/types';
+import { DEFAULT_TENANT_ID } from '../tenant/types';
+import { withTenantFilter, validateTenantOwnership } from '../tenant/db-filter';
 
 interface CouncilRow {
     id: string;
@@ -77,25 +79,27 @@ function getMemberAgentIds(db: Database, councilId: string): string[] {
 
 // MARK: - Council CRUD
 
-export function listCouncils(db: Database): Council[] {
-    const rows = db.query('SELECT * FROM councils ORDER BY updated_at DESC').all() as CouncilRow[];
+export function listCouncils(db: Database, tenantId: string = DEFAULT_TENANT_ID): Council[] {
+    const { query, bindings } = withTenantFilter('SELECT * FROM councils ORDER BY updated_at DESC', tenantId);
+    const rows = db.query(query).all(...bindings) as CouncilRow[];
     return rows.map((row) => rowToCouncil(row, getMemberAgentIds(db, row.id)));
 }
 
-export function getCouncil(db: Database, id: string): Council | null {
+export function getCouncil(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): Council | null {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'councils', id, tenantId)) return null;
     const row = db.query('SELECT * FROM councils WHERE id = ?').get(id) as CouncilRow | null;
     if (!row) return null;
     return rowToCouncil(row, getMemberAgentIds(db, row.id));
 }
 
-export function createCouncil(db: Database, input: CreateCouncilInput): Council {
+export function createCouncil(db: Database, input: CreateCouncilInput, tenantId: string = DEFAULT_TENANT_ID): Council {
     const id = crypto.randomUUID();
 
     db.transaction(() => {
         db.query(
-            `INSERT INTO councils (id, name, description, chairman_agent_id, discussion_rounds)
-             VALUES (?, ?, ?, ?, ?)`
-        ).run(id, input.name, input.description ?? '', input.chairmanAgentId ?? null, input.discussionRounds ?? 2);
+            `INSERT INTO councils (id, name, description, chairman_agent_id, discussion_rounds, tenant_id)
+             VALUES (?, ?, ?, ?, ?, ?)`
+        ).run(id, input.name, input.description ?? '', input.chairmanAgentId ?? null, input.discussionRounds ?? 2, tenantId);
 
         for (let i = 0; i < input.agentIds.length; i++) {
             db.query(
@@ -107,8 +111,8 @@ export function createCouncil(db: Database, input: CreateCouncilInput): Council 
     return getCouncil(db, id) as Council;
 }
 
-export function updateCouncil(db: Database, id: string, input: UpdateCouncilInput): Council | null {
-    const existing = getCouncil(db, id);
+export function updateCouncil(db: Database, id: string, input: UpdateCouncilInput, tenantId: string = DEFAULT_TENANT_ID): Council | null {
+    const existing = getCouncil(db, id, tenantId);
     if (!existing) return null;
 
     db.transaction(() => {
@@ -148,10 +152,11 @@ export function updateCouncil(db: Database, id: string, input: UpdateCouncilInpu
         }
     })();
 
-    return getCouncil(db, id);
+    return getCouncil(db, id, tenantId);
 }
 
-export function deleteCouncil(db: Database, id: string): boolean {
+export function deleteCouncil(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): boolean {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'councils', id, tenantId)) return false;
     const result = db.transaction(() => {
         // council_launch_logs and council_discussion_messages cascade from council_launches
         // Sessions may reference council_launches via council_launch_id
@@ -169,16 +174,18 @@ export function deleteCouncil(db: Database, id: string): boolean {
 export function createCouncilLaunch(
     db: Database,
     params: { id: string; councilId: string; projectId: string; prompt: string },
+    tenantId: string = DEFAULT_TENANT_ID,
 ): CouncilLaunchRow {
     db.query(
-        `INSERT INTO council_launches (id, council_id, project_id, prompt)
-         VALUES (?, ?, ?, ?)`
-    ).run(params.id, params.councilId, params.projectId, params.prompt);
+        `INSERT INTO council_launches (id, council_id, project_id, prompt, tenant_id)
+         VALUES (?, ?, ?, ?, ?)`
+    ).run(params.id, params.councilId, params.projectId, params.prompt, tenantId);
 
     return db.query('SELECT * FROM council_launches WHERE id = ?').get(params.id) as CouncilLaunchRow;
 }
 
-export function getCouncilLaunch(db: Database, id: string): CouncilLaunch | null {
+export function getCouncilLaunch(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): CouncilLaunch | null {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'council_launches', id, tenantId)) return null;
     const row = db.query('SELECT * FROM council_launches WHERE id = ?').get(id) as CouncilLaunchRow | null;
     if (!row) return null;
 
@@ -190,16 +197,16 @@ export function getCouncilLaunch(db: Database, id: string): CouncilLaunch | null
     return rowToLaunch(row, sessionIds);
 }
 
-export function listCouncilLaunches(db: Database, councilId?: string): CouncilLaunch[] {
+export function listCouncilLaunches(db: Database, councilId?: string, tenantId: string = DEFAULT_TENANT_ID): CouncilLaunch[] {
     let rows: CouncilLaunchRow[];
     if (councilId) {
-        rows = db.query(
-            'SELECT * FROM council_launches WHERE council_id = ? ORDER BY created_at DESC'
-        ).all(councilId) as CouncilLaunchRow[];
+        const { query, bindings } = withTenantFilter(
+            'SELECT * FROM council_launches WHERE council_id = ? ORDER BY created_at DESC', tenantId);
+        rows = db.query(query).all(councilId, ...bindings) as CouncilLaunchRow[];
     } else {
-        rows = db.query(
-            'SELECT * FROM council_launches ORDER BY created_at DESC'
-        ).all() as CouncilLaunchRow[];
+        const { query, bindings } = withTenantFilter(
+            'SELECT * FROM council_launches ORDER BY created_at DESC', tenantId);
+        rows = db.query(query).all(...bindings) as CouncilLaunchRow[];
     }
 
     return rows.map((row) => {

--- a/server/db/mcp-servers.ts
+++ b/server/db/mcp-servers.ts
@@ -1,6 +1,8 @@
 import type { Database, SQLQueryBindings } from 'bun:sqlite';
 import type { McpServerConfig, CreateMcpServerConfigInput, UpdateMcpServerConfigInput } from '../../shared/types';
 import { NotFoundError } from '../lib/errors';
+import { DEFAULT_TENANT_ID } from '../tenant/types';
+import { withTenantFilter, validateTenantOwnership } from '../tenant/db-filter';
 
 interface McpServerConfigRow {
     id: string;
@@ -31,22 +33,18 @@ function rowToConfig(row: McpServerConfigRow): McpServerConfig {
 }
 
 /** List all MCP server configs, optionally filtered by agent. */
-export function listMcpServerConfigs(db: Database, agentId?: string): McpServerConfig[] {
-    let rows: McpServerConfigRow[];
+export function listMcpServerConfigs(db: Database, agentId?: string, tenantId: string = DEFAULT_TENANT_ID): McpServerConfig[] {
     if (agentId) {
-        rows = db.query(
-            'SELECT * FROM mcp_server_configs WHERE agent_id = ? ORDER BY name',
-        ).all(agentId) as McpServerConfigRow[];
-    } else {
-        rows = db.query(
-            'SELECT * FROM mcp_server_configs ORDER BY name',
-        ).all() as McpServerConfigRow[];
+        const { query, bindings } = withTenantFilter('SELECT * FROM mcp_server_configs WHERE agent_id = ? ORDER BY name', tenantId);
+        return (db.query(query).all(agentId, ...bindings) as McpServerConfigRow[]).map(rowToConfig);
     }
-    return rows.map(rowToConfig);
+    const { query, bindings } = withTenantFilter('SELECT * FROM mcp_server_configs ORDER BY name', tenantId);
+    return (db.query(query).all(...bindings) as McpServerConfigRow[]).map(rowToConfig);
 }
 
 /** Get a single MCP server config by ID. */
-export function getMcpServerConfig(db: Database, id: string): McpServerConfig | null {
+export function getMcpServerConfig(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): McpServerConfig | null {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'mcp_server_configs', id, tenantId)) return null;
     const row = db.query(
         'SELECT * FROM mcp_server_configs WHERE id = ?',
     ).get(id) as McpServerConfigRow | null;
@@ -65,11 +63,11 @@ export function getActiveServersForAgent(db: Database, agentId: string): McpServ
 }
 
 /** Create a new MCP server config. */
-export function createMcpServerConfig(db: Database, input: CreateMcpServerConfigInput): McpServerConfig {
+export function createMcpServerConfig(db: Database, input: CreateMcpServerConfigInput, tenantId: string = DEFAULT_TENANT_ID): McpServerConfig {
     const id = crypto.randomUUID();
     db.query(
-        `INSERT INTO mcp_server_configs (id, agent_id, name, command, args, env_vars, cwd, enabled)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO mcp_server_configs (id, agent_id, name, command, args, env_vars, cwd, enabled, tenant_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
         id,
         input.agentId ?? null,
@@ -79,6 +77,7 @@ export function createMcpServerConfig(db: Database, input: CreateMcpServerConfig
         JSON.stringify(input.envVars ?? {}),
         input.cwd ?? null,
         input.enabled !== false ? 1 : 0,
+        tenantId,
     );
 
     const created = getMcpServerConfig(db, id);
@@ -87,8 +86,8 @@ export function createMcpServerConfig(db: Database, input: CreateMcpServerConfig
 }
 
 /** Update an existing MCP server config. Returns null if not found. */
-export function updateMcpServerConfig(db: Database, id: string, input: UpdateMcpServerConfigInput): McpServerConfig | null {
-    const existing = getMcpServerConfig(db, id);
+export function updateMcpServerConfig(db: Database, id: string, input: UpdateMcpServerConfigInput, tenantId: string = DEFAULT_TENANT_ID): McpServerConfig | null {
+    const existing = getMcpServerConfig(db, id, tenantId);
     if (!existing) return null;
 
     const fields: string[] = [];
@@ -129,8 +128,8 @@ export function updateMcpServerConfig(db: Database, id: string, input: UpdateMcp
 }
 
 /** Delete an MCP server config. Returns true if deleted, false if not found. */
-export function deleteMcpServerConfig(db: Database, id: string): boolean {
-    const existing = getMcpServerConfig(db, id);
+export function deleteMcpServerConfig(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): boolean {
+    const existing = getMcpServerConfig(db, id, tenantId);
     if (!existing) return false;
     db.query('DELETE FROM mcp_server_configs WHERE id = ?').run(id);
     return true;

--- a/server/db/mention-polling.ts
+++ b/server/db/mention-polling.ts
@@ -9,6 +9,8 @@ import type {
     UpdateMentionPollingInput,
     MentionPollingStatus,
 } from '../../shared/types';
+import { DEFAULT_TENANT_ID } from '../tenant/types';
+import { withTenantFilter, validateTenantOwnership } from '../tenant/db-filter';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -34,13 +36,13 @@ function rowToConfig(row: Record<string, unknown>): MentionPollingConfig {
 
 // ─── CRUD ────────────────────────────────────────────────────────────────────
 
-export function createMentionPollingConfig(db: Database, input: CreateMentionPollingInput): MentionPollingConfig {
+export function createMentionPollingConfig(db: Database, input: CreateMentionPollingInput, tenantId: string = DEFAULT_TENANT_ID): MentionPollingConfig {
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
 
     db.query(`
-        INSERT INTO mention_polling_configs (id, agent_id, repo, mention_username, project_id, interval_seconds, event_filter, allowed_users, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO mention_polling_configs (id, agent_id, repo, mention_username, project_id, interval_seconds, event_filter, allowed_users, tenant_id, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
         id,
         input.agentId,
@@ -50,6 +52,7 @@ export function createMentionPollingConfig(db: Database, input: CreateMentionPol
         input.intervalSeconds ?? 60,
         JSON.stringify(input.eventFilter ?? []),
         JSON.stringify(input.allowedUsers ?? []),
+        tenantId,
         now,
         now,
     );
@@ -57,16 +60,19 @@ export function createMentionPollingConfig(db: Database, input: CreateMentionPol
     return getMentionPollingConfig(db, id)!;
 }
 
-export function getMentionPollingConfig(db: Database, id: string): MentionPollingConfig | null {
+export function getMentionPollingConfig(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): MentionPollingConfig | null {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'mention_polling_configs', id, tenantId)) return null;
     const row = db.query('SELECT * FROM mention_polling_configs WHERE id = ?').get(id) as Record<string, unknown> | null;
     return row ? rowToConfig(row) : null;
 }
 
-export function listMentionPollingConfigs(db: Database, agentId?: string): MentionPollingConfig[] {
-    const rows = agentId
-        ? db.query('SELECT * FROM mention_polling_configs WHERE agent_id = ? ORDER BY created_at DESC').all(agentId)
-        : db.query('SELECT * FROM mention_polling_configs ORDER BY created_at DESC').all();
-    return (rows as Record<string, unknown>[]).map(rowToConfig);
+export function listMentionPollingConfigs(db: Database, agentId?: string, tenantId: string = DEFAULT_TENANT_ID): MentionPollingConfig[] {
+    if (agentId) {
+        const { query, bindings } = withTenantFilter('SELECT * FROM mention_polling_configs WHERE agent_id = ? ORDER BY created_at DESC', tenantId);
+        return (db.query(query).all(agentId, ...bindings) as Record<string, unknown>[]).map(rowToConfig);
+    }
+    const { query, bindings } = withTenantFilter('SELECT * FROM mention_polling_configs ORDER BY created_at DESC', tenantId);
+    return (db.query(query).all(...bindings) as Record<string, unknown>[]).map(rowToConfig);
 }
 
 /**
@@ -86,8 +92,8 @@ export function findDuePollingConfigs(db: Database): MentionPollingConfig[] {
     return (rows as Record<string, unknown>[]).map(rowToConfig);
 }
 
-export function updateMentionPollingConfig(db: Database, id: string, input: UpdateMentionPollingInput): MentionPollingConfig | null {
-    const existing = getMentionPollingConfig(db, id);
+export function updateMentionPollingConfig(db: Database, id: string, input: UpdateMentionPollingInput, tenantId: string = DEFAULT_TENANT_ID): MentionPollingConfig | null {
+    const existing = getMentionPollingConfig(db, id, tenantId);
     if (!existing) return null;
 
     const fields: string[] = [];
@@ -109,7 +115,8 @@ export function updateMentionPollingConfig(db: Database, id: string, input: Upda
     return getMentionPollingConfig(db, id);
 }
 
-export function deleteMentionPollingConfig(db: Database, id: string): boolean {
+export function deleteMentionPollingConfig(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): boolean {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'mention_polling_configs', id, tenantId)) return false;
     const result = db.query('DELETE FROM mention_polling_configs WHERE id = ?').run(id);
     return result.changes > 0;
 }

--- a/server/db/migrations/062_tenant_resource_isolation.ts
+++ b/server/db/migrations/062_tenant_resource_isolation.ts
@@ -1,0 +1,103 @@
+/**
+ * Migration 062: Tenant resource isolation.
+ *
+ * Extends multi-tenant support (from migration 055) to resource tables
+ * that were created after the initial tenant infrastructure:
+ *   councils, council_launches, agent_schedules, schedule_executions,
+ *   workflows, workflow_runs, mention_polling_configs, mcp_server_configs,
+ *   webhook_registrations.
+ *
+ * Backfills tenant_id from agent relationship where possible.
+ */
+
+import { Database } from 'bun:sqlite';
+
+const SAFE_SQL_IDENTIFIER = /^[a-z_][a-z0-9_]*$/i;
+
+function hasColumn(db: Database, table: string, column: string): boolean {
+    if (!SAFE_SQL_IDENTIFIER.test(table)) {
+        throw new Error(`hasColumn: invalid table name '${table}'`);
+    }
+    const cols = db.query(`PRAGMA table_info(${table})`).all() as { name: string }[];
+    return cols.some((c) => c.name === column);
+}
+
+function safeAlter(db: Database, sql: string): void {
+    const match = sql.match(/ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(\w+)/i);
+    if (match && hasColumn(db, match[1], match[2])) return;
+    db.exec(sql);
+}
+
+const TABLES_TO_SCOPE = [
+    'councils',
+    'council_launches',
+    'agent_schedules',
+    'schedule_executions',
+    'workflows',
+    'workflow_runs',
+    'mention_polling_configs',
+    'mcp_server_configs',
+    'webhook_registrations',
+] as const;
+
+/** Tables that have an agent_id FK we can backfill from. */
+const AGENT_FK_TABLES = [
+    'agent_schedules',
+    'schedule_executions',
+    'workflows',
+    'workflow_runs',
+    'mention_polling_configs',
+    'mcp_server_configs',
+    'webhook_registrations',
+] as const;
+
+export function up(db: Database): void {
+    // 1. Add tenant_id column + index to all tables
+    for (const table of TABLES_TO_SCOPE) {
+        safeAlter(db, `ALTER TABLE ${table} ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_${table}_tenant ON ${table}(tenant_id)`);
+    }
+
+    // 2. Backfill from agent relationship where agent_id FK exists
+    for (const table of AGENT_FK_TABLES) {
+        db.exec(`
+            UPDATE ${table} SET tenant_id = (
+                SELECT a.tenant_id FROM agents a WHERE a.id = ${table}.agent_id
+            ) WHERE EXISTS (
+                SELECT 1 FROM agents a WHERE a.id = ${table}.agent_id
+            ) AND tenant_id = 'default'
+        `);
+    }
+
+    // 3. Backfill councils from first participating agent (via council_members)
+    db.exec(`
+        UPDATE councils SET tenant_id = (
+            SELECT a.tenant_id FROM council_members cm
+            JOIN agents a ON a.id = cm.agent_id
+            WHERE cm.council_id = councils.id
+            ORDER BY cm.sort_order ASC
+            LIMIT 1
+        ) WHERE EXISTS (
+            SELECT 1 FROM council_members cm
+            JOIN agents a ON a.id = cm.agent_id
+            WHERE cm.council_id = councils.id
+        ) AND tenant_id = 'default'
+    `);
+
+    // 4. Backfill council_launches from their council
+    db.exec(`
+        UPDATE council_launches SET tenant_id = (
+            SELECT c.tenant_id FROM councils c WHERE c.id = council_launches.council_id
+        ) WHERE EXISTS (
+            SELECT 1 FROM councils c WHERE c.id = council_launches.council_id
+        ) AND tenant_id = 'default'
+    `);
+}
+
+export function down(db: Database): void {
+    // SQLite doesn't support DROP COLUMN before 3.35.0;
+    // tenant_id columns are left in place (harmless with DEFAULT 'default').
+    for (const table of TABLES_TO_SCOPE) {
+        db.exec(`DROP INDEX IF EXISTS idx_${table}_tenant`);
+    }
+}

--- a/server/db/schedules.ts
+++ b/server/db/schedules.ts
@@ -11,6 +11,8 @@ import type {
     ScheduleActionType,
     ScheduleTriggerEvent,
 } from '../../shared/types';
+import { DEFAULT_TENANT_ID } from '../tenant/types';
+import { withTenantFilter, validateTenantOwnership } from '../tenant/db-filter';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -58,14 +60,14 @@ function rowToExecution(row: Record<string, unknown>): ScheduleExecution {
 
 // ─── Schedule CRUD ───────────────────────────────────────────────────────────
 
-export function createSchedule(db: Database, input: CreateScheduleInput): AgentSchedule {
+export function createSchedule(db: Database, input: CreateScheduleInput, tenantId: string = DEFAULT_TENANT_ID): AgentSchedule {
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
 
     db.query(`
         INSERT INTO agent_schedules (id, agent_id, name, description, cron_expression, interval_ms,
-            actions, approval_policy, max_executions, max_budget_per_run, notify_address, trigger_events, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            actions, approval_policy, max_executions, max_budget_per_run, notify_address, trigger_events, tenant_id, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
         id,
         input.agentId,
@@ -79,6 +81,7 @@ export function createSchedule(db: Database, input: CreateScheduleInput): AgentS
         input.maxBudgetPerRun ?? null,
         input.notifyAddress ?? null,
         input.triggerEvents ? JSON.stringify(input.triggerEvents) : null,
+        tenantId,
         now,
         now,
     );
@@ -86,18 +89,21 @@ export function createSchedule(db: Database, input: CreateScheduleInput): AgentS
     return getSchedule(db, id)!;
 }
 
-export function getSchedule(db: Database, id: string): AgentSchedule | null {
+export function getSchedule(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): AgentSchedule | null {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'agent_schedules', id, tenantId)) return null;
     const row = db.query('SELECT * FROM agent_schedules WHERE id = ?').get(id) as Record<string, unknown> | null;
     return row ? rowToSchedule(row) : null;
 }
 
-export function listSchedules(db: Database, agentId?: string): AgentSchedule[] {
+export function listSchedules(db: Database, agentId?: string, tenantId: string = DEFAULT_TENANT_ID): AgentSchedule[] {
     const cronHour = `CAST(SUBSTR(cron_expression, INSTR(cron_expression, ' ') + 1, INSTR(SUBSTR(cron_expression, INSTR(cron_expression, ' ') + 1), ' ') - 1) AS INTEGER)`;
     const orderBy = `ORDER BY CASE WHEN cron_expression = '' OR cron_expression IS NULL THEN 1 ELSE 0 END, ${cronHour} ASC`;
-    const rows = agentId
-        ? db.query(`SELECT * FROM agent_schedules WHERE agent_id = ? ${orderBy}`).all(agentId)
-        : db.query(`SELECT * FROM agent_schedules ${orderBy}`).all();
-    return (rows as Record<string, unknown>[]).map(rowToSchedule);
+    if (agentId) {
+        const { query, bindings } = withTenantFilter(`SELECT * FROM agent_schedules WHERE agent_id = ? ${orderBy}`, tenantId);
+        return (db.query(query).all(agentId, ...bindings) as Record<string, unknown>[]).map(rowToSchedule);
+    }
+    const { query, bindings } = withTenantFilter(`SELECT * FROM agent_schedules ${orderBy}`, tenantId);
+    return (db.query(query).all(...bindings) as Record<string, unknown>[]).map(rowToSchedule);
 }
 
 export function listActiveSchedules(db: Database): AgentSchedule[] {
@@ -121,8 +127,8 @@ export function listDueSchedules(db: Database): AgentSchedule[] {
     return (rows as Record<string, unknown>[]).map(rowToSchedule);
 }
 
-export function updateSchedule(db: Database, id: string, input: UpdateScheduleInput): AgentSchedule | null {
-    const existing = getSchedule(db, id);
+export function updateSchedule(db: Database, id: string, input: UpdateScheduleInput, tenantId: string = DEFAULT_TENANT_ID): AgentSchedule | null {
+    const existing = getSchedule(db, id, tenantId);
     if (!existing) return null;
 
     const fields: string[] = [];
@@ -163,7 +169,8 @@ export function updateScheduleLastRun(db: Database, id: string): void {
     `).run(id);
 }
 
-export function deleteSchedule(db: Database, id: string): boolean {
+export function deleteSchedule(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): boolean {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'agent_schedules', id, tenantId)) return false;
     const result = db.query('DELETE FROM agent_schedules WHERE id = ?').run(id);
     return result.changes > 0;
 }
@@ -211,16 +218,20 @@ export function createExecution(
     return getExecution(db, id)!;
 }
 
-export function getExecution(db: Database, id: string): ScheduleExecution | null {
+export function getExecution(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): ScheduleExecution | null {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'schedule_executions', id, tenantId)) return null;
     const row = db.query('SELECT * FROM schedule_executions WHERE id = ?').get(id) as Record<string, unknown> | null;
     return row ? rowToExecution(row) : null;
 }
 
-export function listExecutions(db: Database, scheduleId?: string, limit: number = 50): ScheduleExecution[] {
-    const rows = scheduleId
-        ? db.query('SELECT * FROM schedule_executions WHERE schedule_id = ? ORDER BY started_at DESC LIMIT ?').all(scheduleId, limit)
-        : db.query('SELECT * FROM schedule_executions ORDER BY started_at DESC LIMIT ?').all(limit);
-    return (rows as Record<string, unknown>[]).map(rowToExecution);
+export function listExecutions(db: Database, scheduleId?: string, limit: number = 50, tenantId: string = DEFAULT_TENANT_ID): ScheduleExecution[] {
+    if (scheduleId) {
+        const { query, bindings } = withTenantFilter('SELECT * FROM schedule_executions WHERE schedule_id = ? ORDER BY started_at DESC LIMIT ?', tenantId);
+        // Insert tenant binding before the LIMIT param
+        return (db.query(query).all(scheduleId, ...bindings, limit) as Record<string, unknown>[]).map(rowToExecution);
+    }
+    const { query, bindings } = withTenantFilter('SELECT * FROM schedule_executions ORDER BY started_at DESC LIMIT ?', tenantId);
+    return (db.query(query).all(...bindings, limit) as Record<string, unknown>[]).map(rowToExecution);
 }
 
 export interface ExecutionFilterOpts {

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1174,6 +1174,27 @@ const MIGRATIONS: Record<number, string[]> = {
         `CREATE INDEX IF NOT EXISTS idx_pr_outcomes_repo ON pr_outcomes(repo)`,
         `CREATE INDEX IF NOT EXISTS idx_pr_outcomes_work_task ON pr_outcomes(work_task_id)`,
     ],
+    62: [
+        // Tenant resource isolation — add tenant_id to tables created after migration 055
+        `ALTER TABLE councils ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'`,
+        `CREATE INDEX IF NOT EXISTS idx_councils_tenant ON councils(tenant_id)`,
+        `ALTER TABLE council_launches ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'`,
+        `CREATE INDEX IF NOT EXISTS idx_council_launches_tenant ON council_launches(tenant_id)`,
+        `ALTER TABLE agent_schedules ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'`,
+        `CREATE INDEX IF NOT EXISTS idx_agent_schedules_tenant ON agent_schedules(tenant_id)`,
+        `ALTER TABLE schedule_executions ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'`,
+        `CREATE INDEX IF NOT EXISTS idx_schedule_executions_tenant ON schedule_executions(tenant_id)`,
+        `ALTER TABLE workflows ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'`,
+        `CREATE INDEX IF NOT EXISTS idx_workflows_tenant ON workflows(tenant_id)`,
+        `ALTER TABLE workflow_runs ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'`,
+        `CREATE INDEX IF NOT EXISTS idx_workflow_runs_tenant ON workflow_runs(tenant_id)`,
+        `ALTER TABLE mention_polling_configs ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'`,
+        `CREATE INDEX IF NOT EXISTS idx_mention_polling_configs_tenant ON mention_polling_configs(tenant_id)`,
+        `ALTER TABLE mcp_server_configs ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'`,
+        `CREATE INDEX IF NOT EXISTS idx_mcp_server_configs_tenant ON mcp_server_configs(tenant_id)`,
+        `ALTER TABLE webhook_registrations ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'`,
+        `CREATE INDEX IF NOT EXISTS idx_webhook_registrations_tenant ON webhook_registrations(tenant_id)`,
+    ],
 };
 
 /** Allowlist pattern for valid SQL identifiers (table/column names). */

--- a/server/db/webhooks.ts
+++ b/server/db/webhooks.ts
@@ -11,6 +11,8 @@ import type {
     WebhookEventType,
     WebhookRegistrationStatus,
 } from '../../shared/types';
+import { DEFAULT_TENANT_ID } from '../tenant/types';
+import { withTenantFilter, validateTenantOwnership } from '../tenant/db-filter';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -49,13 +51,13 @@ function rowToDelivery(row: Record<string, unknown>): WebhookDelivery {
 
 // ─── Registration CRUD ──────────────────────────────────────────────────────
 
-export function createWebhookRegistration(db: Database, input: CreateWebhookRegistrationInput): WebhookRegistration {
+export function createWebhookRegistration(db: Database, input: CreateWebhookRegistrationInput, tenantId: string = DEFAULT_TENANT_ID): WebhookRegistration {
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
 
     db.query(`
-        INSERT INTO webhook_registrations (id, agent_id, repo, events, mention_username, project_id, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO webhook_registrations (id, agent_id, repo, events, mention_username, project_id, tenant_id, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
         id,
         input.agentId,
@@ -63,6 +65,7 @@ export function createWebhookRegistration(db: Database, input: CreateWebhookRegi
         JSON.stringify(input.events),
         input.mentionUsername,
         input.projectId ?? null,
+        tenantId,
         now,
         now,
     );
@@ -70,16 +73,19 @@ export function createWebhookRegistration(db: Database, input: CreateWebhookRegi
     return getWebhookRegistration(db, id)!;
 }
 
-export function getWebhookRegistration(db: Database, id: string): WebhookRegistration | null {
+export function getWebhookRegistration(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): WebhookRegistration | null {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'webhook_registrations', id, tenantId)) return null;
     const row = db.query('SELECT * FROM webhook_registrations WHERE id = ?').get(id) as Record<string, unknown> | null;
     return row ? rowToRegistration(row) : null;
 }
 
-export function listWebhookRegistrations(db: Database, agentId?: string): WebhookRegistration[] {
-    const rows = agentId
-        ? db.query('SELECT * FROM webhook_registrations WHERE agent_id = ? ORDER BY created_at DESC').all(agentId)
-        : db.query('SELECT * FROM webhook_registrations ORDER BY created_at DESC').all();
-    return (rows as Record<string, unknown>[]).map(rowToRegistration);
+export function listWebhookRegistrations(db: Database, agentId?: string, tenantId: string = DEFAULT_TENANT_ID): WebhookRegistration[] {
+    if (agentId) {
+        const { query, bindings } = withTenantFilter('SELECT * FROM webhook_registrations WHERE agent_id = ? ORDER BY created_at DESC', tenantId);
+        return (db.query(query).all(agentId, ...bindings) as Record<string, unknown>[]).map(rowToRegistration);
+    }
+    const { query, bindings } = withTenantFilter('SELECT * FROM webhook_registrations ORDER BY created_at DESC', tenantId);
+    return (db.query(query).all(...bindings) as Record<string, unknown>[]).map(rowToRegistration);
 }
 
 /**
@@ -93,8 +99,8 @@ export function findRegistrationsForRepo(db: Database, repo: string): WebhookReg
     return (rows as Record<string, unknown>[]).map(rowToRegistration);
 }
 
-export function updateWebhookRegistration(db: Database, id: string, input: UpdateWebhookRegistrationInput): WebhookRegistration | null {
-    const existing = getWebhookRegistration(db, id);
+export function updateWebhookRegistration(db: Database, id: string, input: UpdateWebhookRegistrationInput, tenantId: string = DEFAULT_TENANT_ID): WebhookRegistration | null {
+    const existing = getWebhookRegistration(db, id, tenantId);
     if (!existing) return null;
 
     const fields: string[] = [];
@@ -114,7 +120,8 @@ export function updateWebhookRegistration(db: Database, id: string, input: Updat
     return getWebhookRegistration(db, id);
 }
 
-export function deleteWebhookRegistration(db: Database, id: string): boolean {
+export function deleteWebhookRegistration(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): boolean {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'webhook_registrations', id, tenantId)) return false;
     const result = db.query('DELETE FROM webhook_registrations WHERE id = ?').run(id);
     return result.changes > 0;
 }

--- a/server/db/work-tasks.ts
+++ b/server/db/work-tasks.ts
@@ -63,12 +63,14 @@ export function createWorkTask(
         source?: string;
         sourceId?: string;
         requesterInfo?: Record<string, unknown>;
+        tenantId?: string;
     },
 ): WorkTask {
     const id = crypto.randomUUID();
+    const tenantId = params.tenantId ?? DEFAULT_TENANT_ID;
     db.query(
-        `INSERT INTO work_tasks (id, agent_id, project_id, description, source, source_id, requester_info)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`
+        `INSERT INTO work_tasks (id, agent_id, project_id, description, source, source_id, requester_info, tenant_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
         id,
         params.agentId,
@@ -77,6 +79,7 @@ export function createWorkTask(
         params.source ?? 'web',
         params.sourceId ?? null,
         JSON.stringify(params.requesterInfo ?? {}),
+        tenantId,
     );
 
     return getWorkTask(db, id) as WorkTask;
@@ -95,16 +98,18 @@ export function createWorkTaskAtomic(
         source?: string;
         sourceId?: string;
         requesterInfo?: Record<string, unknown>;
+        tenantId?: string;
     },
 ): WorkTask | null {
     const id = crypto.randomUUID();
     const source = params.source ?? 'web';
     const sourceId = params.sourceId ?? null;
     const requesterInfo = JSON.stringify(params.requesterInfo ?? {});
+    const tenantId = params.tenantId ?? DEFAULT_TENANT_ID;
 
     const result = db.query(
-        `INSERT INTO work_tasks (id, agent_id, project_id, description, source, source_id, requester_info)
-         SELECT ?, ?, ?, ?, ?, ?, ?
+        `INSERT INTO work_tasks (id, agent_id, project_id, description, source, source_id, requester_info, tenant_id)
+         SELECT ?, ?, ?, ?, ?, ?, ?, ?
          WHERE NOT EXISTS (
              SELECT 1 FROM work_tasks
              WHERE project_id = ? AND status IN ('branching', 'running', 'validating')
@@ -117,6 +122,7 @@ export function createWorkTaskAtomic(
         source,
         sourceId,
         requesterInfo,
+        tenantId,
         params.projectId,
     );
 

--- a/server/db/workflows.ts
+++ b/server/db/workflows.ts
@@ -12,6 +12,8 @@ import type {
     CreateWorkflowInput,
     UpdateWorkflowInput,
 } from '../../shared/types';
+import { DEFAULT_TENANT_ID } from '../tenant/types';
+import { withTenantFilter, validateTenantOwnership } from '../tenant/db-filter';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -69,14 +71,14 @@ function rowToNodeRun(row: Record<string, unknown>): WorkflowNodeRun {
 
 // ─── Workflow CRUD ───────────────────────────────────────────────────────────
 
-export function createWorkflow(db: Database, input: CreateWorkflowInput): Workflow {
+export function createWorkflow(db: Database, input: CreateWorkflowInput, tenantId: string = DEFAULT_TENANT_ID): Workflow {
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
 
     db.query(`
         INSERT INTO workflows (id, agent_id, name, description, nodes, edges,
-            status, default_project_id, max_concurrency, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?, ?)
+            status, default_project_id, max_concurrency, tenant_id, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?, ?, ?)
     `).run(
         id,
         input.agentId,
@@ -86,6 +88,7 @@ export function createWorkflow(db: Database, input: CreateWorkflowInput): Workfl
         JSON.stringify(input.edges),
         input.defaultProjectId ?? null,
         input.maxConcurrency ?? 2,
+        tenantId,
         now,
         now,
     );
@@ -93,20 +96,23 @@ export function createWorkflow(db: Database, input: CreateWorkflowInput): Workfl
     return getWorkflow(db, id)!;
 }
 
-export function getWorkflow(db: Database, id: string): Workflow | null {
+export function getWorkflow(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): Workflow | null {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'workflows', id, tenantId)) return null;
     const row = db.query('SELECT * FROM workflows WHERE id = ?').get(id) as Record<string, unknown> | null;
     return row ? rowToWorkflow(row) : null;
 }
 
-export function listWorkflows(db: Database, agentId?: string): Workflow[] {
-    const rows = agentId
-        ? db.query('SELECT * FROM workflows WHERE agent_id = ? ORDER BY updated_at DESC').all(agentId)
-        : db.query('SELECT * FROM workflows ORDER BY updated_at DESC').all();
-    return (rows as Record<string, unknown>[]).map(rowToWorkflow);
+export function listWorkflows(db: Database, agentId?: string, tenantId: string = DEFAULT_TENANT_ID): Workflow[] {
+    if (agentId) {
+        const { query, bindings } = withTenantFilter('SELECT * FROM workflows WHERE agent_id = ? ORDER BY updated_at DESC', tenantId);
+        return (db.query(query).all(agentId, ...bindings) as Record<string, unknown>[]).map(rowToWorkflow);
+    }
+    const { query, bindings } = withTenantFilter('SELECT * FROM workflows ORDER BY updated_at DESC', tenantId);
+    return (db.query(query).all(...bindings) as Record<string, unknown>[]).map(rowToWorkflow);
 }
 
-export function updateWorkflow(db: Database, id: string, input: UpdateWorkflowInput): Workflow | null {
-    const existing = getWorkflow(db, id);
+export function updateWorkflow(db: Database, id: string, input: UpdateWorkflowInput, tenantId: string = DEFAULT_TENANT_ID): Workflow | null {
+    const existing = getWorkflow(db, id, tenantId);
     if (!existing) return null;
 
     const sets: string[] = [];
@@ -129,7 +135,8 @@ export function updateWorkflow(db: Database, id: string, input: UpdateWorkflowIn
     return getWorkflow(db, id);
 }
 
-export function deleteWorkflow(db: Database, id: string): boolean {
+export function deleteWorkflow(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): boolean {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'workflows', id, tenantId)) return false;
     const result = db.query('DELETE FROM workflows WHERE id = ?').run(id);
     return result.changes > 0;
 }
@@ -161,7 +168,8 @@ export function createWorkflowRun(
     return getWorkflowRun(db, id)!;
 }
 
-export function getWorkflowRun(db: Database, id: string): WorkflowRun | null {
+export function getWorkflowRun(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): WorkflowRun | null {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'workflow_runs', id, tenantId)) return null;
     const row = db.query('SELECT * FROM workflow_runs WHERE id = ?').get(id) as Record<string, unknown> | null;
     if (!row) return null;
     const run = rowToRun(row);
@@ -169,15 +177,13 @@ export function getWorkflowRun(db: Database, id: string): WorkflowRun | null {
     return run;
 }
 
-export function listWorkflowRuns(db: Database, workflowId?: string, limit = 50): WorkflowRun[] {
-    const rows = workflowId
-        ? db.query('SELECT * FROM workflow_runs WHERE workflow_id = ? ORDER BY started_at DESC LIMIT ?').all(workflowId, limit)
-        : db.query('SELECT * FROM workflow_runs ORDER BY started_at DESC LIMIT ?').all(limit);
-    return (rows as Record<string, unknown>[]).map((row) => {
-        const run = rowToRun(row);
-        // Don't load node runs for list queries (performance)
-        return run;
-    });
+export function listWorkflowRuns(db: Database, workflowId?: string, limit = 50, tenantId: string = DEFAULT_TENANT_ID): WorkflowRun[] {
+    if (workflowId) {
+        const { query, bindings } = withTenantFilter('SELECT * FROM workflow_runs WHERE workflow_id = ? ORDER BY started_at DESC LIMIT ?', tenantId);
+        return (db.query(query).all(workflowId, ...bindings, limit) as Record<string, unknown>[]).map(rowToRun);
+    }
+    const { query, bindings } = withTenantFilter('SELECT * FROM workflow_runs ORDER BY started_at DESC LIMIT ?', tenantId);
+    return (db.query(query).all(...bindings, limit) as Record<string, unknown>[]).map(rowToRun);
 }
 
 export function listActiveRuns(db: Database): WorkflowRun[] {

--- a/server/routes/analytics.ts
+++ b/server/routes/analytics.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Database } from 'bun:sqlite';
+import type { RequestContext } from '../middleware/guards';
 import { json, safeNumParam } from '../lib/response';
 
 interface DailySpendingRow {
@@ -40,57 +41,70 @@ interface MessageCountRow {
     count: number;
 }
 
-export function handleAnalyticsRoutes(req: Request, url: URL, db: Database): Response | null {
+export function handleAnalyticsRoutes(req: Request, url: URL, db: Database, context?: RequestContext): Response | null {
+    const tenantId = context?.tenantId ?? 'default';
+
     // GET /api/analytics/overview — summary stats
     if (url.pathname === '/api/analytics/overview' && req.method === 'GET') {
-        return handleOverview(db);
+        return handleOverview(db, tenantId);
     }
 
     // GET /api/analytics/spending — daily spending over time
     if (url.pathname === '/api/analytics/spending' && req.method === 'GET') {
         const days = safeNumParam(url.searchParams.get('days'), 30);
-        return handleSpending(db, days);
+        return handleSpending(db, days, tenantId);
     }
 
     // GET /api/analytics/sessions — session stats
     if (url.pathname === '/api/analytics/sessions' && req.method === 'GET') {
-        return handleSessionStats(db);
+        return handleSessionStats(db, tenantId);
     }
 
     return null;
 }
 
-function handleOverview(db: Database): Response {
-    // Total sessions & costs
+function handleOverview(db: Database, tenantId: string): Response {
+    const isDefault = tenantId === 'default';
+    const tenantFilter = isDefault ? '' : ' AND a.tenant_id = ?';
+    const tenantBinding = isDefault ? [] : [tenantId];
+
+    // Total sessions & costs (filtered by tenant's agents)
     const sessionStats = db.query(`
         SELECT
             COUNT(*) as total_sessions,
-            SUM(total_cost_usd) as total_cost_usd,
-            SUM(total_algo_spent) as total_algo_spent,
-            SUM(total_turns) as total_turns,
-            SUM(credits_consumed) as total_credits
-        FROM sessions
-    `).get() as Record<string, number | null>;
+            SUM(s.total_cost_usd) as total_cost_usd,
+            SUM(s.total_algo_spent) as total_algo_spent,
+            SUM(s.total_turns) as total_turns,
+            SUM(s.credits_consumed) as total_credits
+        FROM sessions s
+        ${isDefault ? '' : 'JOIN agents a ON s.agent_id = a.id'}
+        WHERE 1=1${isDefault ? '' : tenantFilter}
+    `).get(...tenantBinding) as Record<string, number | null>;
 
     // Active sessions
     const activeCount = db.query(`
-        SELECT COUNT(*) as count FROM sessions WHERE status = 'running'
-    `).get() as MessageCountRow;
+        SELECT COUNT(*) as count FROM sessions s
+        ${isDefault ? '' : 'JOIN agents a ON s.agent_id = a.id'}
+        WHERE s.status = 'running'${isDefault ? '' : tenantFilter}
+    `).get(...tenantBinding) as MessageCountRow;
 
     // Total agents
     const agentCount = db.query(`
-        SELECT COUNT(*) as count FROM agents
-    `).get() as MessageCountRow;
+        SELECT COUNT(*) as count FROM agents a WHERE 1=1${tenantFilter}
+    `).get(...tenantBinding) as MessageCountRow;
 
     // Total projects
     const projectCount = db.query(`
-        SELECT COUNT(*) as count FROM projects
-    `).get() as MessageCountRow;
+        SELECT COUNT(*) as count FROM projects p
+        ${isDefault ? '' : 'WHERE p.tenant_id = ?'}
+    `).get(...tenantBinding) as MessageCountRow;
 
     // Work task breakdown
     const workTasks = db.query(`
-        SELECT status, COUNT(*) as count FROM work_tasks GROUP BY status
-    `).all() as WorkTaskRow[];
+        SELECT wt.status, COUNT(*) as count FROM work_tasks wt
+        ${isDefault ? '' : 'WHERE wt.tenant_id = ?'}
+        GROUP BY wt.status
+    `).all(...tenantBinding) as WorkTaskRow[];
 
     const workTaskMap: Record<string, number> = {};
     for (const row of workTasks) {
@@ -132,10 +146,12 @@ function handleOverview(db: Database): Response {
     });
 }
 
-function handleSpending(db: Database, days: number): Response {
+function handleSpending(db: Database, days: number, tenantId: string): Response {
     const clampedDays = Math.min(Math.max(days, 1), 365);
+    const isDefault = tenantId === 'default';
+    const tenantBinding = isDefault ? [] : [tenantId];
 
-    // Get daily spending data
+    // Get daily spending data (global — not tenant-scoped since daily_spending is an aggregate table)
     const spending = db.query(`
         SELECT date, algo_micro, api_cost_usd
         FROM daily_spending
@@ -146,15 +162,16 @@ function handleSpending(db: Database, days: number): Response {
     // Get session costs by day
     const sessionCosts = db.query(`
         SELECT
-            date(created_at) as date,
+            date(s.created_at) as date,
             COUNT(*) as session_count,
-            SUM(total_cost_usd) as cost_usd,
-            SUM(total_turns) as turns
-        FROM sessions
-        WHERE created_at >= datetime('now', '-' || ? || ' days')
-        GROUP BY date(created_at)
+            SUM(s.total_cost_usd) as cost_usd,
+            SUM(s.total_turns) as turns
+        FROM sessions s
+        ${isDefault ? '' : 'JOIN agents a ON s.agent_id = a.id'}
+        WHERE s.created_at >= datetime('now', '-' || ? || ' days')${isDefault ? '' : ' AND a.tenant_id = ?'}
+        GROUP BY date(s.created_at)
         ORDER BY date ASC
-    `).all(clampedDays) as { date: string; session_count: number; cost_usd: number; turns: number }[];
+    `).all(clampedDays, ...tenantBinding) as { date: string; session_count: number; cost_usd: number; turns: number }[];
 
     return json({
         spending,
@@ -163,7 +180,11 @@ function handleSpending(db: Database, days: number): Response {
     });
 }
 
-function handleSessionStats(db: Database): Response {
+function handleSessionStats(db: Database, tenantId: string): Response {
+    const isDefault = tenantId === 'default';
+    const tenantFilter = isDefault ? '' : ' AND a.tenant_id = ?';
+    const tenantBinding = isDefault ? [] : [tenantId];
+
     // Sessions by agent
     const byAgent = db.query(`
         SELECT
@@ -174,32 +195,38 @@ function handleSessionStats(db: Database): Response {
             SUM(s.total_turns) as total_turns
         FROM sessions s
         LEFT JOIN agents a ON s.agent_id = a.id
-        WHERE s.agent_id IS NOT NULL
+        WHERE s.agent_id IS NOT NULL${tenantFilter}
         GROUP BY s.agent_id
         ORDER BY session_count DESC
-    `).all() as (SessionByAgentRow & { agent_name: string })[];
+    `).all(...tenantBinding) as (SessionByAgentRow & { agent_name: string })[];
 
     // Sessions by source
     const bySource = db.query(`
-        SELECT source, COUNT(*) as count
-        FROM sessions
-        GROUP BY source
-    `).all() as { source: string; count: number }[];
+        SELECT s.source, COUNT(*) as count
+        FROM sessions s
+        ${isDefault ? '' : 'JOIN agents a ON s.agent_id = a.id'}
+        WHERE 1=1${isDefault ? '' : tenantFilter}
+        GROUP BY s.source
+    `).all(...tenantBinding) as { source: string; count: number }[];
 
     // Sessions by status
     const byStatus = db.query(`
-        SELECT status, COUNT(*) as count
-        FROM sessions
-        GROUP BY status
-    `).all() as { status: string; count: number }[];
+        SELECT s.status, COUNT(*) as count
+        FROM sessions s
+        ${isDefault ? '' : 'JOIN agents a ON s.agent_id = a.id'}
+        WHERE 1=1${isDefault ? '' : tenantFilter}
+        GROUP BY s.status
+    `).all(...tenantBinding) as { status: string; count: number }[];
 
     // Recent sessions (last 20)
     const recent = db.query(`
-        SELECT id, agent_id, status, source, total_cost_usd, total_turns, created_at
-        FROM sessions
-        ORDER BY created_at DESC
+        SELECT s.id, s.agent_id, s.status, s.source, s.total_cost_usd, s.total_turns, s.created_at
+        FROM sessions s
+        ${isDefault ? '' : 'JOIN agents a ON s.agent_id = a.id'}
+        WHERE 1=1${isDefault ? '' : tenantFilter}
+        ORDER BY s.created_at DESC
         LIMIT 20
-    `).all() as SessionRow[];
+    `).all(...tenantBinding) as SessionRow[];
 
     return json({
         byAgent,

--- a/server/routes/billing.ts
+++ b/server/routes/billing.ts
@@ -4,6 +4,7 @@
 import type { Database } from 'bun:sqlite';
 import type { BillingService } from '../billing/service';
 import type { UsageMeter } from '../billing/meter';
+import type { RequestContext } from '../middleware/guards';
 import { verifyWebhookSignature } from '../billing/stripe';
 import { json, badRequest, notFound, handleRouteError, safeNumParam } from '../lib/response';
 import { parseBodyOrThrow, ValidationError, CreateSubscriptionSchema } from '../lib/validation';
@@ -17,6 +18,7 @@ export function handleBillingRoutes(
     _db: Database,
     billing?: BillingService | null,
     meter?: UsageMeter | null,
+    _context?: RequestContext,
 ): Response | Promise<Response> | null {
     if (!billing) {
         if (!url.pathname.startsWith('/api/billing')) return null;

--- a/server/routes/councils.ts
+++ b/server/routes/councils.ts
@@ -12,6 +12,7 @@ import {
 } from '../db/councils';
 import type { ProcessManager } from '../process/manager';
 import type { AgentMessenger } from '../algochat/agent-messenger';
+import type { RequestContext } from '../middleware/guards';
 import { parseBodyOrThrow, ValidationError, CreateCouncilSchema, UpdateCouncilSchema, LaunchCouncilSchema, CouncilChatSchema } from '../lib/validation';
 import { json, handleRouteError } from '../lib/response';
 import { NotFoundError } from '../lib/errors';
@@ -40,23 +41,25 @@ export function handleCouncilRoutes(
     db: Database,
     processManager: ProcessManager,
     agentMessenger?: AgentMessenger | null,
+    context?: RequestContext,
 ): Response | Promise<Response> | null {
     const path = url.pathname;
     const method = req.method;
+    const tenantId = context?.tenantId ?? 'default';
 
     // Council CRUD
     if (path === '/api/councils' && method === 'GET') {
-        return json(listCouncils(db));
+        return json(listCouncils(db, tenantId));
     }
 
     if (path === '/api/councils' && method === 'POST') {
-        return handleCreateCouncil(req, db);
+        return handleCreateCouncil(req, db, tenantId);
     }
 
     // Council launches list (optional councilId filter)
     if (path === '/api/council-launches' && method === 'GET') {
         const councilId = url.searchParams.get('councilId') ?? undefined;
-        return json(listCouncilLaunches(db, councilId));
+        return json(listCouncilLaunches(db, councilId, tenantId));
     }
 
     // Council launch by ID
@@ -66,18 +69,18 @@ export function handleCouncilRoutes(
         const action = launchMatch[3];
 
         if (!action && method === 'GET') {
-            const launch = getCouncilLaunch(db, launchId);
+            const launch = getCouncilLaunch(db, launchId, tenantId);
             return launch ? json(launch) : json({ error: 'Not found' }, 404);
         }
 
         if (action === 'logs' && method === 'GET') {
-            const launch = getCouncilLaunch(db, launchId);
+            const launch = getCouncilLaunch(db, launchId, tenantId);
             if (!launch) return json({ error: 'Not found' }, 404);
             return json(getCouncilLaunchLogs(db, launchId));
         }
 
         if (action === 'discussion-messages' && method === 'GET') {
-            const launch = getCouncilLaunch(db, launchId);
+            const launch = getCouncilLaunch(db, launchId, tenantId);
             if (!launch) return json({ error: 'Not found' }, 404);
             return json(getDiscussionMessages(db, launchId));
         }
@@ -108,14 +111,14 @@ export function handleCouncilRoutes(
 
     if (!action) {
         if (method === 'GET') {
-            const council = getCouncil(db, id);
+            const council = getCouncil(db, id, tenantId);
             return council ? json(council) : json({ error: 'Not found' }, 404);
         }
         if (method === 'PUT') {
-            return handleUpdateCouncil(req, db, id);
+            return handleUpdateCouncil(req, db, id, tenantId);
         }
         if (method === 'DELETE') {
-            const deleted = deleteCouncil(db, id);
+            const deleted = deleteCouncil(db, id, tenantId);
             return deleted ? json({ ok: true }) : json({ error: 'Not found' }, 404);
         }
     }
@@ -125,7 +128,7 @@ export function handleCouncilRoutes(
     }
 
     if (action === 'launches' && method === 'GET') {
-        return json(listCouncilLaunches(db, id));
+        return json(listCouncilLaunches(db, id, tenantId));
     }
 
     return null;
@@ -133,10 +136,10 @@ export function handleCouncilRoutes(
 
 // ─── CRUD handlers ────────────────────────────────────────────────────────────
 
-async function handleCreateCouncil(req: Request, db: Database): Promise<Response> {
+async function handleCreateCouncil(req: Request, db: Database, tenantId: string): Promise<Response> {
     try {
         const data = await parseBodyOrThrow(req, CreateCouncilSchema);
-        const council = createCouncil(db, data);
+        const council = createCouncil(db, data, tenantId);
         return json(council, 201);
     } catch (err) {
         if (err instanceof ValidationError) return json({ error: err.detail }, 400);
@@ -144,10 +147,10 @@ async function handleCreateCouncil(req: Request, db: Database): Promise<Response
     }
 }
 
-async function handleUpdateCouncil(req: Request, db: Database, id: string): Promise<Response> {
+async function handleUpdateCouncil(req: Request, db: Database, id: string, tenantId: string): Promise<Response> {
     try {
         const data = await parseBodyOrThrow(req, UpdateCouncilSchema);
-        const council = updateCouncil(db, id, data);
+        const council = updateCouncil(db, id, data, tenantId);
         return council ? json(council) : json({ error: 'Not found' }, 404);
     } catch (err) {
         if (err instanceof ValidationError) return json({ error: err.detail }, 400);

--- a/server/routes/feedback.ts
+++ b/server/routes/feedback.ts
@@ -7,6 +7,7 @@
 
 import type { Database } from 'bun:sqlite';
 import type { OutcomeTrackerService } from '../feedback/outcome-tracker';
+import type { RequestContext } from '../middleware/guards';
 import { json, handleRouteError } from '../lib/response';
 
 export function handleFeedbackRoutes(
@@ -14,6 +15,7 @@ export function handleFeedbackRoutes(
     url: URL,
     _db: Database,
     outcomeTracker: OutcomeTrackerService | null,
+    _context?: RequestContext,
 ): Response | null {
     if (!url.pathname.startsWith('/api/feedback')) return null;
     if (!outcomeTracker) return json({ error: 'Feedback service not available' }, 503);

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -280,15 +280,15 @@ async function handleRoutes(
     if (agentResponse) return agentResponse;
 
     // Persona routes (agent identity/personality)
-    const personaResponse = handlePersonaRoutes(req, url, db);
+    const personaResponse = handlePersonaRoutes(req, url, db, context);
     if (personaResponse) return personaResponse;
 
     // Skill bundle routes (composable tool + prompt packages)
-    const skillBundleResponse = handleSkillBundleRoutes(req, url, db);
+    const skillBundleResponse = handleSkillBundleRoutes(req, url, db, context);
     if (skillBundleResponse) return skillBundleResponse;
 
     // External MCP server config routes
-    const mcpServerResponse = handleMcpServerRoutes(req, url, db);
+    const mcpServerResponse = handleMcpServerRoutes(req, url, db, context);
     if (mcpServerResponse) return mcpServerResponse;
 
     const allowlistResponse = handleAllowlistRoutes(req, url, db);
@@ -297,19 +297,19 @@ async function handleRoutes(
     const githubAllowlistResponse = handleGitHubAllowlistRoutes(req, url, db);
     if (githubAllowlistResponse) return githubAllowlistResponse;
 
-    const analyticsResponse = handleAnalyticsRoutes(req, url, db);
+    const analyticsResponse = handleAnalyticsRoutes(req, url, db, context);
     if (analyticsResponse) return analyticsResponse;
 
     const performanceResponse = handlePerformanceRoutes(req, url, db, performanceCollector ?? null);
     if (performanceResponse) return performanceResponse;
 
-    const usageResponse = handleUsageRoutes(req, url, db);
+    const usageResponse = handleUsageRoutes(req, url, db, context);
     if (usageResponse) return usageResponse;
 
-    const feedbackResponse = handleFeedbackRoutes(req, url, db, outcomeTracker ?? null);
+    const feedbackResponse = handleFeedbackRoutes(req, url, db, outcomeTracker ?? null, context);
     if (feedbackResponse) return feedbackResponse;
 
-    const systemLogResponse = handleSystemLogRoutes(req, url, db);
+    const systemLogResponse = handleSystemLogRoutes(req, url, db, context);
     if (systemLogResponse) return systemLogResponse;
 
     const settingsResponse = await handleSettingsRoutes(req, url, db, context, getAuthConfig());
@@ -318,44 +318,44 @@ async function handleRoutes(
     const sessionResponse = await handleSessionRoutes(req, url, db, processManager, context);
     if (sessionResponse) return sessionResponse;
 
-    const councilResponse = handleCouncilRoutes(req, url, db, processManager, agentMessenger);
+    const councilResponse = handleCouncilRoutes(req, url, db, processManager, agentMessenger, context);
     if (councilResponse) return councilResponse;
 
     if (workTaskService) {
-        const workTaskResponse = handleWorkTaskRoutes(req, url, workTaskService);
+        const workTaskResponse = handleWorkTaskRoutes(req, url, workTaskService, context);
         if (workTaskResponse) return workTaskResponse;
     }
 
     // Schedule routes (automation)
-    const scheduleResponse = handleScheduleRoutes(req, url, db, schedulerService ?? null);
+    const scheduleResponse = handleScheduleRoutes(req, url, db, schedulerService ?? null, context);
     if (scheduleResponse) return scheduleResponse;
 
     // Webhook routes (GitHub event-driven automation)
-    const webhookResponse = handleWebhookRoutes(req, url, db, webhookService ?? null);
+    const webhookResponse = handleWebhookRoutes(req, url, db, webhookService ?? null, context);
     if (webhookResponse) return webhookResponse;
 
     // Mention polling routes (local-first GitHub @mention detection)
-    const pollingResponse = handleMentionPollingRoutes(req, url, db, mentionPollingService ?? null);
+    const pollingResponse = handleMentionPollingRoutes(req, url, db, mentionPollingService ?? null, context);
     if (pollingResponse) return pollingResponse;
 
     // Workflow routes (graph-based orchestration)
-    const workflowResponse = handleWorkflowRoutes(req, url, db, workflowService ?? null);
+    const workflowResponse = handleWorkflowRoutes(req, url, db, workflowService ?? null, context);
     if (workflowResponse) return workflowResponse;
 
     // Sandbox routes (container management)
-    const sandboxResponse = handleSandboxRoutes(req, url, db, sandboxManager);
+    const sandboxResponse = handleSandboxRoutes(req, url, db, sandboxManager, context);
     if (sandboxResponse) return sandboxResponse;
 
     // Marketplace routes
-    const marketplaceResponse = handleMarketplaceRoutes(req, url, db, marketplace, marketplaceFederation);
+    const marketplaceResponse = handleMarketplaceRoutes(req, url, db, marketplace, marketplaceFederation, context);
     if (marketplaceResponse) return marketplaceResponse;
 
     // Reputation routes
-    const reputationResponse = handleReputationRoutes(req, url, db, reputationScorer, reputationAttestation);
+    const reputationResponse = handleReputationRoutes(req, url, db, reputationScorer, reputationAttestation, context);
     if (reputationResponse) return reputationResponse;
 
     // Billing routes
-    const billingResponse = await handleBillingRoutes(req, url, db, billing, usageMeter);
+    const billingResponse = await handleBillingRoutes(req, url, db, billing, usageMeter, context);
     if (billingResponse) return billingResponse;
 
     // Auth flow routes (device authorization for CLI login)

--- a/server/routes/marketplace.ts
+++ b/server/routes/marketplace.ts
@@ -4,6 +4,7 @@
 import type { Database } from 'bun:sqlite';
 import { type MarketplaceService, VerificationGateError } from '../marketplace/service';
 import type { MarketplaceFederation } from '../marketplace/federation';
+import type { RequestContext } from '../middleware/guards';
 import type {
     ListingCategory,
     PricingModel,
@@ -17,6 +18,7 @@ export function handleMarketplaceRoutes(
     _db: Database,
     marketplace?: MarketplaceService | null,
     federation?: MarketplaceFederation | null,
+    _context?: RequestContext,
 ): Response | Promise<Response> | null {
     if (!marketplace) {
         // Only match marketplace paths, return null for non-marketplace paths

--- a/server/routes/mcp-servers.ts
+++ b/server/routes/mcp-servers.ts
@@ -1,4 +1,5 @@
 import type { Database } from 'bun:sqlite';
+import type { RequestContext } from '../middleware/guards';
 import {
     listMcpServerConfigs,
     getMcpServerConfig,
@@ -14,30 +15,33 @@ export function handleMcpServerRoutes(
     req: Request,
     url: URL,
     db: Database,
+    context?: RequestContext,
 ): Response | Promise<Response> | null {
+    const tenantId = context?.tenantId ?? 'default';
+
     // GET /api/mcp-servers — list configs (optional ?agentId=xxx filter)
     if (url.pathname === '/api/mcp-servers' && req.method === 'GET') {
         const agentId = url.searchParams.get('agentId') ?? undefined;
-        const configs = listMcpServerConfigs(db, agentId);
+        const configs = listMcpServerConfigs(db, agentId, tenantId);
         return json(configs);
     }
 
     // POST /api/mcp-servers — create config
     if (url.pathname === '/api/mcp-servers' && req.method === 'POST') {
-        return handleCreate(req, db);
+        return handleCreate(req, db, tenantId);
     }
 
     // PUT /api/mcp-servers/:id — update config
     const putMatch = url.pathname.match(/^\/api\/mcp-servers\/([^/]+)$/);
     if (putMatch && req.method === 'PUT') {
-        return handleUpdate(req, db, putMatch[1]);
+        return handleUpdate(req, db, putMatch[1], tenantId);
     }
 
     // DELETE /api/mcp-servers/:id — delete config
     const deleteMatch = url.pathname.match(/^\/api\/mcp-servers\/([^/]+)$/);
     if (deleteMatch && req.method === 'DELETE') {
         const id = deleteMatch[1];
-        const deleted = deleteMcpServerConfig(db, id);
+        const deleted = deleteMcpServerConfig(db, id, tenantId);
         if (!deleted) return json({ error: 'MCP server config not found' }, 404);
         return json({ ok: true });
     }
@@ -45,16 +49,16 @@ export function handleMcpServerRoutes(
     // POST /api/mcp-servers/:id/test — test connection
     const testMatch = url.pathname.match(/^\/api\/mcp-servers\/([^/]+)\/test$/);
     if (testMatch && req.method === 'POST') {
-        return handleTest(db, testMatch[1]);
+        return handleTest(db, testMatch[1], tenantId);
     }
 
     return null;
 }
 
-async function handleCreate(req: Request, db: Database): Promise<Response> {
+async function handleCreate(req: Request, db: Database, tenantId: string): Promise<Response> {
     try {
         const data = await parseBodyOrThrow(req, CreateMcpServerConfigSchema);
-        const config = createMcpServerConfig(db, data);
+        const config = createMcpServerConfig(db, data, tenantId);
         return json(config, 201);
     } catch (err) {
         if (err instanceof ValidationError) return json({ error: err.detail }, 400);
@@ -62,10 +66,10 @@ async function handleCreate(req: Request, db: Database): Promise<Response> {
     }
 }
 
-async function handleUpdate(req: Request, db: Database, id: string): Promise<Response> {
+async function handleUpdate(req: Request, db: Database, id: string, tenantId: string): Promise<Response> {
     try {
         const data = await parseBodyOrThrow(req, UpdateMcpServerConfigSchema);
-        const config = updateMcpServerConfig(db, id, data);
+        const config = updateMcpServerConfig(db, id, data, tenantId);
         if (!config) return json({ error: 'MCP server config not found' }, 404);
         return json(config);
     } catch (err) {
@@ -74,8 +78,8 @@ async function handleUpdate(req: Request, db: Database, id: string): Promise<Res
     }
 }
 
-async function handleTest(db: Database, id: string): Promise<Response> {
-    const config = getMcpServerConfig(db, id);
+async function handleTest(db: Database, id: string, tenantId: string): Promise<Response> {
+    const config = getMcpServerConfig(db, id, tenantId);
     if (!config) return json({ error: 'MCP server config not found' }, 404);
 
     const manager = new ExternalMcpClientManager();

--- a/server/routes/mention-polling.ts
+++ b/server/routes/mention-polling.ts
@@ -12,6 +12,7 @@
 
 import type { Database } from 'bun:sqlite';
 import type { MentionPollingService } from '../polling/service';
+import type { RequestContext } from '../middleware/guards';
 import {
     listMentionPollingConfigs,
     getMentionPollingConfig,
@@ -93,11 +94,13 @@ export function handleMentionPollingRoutes(
     url: URL,
     db: Database,
     pollingService: MentionPollingService | null,
+    context?: RequestContext,
 ): Response | Promise<Response> | null {
+    const tenantId = context?.tenantId ?? 'default';
     // ── List all polling configs ────────────────────────────────────────────
     if (url.pathname === '/api/mention-polling' && req.method === 'GET') {
         const agentId = url.searchParams.get('agentId') ?? undefined;
-        const configs = listMentionPollingConfigs(db, agentId);
+        const configs = listMentionPollingConfigs(db, agentId, tenantId);
         return json({ configs });
     }
 
@@ -106,7 +109,7 @@ export function handleMentionPollingRoutes(
         return (async () => {
             try {
                 const data = await parseBodyOrThrow(req, CreateMentionPollingSchema);
-                const config = createMentionPollingConfig(db, data);
+                const config = createMentionPollingConfig(db, data, tenantId);
                 log.info('Mention polling config created', { id: config.id, repo: config.repo });
                 return json(config, 201);
             } catch (err) {
@@ -125,7 +128,7 @@ export function handleMentionPollingRoutes(
     const activityMatch = url.pathname.match(/^\/api\/mention-polling\/([^/]+)\/activity$/);
     if (activityMatch && req.method === 'GET') {
         const id = activityMatch[1];
-        const config = getMentionPollingConfig(db, id);
+        const config = getMentionPollingConfig(db, id, tenantId);
         if (!config) return json({ error: 'Polling config not found' }, 404);
 
         const sessions = listPollingActivity(db, config.repo);
@@ -160,7 +163,7 @@ export function handleMentionPollingRoutes(
         if (id === 'stats') return null;
 
         if (req.method === 'GET') {
-            const config = getMentionPollingConfig(db, id);
+            const config = getMentionPollingConfig(db, id, tenantId);
             if (!config) return json({ error: 'Polling config not found' }, 404);
             return json(config);
         }
@@ -169,7 +172,7 @@ export function handleMentionPollingRoutes(
             return (async () => {
                 try {
                     const data = await parseBodyOrThrow(req, UpdateMentionPollingSchema);
-                    const updated = updateMentionPollingConfig(db, id, data);
+                    const updated = updateMentionPollingConfig(db, id, data, tenantId);
                     if (!updated) return json({ error: 'Polling config not found' }, 404);
                     return json(updated);
                 } catch (err) {
@@ -179,7 +182,7 @@ export function handleMentionPollingRoutes(
         }
 
         if (req.method === 'DELETE') {
-            const deleted = deleteMentionPollingConfig(db, id);
+            const deleted = deleteMentionPollingConfig(db, id, tenantId);
             if (!deleted) return json({ error: 'Polling config not found' }, 404);
             return json({ ok: true });
         }

--- a/server/routes/personas.ts
+++ b/server/routes/personas.ts
@@ -1,4 +1,5 @@
 import type { Database } from 'bun:sqlite';
+import type { RequestContext } from '../middleware/guards';
 import { getPersona, upsertPersona, deletePersona } from '../db/personas';
 import { getAgent } from '../db/agents';
 import { parseBodyOrThrow, ValidationError, UpsertPersonaSchema } from '../lib/validation';
@@ -8,12 +9,15 @@ export function handlePersonaRoutes(
     req: Request,
     url: URL,
     db: Database,
+    context?: RequestContext,
 ): Response | Promise<Response> | null {
+    const tenantId = context?.tenantId ?? 'default';
+
     // GET /api/agents/:id/persona
     const getMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/persona$/);
     if (getMatch && req.method === 'GET') {
         const agentId = getMatch[1];
-        const agent = getAgent(db, agentId);
+        const agent = getAgent(db, agentId, tenantId);
         if (!agent) return json({ error: 'Agent not found' }, 404);
 
         const persona = getPersona(db, agentId);
@@ -24,14 +28,14 @@ export function handlePersonaRoutes(
     // PUT /api/agents/:id/persona
     const putMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/persona$/);
     if (putMatch && req.method === 'PUT') {
-        return handleUpsert(req, db, putMatch[1]);
+        return handleUpsert(req, db, putMatch[1], tenantId);
     }
 
     // DELETE /api/agents/:id/persona
     const deleteMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/persona$/);
     if (deleteMatch && req.method === 'DELETE') {
         const agentId = deleteMatch[1];
-        const agent = getAgent(db, agentId);
+        const agent = getAgent(db, agentId, tenantId);
         if (!agent) return json({ error: 'Agent not found' }, 404);
 
         const deleted = deletePersona(db, agentId);
@@ -42,9 +46,9 @@ export function handlePersonaRoutes(
     return null;
 }
 
-async function handleUpsert(req: Request, db: Database, agentId: string): Promise<Response> {
+async function handleUpsert(req: Request, db: Database, agentId: string, tenantId: string): Promise<Response> {
     try {
-        const agent = getAgent(db, agentId);
+        const agent = getAgent(db, agentId, tenantId);
         if (!agent) return json({ error: 'Agent not found' }, 404);
 
         const data = await parseBodyOrThrow(req, UpsertPersonaSchema);

--- a/server/routes/reputation.ts
+++ b/server/routes/reputation.ts
@@ -4,6 +4,7 @@
 import type { Database } from 'bun:sqlite';
 import type { ReputationScorer } from '../reputation/scorer';
 import type { ReputationAttestation } from '../reputation/attestation';
+import type { RequestContext } from '../middleware/guards';
 import { IdentityVerification, type VerificationTier } from '../reputation/identity-verification';
 import { json, badRequest, notFound, handleRouteError, safeNumParam } from '../lib/response';
 import { parseBodyOrThrow, ValidationError, RecordReputationEventSchema } from '../lib/validation';
@@ -16,6 +17,7 @@ export function handleReputationRoutes(
     _db: Database,
     scorer?: ReputationScorer | null,
     attestation?: ReputationAttestation | null,
+    _context?: RequestContext,
 ): Response | Promise<Response> | null {
     if (!scorer) {
         if (!url.pathname.startsWith('/api/reputation')) return null;

--- a/server/routes/sandbox.ts
+++ b/server/routes/sandbox.ts
@@ -3,6 +3,8 @@
  */
 import type { Database } from 'bun:sqlite';
 import type { SandboxManager } from '../sandbox/manager';
+import type { RequestContext } from '../middleware/guards';
+import { getAgent } from '../db/agents';
 import { getAgentPolicy, setAgentPolicy, removeAgentPolicy, listAgentPolicies } from '../sandbox/policy';
 import { json, notFound, handleRouteError } from '../lib/response';
 import { parseBodyOrThrow, ValidationError, SetSandboxPolicySchema, AssignSandboxSchema } from '../lib/validation';
@@ -12,9 +14,11 @@ export function handleSandboxRoutes(
     url: URL,
     db: Database,
     sandboxManager?: SandboxManager | null,
+    context?: RequestContext,
 ): Response | Promise<Response> | null {
     const path = url.pathname;
     const method = req.method;
+    const tenantId = context?.tenantId ?? 'default';
 
     // Pool stats
     if (path === '/api/sandbox/stats' && method === 'GET') {
@@ -33,6 +37,8 @@ export function handleSandboxRoutes(
     const policyMatch = path.match(/^\/api\/sandbox\/policies\/([^/]+)$/);
     if (policyMatch) {
         const agentId = policyMatch[1];
+        const agent = getAgent(db, agentId, tenantId);
+        if (!agent) return json({ error: 'Agent not found' }, 404);
 
         if (method === 'GET') {
             const policy = getAgentPolicy(db, agentId);

--- a/server/routes/schedules.ts
+++ b/server/routes/schedules.ts
@@ -1,5 +1,6 @@
 import type { Database } from 'bun:sqlite';
 import type { SchedulerService } from '../scheduler/service';
+import type { RequestContext } from '../middleware/guards';
 import { validateScheduleFrequency } from '../scheduler/service';
 import {
     listSchedules,
@@ -26,35 +27,38 @@ export function handleScheduleRoutes(
     url: URL,
     db: Database,
     schedulerService: SchedulerService | null,
+    context?: RequestContext,
 ): Response | Promise<Response> | null {
+    const tenantId = context?.tenantId ?? 'default';
+
     // List schedules
     if (url.pathname === '/api/schedules' && req.method === 'GET') {
         const agentId = url.searchParams.get('agentId') ?? undefined;
-        const schedules = listSchedules(db, agentId);
+        const schedules = listSchedules(db, agentId, tenantId);
         return json(schedules);
     }
 
     // Create schedule
     if (url.pathname === '/api/schedules' && req.method === 'POST') {
-        return handleCreateSchedule(req, db);
+        return handleCreateSchedule(req, db, tenantId);
     }
 
     // Get single schedule
     const scheduleMatch = url.pathname.match(/^\/api\/schedules\/([^/]+)$/);
     if (scheduleMatch && req.method === 'GET') {
-        const schedule = getSchedule(db, scheduleMatch[1]);
+        const schedule = getSchedule(db, scheduleMatch[1], tenantId);
         if (!schedule) return json({ error: 'Schedule not found' }, 404);
         return json(schedule);
     }
 
     // Update schedule
     if (scheduleMatch && req.method === 'PUT') {
-        return handleUpdateSchedule(req, db, scheduleMatch[1]);
+        return handleUpdateSchedule(req, db, scheduleMatch[1], tenantId);
     }
 
     // Delete schedule
     if (scheduleMatch && req.method === 'DELETE') {
-        const deleted = deleteSchedule(db, scheduleMatch[1]);
+        const deleted = deleteSchedule(db, scheduleMatch[1], tenantId);
         if (!deleted) return json({ error: 'Schedule not found' }, 404);
         return json({ ok: true });
     }
@@ -63,7 +67,7 @@ export function handleScheduleRoutes(
     const execsMatch = url.pathname.match(/^\/api\/schedules\/([^/]+)\/executions$/);
     if (execsMatch && req.method === 'GET') {
         const limit = safeNumParam(url.searchParams.get('limit'), 50);
-        const executions = listExecutions(db, execsMatch[1], limit);
+        const executions = listExecutions(db, execsMatch[1], limit, tenantId);
         return json(executions);
     }
 
@@ -82,7 +86,7 @@ export function handleScheduleRoutes(
             return json(result);
         }
         // Backwards-compatible: plain array when no filters
-        const executions = listExecutions(db, undefined, limit);
+        const executions = listExecutions(db, undefined, limit, tenantId);
         return json(executions);
     }
 
@@ -170,7 +174,7 @@ function scanScheduleActions(actions: Array<{ prompt?: string; description?: str
     return null;
 }
 
-async function handleCreateSchedule(req: Request, db: Database): Promise<Response> {
+async function handleCreateSchedule(req: Request, db: Database, tenantId: string): Promise<Response> {
     try {
         const data = await parseBodyOrThrow(req, CreateScheduleSchema);
 
@@ -183,7 +187,7 @@ async function handleCreateSchedule(req: Request, db: Database): Promise<Respons
         const injectionError = scanScheduleActions(data.actions);
         if (injectionError) return badRequest(injectionError);
 
-        const schedule = createSchedule(db, data);
+        const schedule = createSchedule(db, data, tenantId);
 
         // Compute and persist next_run_at so the scheduler picks it up (null for event-only)
         const nextRun = computeNextRun(schedule.cronExpression, schedule.intervalMs);
@@ -207,13 +211,13 @@ function isScheduleFrequencyError(err: unknown): boolean {
     return msg.includes('Minimum interval') || msg.includes('fires every') || msg.includes('too short');
 }
 
-async function handleUpdateSchedule(req: Request, db: Database, id: string): Promise<Response> {
+async function handleUpdateSchedule(req: Request, db: Database, id: string, tenantId: string): Promise<Response> {
     try {
         const data = await parseBodyOrThrow(req, UpdateScheduleSchema);
 
         // Validate frequency constraints if cron/interval is being updated
         if (data.cronExpression !== undefined || data.intervalMs !== undefined) {
-            const existing = getSchedule(db, id);
+            const existing = getSchedule(db, id, tenantId);
             if (!existing) return json({ error: 'Schedule not found' }, 404);
             const effectiveCron = data.cronExpression ?? existing.cronExpression;
             const effectiveInterval = data.intervalMs ?? existing.intervalMs;
@@ -225,7 +229,7 @@ async function handleUpdateSchedule(req: Request, db: Database, id: string): Pro
             if (injectionError) return badRequest(injectionError);
         }
 
-        const schedule = updateSchedule(db, id, data);
+        const schedule = updateSchedule(db, id, data, tenantId);
         if (!schedule) return json({ error: 'Schedule not found' }, 404);
 
         // Recompute next_run_at if cron/interval changed

--- a/server/routes/skill-bundles.ts
+++ b/server/routes/skill-bundles.ts
@@ -1,4 +1,5 @@
 import type { Database } from 'bun:sqlite';
+import type { RequestContext } from '../middleware/guards';
 import {
     listBundles, getBundle, createBundle, updateBundle, deleteBundle,
     getAgentBundles, assignBundle, unassignBundle,
@@ -13,9 +14,11 @@ export function handleSkillBundleRoutes(
     req: Request,
     url: URL,
     db: Database,
+    context?: RequestContext,
 ): Response | Promise<Response> | null {
     const path = url.pathname;
     const method = req.method;
+    const tenantId = context?.tenantId ?? 'default';
 
     // ─── Bundle CRUD ──────────────────────────────────────────────────────
 
@@ -56,14 +59,14 @@ export function handleSkillBundleRoutes(
     const agentSkillsGet = path.match(/^\/api\/agents\/([^/]+)\/skills$/);
     if (agentSkillsGet && method === 'GET') {
         const agentId = agentSkillsGet[1];
-        const agent = getAgent(db, agentId);
+        const agent = getAgent(db, agentId, tenantId);
         if (!agent) return json({ error: 'Agent not found' }, 404);
         return json(getAgentBundles(db, agentId));
     }
 
     // POST /api/agents/:id/skills
     if (agentSkillsGet && method === 'POST') {
-        return handleAssignBundle(req, db, agentSkillsGet[1]);
+        return handleAssignBundle(req, db, agentSkillsGet[1], tenantId);
     }
 
     // DELETE /api/agents/:id/skills/:bundleId
@@ -71,7 +74,7 @@ export function handleSkillBundleRoutes(
     if (agentSkillDelete && method === 'DELETE') {
         const agentId = agentSkillDelete[1];
         const bundleId = agentSkillDelete[2];
-        const agent = getAgent(db, agentId);
+        const agent = getAgent(db, agentId, tenantId);
         if (!agent) return json({ error: 'Agent not found' }, 404);
 
         const removed = unassignBundle(db, agentId, bundleId);
@@ -85,14 +88,14 @@ export function handleSkillBundleRoutes(
     const projectSkillsGet = path.match(/^\/api\/projects\/([^/]+)\/skills$/);
     if (projectSkillsGet && method === 'GET') {
         const projectId = projectSkillsGet[1];
-        const project = getProject(db, projectId);
+        const project = getProject(db, projectId, tenantId);
         if (!project) return json({ error: 'Project not found' }, 404);
         return json(getProjectBundles(db, projectId));
     }
 
     // POST /api/projects/:id/skills
     if (projectSkillsGet && method === 'POST') {
-        return handleAssignProjectBundle(req, db, projectSkillsGet[1]);
+        return handleAssignProjectBundle(req, db, projectSkillsGet[1], tenantId);
     }
 
     // DELETE /api/projects/:id/skills/:bundleId
@@ -100,7 +103,7 @@ export function handleSkillBundleRoutes(
     if (projectSkillDelete && method === 'DELETE') {
         const projectId = projectSkillDelete[1];
         const bundleId = projectSkillDelete[2];
-        const project = getProject(db, projectId);
+        const project = getProject(db, projectId, tenantId);
         if (!project) return json({ error: 'Project not found' }, 404);
 
         const removed = unassignProjectBundle(db, projectId, bundleId);
@@ -134,9 +137,9 @@ async function handleUpdateBundle(req: Request, db: Database, id: string): Promi
     }
 }
 
-async function handleAssignBundle(req: Request, db: Database, agentId: string): Promise<Response> {
+async function handleAssignBundle(req: Request, db: Database, agentId: string, tenantId: string): Promise<Response> {
     try {
-        const agent = getAgent(db, agentId);
+        const agent = getAgent(db, agentId, tenantId);
         if (!agent) return json({ error: 'Agent not found' }, 404);
 
         const data = await parseBodyOrThrow(req, AssignSkillBundleSchema);
@@ -149,9 +152,9 @@ async function handleAssignBundle(req: Request, db: Database, agentId: string): 
     }
 }
 
-async function handleAssignProjectBundle(req: Request, db: Database, projectId: string): Promise<Response> {
+async function handleAssignProjectBundle(req: Request, db: Database, projectId: string, tenantId: string): Promise<Response> {
     try {
-        const project = getProject(db, projectId);
+        const project = getProject(db, projectId, tenantId);
         if (!project) return json({ error: 'Project not found' }, 404);
 
         const data = await parseBodyOrThrow(req, AssignSkillBundleSchema);

--- a/server/routes/system-logs.ts
+++ b/server/routes/system-logs.ts
@@ -4,9 +4,10 @@
  */
 
 import type { Database } from 'bun:sqlite';
+import type { RequestContext } from '../middleware/guards';
 import { json, safeNumParam } from '../lib/response';
 
-export function handleSystemLogRoutes(req: Request, url: URL, db: Database): Response | null {
+export function handleSystemLogRoutes(req: Request, url: URL, db: Database, _context?: RequestContext): Response | null {
     // GET /api/system-logs — aggregated system logs
     if (url.pathname === '/api/system-logs' && req.method === 'GET') {
         const limit = safeNumParam(url.searchParams.get('limit'), 100);

--- a/server/routes/usage.ts
+++ b/server/routes/usage.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Database } from 'bun:sqlite';
+import type { RequestContext } from '../middleware/guards';
 import { json, safeNumParam } from '../lib/response';
 
 interface ScheduleUsageRow {
@@ -47,7 +48,7 @@ interface ExecutionAnomalyRow {
     anomaly_type: string;
 }
 
-export function handleUsageRoutes(req: Request, url: URL, db: Database): Response | null {
+export function handleUsageRoutes(req: Request, url: URL, db: Database, _context?: RequestContext): Response | null {
     // GET /api/usage/summary — per-schedule aggregates + anomaly flags
     if (url.pathname === '/api/usage/summary' && req.method === 'GET') {
         const days = safeNumParam(url.searchParams.get('days'), 30);

--- a/server/routes/webhooks.ts
+++ b/server/routes/webhooks.ts
@@ -14,6 +14,7 @@
 
 import type { Database } from 'bun:sqlite';
 import type { WebhookService, GitHubWebhookPayload } from '../webhooks/service';
+import type { RequestContext } from '../middleware/guards';
 import {
     listWebhookRegistrations,
     getWebhookRegistration,
@@ -168,7 +169,9 @@ export function handleWebhookRoutes(
     url: URL,
     db: Database,
     webhookService: WebhookService | null,
+    context?: RequestContext,
 ): Response | Promise<Response> | null {
+    const tenantId = context?.tenantId ?? 'default';
     // ── GitHub webhook receiver ─────────────────────────────────────────────
     if (url.pathname === '/webhooks/github' && req.method === 'POST') {
         if (!webhookService) {
@@ -180,7 +183,7 @@ export function handleWebhookRoutes(
     // ── List all registrations ──────────────────────────────────────────────
     if (url.pathname === '/api/webhooks' && req.method === 'GET') {
         const agentId = url.searchParams.get('agentId') ?? undefined;
-        const registrations = listWebhookRegistrations(db, agentId);
+        const registrations = listWebhookRegistrations(db, agentId, tenantId);
         return json({ registrations });
     }
 
@@ -189,7 +192,7 @@ export function handleWebhookRoutes(
         return (async () => {
             try {
                 const data = await parseBodyOrThrow(req, CreateWebhookRegistrationSchema);
-                const registration = createWebhookRegistration(db, data);
+                const registration = createWebhookRegistration(db, data, tenantId);
                 const ip = getClientIp(req);
                 recordAudit(db, 'webhook_register', ip, 'webhook', registration.id, `repo=${registration.repo}`, null, ip);
                 log.info('Webhook registration created', { id: registration.id, repo: registration.repo });
@@ -216,7 +219,7 @@ export function handleWebhookRoutes(
         if (id === 'deliveries') return null;
 
         if (req.method === 'GET') {
-            const registration = getWebhookRegistration(db, id);
+            const registration = getWebhookRegistration(db, id, tenantId);
             if (!registration) return json({ error: 'Webhook registration not found' }, 404);
             return json(registration);
         }
@@ -225,7 +228,7 @@ export function handleWebhookRoutes(
             return (async () => {
                 try {
                     const data = await parseBodyOrThrow(req, UpdateWebhookRegistrationSchema);
-                    const updated = updateWebhookRegistration(db, id, data);
+                    const updated = updateWebhookRegistration(db, id, data, tenantId);
                     if (!updated) return json({ error: 'Webhook registration not found' }, 404);
                     return json(updated);
                 } catch (err) {
@@ -235,7 +238,7 @@ export function handleWebhookRoutes(
         }
 
         if (req.method === 'DELETE') {
-            const deleted = deleteWebhookRegistration(db, id);
+            const deleted = deleteWebhookRegistration(db, id, tenantId);
             if (!deleted) return json({ error: 'Webhook registration not found' }, 404);
             const ip = getClientIp(req);
             recordAudit(db, 'webhook_delete', ip, 'webhook', id, null, null, ip);

--- a/server/routes/work-tasks.ts
+++ b/server/routes/work-tasks.ts
@@ -1,4 +1,5 @@
 import type { WorkTaskService } from '../work/service';
+import type { RequestContext } from '../middleware/guards';
 import { parseBodyOrThrow, ValidationError, CreateWorkTaskSchema } from '../lib/validation';
 import { json, handleRouteError } from '../lib/response';
 
@@ -6,19 +7,21 @@ export function handleWorkTaskRoutes(
     req: Request,
     url: URL,
     workTaskService: WorkTaskService,
+    context?: RequestContext,
 ): Response | Promise<Response> | null {
     const path = url.pathname;
     const method = req.method;
+    const tenantId = context?.tenantId ?? 'default';
 
     // GET /api/work-tasks — list (optional ?agentId= filter)
     if (path === '/api/work-tasks' && method === 'GET') {
         const agentId = url.searchParams.get('agentId') ?? undefined;
-        return json(workTaskService.listTasks(agentId));
+        return json(workTaskService.listTasks(agentId, tenantId));
     }
 
     // POST /api/work-tasks — create
     if (path === '/api/work-tasks' && method === 'POST') {
-        return handleCreate(req, workTaskService);
+        return handleCreate(req, workTaskService, tenantId);
     }
 
     // POST /api/work-tasks/:id/cancel — cancel a running task
@@ -30,7 +33,7 @@ export function handleWorkTaskRoutes(
     // GET /api/work-tasks/:id — get single
     const idMatch = path.match(/^\/api\/work-tasks\/([^/]+)$/);
     if (idMatch && method === 'GET') {
-        const task = workTaskService.getTask(idMatch[1]);
+        const task = workTaskService.getTask(idMatch[1], tenantId);
         if (!task) return json({ error: 'Work task not found' }, 404);
         return json(task);
     }
@@ -44,7 +47,7 @@ async function handleCancel(taskId: string, workTaskService: WorkTaskService): P
     return json(task);
 }
 
-async function handleCreate(req: Request, workTaskService: WorkTaskService): Promise<Response> {
+async function handleCreate(req: Request, workTaskService: WorkTaskService, tenantId: string): Promise<Response> {
     try {
         const data = await parseBodyOrThrow(req, CreateWorkTaskSchema);
 
@@ -55,7 +58,7 @@ async function handleCreate(req: Request, workTaskService: WorkTaskService): Pro
             source: data.source,
             sourceId: data.sourceId,
             requesterInfo: data.requesterInfo,
-        });
+        }, tenantId);
 
         return json(task, 201);
     } catch (err) {

--- a/server/routes/workflows.ts
+++ b/server/routes/workflows.ts
@@ -1,5 +1,6 @@
 import type { Database } from 'bun:sqlite';
 import type { WorkflowService } from '../workflow/service';
+import type { RequestContext } from '../middleware/guards';
 import {
     listWorkflows,
     getWorkflow,
@@ -25,35 +26,38 @@ export function handleWorkflowRoutes(
     url: URL,
     db: Database,
     workflowService: WorkflowService | null,
+    context?: RequestContext,
 ): Response | Promise<Response> | null {
+    const tenantId = context?.tenantId ?? 'default';
+
     // List workflows
     if (url.pathname === '/api/workflows' && req.method === 'GET') {
         const agentId = url.searchParams.get('agentId') ?? undefined;
-        const workflows = listWorkflows(db, agentId);
+        const workflows = listWorkflows(db, agentId, tenantId);
         return json(workflows);
     }
 
     // Create workflow
     if (url.pathname === '/api/workflows' && req.method === 'POST') {
-        return handleCreateWorkflow(req, db);
+        return handleCreateWorkflow(req, db, tenantId);
     }
 
     // Get single workflow
     const workflowMatch = url.pathname.match(/^\/api\/workflows\/([^/]+)$/);
     if (workflowMatch && req.method === 'GET') {
-        const workflow = getWorkflow(db, workflowMatch[1]);
+        const workflow = getWorkflow(db, workflowMatch[1], tenantId);
         if (!workflow) return json({ error: 'Workflow not found' }, 404);
         return json(workflow);
     }
 
     // Update workflow
     if (workflowMatch && req.method === 'PUT') {
-        return handleUpdateWorkflow(req, db, workflowMatch[1]);
+        return handleUpdateWorkflow(req, db, workflowMatch[1], tenantId);
     }
 
     // Delete workflow
     if (workflowMatch && req.method === 'DELETE') {
-        const deleted = deleteWorkflow(db, workflowMatch[1]);
+        const deleted = deleteWorkflow(db, workflowMatch[1], tenantId);
         if (!deleted) return json({ error: 'Workflow not found' }, 404);
         return json({ ok: true });
     }
@@ -68,21 +72,21 @@ export function handleWorkflowRoutes(
     const runsMatch = url.pathname.match(/^\/api\/workflows\/([^/]+)\/runs$/);
     if (runsMatch && req.method === 'GET') {
         const limit = safeNumParam(url.searchParams.get('limit'), 50);
-        const runs = listWorkflowRuns(db, runsMatch[1], limit);
+        const runs = listWorkflowRuns(db, runsMatch[1], limit, tenantId);
         return json(runs);
     }
 
     // List all workflow runs
     if (url.pathname === '/api/workflow-runs' && req.method === 'GET') {
         const limit = safeNumParam(url.searchParams.get('limit'), 50);
-        const runs = listWorkflowRuns(db, undefined, limit);
+        const runs = listWorkflowRuns(db, undefined, limit, tenantId);
         return json(runs);
     }
 
     // Get single run (with node runs)
     const runMatch = url.pathname.match(/^\/api\/workflow-runs\/([^/]+)$/);
     if (runMatch && req.method === 'GET') {
-        const run = getWorkflowRun(db, runMatch[1]);
+        const run = getWorkflowRun(db, runMatch[1], tenantId);
         if (!run) return json({ error: 'Workflow run not found' }, 404);
         return json(run);
     }
@@ -111,10 +115,10 @@ export function handleWorkflowRoutes(
     return null;
 }
 
-async function handleCreateWorkflow(req: Request, db: Database): Promise<Response> {
+async function handleCreateWorkflow(req: Request, db: Database, tenantId: string): Promise<Response> {
     try {
         const data = await parseBodyOrThrow(req, CreateWorkflowSchema);
-        const workflow = createWorkflow(db, data);
+        const workflow = createWorkflow(db, data, tenantId);
         return json(workflow, 201);
     } catch (err) {
         if (err instanceof ValidationError) return badRequest(err.detail);
@@ -122,10 +126,10 @@ async function handleCreateWorkflow(req: Request, db: Database): Promise<Respons
     }
 }
 
-async function handleUpdateWorkflow(req: Request, db: Database, id: string): Promise<Response> {
+async function handleUpdateWorkflow(req: Request, db: Database, id: string, tenantId: string): Promise<Response> {
     try {
         const data = await parseBodyOrThrow(req, UpdateWorkflowSchema);
-        const workflow = updateWorkflow(db, id, data);
+        const workflow = updateWorkflow(db, id, data, tenantId);
         if (!workflow) return json({ error: 'Workflow not found' }, 404);
         return json(workflow);
     } catch (err) {

--- a/server/tenant/db-filter.ts
+++ b/server/tenant/db-filter.ts
@@ -54,6 +54,15 @@ export const TENANT_SCOPED_TABLES = [
     'agent_reputation',
     'sandbox_configs',
     'notification_channels',
+    'councils',
+    'council_launches',
+    'agent_schedules',
+    'schedule_executions',
+    'workflows',
+    'workflow_runs',
+    'mention_polling_configs',
+    'mcp_server_configs',
+    'webhook_registrations',
 ] as const;
 
 /**

--- a/server/work/service.ts
+++ b/server/work/service.ts
@@ -87,9 +87,9 @@ export class WorkTaskService {
             ?? resolve(dirname(projectWorkingDir), '.corvid-worktrees');
     }
 
-    async create(input: CreateWorkTaskInput): Promise<WorkTask> {
+    async create(input: CreateWorkTaskInput, tenantId?: string): Promise<WorkTask> {
         // Validate agent exists
-        const agent = getAgent(this.db, input.agentId);
+        const agent = getAgent(this.db, input.agentId, tenantId);
         if (!agent) {
             throw new NotFoundError('Agent', input.agentId);
         }
@@ -101,7 +101,7 @@ export class WorkTaskService {
         }
 
         // Validate project exists with a workingDir
-        const project = getProject(this.db, projectId);
+        const project = getProject(this.db, projectId, tenantId);
         if (!project) {
             throw new NotFoundError('Project', projectId);
         }
@@ -117,6 +117,7 @@ export class WorkTaskService {
             source: input.source,
             sourceId: input.sourceId,
             requesterInfo: input.requesterInfo,
+            tenantId,
         });
         if (!task) {
             throw new ConflictError('Another task is already active on project', { projectId });
@@ -252,12 +253,12 @@ export class WorkTaskService {
         return updated ?? task;
     }
 
-    getTask(id: string): WorkTask | null {
-        return getWorkTask(this.db, id);
+    getTask(id: string, tenantId?: string): WorkTask | null {
+        return getWorkTask(this.db, id, tenantId);
     }
 
-    listTasks(agentId?: string): WorkTask[] {
-        return dbListWorkTasks(this.db, agentId);
+    listTasks(agentId?: string, tenantId?: string): WorkTask[] {
+        return dbListWorkTasks(this.db, agentId, tenantId);
     }
 
     async cancelTask(id: string): Promise<WorkTask | null> {


### PR DESCRIPTION
## Summary
- Adds `tenant_id` column + index to 9 tables (councils, council_launches, agent_schedules, schedule_executions, workflows, workflow_runs, mention_polling_configs, mcp_server_configs, webhook_registrations) via migration 062
- Updates all DB CRUD functions in 7 modules with `withTenantFilter`/`validateTenantOwnership` for tenant-scoped reads and mutations
- Wires `RequestContext` through all 14 previously-unscoped route handlers (categories A–D) in `index.ts`
- Adds agent ownership validation for persona, skill-bundle, and sandbox routes
- Adds tenant-filtered SQL to analytics overview/spending/session queries

## Test plan
- [x] 43 new cross-tenant isolation tests (88 total, up from 45)
- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 4402/4402 pass
- [x] `bun run spec:check` — 38/38 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)