### PR TITLE
fix: resolve baseline migration schema drift

### DIFF
--- a/server/__tests__/migrate.test.ts
+++ b/server/__tests__/migrate.test.ts
@@ -288,6 +288,17 @@ describe('baseline migration (001_baseline.ts)', () => {
             expect(getCols(db1)).toEqual(getCols(db2));
         }
 
+        // Compare indexes (catches name mismatches like idx_foo_ts vs idx_foo_timestamp)
+        const getIndexes = (d: Database) =>
+            (d.query("SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%' ORDER BY name").all() as { name: string }[])
+                .map((i) => i.name);
+        expect(getIndexes(db1)).toEqual(getIndexes(db2));
+
+        // Compare schema versions
+        const getVersion = (d: Database) =>
+            (d.query('SELECT version FROM schema_version LIMIT 1').get() as { version: number })?.version;
+        expect(getVersion(db1)).toEqual(getVersion(db2));
+
         db1.close();
         db2.close();
     });

--- a/server/db/migrations/001_baseline.ts
+++ b/server/db/migrations/001_baseline.ts
@@ -12,7 +12,8 @@
  * - Fresh DBs run this to get to version 52's schema in one shot.
  *
  * Version 52 is the "bridge version" — the last legacy version and the
- * starting point for file-based migrations.
+ * starting point for file-based migrations. Tables introduced in versions
+ * 53+ are created by their own file-based migration (053–062).
  */
 
 import { Database } from 'bun:sqlite';
@@ -894,18 +895,6 @@ export function up(db: Database): void {
     safeAlter(db, `ALTER TABLE agent_messages ADD COLUMN fire_and_forget INTEGER DEFAULT 0`);
     safeAlter(db, `ALTER TABLE agent_messages ADD COLUMN message_version INTEGER DEFAULT 1`);
     safeAlter(db, `ALTER TABLE agent_messages ADD COLUMN error_code TEXT DEFAULT NULL`);
-
-    // ── v61: Server health snapshots (uptime monitoring) ─────────────────
-    db.exec(`CREATE TABLE IF NOT EXISTS server_health_snapshots (
-        id              INTEGER PRIMARY KEY AUTOINCREMENT,
-        timestamp       TEXT    NOT NULL DEFAULT (datetime('now')),
-        status          TEXT    NOT NULL,
-        response_time_ms INTEGER DEFAULT NULL,
-        dependencies    TEXT    DEFAULT NULL,
-        source          TEXT    NOT NULL DEFAULT 'internal'
-    )`);
-    db.exec(`CREATE INDEX IF NOT EXISTS idx_server_health_snap_ts ON server_health_snapshots(timestamp)`);
-    db.exec(`CREATE INDEX IF NOT EXISTS idx_server_health_snap_status ON server_health_snapshots(status)`);
 }
 
 /**
@@ -923,8 +912,6 @@ export function down(db: Database): void {
 
     // Drop tables in reverse dependency order
     const tables = [
-        'server_health_snapshots',
-        'performance_metrics',
         'project_skills',
         'agent_skills',
         'skill_bundles',

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,6 +1,6 @@
 import { Database } from 'bun:sqlite';
 
-const SCHEMA_VERSION = 58;
+const SCHEMA_VERSION = 62;
 
 const MIGRATIONS: Record<number, string[]> = {
     1: [


### PR DESCRIPTION
## Summary
- Removes mislabeled v61 server_health_snapshots section from baseline migration (001) — this table is properly created by `060_health_snapshots.ts` with correct index names
- Fixes baseline `down()` dropping tables it never created (`performance_metrics`, `server_health_snapshots`)
- Updates `SCHEMA_VERSION` from 58 to 62 to match actual inline migration count
- Adds index parity and version parity assertions to the migration drift test

## Root cause
The baseline migration included `server_health_snapshots` with shortened index names (`idx_server_health_snap_ts`) while `060_health_snapshots.ts` used full names (`idx_server_health_snapshots_timestamp`). Since both used `CREATE INDEX IF NOT EXISTS` with different names, the file-based path ended up with 4 indexes on that table instead of 2. The stale `SCHEMA_VERSION=58` also meant the legacy path relied entirely on `reconcileTables()` for migrations 59-62.

## Test plan
- [x] Migration tests pass (17/17, 136 expects)
- [x] Full suite: 4416 pass (1 pre-existing logger test failure unrelated to this PR)
- [x] `tsc --noEmit` clean
- [x] Verified zero schema drift between file-based and legacy paths (tables, columns, indexes, version)

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)