### PR TITLE
chore: move off-limits repos to .claude config file

### DIFF
--- a/.claude/off-limits-repos.txt
+++ b/.claude/off-limits-repos.txt
@@ -1,0 +1,6 @@
+# Contributor-owned repos — do not create issues, PRs, or commits
+# unless explicitly asked by the repo owner.
+CorvidLabs/rust-server
+CorvidLabs/rust-game
+CorvidLabs/rust-ui
+CorvidLabs/rust-learning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,16 +150,10 @@ Protected files cannot be modified even in full-auto mode.
 4. **Respect blocked-by markers.** If an issue has `<!-- blocked-by: #N -->` in its body or comments, do not work on it until the blocking issue is closed.
 5. **When reviewing human PRs,** be constructive and help get the PR merged. Don't nag about timeline — offer to help fix issues instead.
 
-### Off-Limits Repositories
+### Contributor-Owned Repositories
 
-Do **not** create issues, PRs, commits, or any code contributions on these repos unless explicitly asked by the repo owner or assigned maintainer:
-
-- `CorvidLabs/rust-server` — 0xGaspar's project
-- `CorvidLabs/rust-game` — 0xGaspar's project
-- `CorvidLabs/rust-ui` — 0xGaspar's project
-- `CorvidLabs/rust-learning` — 0xGaspar's project
-
-These repos belong to human contributors. Helping is welcome **only when asked**. Filing issues, planning roadmaps, or submitting unsolicited PRs on these repos is not allowed.
+Some repos are owned by human contributors and are off-limits for autonomous agent work.
+See `.claude/off-limits-repos.txt` for the list. Do **not** create issues, PRs, commits, or any code contributions on those repos unless explicitly asked by the repo owner or assigned maintainer. Helping is welcome **only when asked**.
 
 ### Focus Priorities
 


### PR DESCRIPTION
## Summary
- Replaces the "Off-Limits Repositories" section in CLAUDE.md that named specific contributors with a generic "Contributor-Owned Repositories" section
- Moves the specific repo list to `.claude/off-limits-repos.txt` (private config, not prominent in project docs)
- No behavior change — same repos are still off-limits for autonomous agent work

## Test plan
- [x] CLAUDE.md still references off-limits repos via the config file
- [x] `.claude/off-limits-repos.txt` contains the correct repo list

🤖 Generated with [Claude Code](https://claude.com/claude-code)