### PR TITLE
security: pin GH Actions to SHA, add permissions, pin Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build & Test (${{ matrix.os }})
@@ -19,9 +22,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: oven-sh/setup-bun@v2.1.2
+      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2.1.2
         with:
           bun-version: "1.3.8"
 
@@ -50,9 +53,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: oven-sh/setup-bun@v2.1.2
+      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2.1.2
         with:
           bun-version: "1.3.8"
 
@@ -67,7 +70,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de  # v5
         with:
           files: coverage/server/lcov.info,coverage/client/lcov.info
           flags: server,client
@@ -82,7 +85,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Approve or request changes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -106,9 +109,9 @@ jobs:
     # Tests that need external services are skipped gracefully in CI.
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: oven-sh/setup-bun@v2.1.2
+      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2.1.2
         with:
           bun-version: "1.3.8"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,15 +24,15 @@ jobs:
         language: [javascript-typescript]
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7aefa1c9aed02ae41531ec219164e64a0f087410  # v4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
-      - uses: oven-sh/setup-bun@v2.1.2
+      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2.1.2
         with:
           bun-version: "1.3.8"
 
@@ -40,6 +40,6 @@ jobs:
         run: bun install
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7aefa1c9aed02ae41531ec219164e64a0f087410  # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,16 +26,16 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up QEMU (multi-platform)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -53,7 +53,7 @@ jobs:
             type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           file: deploy/Dockerfile

--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -6,6 +6,10 @@ on:
     - cron: '*/5 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   health-check:
     name: Health Check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -83,7 +83,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2
         with:
           tag_name: ${{ steps.tag.outputs.version }}
           name: ${{ steps.tag.outputs.version }}

--- a/.github/workflows/task-check.yml
+++ b/.github/workflows/task-check.yml
@@ -4,13 +4,16 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+permissions:
+  pull-requests: read
+
 jobs:
   check-tasks:
     name: Task list complete
     runs-on: ubuntu-latest
     steps:
       - name: Check for unchecked task items
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Build Angular client ────────────────────────────────
-FROM oven/bun:1.3.8 AS client-build
+FROM oven/bun:1.3.8@sha256:371d30538b69303ced927bb5915697ac7e2fa8cb409ee332c66009de64de5aa3 AS client-build
 WORKDIR /app/client
 
 # Install client dependencies
@@ -14,7 +14,7 @@ COPY client/ .
 RUN bun run build
 
 # ── Stage 2: Production image ───────────────────────────────────
-FROM oven/bun:1.3.8 AS production
+FROM oven/bun:1.3.8@sha256:371d30538b69303ced927bb5915697ac7e2fa8cb409ee332c66009de64de5aa3 AS production
 WORKDIR /app
 
 # Install server dependencies only

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -25,6 +25,14 @@ services:
       - LOCALNET_ALGOD_URL=${LOCALNET_ALGOD_URL:-}
       - LOCALNET_KMD_URL=${LOCALNET_KMD_URL:-}
       - LOCALNET_INDEXER_URL=${LOCALNET_INDEXER_URL:-}
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 2G
+        reservations:
+          cpus: "0.5"
+          memory: 512M
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "bun", "-e", "const r = await fetch('http://localhost:3000/health/ready'); process.exit(r.ok ? 0 : 1)"]

--- a/server/sandbox/Dockerfile.agent
+++ b/server/sandbox/Dockerfile.agent
@@ -4,7 +4,7 @@
 # Build:  docker build -t corvid-agent-sandbox:latest -f server/sandbox/Dockerfile.agent .
 # Usage:  Managed by SandboxManager — not invoked directly.
 
-FROM oven/bun:1-slim
+FROM oven/bun:1-slim@sha256:5d5863f35ad9b3acceee8dc134fb2b89f07831129eaeec81af2b19a23dabe3e0
 
 # Install git (needed for agent work tasks) and basic tools
 RUN apt-get update && \


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to commit SHA hashes across 6 workflow files for supply-chain safety (security.yml was already compliant — used as reference)
- Add explicit `permissions` blocks to `ci.yml`, `heartbeat.yml`, and `task-check.yml` (principle of least privilege)
- Pin Dockerfile base images (`oven/bun:1-slim`, `oven/bun:1.3.8`) to digest hashes
- Add CPU/memory resource limits to `docker-compose.yml` (2 CPU / 2GB limit, 0.5 CPU / 512MB reservation)

## Test plan
- [x] All 4417 tests pass
- [x] TypeScript check passes
- [x] YAML syntax verified (no parse errors)
- [x] SHA hashes verified via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`
- [x] Docker digests verified via Docker Hub API

Closes #462, closes #464, closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)