### PR TITLE
security: add SSRF private IP range blocking

### DIFF
--- a/server/__tests__/ssrf-guard.test.ts
+++ b/server/__tests__/ssrf-guard.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'bun:test';
+import {
+    isPrivateIPv4,
+    isPrivateIPv6,
+    isPrivateIP,
+    validateUrlTarget,
+} from '../lib/ssrf-guard';
+
+// ── isPrivateIPv4 ────────────────────────────────────────────────────
+
+describe('isPrivateIPv4', () => {
+    test('blocks RFC1918 10.x.x.x', () => {
+        expect(isPrivateIPv4('10.0.0.1')).toBe(true);
+        expect(isPrivateIPv4('10.255.255.255')).toBe(true);
+    });
+
+    test('blocks RFC1918 172.16-31.x.x', () => {
+        expect(isPrivateIPv4('172.16.0.1')).toBe(true);
+        expect(isPrivateIPv4('172.31.255.255')).toBe(true);
+    });
+
+    test('allows 172.32.x.x (outside range)', () => {
+        expect(isPrivateIPv4('172.32.0.1')).toBe(false);
+    });
+
+    test('blocks RFC1918 192.168.x.x', () => {
+        expect(isPrivateIPv4('192.168.0.1')).toBe(true);
+        expect(isPrivateIPv4('192.168.255.255')).toBe(true);
+    });
+
+    test('blocks loopback 127.x.x.x', () => {
+        expect(isPrivateIPv4('127.0.0.1')).toBe(true);
+        expect(isPrivateIPv4('127.255.255.255')).toBe(true);
+    });
+
+    test('blocks link-local 169.254.x.x', () => {
+        expect(isPrivateIPv4('169.254.0.1')).toBe(true);
+        expect(isPrivateIPv4('169.254.169.254')).toBe(true); // AWS metadata
+    });
+
+    test('blocks 0.0.0.0/8', () => {
+        expect(isPrivateIPv4('0.0.0.0')).toBe(true);
+    });
+
+    test('blocks CGN shared 100.64.x.x', () => {
+        expect(isPrivateIPv4('100.64.0.1')).toBe(true);
+        expect(isPrivateIPv4('100.127.255.255')).toBe(true);
+    });
+
+    test('blocks multicast 224+', () => {
+        expect(isPrivateIPv4('224.0.0.1')).toBe(true);
+        expect(isPrivateIPv4('239.255.255.255')).toBe(true);
+    });
+
+    test('allows public IPs', () => {
+        expect(isPrivateIPv4('8.8.8.8')).toBe(false);
+        expect(isPrivateIPv4('1.1.1.1')).toBe(false);
+        expect(isPrivateIPv4('93.184.216.34')).toBe(false);
+        expect(isPrivateIPv4('203.0.114.0')).toBe(false);
+    });
+
+    test('rejects malformed addresses', () => {
+        expect(isPrivateIPv4('not-an-ip')).toBe(false);
+        expect(isPrivateIPv4('256.1.1.1')).toBe(false);
+        expect(isPrivateIPv4('1.2.3')).toBe(false);
+    });
+});
+
+// ── isPrivateIPv6 ────────────────────────────────────────────────────
+
+describe('isPrivateIPv6', () => {
+    test('blocks loopback ::1', () => {
+        expect(isPrivateIPv6('::1')).toBe(true);
+    });
+
+    test('blocks unique local fc00::/7', () => {
+        expect(isPrivateIPv6('fc00::1')).toBe(true);
+        expect(isPrivateIPv6('fd12:3456::1')).toBe(true);
+    });
+
+    test('blocks link-local fe80::', () => {
+        expect(isPrivateIPv6('fe80::1')).toBe(true);
+    });
+
+    test('blocks IPv4-mapped private', () => {
+        expect(isPrivateIPv6('::ffff:127.0.0.1')).toBe(true);
+        expect(isPrivateIPv6('::ffff:10.0.0.1')).toBe(true);
+        expect(isPrivateIPv6('::ffff:192.168.1.1')).toBe(true);
+    });
+
+    test('allows IPv4-mapped public', () => {
+        expect(isPrivateIPv6('::ffff:8.8.8.8')).toBe(false);
+    });
+
+    test('blocks multicast ff::', () => {
+        expect(isPrivateIPv6('ff02::1')).toBe(true);
+    });
+
+    test('allows public IPv6', () => {
+        expect(isPrivateIPv6('2001:4860:4860::8888')).toBe(false);
+    });
+});
+
+// ── isPrivateIP (unified) ────────────────────────────────────────────
+
+describe('isPrivateIP', () => {
+    test('dispatches IPv4', () => {
+        expect(isPrivateIP('10.0.0.1')).toBe(true);
+        expect(isPrivateIP('8.8.8.8')).toBe(false);
+    });
+
+    test('dispatches IPv6', () => {
+        expect(isPrivateIP('::1')).toBe(true);
+        expect(isPrivateIP('2001:4860:4860::8888')).toBe(false);
+    });
+});
+
+// ── validateUrlTarget ────────────────────────────────────────────────
+
+describe('validateUrlTarget', () => {
+    test('blocks direct private IP URLs', async () => {
+        const result = await validateUrlTarget('http://127.0.0.1:8080/admin');
+        expect(result).toContain('private/reserved');
+    });
+
+    test('blocks 169.254.169.254 (cloud metadata)', async () => {
+        const result = await validateUrlTarget('http://169.254.169.254/latest/meta-data/');
+        expect(result).toContain('private/reserved');
+    });
+
+    test('blocks 10.x private network', async () => {
+        const result = await validateUrlTarget('http://10.0.0.1/internal');
+        expect(result).toContain('private/reserved');
+    });
+
+    test('rejects invalid URLs', async () => {
+        const result = await validateUrlTarget('not-a-url');
+        expect(result).toBe('Invalid URL');
+    });
+
+    test('allows public URLs', async () => {
+        const result = await validateUrlTarget('https://api.github.com/repos');
+        expect(result).toBeNull();
+    });
+});

--- a/server/lib/ssrf-guard.ts
+++ b/server/lib/ssrf-guard.ts
@@ -1,0 +1,160 @@
+/**
+ * SSRF (Server-Side Request Forgery) protection.
+ *
+ * Validates URLs before making outbound HTTP requests to ensure they
+ * don't resolve to private/internal IP ranges. Prevents agents and
+ * user-supplied URLs from reaching internal infrastructure.
+ */
+
+import { createLogger } from './logger';
+
+const log = createLogger('SSRFGuard');
+
+/**
+ * IPv4 private and reserved ranges that should never be reached
+ * by outbound server requests.
+ *
+ * Each entry: [startIP (as 32-bit integer), mask (as 32-bit integer), label]
+ */
+const BLOCKED_IPV4_RANGES: Array<[number, number, string]> = [
+    [ip4ToInt('10.0.0.0'), cidrMask(8), 'RFC1918 10/8'],
+    [ip4ToInt('172.16.0.0'), cidrMask(12), 'RFC1918 172.16/12'],
+    [ip4ToInt('192.168.0.0'), cidrMask(16), 'RFC1918 192.168/16'],
+    [ip4ToInt('127.0.0.0'), cidrMask(8), 'Loopback'],
+    [ip4ToInt('169.254.0.0'), cidrMask(16), 'Link-local'],
+    [ip4ToInt('0.0.0.0'), cidrMask(8), 'Current network'],
+    [ip4ToInt('100.64.0.0'), cidrMask(10), 'CGN shared'],
+    [ip4ToInt('192.0.0.0'), cidrMask(24), 'IETF protocol'],
+    [ip4ToInt('192.0.2.0'), cidrMask(24), 'TEST-NET-1'],
+    [ip4ToInt('198.51.100.0'), cidrMask(24), 'TEST-NET-2'],
+    [ip4ToInt('203.0.113.0'), cidrMask(24), 'TEST-NET-3'],
+    [ip4ToInt('224.0.0.0'), cidrMask(4), 'Multicast'],
+    [ip4ToInt('240.0.0.0'), cidrMask(4), 'Reserved'],
+];
+
+/**
+ * IPv6 prefixes that should be blocked.
+ * Checked as lowercase hex prefix matches.
+ */
+const BLOCKED_IPV6_PREFIXES = [
+    '::1',          // Loopback
+    '::ffff:',      // IPv4-mapped (checked separately with v4 rules)
+    'fc',           // Unique local (fc00::/7)
+    'fd',           // Unique local (fc00::/7)
+    'fe80:',        // Link-local
+    'ff',           // Multicast
+];
+
+/** Convert dotted IPv4 string to 32-bit integer. */
+function ip4ToInt(ip: string): number {
+    const parts = ip.split('.').map(Number);
+    return ((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0;
+}
+
+/** Create a CIDR bitmask for the given prefix length. */
+function cidrMask(bits: number): number {
+    return bits === 0 ? 0 : (~0 << (32 - bits)) >>> 0;
+}
+
+/**
+ * Check whether an IPv4 address string falls in a private/reserved range.
+ */
+export function isPrivateIPv4(ip: string): boolean {
+    const parts = ip.split('.');
+    if (parts.length !== 4) return false;
+
+    const nums = parts.map(Number);
+    if (nums.some((n) => isNaN(n) || n < 0 || n > 255)) return false;
+
+    const addr = ip4ToInt(ip);
+    for (const [start, mask] of BLOCKED_IPV4_RANGES) {
+        if ((addr & mask) === (start & mask)) return true;
+    }
+    return false;
+}
+
+/**
+ * Check whether an IPv6 address string falls in a private/reserved range.
+ * Also handles IPv4-mapped IPv6 addresses (::ffff:x.x.x.x).
+ */
+export function isPrivateIPv6(ip: string): boolean {
+    const lower = ip.toLowerCase();
+
+    // IPv4-mapped IPv6 — extract the v4 portion and check it
+    const v4Mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (v4Mapped) return isPrivateIPv4(v4Mapped[1]);
+
+    for (const prefix of BLOCKED_IPV6_PREFIXES) {
+        if (lower === prefix || lower.startsWith(prefix)) return true;
+    }
+
+    return false;
+}
+
+/**
+ * Check whether an IP address (v4 or v6) is private/reserved.
+ */
+export function isPrivateIP(ip: string): boolean {
+    if (ip.includes(':')) return isPrivateIPv6(ip);
+    return isPrivateIPv4(ip);
+}
+
+/**
+ * Resolve a hostname to its IP addresses and check if any are private.
+ * Returns the blocking reason if blocked, or null if safe.
+ */
+export async function validateUrlTarget(url: string): Promise<string | null> {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return 'Invalid URL';
+    }
+
+    const hostname = parsed.hostname;
+
+    // Direct IP check (no DNS needed)
+    if (isPrivateIP(hostname)) {
+        return `Blocked: ${hostname} is a private/reserved IP`;
+    }
+
+    // DNS resolution check
+    try {
+        const { resolve4, resolve6 } = await import('node:dns/promises');
+        const results: string[] = [];
+
+        try {
+            const v4 = await resolve4(hostname);
+            results.push(...v4);
+        } catch {
+            // No A records — fine
+        }
+
+        try {
+            const v6 = await resolve6(hostname);
+            results.push(...v6);
+        } catch {
+            // No AAAA records — fine
+        }
+
+        for (const ip of results) {
+            if (isPrivateIP(ip)) {
+                log.warn('SSRF blocked: DNS resolved to private IP', {
+                    url,
+                    hostname,
+                    resolvedIp: ip,
+                });
+                return `Blocked: ${hostname} resolves to private IP ${ip}`;
+            }
+        }
+    } catch (err) {
+        // DNS resolution failed entirely — could be a non-existent domain.
+        // Don't block on DNS failure; let the actual fetch handle it.
+        log.debug('DNS resolution failed for SSRF check', {
+            hostname,
+            error: err instanceof Error ? err.message : String(err),
+        });
+    }
+
+    return null;
+}


### PR DESCRIPTION
## Summary
- New `server/lib/ssrf-guard.ts` module with comprehensive private IP range detection
- Blocks all RFC1918, loopback, link-local, CGN shared, multicast, and reserved ranges (IPv4)
- Blocks IPv6 unique local (fc00::/7), link-local (fe80::), multicast, and loopback (::1)
- Handles IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)
- `validateUrlTarget()` async function performs DNS resolution and checks all resolved IPs
- 25 unit tests covering all blocked ranges, edge cases, and async validation

**Integration note:** Call sites (e.g. `web-search.ts`, health checks) should call `validateUrlTarget(url)` before making outbound requests. This PR provides the guard library; integration into specific call sites can follow.

## Test plan
- [x] 25 new SSRF guard tests pass
- [x] All 4442 tests pass
- [x] TypeScript check passes

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)