### PR TITLE
ci: extract composite action for workspace setup

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -1,0 +1,38 @@
+name: Setup Workspace
+description: Install Bun, cache dependencies, and install packages (repo must already be checked out)
+
+inputs:
+  bun-version:
+    description: Bun version to install
+    required: false
+    default: "1.3.8"
+  install-client:
+    description: Also install client dependencies
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2.1.2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Cache Bun dependencies
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+      with:
+        path: |
+          ~/.bun/install/cache
+          node_modules
+          client/node_modules
+        key: bun-${{ runner.os }}-${{ hashFiles('bun.lock', 'client/bun.lock') }}
+        restore-keys: |
+          bun-${{ runner.os }}-
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        bun install
+        if [ "${{ inputs.install-client }}" = "true" ]; then
+          cd client && bun install
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2.1.2
-        with:
-          bun-version: "1.3.8"
-
-      - name: Install dependencies
-        run: bun install && cd client && bun install
+      - uses: ./.github/actions/setup-workspace
 
       - name: TypeScript check
         run: bunx tsc --noEmit --skipLibCheck
@@ -54,13 +48,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2.1.2
-        with:
-          bun-version: "1.3.8"
-
-      - name: Install dependencies
-        run: bun install && cd client && bun install
+      - uses: ./.github/actions/setup-workspace
 
       - name: Server tests with coverage
         run: bun test --coverage --coverage-reporter=lcov --coverage-dir=coverage/server
@@ -105,18 +93,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: build
-    # E2E tests require a running server and may need Claude API for some tests.
-    # Tests that need external services are skipped gracefully in CI.
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2.1.2
-        with:
-          bun-version: "1.3.8"
-
-      - name: Install dependencies
-        run: bun install && cd client && bun install
+      - uses: ./.github/actions/setup-workspace
 
       - name: Build client
         run: bun run build:client


### PR DESCRIPTION
## Summary
- Extracts repeated Bun setup, dependency caching, and package install into `.github/actions/setup-workspace` composite action
- Build, coverage, and E2E jobs now use `uses: ./.github/actions/setup-workspace` instead of duplicating setup steps
- Adds Bun dependency caching (keyed on `bun.lock` hashes) — was not present before

## Changes
- **New:** `.github/actions/setup-workspace/action.yml` — composite action with `setup-bun`, `actions/cache`, and `bun install` (all SHA-pinned)
- **Modified:** `.github/workflows/ci.yml` — 3 jobs use composite action, review job unchanged (only needs checkout)

Closes #458

## Test plan
- [x] CI runs successfully on this PR (validates the composite action works)
- [x] Verify caching works on second run (cache hit in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)