### PR TITLE
fix: add missing subscription_items table for UsageMeter

### DIFF
--- a/server/__tests__/routes-billing.test.ts
+++ b/server/__tests__/routes-billing.test.ts
@@ -152,4 +152,61 @@ describe('Billing Routes', () => {
         expect(data[0].tenantId).toBe(tenantId);
         expect(data[0].amountCents).toBe(5000);
     });
+
+    // ─── Subscription Items ───────────────────────────────────────────────────
+
+    it('POST /api/billing/subscription creates with stripeItems', async () => {
+        const itemTenantId = crypto.randomUUID();
+        db.query(
+            "INSERT INTO tenants (id, name, slug, owner_email) VALUES (?, 'Items Tenant', ?, 'items@example.com')",
+        ).run(itemTenantId, `items-tenant-${Date.now()}`);
+
+        const { req, url } = fakeReq('POST', '/api/billing/subscription', {
+            tenantId: itemTenantId,
+            stripeSubscriptionId: 'sub_items_123',
+            plan: 'pro',
+            periodStart: '2026-03-01T00:00:00Z',
+            periodEnd: '2026-04-01T00:00:00Z',
+            stripeItems: [{ id: 'si_metered_001', priceId: 'price_metered_001' }],
+        });
+        const res = await handleBillingRoutes(req, url, db, billing, meter)!;
+        expect(res!.status).toBe(201);
+
+        // Verify subscription_items table has the item
+        const items = db.query(
+            'SELECT * FROM subscription_items WHERE stripe_item_id = ?',
+        ).all('si_metered_001') as Array<{ stripe_item_id: string; stripe_price_id: string }>;
+        expect(items.length).toBe(1);
+        expect(items[0].stripe_price_id).toBe('price_metered_001');
+    });
+
+    // ─── UsageMeter.reportAll() ───────────────────────────────────────────────
+
+    it('reportAll() runs without error on subscription_items table', async () => {
+        // reportAll should query successfully now that subscription_items exists
+        const result = await meter.reportAll();
+        expect(typeof result.reported).toBe('number');
+        expect(typeof result.failed).toBe('number');
+    });
+
+    it('reportAll() skips records without subscription items', async () => {
+        // Create a tenant with subscription and usage but no subscription items
+        const noItemTenantId = crypto.randomUUID();
+        db.query(
+            "INSERT INTO tenants (id, name, slug, owner_email) VALUES (?, 'NoItem Tenant', ?, 'noitem@example.com')",
+        ).run(noItemTenantId, `noitem-tenant-${Date.now()}`);
+
+        billing.createSubscription(
+            noItemTenantId,
+            'sub_noitem_123',
+            'pro',
+            '2026-03-01T00:00:00Z',
+            '2026-04-01T00:00:00Z',
+        );
+        billing.recordUsage(noItemTenantId, 100, 5, 1);
+
+        const result = await meter.reportAll();
+        // Should succeed but report 0 — skips records without stripe_item_id
+        expect(result.reported).toBe(0);
+    });
 });

--- a/server/billing/service.ts
+++ b/server/billing/service.ts
@@ -79,6 +79,7 @@ export class BillingService {
         plan: string,
         periodStart: string,
         periodEnd: string,
+        stripeItems?: Array<{ id: string; priceId?: string }>,
     ): Subscription {
         const id = crypto.randomUUID();
         this.db.query(`
@@ -87,6 +88,13 @@ export class BillingService {
                  current_period_start, current_period_end)
             VALUES (?, ?, ?, ?, 'active', ?, ?)
         `).run(id, tenantId, stripeSubscriptionId, plan, periodStart, periodEnd);
+
+        // Persist Stripe subscription item IDs for metered billing
+        if (stripeItems) {
+            for (const item of stripeItems) {
+                this.addSubscriptionItem(id, item.id, item.priceId);
+            }
+        }
 
         log.info('Created subscription', { tenantId, plan, stripeSubscriptionId });
         return this.getSubscription(tenantId)!;
@@ -105,6 +113,21 @@ export class BillingService {
             SET status = ?, updated_at = datetime('now')
             WHERE tenant_id = ? AND status != 'canceled'
         `).run(status, tenantId);
+    }
+
+    /**
+     * Add a Stripe subscription item to a local subscription.
+     */
+    addSubscriptionItem(
+        subscriptionId: string,
+        stripeItemId: string,
+        stripePriceId?: string,
+    ): void {
+        const id = crypto.randomUUID();
+        this.db.query(`
+            INSERT INTO subscription_items (id, subscription_id, stripe_item_id, stripe_price_id)
+            VALUES (?, ?, ?, ?)
+        `).run(id, subscriptionId, stripeItemId, stripePriceId ?? null);
     }
 
     cancelSubscription(tenantId: string, atPeriodEnd: boolean = true): void {

--- a/server/db/migrations/001_baseline.ts
+++ b/server/db/migrations/001_baseline.ts
@@ -753,6 +753,15 @@ export function up(db: Database): void {
         updated_at TEXT DEFAULT (datetime('now'))
     )`);
     db.exec(`CREATE INDEX IF NOT EXISTS idx_subscriptions_tenant ON subscriptions(tenant_id)`);
+    db.exec(`CREATE TABLE IF NOT EXISTS subscription_items (
+        id TEXT PRIMARY KEY,
+        subscription_id TEXT NOT NULL,
+        stripe_item_id TEXT NOT NULL,
+        stripe_price_id TEXT DEFAULT NULL,
+        created_at TEXT DEFAULT (datetime('now')),
+        FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_subscription_items_sub ON subscription_items(subscription_id)`);
     db.exec(`CREATE TABLE IF NOT EXISTS usage_records (
         id TEXT PRIMARY KEY,
         tenant_id TEXT NOT NULL,
@@ -920,6 +929,7 @@ export function down(db: Database): void {
         'health_snapshots',
         'invoices',
         'usage_records',
+        'subscription_items',
         'subscriptions',
         'api_keys',
         'tenants',

--- a/server/db/migrations/063_subscription_items.ts
+++ b/server/db/migrations/063_subscription_items.ts
@@ -1,0 +1,25 @@
+/**
+ * Migration 063: Add subscription_items table.
+ *
+ * Links Stripe subscription item IDs to local subscriptions,
+ * enabling the UsageMeter to report metered usage to Stripe.
+ * Previously, reportAll() failed because this table was missing.
+ */
+
+import { Database } from 'bun:sqlite';
+
+export function up(db: Database): void {
+    db.exec(`CREATE TABLE IF NOT EXISTS subscription_items (
+        id TEXT PRIMARY KEY,
+        subscription_id TEXT NOT NULL,
+        stripe_item_id TEXT NOT NULL,
+        stripe_price_id TEXT DEFAULT NULL,
+        created_at TEXT DEFAULT (datetime('now')),
+        FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE
+    )`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_subscription_items_sub ON subscription_items(subscription_id)`);
+}
+
+export function down(db: Database): void {
+    db.exec('DROP TABLE IF EXISTS subscription_items');
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,6 +1,6 @@
 import { Database } from 'bun:sqlite';
 
-const SCHEMA_VERSION = 62;
+const SCHEMA_VERSION = 63;
 
 const MIGRATIONS: Record<number, string[]> = {
     1: [
@@ -1194,6 +1194,19 @@ const MIGRATIONS: Record<number, string[]> = {
         `CREATE INDEX IF NOT EXISTS idx_mcp_server_configs_tenant ON mcp_server_configs(tenant_id)`,
         `ALTER TABLE webhook_registrations ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'`,
         `CREATE INDEX IF NOT EXISTS idx_webhook_registrations_tenant ON webhook_registrations(tenant_id)`,
+    ],
+    63: [
+        // Subscription items — links Stripe subscription item IDs to local subscriptions
+        // Required by UsageMeter to report metered usage to Stripe
+        `CREATE TABLE IF NOT EXISTS subscription_items (
+            id TEXT PRIMARY KEY,
+            subscription_id TEXT NOT NULL,
+            stripe_item_id TEXT NOT NULL,
+            stripe_price_id TEXT DEFAULT NULL,
+            created_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE
+        )`,
+        `CREATE INDEX IF NOT EXISTS idx_subscription_items_sub ON subscription_items(subscription_id)`,
     ],
 };
 

--- a/server/lib/validation.ts
+++ b/server/lib/validation.ts
@@ -550,6 +550,10 @@ export const CreateSubscriptionSchema = z.object({
     plan: z.string().min(1, 'plan is required'),
     periodStart: z.string().min(1, 'periodStart is required'),
     periodEnd: z.string().min(1, 'periodEnd is required'),
+    stripeItems: z.array(z.object({
+        id: z.string().min(1),
+        priceId: z.string().optional(),
+    })).optional(),
 });
 
 // ─── Personas ───────────────────────────────────────────────────────────────

--- a/server/routes/billing.ts
+++ b/server/routes/billing.ts
@@ -94,6 +94,7 @@ async function handleCreateSubscription(
             body.plan,
             body.periodStart,
             body.periodEnd,
+            body.stripeItems,
         );
 
         return json(sub, 201);


### PR DESCRIPTION
## Summary
- Adds the `subscription_items` table that `UsageMeter.reportAll()` queries via LEFT JOIN but was never created
- The missing table caused the hourly metering cycle to fail silently every hour — usage was never reported to Stripe
- `BillingService.createSubscription()` now accepts optional `stripeItems` array to persist Stripe subscription item IDs at creation time

## Changes
- **Migration 063**: Creates `subscription_items` table with FK to `subscriptions`
- **Baseline migration**: Updated with new table and drop order
- **BillingService**: New `addSubscriptionItem()` method; `createSubscription()` accepts `stripeItems`
- **Validation schema**: `CreateSubscriptionSchema` accepts optional `stripeItems` array
- **Tests**: 3 new tests covering subscription item persistence and `reportAll()` execution

Closes #472

## Test plan
- [x] All 4445 tests pass (3 new)
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun run spec:check` passes
- [x] Migration baseline test confirms schema parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)