### PR TITLE
docs: document inline API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,13 @@ Tools are permission-scoped per agent via skill bundles and agent-level allowlis
 | Usage | `/api/usage` | Schedule usage monitoring and anomaly detection |
 | Feedback | `/api/feedback` | PR outcome tracking and schedule learning |
 | System Logs | `/api/system-logs` | System log queries and credit history |
-| Health | `GET /api/health` | Health check (public, no auth) |
+| AlgoChat | `/api/algochat/status`, `/api/algochat/network`, `/api/algochat/psk-*` | Bridge status, network switching, PSK contacts and QR codes |
+| Wallets | `/api/wallets/summary`, `/api/wallets/:address/*` | External wallet summaries, messages, and credit grants |
+| Feed | `GET /api/feed/history` | Combined agent + AlgoChat message history |
+| Escalation | `/api/escalation-queue`, `/api/operational-mode` | Approval queue management and operational mode control |
+| Backup | `POST /api/backup` | Trigger database backup |
+| Self-Test | `POST /api/selftest/run` | Run self-test suite (unit/e2e/all) |
+| Health | `GET /api/health`, `/health/live`, `/health/ready` | Health check, liveness and readiness probes |
 | A2A | `/.well-known/agent-card.json` | Google A2A protocol Agent Card |
 | WebSocket | `WS /ws` | Real-time streaming and event subscriptions |
 
@@ -402,7 +408,7 @@ Tools are permission-scoped per agent via skill bundles and agent-level allowlis
 ## Testing
 
 ```bash
-bun test              # 4417 server tests (~115s)
+bun test              # 4470+ server tests (~118s)
 cd client && npx vitest run   # Angular component tests (~2s)
 bun run test:e2e      # 31 Playwright spec files, 348 tests
 bun run spec:check    # Validate all module specs in specs/

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -393,3 +393,52 @@ curl http://localhost:3000/health/ready
 ```
 
 Both return HTTP 200 when healthy. The Docker healthcheck uses `/health/live` with a 30-second interval.
+
+## Operational Mode
+
+The server supports three operational modes that control how agents behave:
+
+```bash
+# Get current mode
+curl http://localhost:3000/api/operational-mode \
+  -H "Authorization: Bearer $API_KEY"
+
+# Set mode (autonomous, supervised, or paused)
+curl -X POST http://localhost:3000/api/operational-mode \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"mode": "supervised"}'
+```
+
+- **autonomous** — agents execute without human approval (default)
+- **supervised** — agents queue actions for approval via the escalation queue
+- **paused** — no new agent sessions are started
+
+### Escalation Queue
+
+When in supervised mode, pending approvals accumulate in the escalation queue:
+
+```bash
+# List pending escalations
+curl http://localhost:3000/api/escalation-queue \
+  -H "Authorization: Bearer $API_KEY"
+
+# Approve or deny an escalation
+curl -X POST http://localhost:3000/api/escalation-queue/{id}/resolve \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"approved": true}'
+```
+
+## Self-Test
+
+Run the built-in self-test suite to verify server health:
+
+```bash
+curl -X POST http://localhost:3000/api/selftest/run \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"scope": "all"}'
+```
+
+Scope options: `unit`, `e2e`, `all`.


### PR DESCRIPTION
## Summary
- Adds 6 missing endpoint groups to README API table: AlgoChat, Wallets, Feed, Escalation, Backup, Self-Test
- Expands Health row to include `/health/live` and `/health/ready` probes
- Adds operational mode, escalation queue, and self-test sections to self-hosting guide with curl examples
- Updates test count in README (4417 → 4470+)

Closes #467

## Test plan
- [x] Documentation renders correctly on GitHub
- [x] curl examples are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)