### PR TITLE
ci: add SBOM generation and Docker image signing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write  # Cosign keyless signing via Sigstore OIDC
 
 env:
   REGISTRY: ghcr.io
@@ -41,6 +42,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad  # v4.0.0
+
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
@@ -53,6 +57,7 @@ jobs:
             type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
@@ -63,3 +68,29 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Sign image with cosign (keyless)
+        run: |
+          cosign sign --yes \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11  # v0.23.0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom.cyclonedx.json
+          upload-artifact: false
+
+      - name: Attest SBOM to image
+        run: |
+          cosign attest --yes --predicate sbom.cyclonedx.json \
+            --type cyclonedx \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cyclonedx.json
+          retention-days: 90

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write  # Required for cosign keyless signing in docker job
 
 jobs:
   # ── Run the full CI suite before releasing ──────────────────────
@@ -28,6 +29,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write  # Cosign keyless signing via Sigstore OIDC
 
   # ── Create GitHub Release ───────────────────────────────────────
   release:
@@ -39,6 +41,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8.0.0
+        with:
+          name: sbom-cyclonedx
 
       - name: Determine tag
         id: tag
@@ -79,6 +86,11 @@ jobs:
             echo ""
             echo ""
             echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG:-$(git rev-list --max-parents=0 HEAD | head -1)}...$TAG"
+            echo ""
+            echo "## Supply Chain Security"
+            echo ""
+            echo "This release includes a CycloneDX SBOM (\`sbom.cyclonedx.json\`) attached as a release asset."
+            echo "The Docker image is signed with [Sigstore cosign](https://docs.sigstore.dev/). See [docs/supply-chain-verification.md](docs/supply-chain-verification.md) for verification instructions."
             echo "CHANGELOG_EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -90,3 +102,4 @@ jobs:
           body: ${{ steps.changelog.outputs.changelog }}
           prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
           generate_release_notes: false
+          files: sbom.cyclonedx.json

--- a/docs/hardening-guide.md
+++ b/docs/hardening-guide.md
@@ -81,6 +81,12 @@
 - [ ] Consider lower limits for public-facing instances
 - [ ] Exempt trusted IPs via reverse proxy configuration
 
+### Supply Chain Verification
+
+- [ ] Verify Docker image signatures before deploying: `cosign verify`
+- [ ] Verify SBOM attestation: `cosign verify-attestation --type cyclonedx`
+- [ ] See [supply-chain-verification.md](supply-chain-verification.md) for full instructions
+
 ## Security Testing
 
 Run the automated security audit tests:

--- a/docs/supply-chain-verification.md
+++ b/docs/supply-chain-verification.md
@@ -1,0 +1,75 @@
+# Supply Chain Verification
+
+corvid-agent Docker images are signed with [Sigstore cosign](https://docs.sigstore.dev/) using keyless signing, and every release includes a CycloneDX SBOM (Software Bill of Materials) attested to the image.
+
+## Prerequisites
+
+Install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/):
+
+```bash
+# macOS
+brew install cosign
+
+# Linux (download binary)
+curl -sSfL https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 -o /usr/local/bin/cosign
+chmod +x /usr/local/bin/cosign
+```
+
+## Verifying Image Signatures
+
+Every Docker image pushed to `ghcr.io/corvidlabs/corvid-agent` is signed in CI using Sigstore's keyless signing flow (Fulcio + Rekor). Verify a pulled image:
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp "https://github.com/CorvidLabs/corvid-agent/" \
+  ghcr.io/corvidlabs/corvid-agent:<tag>
+```
+
+Replace `<tag>` with the version you want to verify (e.g. `0.15.0`, `latest`).
+
+A successful verification prints the signing certificate details and confirms the image was built and signed by the CorvidLabs/corvid-agent GitHub Actions workflow.
+
+## Verifying the SBOM Attestation
+
+Each image has a CycloneDX SBOM attached as an in-toto attestation. To verify and inspect it:
+
+```bash
+# Verify the attestation signature and print the SBOM
+cosign verify-attestation \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp "https://github.com/CorvidLabs/corvid-agent/" \
+  --type cyclonedx \
+  ghcr.io/corvidlabs/corvid-agent:<tag>
+```
+
+To extract just the SBOM content:
+
+```bash
+cosign verify-attestation \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp "https://github.com/CorvidLabs/corvid-agent/" \
+  --type cyclonedx \
+  ghcr.io/corvidlabs/corvid-agent:<tag> \
+  | jq -r '.payload' | base64 -d | jq '.predicate'
+```
+
+## Downloading the SBOM from GitHub Releases
+
+Each GitHub Release includes the SBOM as a downloadable asset (`sbom.cyclonedx.json`). You can download it from the [Releases page](https://github.com/CorvidLabs/corvid-agent/releases) or via the CLI:
+
+```bash
+gh release download <tag> --pattern 'sbom.cyclonedx.json' --repo CorvidLabs/corvid-agent
+```
+
+## How It Works
+
+The release pipeline generates and attaches supply chain metadata automatically:
+
+1. **Build & push**: Multi-platform Docker image is built and pushed to GHCR.
+2. **Sign**: cosign signs the image digest using keyless signing (GitHub OIDC token → Fulcio certificate → Rekor transparency log).
+3. **SBOM**: [Syft](https://github.com/anchore/syft) scans the pushed image and generates a CycloneDX JSON SBOM.
+4. **Attest**: cosign attaches the SBOM to the image as a signed in-toto attestation.
+5. **Release asset**: The SBOM is uploaded to the GitHub Release for direct download.
+
+All signing operations are keyless — no long-lived keys to manage. The signing identity is the GitHub Actions workflow, verifiable via Sigstore's public transparency log ([Rekor](https://rekor.sigstore.dev/)).


### PR DESCRIPTION
## Summary

- Add cosign keyless signing (Sigstore OIDC) for Docker images in `docker-publish.yml`
- Generate CycloneDX SBOM using Syft (`anchore/sbom-action`) and attest it to the image
- Upload SBOM as both a CI artifact (90-day retention) and GitHub Release asset
- Add `id-token: write` permission to `docker-publish.yml` and `release.yml` for Sigstore OIDC
- Add `docs/supply-chain-verification.md` with verification instructions
- Update `docs/hardening-guide.md` with supply chain verification checklist
- All new actions SHA-pinned per project convention

## Verification

Users can verify image signatures and SBOM attestations:

```bash
# Verify image signature
cosign verify \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  --certificate-identity-regexp "https://github.com/CorvidLabs/corvid-agent/" \
  ghcr.io/corvidlabs/corvid-agent:<tag>

# Verify SBOM attestation
cosign verify-attestation \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  --certificate-identity-regexp "https://github.com/CorvidLabs/corvid-agent/" \
  --type cyclonedx \
  ghcr.io/corvidlabs/corvid-agent:<tag>
```

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` passes (1 pre-existing failure in `logger.test.ts` unrelated to this change)
- [x] Workflow YAML validated (actions SHA-pinned, permissions correct)

### Post-merge verification (on next tag push)

These steps require a release tag push and cannot be verified pre-merge:

- Verify workflows execute correctly on next tag push (SBOM generation, signing, attestation)
- Verify `cosign verify` succeeds against a signed image
- Verify SBOM is attached to GitHub Release

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)