### PR TITLE
security: fix script injection in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,13 +77,15 @@ jobs:
       - name: Approve or request changes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BUILD_RESULT: ${{ needs.build.result }}
         run: |
-          if [ "${{ needs.build.result }}" = "success" ]; then
-            gh pr review ${{ github.event.pull_request.number }} \
+          if [ "$BUILD_RESULT" = "success" ]; then
+            gh pr review "$PR_NUMBER" \
               --approve \
               --body "All CI checks passed (tsc, tests, spec:check, client build) across ubuntu, macos, and windows."
           else
-            gh pr review ${{ github.event.pull_request.number }} \
+            gh pr review "$PR_NUMBER" \
               --request-changes \
               --body "CI checks failed. Please review the build logs and fix the issues before merging."
           fi

--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -19,8 +19,9 @@ jobs:
     steps:
       - name: Ping health endpoint
         id: health
+        env:
+          HEALTH_URL: ${{ secrets.HEALTH_URL }}
         run: |
-          HEALTH_URL="${{ secrets.HEALTH_URL }}"
           if [ -z "$HEALTH_URL" ]; then
             echo "HEALTH_URL secret not set — skipping"
             echo "status=skipped" >> "$GITHUB_OUTPUT"
@@ -45,19 +46,23 @@ jobs:
 
       - name: Record failure
         if: steps.health.outputs.status == 'unhealthy'
+        env:
+          HTTP_CODE: ${{ steps.health.outputs.http_code }}
         run: |
           # Write failure to a file that persists via cache for consecutive-check tracking
-          echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) HTTP=${{ steps.health.outputs.http_code }}" >> /tmp/heartbeat_failures.txt
-          echo "::warning::Health check failed with HTTP ${{ steps.health.outputs.http_code }}"
+          echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) HTTP=$HTTP_CODE" >> /tmp/heartbeat_failures.txt
+          echo "::warning::Health check failed with HTTP $HTTP_CODE"
 
       - name: Create incident issue on failure
         if: steps.health.outputs.status == 'unhealthy'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HTTP_CODE: ${{ steps.health.outputs.http_code }}
         run: |
           # Check if there's already an open incident issue
           EXISTING=$(gh issue list \
-            --repo "${{ github.repository }}" \
+            --repo "$REPO" \
             --label "P0,incident" \
             --state open \
             --limit 1 \
@@ -67,21 +72,21 @@ jobs:
           if [ -n "$EXISTING" ]; then
             echo "Open incident issue #$EXISTING already exists — adding comment"
             gh issue comment "$EXISTING" \
-              --repo "${{ github.repository }}" \
-              --body "Heartbeat check failed again at $(date -u +%Y-%m-%dT%H:%M:%SZ). HTTP status: ${{ steps.health.outputs.http_code }}"
+              --repo "$REPO" \
+              --body "Heartbeat check failed again at $(date -u +%Y-%m-%dT%H:%M:%SZ). HTTP status: $HTTP_CODE"
             exit 0
           fi
 
           # Create new incident issue
           gh issue create \
-            --repo "${{ github.repository }}" \
+            --repo "$REPO" \
             --title "[P0] Server health check failing" \
             --label "P0,incident" \
-            --body "$(cat <<'EOF'
+            --body "$(cat <<EOF
           ## Incident: Server Health Check Failure
 
           **Detected at:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
-          **HTTP Status:** ${{ steps.health.outputs.http_code }}
+          **HTTP Status:** $HTTP_CODE
           **Source:** GitHub Actions heartbeat workflow
 
           ### Recovery Steps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,17 +42,21 @@ jobs:
 
       - name: Determine tag
         id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "version=$INPUT_TAG" >> "$GITHUB_OUTPUT"
           else
             echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check if pre-release
         id: prerelease
+        env:
+          TAG: ${{ steps.tag.outputs.version }}
         run: |
-          TAG="${{ steps.tag.outputs.version }}"
           if echo "$TAG" | grep -qE '-(alpha|beta|rc)'; then
             echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           else
@@ -61,8 +65,10 @@ jobs:
 
       - name: Generate changelog
         id: changelog
+        env:
+          TAG: ${{ steps.tag.outputs.version }}
+          REPO: ${{ github.repository }}
         run: |
-          TAG="${{ steps.tag.outputs.version }}"
           # Find the previous tag
           PREV_TAG=$(git tag --sort=-version:refname | grep -E '^v' | grep -v "^${TAG}$" | head -n1)
           if [ -z "$PREV_TAG" ]; then
@@ -78,7 +84,7 @@ jobs:
             git log "$RANGE" --pretty=format:"* %s (%h)" --no-merges
             echo ""
             echo ""
-            echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG:-$(git rev-list --max-parents=0 HEAD | head -1)}...$TAG"
+            echo "**Full Changelog**: https://github.com/${REPO}/compare/${PREV_TAG:-$(git rev-list --max-parents=0 HEAD | head -1)}...$TAG"
             echo "CHANGELOG_EOF"
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

- **release.yml**: Move `${{ inputs.tag }}`, `${{ steps.tag.outputs.version }}`, `${{ github.event_name }}`, and `${{ github.repository }}` from shell `run:` blocks to `env:` variables to prevent script injection via crafted workflow_dispatch inputs or tag names
- **ci.yml**: Move `${{ github.event.pull_request.number }}` and `${{ needs.build.result }}` to `env:` variables in the review job
- **heartbeat.yml**: Move `${{ secrets.HEALTH_URL }}`, `${{ steps.health.outputs.http_code }}`, and `${{ github.repository }}` to `env:` variables

The primary vulnerability was in `release.yml` where `${{ inputs.tag }}` was directly interpolated in a shell `run:` block, allowing arbitrary command execution via a crafted tag value in workflow_dispatch. The other fixes are defense-in-depth hardening.

Closes #429

## Test plan

- [x] Verify CI workflow passes (no functional change, only variable binding mechanism)
- [x] Verify release workflow still correctly determines tag from both push and workflow_dispatch triggers
- [x] Verify heartbeat workflow still creates incident issues on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)