### PR TITLE
feat: add Cache-Control headers for static assets

### DIFF
--- a/server/__tests__/cache-control.test.ts
+++ b/server/__tests__/cache-control.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'bun:test';
+
+/**
+ * Tests for the cache-control header logic used in static file serving.
+ * The pattern matches Angular's outputHashing:"all" filenames (e.g. main.abc12345.js).
+ */
+
+const HASHED_ASSET_PATTERN = /\.[a-f0-9]{8,}\.\w+$/;
+
+function getCacheControl(pathname: string): string {
+    const basename = pathname.split('/').pop() ?? '';
+    if (HASHED_ASSET_PATTERN.test(basename)) {
+        return 'public, max-age=31536000, immutable';
+    } else if (basename === 'index.html') {
+        return 'no-cache, no-store, must-revalidate';
+    } else {
+        return 'public, max-age=3600';
+    }
+}
+
+describe('Cache-Control headers', () => {
+    describe('hashed assets (immutable, 1 year)', () => {
+        test('JS bundle with 8-char hash', () => {
+            expect(getCacheControl('/main.a1b2c3d4.js')).toBe('public, max-age=31536000, immutable');
+        });
+
+        test('CSS with long hash', () => {
+            expect(getCacheControl('/styles.a1b2c3d4e5f6.css')).toBe('public, max-age=31536000, immutable');
+        });
+
+        test('uppercase hex does not match (Angular uses lowercase)', () => {
+            expect(getCacheControl('/chunk-ABCD1234.js')).not.toBe('public, max-age=31536000, immutable');
+        });
+
+        test('chunk with dot-separated hash', () => {
+            expect(getCacheControl('/chunk.abcd1234.js')).toBe('public, max-age=31536000, immutable');
+        });
+
+        test('nested path with hash', () => {
+            expect(getCacheControl('/assets/fonts/icon.ab12cd34.woff2')).toBe('public, max-age=31536000, immutable');
+        });
+
+        test('media with hash', () => {
+            expect(getCacheControl('/media/logo.deadbeef.svg')).toBe('public, max-age=31536000, immutable');
+        });
+    });
+
+    describe('index.html (no-cache)', () => {
+        test('root index.html', () => {
+            expect(getCacheControl('/index.html')).toBe('no-cache, no-store, must-revalidate');
+        });
+
+        test('index.html in path', () => {
+            // basename extraction means this still matches
+            expect(getCacheControl('/some/path/index.html')).toBe('no-cache, no-store, must-revalidate');
+        });
+    });
+
+    describe('other static files (1 hour)', () => {
+        test('favicon', () => {
+            expect(getCacheControl('/favicon.ico')).toBe('public, max-age=3600');
+        });
+
+        test('robots.txt', () => {
+            expect(getCacheControl('/robots.txt')).toBe('public, max-age=3600');
+        });
+
+        test('manifest.json', () => {
+            expect(getCacheControl('/manifest.json')).toBe('public, max-age=3600');
+        });
+
+        test('unhashed JS (no hash in filename)', () => {
+            expect(getCacheControl('/polyfills.js')).toBe('public, max-age=3600');
+        });
+
+        test('asset without hash', () => {
+            expect(getCacheControl('/assets/logo.svg')).toBe('public, max-age=3600');
+        });
+    });
+
+    describe('hash pattern edge cases', () => {
+        test('short hex (7 chars) does not match immutable', () => {
+            expect(getCacheControl('/main.a1b2c3d.js')).toBe('public, max-age=3600');
+        });
+
+        test('non-hex chars do not match', () => {
+            expect(getCacheControl('/main.ghijklmn.js')).toBe('public, max-age=3600');
+        });
+
+        test('hash with no extension after does not match', () => {
+            // Pattern requires .\w+ after the hash
+            expect(getCacheControl('/main.a1b2c3d4')).toBe('public, max-age=3600');
+        });
+    });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -740,7 +740,17 @@ const server = Bun.serve<WsData>({
 
                 // Check if path exists as a file
                 if (existsSync(filePath) && !filePath.endsWith('/')) {
-                    return instrumentResponse(new Response(Bun.file(filePath)), '/static');
+                    const headers: Record<string, string> = {};
+                    const basename = url.pathname.split('/').pop() ?? '';
+                    // Angular outputHashing:"all" produces files like main.abc1234f.js
+                    if (/\.[a-f0-9]{8,}\.\w+$/.test(basename)) {
+                        headers['Cache-Control'] = 'public, max-age=31536000, immutable';
+                    } else if (basename === 'index.html') {
+                        headers['Cache-Control'] = 'no-cache, no-store, must-revalidate';
+                    } else {
+                        headers['Cache-Control'] = 'public, max-age=3600';
+                    }
+                    return instrumentResponse(new Response(Bun.file(filePath), { headers }), '/static');
                 }
 
                 // SPA fallback - serve index.html for unmatched routes
@@ -748,7 +758,10 @@ const server = Bun.serve<WsData>({
                 if (existsSync(indexPath)) {
                     return instrumentResponse(
                         new Response(Bun.file(indexPath), {
-                            headers: { 'Content-Type': 'text/html' },
+                            headers: {
+                                'Content-Type': 'text/html',
+                                'Cache-Control': 'no-cache, no-store, must-revalidate',
+                            },
                         }),
                         '/static',
                     );


### PR DESCRIPTION
## Summary

- Hashed assets (e.g. `main.a1b2c3d4.js`) → `Cache-Control: public, max-age=31536000, immutable`
- `index.html` and SPA fallback → `Cache-Control: no-cache, no-store, must-revalidate`
- Other static files (favicon, robots.txt) → `Cache-Control: public, max-age=3600`

Angular's `outputHashing: "all"` ensures content-addressed filenames for JS/CSS/media, making aggressive caching safe. The `index.html` must never be cached since it references the hashed assets.

Closes #451

## Test plan

- [x] 16 unit tests covering hash pattern matching, index.html detection, and edge cases
- [x] All 4470 existing tests pass
- [x] tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)