### PR TITLE
ci: add SBOM generation and Docker image signing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write  # Required for keyless Cosign signing via Sigstore/Fulcio
 
 env:
   REGISTRY: ghcr.io
@@ -53,6 +54,7 @@ jobs:
             type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
@@ -63,3 +65,32 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@3454372be43b31757badb472a6eb1a218938bcbf  # v3
+
+      - name: Sign Docker image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@fc46e51fd3cb168ffb36c6d1915723c47db58abb  # v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-spdx.json
+
+      - name: Attest SBOM to image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign attest --yes --predicate sbom-spdx.json --type spdxjson "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6db9a8b7a0d7c1b4e6bac2e267a29  # v4
+        with:
+          name: sbom
+          path: sbom-spdx.json
+          retention-days: 90

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -170,6 +170,29 @@ Key defaults baked into the image:
 - `NODE_ENV=production`
 - Healthcheck on `/health/live` every 30 seconds
 
+### Image Verification
+
+Released Docker images are signed with [Cosign](https://github.com/sigstore/cosign) (keyless, via Sigstore/Fulcio) and include an SPDX SBOM attestation.
+
+Verify the image signature:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp "https://github.com/CorvidLabs/corvid-agent" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  ghcr.io/corvidlabs/corvid-agent:latest
+```
+
+Verify and extract the SBOM attestation:
+
+```bash
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity-regexp "https://github.com/CorvidLabs/corvid-agent" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  ghcr.io/corvidlabs/corvid-agent:latest | jq -r '.payload' | base64 -d | jq .
+```
+
 ### Reverse Proxy
 
 When `BIND_HOST=0.0.0.0`, the API is exposed on all interfaces. In production, always place the server behind a reverse proxy with TLS. The `deploy/` directory includes configurations for both Nginx and Caddy:


### PR DESCRIPTION
## Summary

- **Cosign keyless signing**: Docker images are signed using Sigstore/Fulcio OIDC tokens from GitHub Actions. No private keys to manage.
- **SBOM generation**: Syft generates an SPDX JSON bill of materials from the published image.
- **SBOM attestation**: The SBOM is attached to the image as a Cosign attestation, verifiable with `cosign verify-attestation`.
- **Artifact upload**: SBOM JSON uploaded as a CI artifact for 90-day retention.
- **Documentation**: Verification commands added to `docs/self-hosting.md`.

Closes #449

## Test plan

- [x] Trigger a workflow_dispatch or tag push to verify the full pipeline
- [x] Run `cosign verify` against the published image
- [x] Run `cosign verify-attestation --type spdxjson` to verify SBOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)