### PR TITLE
feat: deprecate WebSocket query-string auth in favor of Bearer header

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -286,8 +286,10 @@ When specific origins are configured, only matching request origins receive CORS
 
 WebSocket connections authenticate via:
 
-1. `Authorization: Bearer <key>` header (standard path)
-2. `?key=<key>` query parameter (for browsers that cannot set headers on WebSocket upgrade)
+1. `Authorization: Bearer <key>` header (**preferred** -- use for SDKs, A2A, and programmatic clients)
+2. `?key=<key>` query parameter (**deprecated** -- for browsers that cannot set headers on WebSocket upgrade)
+
+The query-string method logs a deprecation warning on each connection. Use the `Authorization` header whenever your client supports setting headers on WebSocket upgrade requests. For browser-based clients where headers cannot be set, the query parameter remains available but should be used only over HTTPS to prevent token leakage via server logs and network intermediaries.
 
 ### Rate Limiting
 

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -5,8 +5,9 @@
  * - If API_KEY is set, all non-OPTIONS routes require `Authorization: Bearer <key>`.
  * - If BIND_HOST !== 127.0.0.1 and no API_KEY is set, a random key is generated
  *   on first run and persisted to .env (admin bootstrap).
- * - WebSocket connections authenticate via `?key=<key>` query param. When API_KEY
- *   is set, unauthenticated upgrade requests are rejected with 401.
+ * - WebSocket connections authenticate via `Authorization: Bearer <key>` header
+ *   (preferred) or `?key=<key>` query param (deprecated, for browsers). When
+ *   API_KEY is set, unauthenticated upgrade requests are rejected with 401.
  * - Health endpoint (/api/health) is always public (monitoring probes need it).
  */
 
@@ -248,23 +249,29 @@ export function checkHttpAuth(req: Request, url: URL, config: AuthConfig): Respo
 
 /**
  * Check whether a WebSocket upgrade request is authenticated.
- * Supports `?key=<key>` query parameter.
+ * Supports both `Authorization: Bearer <key>` header (preferred)
+ * and `?key=<key>` query parameter (deprecated).
  * Returns true if authenticated, false if not.
  */
 export function checkWsAuth(req: Request, url: URL, config: AuthConfig): boolean {
     // No API key configured = auth disabled
     if (!config.apiKey) return true;
 
-    // Check Authorization header first (standard path)
+    // Check Authorization header first (preferred path)
     const authHeader = req.headers.get('Authorization');
     if (authHeader) {
         const match = authHeader.match(/^Bearer\s+(.+)$/i);
         if (match && isValidApiKey(match[1], config)) return true;
     }
 
-    // Check query parameter (browsers can't set headers on WebSocket upgrade)
+    // Check query parameter (deprecated — tokens in URLs leak via logs and referrers)
     const key = url.searchParams.get('key');
-    if (key && isValidApiKey(key, config)) return true;
+    if (key && isValidApiKey(key, config)) {
+        log.warn('WebSocket auth via query string is deprecated — use Authorization: Bearer header instead', {
+            ip: req.headers.get('x-forwarded-for') ?? 'unknown',
+        });
+        return true;
+    }
 
     log.warn('Rejected WebSocket connection: invalid or missing auth', { ip: req.headers.get('x-forwarded-for') ?? 'unknown' });
     return false;


### PR DESCRIPTION
## Summary

- Server already supports both `Authorization: Bearer` header and `?key=` query param for WebSocket auth
- Added deprecation warning when query-string auth is used (logged on each connection)
- Updated `docs/self-hosting.md` to clearly document both methods and recommend Bearer header
- Updated module docstring in `server/middleware/auth.ts`

### Migration plan

| Client type | Current auth | Migration target | Timeline |
|---|---|---|---|
| SDKs, A2A, programmatic | `?key=` or header | `Authorization: Bearer` header | Now |
| Browser WebSocket (Angular dashboard) | `?key=` query param | `?key=` (browser limitation) | Use ticket-based auth in follow-up |

Browser `WebSocket` API cannot set custom headers, so `?key=` remains necessary for browser clients. A follow-up can implement ticket-based auth (`POST /api/auth/ws-ticket` returns a short-lived token that replaces the API key in the query string).

Closes #452

## Test plan

- [x] All 4492 tests pass
- [x] tsc clean
- [x] Verify deprecation warning appears in server logs when connecting via `?key=`
- [x] Verify Bearer header auth still works for WS connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)