### PR TITLE
refactor: decompose polling/service.ts into 3 focused services

### DIFF
--- a/server/__tests__/polling-service.test.ts
+++ b/server/__tests__/polling-service.test.ts
@@ -10,6 +10,7 @@ import { createAgent } from '../db/agents';
 import { createProject } from '../db/projects';
 import { createMentionPollingConfig, findDuePollingConfigs } from '../db/mention-polling';
 import { MentionPollingService } from '../polling/service';
+import { CIRetryService } from '../polling/ci-retry';
 
 // ─── Test Setup ─────────────────────────────────────────────────────────────
 
@@ -375,13 +376,14 @@ describe('buildPrompt', () => {
 
 // ─── CI fix session prompt ──────────────────────────────────────────────────
 
-describe('spawnCIFixSession', () => {
+describe('spawnCIFixSession (via CIRetryService)', () => {
     test('creates a session with CI fix instructions', async () => {
-        const service = new MentionPollingService(db, mockProcessManager);
+        const mockRunGh = mock(async () => ({ ok: true, stdout: '', stderr: '' }));
+        const ciRetry = new CIRetryService(db, mockProcessManager as any, mockRunGh);
         const spawn = (repo: string, prNumber: number, prTitle: string, failedChecks: string[], aId: string, pId: string) =>
-            (service as unknown as {
-                spawnCIFixSession: (r: string, n: number, t: string, f: string[], a: string, p: string) => Promise<void>;
-            }).spawnCIFixSession(repo, prNumber, prTitle, failedChecks, aId, pId);
+            (ciRetry as unknown as {
+                spawnFixSession: (r: string, n: number, t: string, f: string[], a: string, p: string) => Promise<void>;
+            }).spawnFixSession(repo, prNumber, prTitle, failedChecks, aId, pId);
 
         await spawn('CorvidLabs/corvid-agent', 42, 'Fix bug', ['Build & Test', 'Lint'], agentId, projectId);
 
@@ -397,11 +399,12 @@ describe('spawnCIFixSession', () => {
     });
 
     test('uses corvid_create_work_task instruction for home repo', async () => {
-        const service = new MentionPollingService(db, mockProcessManager);
+        const mockRunGh = mock(async () => ({ ok: true, stdout: '', stderr: '' }));
+        const ciRetry = new CIRetryService(db, mockProcessManager as any, mockRunGh);
         const spawn = (repo: string, prNumber: number, prTitle: string, failedChecks: string[], aId: string, pId: string) =>
-            (service as unknown as {
-                spawnCIFixSession: (r: string, n: number, t: string, f: string[], a: string, p: string) => Promise<void>;
-            }).spawnCIFixSession(repo, prNumber, prTitle, failedChecks, aId, pId);
+            (ciRetry as unknown as {
+                spawnFixSession: (r: string, n: number, t: string, f: string[], a: string, p: string) => Promise<void>;
+            }).spawnFixSession(repo, prNumber, prTitle, failedChecks, aId, pId);
 
         await spawn('CorvidLabs/corvid-agent', 10, 'Test PR', ['tests'], agentId, projectId);
 
@@ -445,12 +448,13 @@ describe('dedup integration', () => {
 
 // ─── CI retry cooldown ──────────────────────────────────────────────────────
 
-describe('CI retry cooldown', () => {
+describe('CI retry cooldown (via CIRetryService)', () => {
     test('cooldown map tracks last spawn time per PR', () => {
-        const service = new MentionPollingService(db, mockProcessManager);
-        const cooldownMap = (service as unknown as {
-            ciRetryLastSpawn: Map<string, number>;
-        }).ciRetryLastSpawn;
+        const mockRunGh = mock(async () => ({ ok: true, stdout: '', stderr: '' }));
+        const ciRetry = new CIRetryService(db, mockProcessManager as any, mockRunGh);
+        const cooldownMap = (ciRetry as unknown as {
+            lastSpawn: Map<string, number>;
+        }).lastSpawn;
 
         const key = 'CorvidLabs/corvid-agent#42';
         cooldownMap.set(key, Date.now());

--- a/server/polling/auto-merge.ts
+++ b/server/polling/auto-merge.ts
@@ -1,0 +1,130 @@
+/**
+ * AutoMergeService — squash-merges open PRs authored by the agent that have all CI checks passing.
+ *
+ * Extracted from MentionPollingService to isolate auto-merge concerns.
+ * Runs on a 2-minute interval, scanning active polling configs for repos to check.
+ */
+
+import type { Database } from 'bun:sqlite';
+import { createLogger } from '../lib/logger';
+import { resolveFullRepo } from './github-searcher';
+
+const log = createLogger('AutoMerge');
+
+/** How often to check for mergeable PRs. */
+export const AUTO_MERGE_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
+
+export type RunGhFn = (args: string[]) => Promise<{ ok: boolean; stdout: string; stderr: string }>;
+
+export class AutoMergeService {
+    private db: Database;
+    private runGh: RunGhFn;
+    private timer: ReturnType<typeof setInterval> | null = null;
+    private running = false;
+
+    constructor(db: Database, runGh: RunGhFn) {
+        this.db = db;
+        this.runGh = runGh;
+    }
+
+    start(): void {
+        if (this.running) return;
+        this.running = true;
+        this.checkAll();
+        this.timer = setInterval(() => this.checkAll(), AUTO_MERGE_INTERVAL_MS);
+    }
+
+    stop(): void {
+        this.running = false;
+        if (this.timer) {
+            clearInterval(this.timer);
+            this.timer = null;
+        }
+    }
+
+    /**
+     * Find open PRs authored by the polling agent username that have all CI
+     * checks passing, and squash-merge them automatically.
+     */
+    async checkAll(): Promise<void> {
+        if (!this.running) return;
+
+        try {
+            // Gather unique repos from active polling configs
+            const allConfigs = this.db.query(
+                `SELECT repo, mention_username FROM mention_polling_configs WHERE status = 'active'`
+            ).all() as Array<{ repo: string; mention_username: string }>;
+
+            // Deduplicate by repo+username
+            const seen = new Set<string>();
+            const targets: Array<{ repo: string; username: string }> = [];
+            for (const c of allConfigs) {
+                const key = `${c.repo}:${c.mention_username}`;
+                if (seen.has(key)) continue;
+                seen.add(key);
+                targets.push({ repo: c.repo, username: c.mention_username });
+            }
+
+            for (const { repo, username } of targets) {
+                await this.mergeForRepo(repo, username);
+            }
+        } catch (err) {
+            log.error('Error in auto-merge loop', { error: err instanceof Error ? err.message : String(err) });
+        }
+    }
+
+    /**
+     * Auto-merge passing PRs for a specific repo authored by the given username.
+     */
+    private async mergeForRepo(repo: string, username: string): Promise<void> {
+        // List open PRs authored by the agent
+        const searchQualifier = repo.includes('/') ? `repo:${repo}` : `org:${repo}`;
+        const result = await this.runGh([
+            'api', 'search/issues',
+            '-X', 'GET',
+            '-f', `q=${searchQualifier} is:pr is:open author:${username}`,
+            '-f', 'per_page=20',
+        ]);
+
+        if (!result.ok || !result.stdout.trim()) return;
+
+        const parsed = JSON.parse(result.stdout) as { items?: Array<Record<string, unknown>> };
+        const prs = parsed.items ?? [];
+        if (prs.length === 0) return;
+
+        for (const pr of prs) {
+            const prNumber = pr.number as number;
+            const prUrl = (pr.html_url as string) ?? '';
+            const prRepo = resolveFullRepo(repo, prUrl);
+
+            // Check if all CI checks have passed
+            const statusResult = await this.runGh([
+                'pr', 'checks', String(prNumber),
+                '--repo', prRepo,
+                '--json', 'state',
+                '--jq', '[.[].state] | if length == 0 then "none" elif all(. == "SUCCESS") then "pass" else "fail" end',
+            ]);
+
+            if (!statusResult.ok || statusResult.stdout.trim() !== 'pass') {
+                continue;
+            }
+
+            // All checks pass — merge it
+            const mergeResult = await this.runGh([
+                'pr', 'merge', String(prNumber),
+                '--repo', prRepo,
+                '--squash',
+                '--delete-branch',
+            ]);
+
+            if (mergeResult.ok) {
+                log.info('Auto-merged PR', { repo: prRepo, number: prNumber });
+            } else {
+                log.debug('Failed to auto-merge PR', {
+                    repo: prRepo, number: prNumber,
+                    error: mergeResult.stderr,
+                });
+            }
+        }
+    }
+}

--- a/server/polling/auto-update.ts
+++ b/server/polling/auto-update.ts
@@ -1,0 +1,157 @@
+/**
+ * AutoUpdateService — checks if origin/main has new commits, pulls, and restarts.
+ *
+ * Extracted from MentionPollingService to isolate self-update concerns.
+ * Runs on a 5-minute interval. Waits for all running sessions to finish
+ * before pulling and exiting with code 75 to signal restart.
+ */
+
+import type { Database } from 'bun:sqlite';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('AutoUpdate');
+
+/** How often to check if origin/main has new commits. */
+export const AUTO_UPDATE_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+export class AutoUpdateService {
+    private db: Database;
+    private timer: ReturnType<typeof setInterval> | null = null;
+    private running = false;
+
+    constructor(db: Database) {
+        this.db = db;
+    }
+
+    start(): void {
+        if (this.running) return;
+        this.running = true;
+        this.timer = setInterval(() => this.check(), AUTO_UPDATE_INTERVAL_MS);
+    }
+
+    stop(): void {
+        this.running = false;
+        if (this.timer) {
+            clearInterval(this.timer);
+            this.timer = null;
+        }
+    }
+
+    /**
+     * Check if origin/main has new commits. If so, wait for all running
+     * sessions to finish, pull the changes, and exit so the wrapper
+     * script restarts the server with the new code.
+     */
+    async check(): Promise<void> {
+        if (!this.running) return;
+
+        try {
+            // Fetch latest from origin
+            const fetchResult = Bun.spawnSync(['git', 'fetch', 'origin', 'main'], {
+                cwd: import.meta.dir + '/..',
+                stdout: 'pipe', stderr: 'pipe',
+            });
+            if (fetchResult.exitCode !== 0) return;
+
+            // Only auto-update if we're on the main branch
+            const currentBranch = Bun.spawnSync(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], {
+                cwd: import.meta.dir + '/..',
+                stdout: 'pipe',
+            }).stdout.toString().trim();
+
+            if (currentBranch !== 'main') {
+                log.debug('Skipping auto-update — not on main branch', { branch: currentBranch });
+                return;
+            }
+
+            // Compare local main with origin/main
+            const localHash = Bun.spawnSync(['git', 'rev-parse', 'HEAD'], {
+                cwd: import.meta.dir + '/..',
+                stdout: 'pipe',
+            }).stdout.toString().trim();
+
+            const remoteHash = Bun.spawnSync(['git', 'rev-parse', 'origin/main'], {
+                cwd: import.meta.dir + '/..',
+                stdout: 'pipe',
+            }).stdout.toString().trim();
+
+            if (localHash === remoteHash) return;
+
+            log.info('New commits detected on origin/main', { local: localHash.slice(0, 8), remote: remoteHash.slice(0, 8) });
+
+            // Check for running sessions — wait for them to finish
+            const running = this.db.query(
+                `SELECT COUNT(*) as count FROM sessions WHERE status = 'running' AND pid IS NOT NULL`
+            ).get() as { count: number } | null;
+
+            const activeCount = running?.count ?? 0;
+            if (activeCount > 0) {
+                log.info('Deferring auto-update — waiting for active sessions to finish', { activeCount });
+                return;
+            }
+
+            // No active sessions — pull and restart
+            log.info('No active sessions — pulling and restarting');
+
+            const pullResult = Bun.spawnSync(['git', 'pull', '--rebase', 'origin', 'main'], {
+                cwd: import.meta.dir + '/..',
+                stdout: 'pipe', stderr: 'pipe',
+            });
+
+            if (pullResult.exitCode !== 0) {
+                log.error('Git pull failed', { stderr: pullResult.stderr.toString().trim() });
+                return;
+            }
+
+            // Check if bun.lock changed — if so, install updated dependencies
+            // before restarting to avoid running with stale node_modules.
+            const lockDiff = Bun.spawnSync(
+                ['git', 'diff', localHash, 'HEAD', '--name-only', '--', 'bun.lock', 'package.json'],
+                { cwd: import.meta.dir + '/..', stdout: 'pipe' },
+            );
+            const changedFiles = lockDiff.stdout.toString().trim();
+            if (changedFiles) {
+                log.info('Dependencies changed — running bun install', { changedFiles });
+                const installResult = Bun.spawnSync(
+                    ['bun', 'install', '--frozen-lockfile', '--ignore-scripts'],
+                    { cwd: import.meta.dir + '/..', stdout: 'pipe', stderr: 'pipe' },
+                );
+                if (installResult.exitCode !== 0) {
+                    log.error('bun install failed after pull — reverting', {
+                        stderr: installResult.stderr.toString().trim(),
+                    });
+                    // Roll back to the known-good commit so we don't run with mismatched code + deps
+                    Bun.spawnSync(['git', 'reset', '--hard', localHash], {
+                        cwd: import.meta.dir + '/..',
+                        stdout: 'pipe', stderr: 'pipe',
+                    });
+                    return;
+                }
+                log.info('bun install completed successfully');
+            }
+
+            // Verify pull actually advanced HEAD to origin/main
+            const newLocalHash = Bun.spawnSync(['git', 'rev-parse', 'HEAD'], {
+                cwd: import.meta.dir + '/..',
+                stdout: 'pipe',
+            }).stdout.toString().trim();
+
+            if (newLocalHash === localHash) {
+                log.warn('Git pull did not advance HEAD — skipping restart to avoid loop', {
+                    hash: localHash.slice(0, 8),
+                });
+                return;
+            }
+
+            log.info('Git pull successful — exiting for restart', {
+                oldHash: localHash.slice(0, 8),
+                newHash: newLocalHash.slice(0, 8),
+            });
+            // Exit with code 75 (EX_TEMPFAIL) to signal "restart me"
+            // The run-loop.sh wrapper and launchd both treat non-zero as restartable
+            process.exit(75);
+        } catch (err) {
+            log.error('Error in auto-update check', { error: err instanceof Error ? err.message : String(err) });
+        }
+    }
+}

--- a/server/polling/ci-retry.ts
+++ b/server/polling/ci-retry.ts
@@ -1,0 +1,212 @@
+/**
+ * CIRetryService — spawns fix sessions for PRs authored by the agent with failed CI.
+ *
+ * Extracted from MentionPollingService to isolate CI retry concerns.
+ * Runs on a 10-minute interval with a 30-minute per-PR cooldown.
+ */
+
+import type { Database } from 'bun:sqlite';
+import type { ProcessManager } from '../process/manager';
+import { createLogger } from '../lib/logger';
+import { createSession } from '../db/sessions';
+import { resolveFullRepo } from './github-searcher';
+
+const log = createLogger('CIRetry');
+
+/** How often to check for CI-failed PRs and spawn fix sessions. */
+export const CI_RETRY_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
+
+/** Cooldown per PR before spawning another CI-fix session. */
+export const CI_RETRY_COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes
+
+export type RunGhFn = (args: string[]) => Promise<{ ok: boolean; stdout: string; stderr: string }>;
+
+export class CIRetryService {
+    private db: Database;
+    private processManager: ProcessManager;
+    private runGh: RunGhFn;
+    private timer: ReturnType<typeof setInterval> | null = null;
+    private running = false;
+    /** Tracks last CI-fix session spawn time per "repo#number" to enforce cooldown. */
+    private lastSpawn = new Map<string, number>();
+
+    constructor(db: Database, processManager: ProcessManager, runGh: RunGhFn) {
+        this.db = db;
+        this.processManager = processManager;
+        this.runGh = runGh;
+    }
+
+    start(): void {
+        if (this.running) return;
+        this.running = true;
+        // Don't run immediately on start — wait for the first interval
+        this.timer = setInterval(() => this.checkAll(), CI_RETRY_INTERVAL_MS);
+    }
+
+    stop(): void {
+        this.running = false;
+        if (this.timer) {
+            clearInterval(this.timer);
+            this.timer = null;
+        }
+    }
+
+    /**
+     * Find open PRs authored by the agent with failed CI and spawn sessions
+     * to fix them.
+     */
+    async checkAll(): Promise<void> {
+        if (!this.running) return;
+
+        try {
+            const allConfigs = this.db.query(
+                `SELECT repo, mention_username, agent_id, project_id FROM mention_polling_configs WHERE status = 'active'`
+            ).all() as Array<{ repo: string; mention_username: string; agent_id: string; project_id: string }>;
+
+            const seen = new Set<string>();
+            for (const c of allConfigs) {
+                const key = `${c.repo}:${c.mention_username}`;
+                if (seen.has(key)) continue;
+                seen.add(key);
+                await this.retryForRepo(c.repo, c.mention_username, c.agent_id, c.project_id);
+            }
+        } catch (err) {
+            log.error('Error in CI retry loop', { error: err instanceof Error ? err.message : String(err) });
+        }
+    }
+
+    /**
+     * For a specific repo, find open PRs by the agent with failed CI and spawn fix sessions.
+     */
+    private async retryForRepo(
+        repo: string, username: string, agentId: string, projectId: string,
+    ): Promise<void> {
+        const searchQualifier = repo.includes('/') ? `repo:${repo}` : `org:${repo}`;
+        const result = await this.runGh([
+            'api', 'search/issues',
+            '-X', 'GET',
+            '-f', `q=${searchQualifier} is:pr is:open author:${username}`,
+            '-f', 'per_page=20',
+        ]);
+
+        if (!result.ok || !result.stdout.trim()) return;
+
+        const parsed = JSON.parse(result.stdout) as { items?: Array<Record<string, unknown>> };
+        const prs = parsed.items ?? [];
+
+        for (const pr of prs) {
+            const prNumber = pr.number as number;
+            const prTitle = (pr.title as string) ?? '';
+            const prUrl = (pr.html_url as string) ?? '';
+            const prRepo = resolveFullRepo(repo, prUrl);
+            const cooldownKey = `${prRepo}#${prNumber}`;
+
+            // Enforce cooldown
+            const lastSpawn = this.lastSpawn.get(cooldownKey);
+            if (lastSpawn && Date.now() - lastSpawn < CI_RETRY_COOLDOWN_MS) continue;
+
+            // Skip if there's already a running session for this PR
+            const sessionPrefix = `Poll: ${prRepo} #${prNumber}:`;
+            const existing = this.db.query(
+                `SELECT id FROM sessions WHERE name LIKE ? AND status = 'running'`
+            ).get(sessionPrefix + '%') as { id: string } | null;
+            if (existing) continue;
+
+            // Check CI status — only act on failures (not pending/success)
+            const statusResult = await this.runGh([
+                'pr', 'checks', String(prNumber),
+                '--repo', prRepo,
+                '--json', 'state,name',
+                '--jq', '[.[] | {name, state}]',
+            ]);
+
+            if (!statusResult.ok || !statusResult.stdout.trim()) continue;
+
+            const checks = JSON.parse(statusResult.stdout) as Array<{ name: string; state: string }>;
+            const hasFailure = checks.some(c => c.state === 'FAILURE');
+            const hasPending = checks.some(c => c.state === 'PENDING' || c.state === 'QUEUED' || c.state === 'IN_PROGRESS');
+            if (!hasFailure || hasPending) continue;
+
+            // Get failed check names for the prompt
+            const failedChecks = checks.filter(c => c.state === 'FAILURE').map(c => c.name);
+
+            log.info('Spawning CI-fix session for failing PR', {
+                repo: prRepo, number: prNumber, failedChecks,
+            });
+
+            this.lastSpawn.set(cooldownKey, Date.now());
+            await this.spawnFixSession(prRepo, prNumber, prTitle, failedChecks, agentId, projectId);
+        }
+    }
+
+    /**
+     * Create a session that checks out a PR branch and fixes CI failures.
+     */
+    private async spawnFixSession(
+        repo: string, prNumber: number, prTitle: string,
+        failedChecks: string[], agentId: string, projectId: string,
+    ): Promise<void> {
+        const repoName = repo.split('/')[1];
+        const workDir = `/tmp/${repoName}-pr-${prNumber}`;
+        const isHomeRepo = repo === 'CorvidLabs/corvid-agent';
+
+        const cloneStep = isHomeRepo
+            ? `1. Use \`corvid_create_work_task\` is NOT appropriate here — you need to fix an existing PR branch.\n   Clone the repo: \`gh repo clone ${repo} ${workDir} && cd ${workDir} && gh pr checkout ${prNumber}\``
+            : `1. Clone the repo and check out the PR branch:\n   \`gh repo clone ${repo} ${workDir} && cd ${workDir} && gh pr checkout ${prNumber}\``;
+
+        const prompt = [
+            `## CI Fix — PR #${prNumber} has failing checks`,
+            ``,
+            `**Repository:** ${repo}`,
+            `**PR:** #${prNumber} "${prTitle}"`,
+            `**Failing checks:** ${failedChecks.join(', ')}`,
+            ``,
+            `## Instructions`,
+            ``,
+            `PR #${prNumber} was authored by you and has CI failures that need to be fixed.`,
+            ``,
+            `Steps:`,
+            cloneStep,
+            `2. Read the CI failure logs:`,
+            `   \`gh pr checks ${prNumber} --repo ${repo}\``,
+            `   For each failed check, get the log URL and investigate.`,
+            `3. Read the PR diff to understand what was changed:`,
+            `   \`gh pr diff ${prNumber} --repo ${repo}\``,
+            `4. Run the failing checks locally to reproduce:`,
+            `   \`bunx tsc --noEmit --skipLibCheck\``,
+            `   \`bun test\``,
+            `5. Fix the issues on the existing branch:`,
+            `   - Edit the relevant files`,
+            `   - Commit: \`git add -A && git commit -m "fix: resolve CI failures"\``,
+            `   - Push to the existing branch: \`git push\``,
+            `6. Do NOT create a new PR. Push fixes to the existing branch.`,
+            `7. After pushing, verify the checks are running:`,
+            `   \`gh pr checks ${prNumber} --repo ${repo}\``,
+            ``,
+            `Rules:`,
+            `- Do NOT create a new PR — fix the existing one.`,
+            `- Do NOT close or abandon the PR.`,
+            `- Focus on making CI pass, not on adding new features.`,
+            `- If a test is genuinely wrong (testing incorrect behavior), fix the test.`,
+            `- If the code is wrong, fix the code.`,
+        ].join('\n');
+
+        try {
+            const session = createSession(this.db, {
+                projectId,
+                agentId,
+                name: `Poll: ${repo} #${prNumber}: ${prTitle.slice(0, 40)}`,
+                initialPrompt: prompt,
+                source: 'agent',
+            });
+
+            this.processManager.startProcess(session, prompt, { schedulerMode: true });
+            log.info('CI-fix session created', { repo, prNumber, sessionId: session.id });
+        } catch (err) {
+            log.error('Failed to create CI-fix session', {
+                repo, prNumber,
+                error: err instanceof Error ? err.message : String(err),
+            });
+        }
+    }
+}

--- a/server/polling/service.ts
+++ b/server/polling/service.ts
@@ -9,6 +9,11 @@
  * - Polls on a per-config interval (default 60s, min 30s)
  * - Tracks last-seen comment ID to avoid processing duplicates
  * - Reuses the same trigger logic as WebhookService (sessions + work tasks)
+ *
+ * Auto-merge, CI retry, and auto-update concerns are delegated to:
+ * - ./auto-merge.ts — squash-merge passing PRs
+ * - ./ci-retry.ts — spawn fix sessions for CI failures
+ * - ./auto-update.ts — pull new commits and restart
  */
 
 import type { Database } from 'bun:sqlite';
@@ -22,7 +27,6 @@ import {
     incrementPollingTriggerCount,
     updateProcessedIds,
 } from '../db/mention-polling';
-// Webhook delivery helpers not needed here — polling uses its own trigger tracking
 import { getAgent } from '../db/agents';
 import { createSession } from '../db/sessions';
 import { createLogger } from '../lib/logger';
@@ -37,6 +41,9 @@ import {
     resolveFullRepo,
     type DetectedMention,
 } from './github-searcher';
+import { AutoMergeService } from './auto-merge';
+import { CIRetryService } from './ci-retry';
+import { AutoUpdateService } from './auto-update';
 
 const log = createLogger('MentionPoller');
 const TRIGGER_DEDUP_NS = 'polling:triggers';
@@ -53,34 +60,15 @@ const MIN_TRIGGER_GAP_MS = 60_000;
 /** Max sessions spawned per config per poll cycle — prevents stampede. */
 const MAX_TRIGGERS_PER_CYCLE = 5;
 
-// DetectedMention type imported from ./github-searcher
-
 type PollingEventCallback = (event: {
     type: 'mention_poll_trigger';
     data: unknown;
 }) => void;
 
-/** How often to check for mergeable PRs (auto-merge loop). */
-const AUTO_MERGE_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
-
-/** How often to check for CI-failed PRs and spawn fix sessions. */
-const CI_RETRY_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
-
-/** Cooldown per PR before spawning another CI-fix session. */
-const CI_RETRY_COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes
-
-/** How often to check if origin/main has new commits. */
-const AUTO_UPDATE_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
-
 export class MentionPollingService {
     private db: Database;
     private processManager: ProcessManager;
     private loopTimer: ReturnType<typeof setInterval> | null = null;
-    private autoMergeTimer: ReturnType<typeof setInterval> | null = null;
-    private ciRetryTimer: ReturnType<typeof setInterval> | null = null;
-    private autoUpdateTimer: ReturnType<typeof setInterval> | null = null;
-    /** Tracks last CI-fix session spawn time per "repo#number" to enforce cooldown. */
-    private ciRetryLastSpawn = new Map<string, number>();
     private activePolls = new Set<string>(); // config IDs currently being polled
     private dedup = DedupService.global();
     private schedulerService: SchedulerService | null = null;
@@ -94,6 +82,11 @@ export class MentionPollingService {
     /** Extracted GitHub search module — handles mention/assignment/review searches. */
     private searcher: GitHubSearcher;
 
+    /** Delegated sub-services. */
+    private autoMerge: AutoMergeService;
+    private ciRetry: CIRetryService;
+    private autoUpdate: AutoUpdateService;
+
     constructor(
         db: Database,
         processManager: ProcessManager,
@@ -104,6 +97,11 @@ export class MentionPollingService {
         // Rate limit triggers: 60s TTL matches MIN_TRIGGER_GAP_MS, bounded at 500 entries
         this.dedup.register(TRIGGER_DEDUP_NS, { maxSize: 500, ttlMs: MIN_TRIGGER_GAP_MS });
         this.searcher = new GitHubSearcher((args) => this.runGh(args));
+
+        // Initialize sub-services
+        this.autoMerge = new AutoMergeService(db, (args) => this.runGh(args));
+        this.ciRetry = new CIRetryService(db, processManager, (args) => this.runGh(args));
+        this.autoUpdate = new AutoUpdateService(db);
     }
 
     /** Set scheduler service for triggering event-based schedules. */
@@ -117,7 +115,7 @@ export class MentionPollingService {
         return () => this.eventCallbacks.delete(callback);
     }
 
-    /** Start the polling loop. */
+    /** Start the polling loop and all sub-services. */
     start(): void {
         if (this.running) return;
         this.running = true;
@@ -128,36 +126,24 @@ export class MentionPollingService {
         this.pollDueConfigs();
         this.loopTimer = setInterval(() => this.pollDueConfigs(), POLL_LOOP_INTERVAL_MS);
 
-        // Auto-merge loop: squash-merge PRs authored by the agent that pass CI
-        this.autoMergePRs();
-        this.autoMergeTimer = setInterval(() => this.autoMergePRs(), AUTO_MERGE_INTERVAL_MS);
-
-        // CI retry loop: spawn fix sessions for PRs with failed CI
-        this.ciRetryTimer = setInterval(() => this.retryFailedCIPRs(), CI_RETRY_INTERVAL_MS);
-
-        // Auto-update loop: pull new commits and restart when sessions are idle
-        this.autoUpdateTimer = setInterval(() => this.checkForUpdates(), AUTO_UPDATE_INTERVAL_MS);
+        // Start sub-services
+        this.autoMerge.start();
+        this.ciRetry.start();
+        this.autoUpdate.start();
     }
 
-    /** Stop the polling loop. */
+    /** Stop the polling loop and all sub-services. */
     stop(): void {
         this.running = false;
         if (this.loopTimer) {
             clearInterval(this.loopTimer);
             this.loopTimer = null;
         }
-        if (this.autoMergeTimer) {
-            clearInterval(this.autoMergeTimer);
-            this.autoMergeTimer = null;
-        }
-        if (this.ciRetryTimer) {
-            clearInterval(this.ciRetryTimer);
-            this.ciRetryTimer = null;
-        }
-        if (this.autoUpdateTimer) {
-            clearInterval(this.autoUpdateTimer);
-            this.autoUpdateTimer = null;
-        }
+
+        this.autoMerge.stop();
+        this.ciRetry.stop();
+        this.autoUpdate.stop();
+
         log.info('Mention polling service stopped');
     }
 
@@ -202,375 +188,6 @@ export class MentionPollingService {
             await Promise.allSettled(promises);
         } catch (err) {
             log.error('Error in poll loop', { error: err instanceof Error ? err.message : String(err) });
-        }
-    }
-
-    // ─── Auto-Merge Loop ─────────────────────────────────────────────────
-
-    /**
-     * Find open PRs authored by the polling agent username that have all CI
-     * checks passing, and squash-merge them automatically.
-     */
-    private async autoMergePRs(): Promise<void> {
-        if (!this.running) return;
-
-        try {
-            // Gather unique repos from active polling configs
-            const allConfigs = this.db.query(
-                `SELECT repo, mention_username FROM mention_polling_configs WHERE status = 'active'`
-            ).all() as Array<{ repo: string; mention_username: string }>;
-
-            // Deduplicate by repo+username
-            const seen = new Set<string>();
-            const targets: Array<{ repo: string; username: string }> = [];
-            for (const c of allConfigs) {
-                const key = `${c.repo}:${c.mention_username}`;
-                if (seen.has(key)) continue;
-                seen.add(key);
-                targets.push({ repo: c.repo, username: c.mention_username });
-            }
-
-            for (const { repo, username } of targets) {
-                await this.autoMergeForRepo(repo, username);
-            }
-        } catch (err) {
-            log.error('Error in auto-merge loop', { error: err instanceof Error ? err.message : String(err) });
-        }
-    }
-
-    /**
-     * Auto-merge passing PRs for a specific repo authored by the given username.
-     */
-    private async autoMergeForRepo(repo: string, username: string): Promise<void> {
-        // List open PRs authored by the agent
-        const searchQualifier = repo.includes('/') ? `repo:${repo}` : `org:${repo}`;
-        const result = await this.runGh([
-            'api', 'search/issues',
-            '-X', 'GET',
-            '-f', `q=${searchQualifier} is:pr is:open author:${username}`,
-            '-f', 'per_page=20',
-        ]);
-
-        if (!result.ok || !result.stdout.trim()) return;
-
-        const parsed = JSON.parse(result.stdout) as { items?: Array<Record<string, unknown>> };
-        const prs = parsed.items ?? [];
-        if (prs.length === 0) return;
-
-        for (const pr of prs) {
-            const prNumber = pr.number as number;
-            const prUrl = (pr.html_url as string) ?? '';
-            const prRepo = resolveFullRepo(repo, prUrl);
-
-            // Check if all CI checks have passed
-            const statusResult = await this.runGh([
-                'pr', 'checks', String(prNumber),
-                '--repo', prRepo,
-                '--json', 'state',
-                '--jq', '[.[].state] | if length == 0 then "none" elif all(. == "SUCCESS") then "pass" else "fail" end',
-            ]);
-
-            if (!statusResult.ok || statusResult.stdout.trim() !== 'pass') {
-                continue;
-            }
-
-            // All checks pass — merge it
-            const mergeResult = await this.runGh([
-                'pr', 'merge', String(prNumber),
-                '--repo', prRepo,
-                '--squash',
-                '--delete-branch',
-            ]);
-
-            if (mergeResult.ok) {
-                log.info('Auto-merged PR', { repo: prRepo, number: prNumber });
-            } else {
-                log.debug('Failed to auto-merge PR', {
-                    repo: prRepo, number: prNumber,
-                    error: mergeResult.stderr,
-                });
-            }
-        }
-    }
-
-    // ─── CI Retry Loop ─────────────────────────────────────────────────
-
-    /**
-     * Find open PRs authored by the agent with failed CI and spawn sessions
-     * to fix them. Runs every 10 minutes with a 30-minute per-PR cooldown.
-     */
-    private async retryFailedCIPRs(): Promise<void> {
-        if (!this.running) return;
-
-        try {
-            const allConfigs = this.db.query(
-                `SELECT repo, mention_username, agent_id, project_id FROM mention_polling_configs WHERE status = 'active'`
-            ).all() as Array<{ repo: string; mention_username: string; agent_id: string; project_id: string }>;
-
-            const seen = new Set<string>();
-            for (const c of allConfigs) {
-                const key = `${c.repo}:${c.mention_username}`;
-                if (seen.has(key)) continue;
-                seen.add(key);
-                await this.retryFailedCIForRepo(c.repo, c.mention_username, c.agent_id, c.project_id);
-            }
-        } catch (err) {
-            log.error('Error in CI retry loop', { error: err instanceof Error ? err.message : String(err) });
-        }
-    }
-
-    /**
-     * For a specific repo, find open PRs by the agent with failed CI and spawn fix sessions.
-     */
-    private async retryFailedCIForRepo(
-        repo: string, username: string, agentId: string, projectId: string,
-    ): Promise<void> {
-        const searchQualifier = repo.includes('/') ? `repo:${repo}` : `org:${repo}`;
-        const result = await this.runGh([
-            'api', 'search/issues',
-            '-X', 'GET',
-            '-f', `q=${searchQualifier} is:pr is:open author:${username}`,
-            '-f', 'per_page=20',
-        ]);
-
-        if (!result.ok || !result.stdout.trim()) return;
-
-        const parsed = JSON.parse(result.stdout) as { items?: Array<Record<string, unknown>> };
-        const prs = parsed.items ?? [];
-
-        for (const pr of prs) {
-            const prNumber = pr.number as number;
-            const prTitle = (pr.title as string) ?? '';
-            const prUrl = (pr.html_url as string) ?? '';
-            const prRepo = resolveFullRepo(repo, prUrl);
-            const cooldownKey = `${prRepo}#${prNumber}`;
-
-            // Enforce cooldown
-            const lastSpawn = this.ciRetryLastSpawn.get(cooldownKey);
-            if (lastSpawn && Date.now() - lastSpawn < CI_RETRY_COOLDOWN_MS) continue;
-
-            // Skip if there's already a running session for this PR
-            const sessionPrefix = `Poll: ${prRepo} #${prNumber}:`;
-            const existing = this.db.query(
-                `SELECT id FROM sessions WHERE name LIKE ? AND status = 'running'`
-            ).get(sessionPrefix + '%') as { id: string } | null;
-            if (existing) continue;
-
-            // Check CI status — only act on failures (not pending/success)
-            const statusResult = await this.runGh([
-                'pr', 'checks', String(prNumber),
-                '--repo', prRepo,
-                '--json', 'state,name',
-                '--jq', '[.[] | {name, state}]',
-            ]);
-
-            if (!statusResult.ok || !statusResult.stdout.trim()) continue;
-
-            const checks = JSON.parse(statusResult.stdout) as Array<{ name: string; state: string }>;
-            const hasFailure = checks.some(c => c.state === 'FAILURE');
-            const hasPending = checks.some(c => c.state === 'PENDING' || c.state === 'QUEUED' || c.state === 'IN_PROGRESS');
-            if (!hasFailure || hasPending) continue;
-
-            // Get failed check names for the prompt
-            const failedChecks = checks.filter(c => c.state === 'FAILURE').map(c => c.name);
-
-            log.info('Spawning CI-fix session for failing PR', {
-                repo: prRepo, number: prNumber, failedChecks,
-            });
-
-            this.ciRetryLastSpawn.set(cooldownKey, Date.now());
-            await this.spawnCIFixSession(prRepo, prNumber, prTitle, failedChecks, agentId, projectId);
-        }
-    }
-
-    /**
-     * Create a session that checks out a PR branch and fixes CI failures.
-     */
-    private async spawnCIFixSession(
-        repo: string, prNumber: number, prTitle: string,
-        failedChecks: string[], agentId: string, projectId: string,
-    ): Promise<void> {
-        const repoName = repo.split('/')[1];
-        const workDir = `/tmp/${repoName}-pr-${prNumber}`;
-        const isHomeRepo = repo === 'CorvidLabs/corvid-agent';
-
-        const cloneStep = isHomeRepo
-            ? `1. Use \`corvid_create_work_task\` is NOT appropriate here — you need to fix an existing PR branch.\n   Clone the repo: \`gh repo clone ${repo} ${workDir} && cd ${workDir} && gh pr checkout ${prNumber}\``
-            : `1. Clone the repo and check out the PR branch:\n   \`gh repo clone ${repo} ${workDir} && cd ${workDir} && gh pr checkout ${prNumber}\``;
-
-        const prompt = [
-            `## CI Fix — PR #${prNumber} has failing checks`,
-            ``,
-            `**Repository:** ${repo}`,
-            `**PR:** #${prNumber} "${prTitle}"`,
-            `**Failing checks:** ${failedChecks.join(', ')}`,
-            ``,
-            `## Instructions`,
-            ``,
-            `PR #${prNumber} was authored by you and has CI failures that need to be fixed.`,
-            ``,
-            `Steps:`,
-            cloneStep,
-            `2. Read the CI failure logs:`,
-            `   \`gh pr checks ${prNumber} --repo ${repo}\``,
-            `   For each failed check, get the log URL and investigate.`,
-            `3. Read the PR diff to understand what was changed:`,
-            `   \`gh pr diff ${prNumber} --repo ${repo}\``,
-            `4. Run the failing checks locally to reproduce:`,
-            `   \`bunx tsc --noEmit --skipLibCheck\``,
-            `   \`bun test\``,
-            `5. Fix the issues on the existing branch:`,
-            `   - Edit the relevant files`,
-            `   - Commit: \`git add -A && git commit -m "fix: resolve CI failures"\``,
-            `   - Push to the existing branch: \`git push\``,
-            `6. Do NOT create a new PR. Push fixes to the existing branch.`,
-            `7. After pushing, verify the checks are running:`,
-            `   \`gh pr checks ${prNumber} --repo ${repo}\``,
-            ``,
-            `Rules:`,
-            `- Do NOT create a new PR — fix the existing one.`,
-            `- Do NOT close or abandon the PR.`,
-            `- Focus on making CI pass, not on adding new features.`,
-            `- If a test is genuinely wrong (testing incorrect behavior), fix the test.`,
-            `- If the code is wrong, fix the code.`,
-        ].join('\n');
-
-        try {
-            const session = createSession(this.db, {
-                projectId,
-                agentId,
-                name: `Poll: ${repo} #${prNumber}: ${prTitle.slice(0, 40)}`,
-                initialPrompt: prompt,
-                source: 'agent',
-            });
-
-            this.processManager.startProcess(session, prompt, { schedulerMode: true });
-            log.info('CI-fix session created', { repo, prNumber, sessionId: session.id });
-        } catch (err) {
-            log.error('Failed to create CI-fix session', {
-                repo, prNumber,
-                error: err instanceof Error ? err.message : String(err),
-            });
-        }
-    }
-
-    // ─── Auto-Update Loop ──────────────────────────────────────────────
-
-    /**
-     * Check if origin/main has new commits. If so, wait for all running
-     * sessions to finish, pull the changes, and exit so the wrapper
-     * script restarts the server with the new code.
-     */
-    private async checkForUpdates(): Promise<void> {
-        if (!this.running) return;
-
-        try {
-            // Fetch latest from origin
-            const fetchResult = Bun.spawnSync(['git', 'fetch', 'origin', 'main'], {
-                cwd: import.meta.dir + '/..',
-                stdout: 'pipe', stderr: 'pipe',
-            });
-            if (fetchResult.exitCode !== 0) return;
-
-            // Only auto-update if we're on the main branch
-            const currentBranch = Bun.spawnSync(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], {
-                cwd: import.meta.dir + '/..',
-                stdout: 'pipe',
-            }).stdout.toString().trim();
-
-            if (currentBranch !== 'main') {
-                log.debug('Skipping auto-update — not on main branch', { branch: currentBranch });
-                return;
-            }
-
-            // Compare local main with origin/main
-            const localHash = Bun.spawnSync(['git', 'rev-parse', 'HEAD'], {
-                cwd: import.meta.dir + '/..',
-                stdout: 'pipe',
-            }).stdout.toString().trim();
-
-            const remoteHash = Bun.spawnSync(['git', 'rev-parse', 'origin/main'], {
-                cwd: import.meta.dir + '/..',
-                stdout: 'pipe',
-            }).stdout.toString().trim();
-
-            if (localHash === remoteHash) return;
-
-            log.info('New commits detected on origin/main', { local: localHash.slice(0, 8), remote: remoteHash.slice(0, 8) });
-
-            // Check for running sessions — wait for them to finish
-            const running = this.db.query(
-                `SELECT COUNT(*) as count FROM sessions WHERE status = 'running' AND pid IS NOT NULL`
-            ).get() as { count: number } | null;
-
-            const activeCount = running?.count ?? 0;
-            if (activeCount > 0) {
-                log.info('Deferring auto-update — waiting for active sessions to finish', { activeCount });
-                return;
-            }
-
-            // No active sessions — pull and restart
-            log.info('No active sessions — pulling and restarting');
-
-            const pullResult = Bun.spawnSync(['git', 'pull', '--rebase', 'origin', 'main'], {
-                cwd: import.meta.dir + '/..',
-                stdout: 'pipe', stderr: 'pipe',
-            });
-
-            if (pullResult.exitCode !== 0) {
-                log.error('Git pull failed', { stderr: pullResult.stderr.toString().trim() });
-                return;
-            }
-
-            // Check if bun.lock changed — if so, install updated dependencies
-            // before restarting to avoid running with stale node_modules.
-            const lockDiff = Bun.spawnSync(
-                ['git', 'diff', localHash, 'HEAD', '--name-only', '--', 'bun.lock', 'package.json'],
-                { cwd: import.meta.dir + '/..', stdout: 'pipe' },
-            );
-            const changedFiles = lockDiff.stdout.toString().trim();
-            if (changedFiles) {
-                log.info('Dependencies changed — running bun install', { changedFiles });
-                const installResult = Bun.spawnSync(
-                    ['bun', 'install', '--frozen-lockfile', '--ignore-scripts'],
-                    { cwd: import.meta.dir + '/..', stdout: 'pipe', stderr: 'pipe' },
-                );
-                if (installResult.exitCode !== 0) {
-                    log.error('bun install failed after pull — reverting', {
-                        stderr: installResult.stderr.toString().trim(),
-                    });
-                    // Roll back to the known-good commit so we don't run with mismatched code + deps
-                    Bun.spawnSync(['git', 'reset', '--hard', localHash], {
-                        cwd: import.meta.dir + '/..',
-                        stdout: 'pipe', stderr: 'pipe',
-                    });
-                    return;
-                }
-                log.info('bun install completed successfully');
-            }
-
-            // Verify pull actually advanced HEAD to origin/main
-            const newLocalHash = Bun.spawnSync(['git', 'rev-parse', 'HEAD'], {
-                cwd: import.meta.dir + '/..',
-                stdout: 'pipe',
-            }).stdout.toString().trim();
-
-            if (newLocalHash === localHash) {
-                log.warn('Git pull did not advance HEAD — skipping restart to avoid loop', {
-                    hash: localHash.slice(0, 8),
-                });
-                return;
-            }
-
-            log.info('Git pull successful — exiting for restart', {
-                oldHash: localHash.slice(0, 8),
-                newHash: newLocalHash.slice(0, 8),
-            });
-            // Exit with code 75 (EX_TEMPFAIL) to signal "restart me"
-            // The run-loop.sh wrapper and launchd both treat non-zero as restartable
-            process.exit(75);
-        } catch (err) {
-            log.error('Error in auto-update check', { error: err instanceof Error ? err.message : String(err) });
         }
     }
 
@@ -866,8 +483,6 @@ export class MentionPollingService {
     }
 
     // ─── Helpers ─────────────────────────────────────────────────────────────
-    // repoQualifier, resolveFullRepo, shouldPollEventType, containsMention,
-    // filterNewMentions, and escapeRegex are now in ./github-searcher.ts
 
     private buildPrompt(config: MentionPollingConfig, mention: DetectedMention): string {
         // Resolve the actual owner/repo from the mention URL when config.repo is an org/user name.


### PR DESCRIPTION
## Summary
- Extracts auto-merge, CI retry, and auto-update into dedicated modules from the 1087-line `MentionPollingService`
- `auto-merge.ts` (130 LOC) — squash-merge passing PRs authored by agent
- `ci-retry.ts` (212 LOC) — spawn fix sessions for CI-failed PRs with cooldown
- `auto-update.ts` (157 LOC) — pull origin/main and restart when idle
- `service.ts` reduced to 701 LOC, focused on its core concern (mention polling)
- No public API changes — same constructor signature, same `start()`/`stop()`/`getStats()`

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 4492 pass, 0 fail
- [x] `bun run spec:check` — 38 specs pass
- [x] Updated 3 tests to reference `CIRetryService` directly

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)