### PR TITLE
refactor: consolidate inline DB count casts with queryCount() helper

### DIFF
--- a/server/__tests__/algochat-bridge.test.ts
+++ b/server/__tests__/algochat-bridge.test.ts
@@ -16,6 +16,7 @@
 import { test, expect, beforeEach, afterEach, describe } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { runMigrations } from '../db/schema';
+import { queryCount } from '../db/types';
 import { parseGroupPrefix, reassembleGroupMessage, splitMessage } from '../algochat/group-sender';
 import { formatApprovalForChain, parseApprovalResponse } from '../algochat/approval-format';
 
@@ -268,11 +269,7 @@ describe('psk_contacts DB operations', () => {
         insertContact('c2', 'Bob', NETWORK, 'ALGO_ADDR', 1);  // matched, active
         insertContact('c3', 'Carol', NETWORK, null, 0);        // unmatched, inactive
 
-        const row = db.prepare(
-            'SELECT COUNT(*) as count FROM psk_contacts WHERE network = ? AND active = 1 AND mobile_address IS NULL'
-        ).get(NETWORK) as { count: number };
-
-        expect(row.count).toBe(1); // only Alice
+        expect(queryCount(db, 'SELECT COUNT(*) as cnt FROM psk_contacts WHERE network = ? AND active = 1 AND mobile_address IS NULL', NETWORK)).toBe(1); // only Alice
     });
 
     test('list contacts ordered by created_at ASC', () => {

--- a/server/__tests__/credits.test.ts
+++ b/server/__tests__/credits.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, beforeEach, afterEach, describe } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { runMigrations } from '../db/schema';
+import { queryCount } from '../db/types';
 import {
     getCreditConfig,
     updateCreditConfig,
@@ -78,8 +79,7 @@ describe('Balance', () => {
     test('getBalance is idempotent (creates ledger row once)', () => {
         getBalance(db, WALLET);
         getBalance(db, WALLET);
-        const rows = db.query('SELECT COUNT(*) as count FROM credit_ledger WHERE wallet_address = ?').get(WALLET) as { count: number };
-        expect(rows.count).toBe(1);
+        expect(queryCount(db, 'SELECT COUNT(*) as cnt FROM credit_ledger WHERE wallet_address = ?', WALLET)).toBe(1);
     });
 
     test('available = credits - reserved', () => {

--- a/server/__tests__/dedup.test.ts
+++ b/server/__tests__/dedup.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { DedupService } from '../lib/dedup';
+import { queryCount } from '../db/types';
 
 describe('DedupService', () => {
     let service: DedupService;
@@ -302,10 +303,10 @@ describe('DedupService', () => {
             svc2.stop();
 
             // Verify the dedup_state table is clean
-            const rows = db.query(`SELECT COUNT(*) as cnt FROM dedup_state`).get() as { cnt: number };
+            const dedupCount = queryCount(db, 'SELECT COUNT(*) as cnt FROM dedup_state');
             // After stop(), any keys that were restored and then stopped should be persisted
             // but the expired ones from svc1 were cleaned on svc2 startup
-            expect(rows.cnt).toBeLessThanOrEqual(1);
+            expect(dedupCount).toBeLessThanOrEqual(1);
         });
 
         test('creates dedup_state table automatically', () => {

--- a/server/__tests__/retention.test.ts
+++ b/server/__tests__/retention.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { pruneTable, runRetentionCleanup, RETENTION_POLICIES } from '../db/retention';
 import { runMigrations } from '../db/schema';
+import { queryCount } from '../db/types';
 
 let db: Database;
 
@@ -34,8 +35,8 @@ describe('pruneTable', () => {
         expect(deleted).toBe(1);
 
         // New record should still exist
-        const remaining = db.query(`SELECT COUNT(*) as count FROM audit_log`).get() as { count: number };
-        expect(remaining.count).toBe(1);
+        const remaining = queryCount(db, 'SELECT COUNT(*) as cnt FROM audit_log');
+        expect(remaining).toBe(1);
     });
 
     test('returns 0 when no records to prune', () => {
@@ -58,8 +59,7 @@ describe('pruneTable', () => {
         const deleted = pruneTable(db, { table: 'daily_spending', timestampColumn: 'date', retentionDays: 90 });
         expect(deleted).toBe(1);
 
-        const remaining = db.query(`SELECT COUNT(*) as count FROM daily_spending`).get() as { count: number };
-        expect(remaining.count).toBe(1);
+        expect(queryCount(db, 'SELECT COUNT(*) as cnt FROM daily_spending')).toBe(1);
     });
 
     test('handles empty table', () => {
@@ -88,11 +88,8 @@ describe('runRetentionCleanup', () => {
 
         runRetentionCleanup(db);
 
-        const spending = db.query(`SELECT COUNT(*) as count FROM daily_spending`).get() as { count: number };
-        expect(spending.count).toBe(0);
-
-        const audit = db.query(`SELECT COUNT(*) as count FROM audit_log`).get() as { count: number };
-        expect(audit.count).toBe(0);
+        expect(queryCount(db, 'SELECT COUNT(*) as cnt FROM daily_spending')).toBe(0);
+        expect(queryCount(db, 'SELECT COUNT(*) as cnt FROM audit_log')).toBe(0);
     });
 
     test('preserves recent records', () => {
@@ -101,8 +98,7 @@ describe('runRetentionCleanup', () => {
 
         runRetentionCleanup(db);
 
-        const spending = db.query(`SELECT COUNT(*) as count FROM daily_spending`).get() as { count: number };
-        expect(spending.count).toBe(1);
+        expect(queryCount(db, 'SELECT COUNT(*) as cnt FROM daily_spending')).toBe(1);
     });
 });
 

--- a/server/algochat/psk-contact-manager.ts
+++ b/server/algochat/psk-contact-manager.ts
@@ -13,6 +13,7 @@ import type { AlgoChatService } from './service';
 import { PSKManager } from './psk';
 import type { PSKMessage } from './psk';
 import { createLogger } from '../lib/logger';
+import { queryCount } from '../db/types';
 
 const log = createLogger('PSKContactManager');
 
@@ -280,10 +281,7 @@ export class PSKContactManager {
 
     /** Check whether there are unmatched contacts (no mobile_address yet). */
     hasUnmatchedContacts(): boolean {
-        const row = this.db.prepare(
-            'SELECT COUNT(*) as count FROM psk_contacts WHERE network = ? AND active = 1 AND mobile_address IS NULL'
-        ).get(this.config.network) as { count: number };
-        return row.count > 0;
+        return queryCount(this.db, 'SELECT COUNT(*) as cnt FROM psk_contacts WHERE network = ? AND active = 1 AND mobile_address IS NULL', this.config.network) > 0;
     }
 
     /**

--- a/server/db/agent-memories.ts
+++ b/server/db/agent-memories.ts
@@ -1,5 +1,6 @@
 import type { Database } from 'bun:sqlite';
 import type { AgentMemory, MemoryStatus } from '../../shared/types';
+import { queryCount } from './types';
 
 interface AgentMemoryRow {
     id: string;
@@ -173,8 +174,5 @@ export function getPendingMemories(
 }
 
 export function countPendingMemories(db: Database): number {
-    const row = db.query(
-        "SELECT COUNT(*) as count FROM agent_memories WHERE status IN ('pending', 'failed')"
-    ).get() as { count: number };
-    return row.count;
+    return queryCount(db, "SELECT COUNT(*) as cnt FROM agent_memories WHERE status IN ('pending', 'failed')");
 }

--- a/server/db/agent-messages.ts
+++ b/server/db/agent-messages.ts
@@ -1,6 +1,7 @@
 import type { Database } from 'bun:sqlite';
 import type { AgentMessage, AgentMessageStatus, MessageErrorCode } from '../../shared/types';
 import { MESSAGE_PROTOCOL_VERSION } from '../../shared/types';
+import { queryCount } from './types';
 
 interface AgentMessageRow {
     id: string;
@@ -174,8 +175,7 @@ export function searchAgentMessages(
 
     const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
-    const countRow = db.query(`SELECT COUNT(*) as cnt FROM agent_messages ${where}`).get(...(params as string[])) as { cnt: number };
-    const total = countRow.cnt;
+    const total = queryCount(db, `SELECT COUNT(*) as cnt FROM agent_messages ${where}`, ...(params as string[]));
 
     const limit = Math.min(options.limit ?? 50, 100);
     const offset = options.offset ?? 0;

--- a/server/db/algochat-messages.ts
+++ b/server/db/algochat-messages.ts
@@ -1,4 +1,5 @@
 import type { Database } from 'bun:sqlite';
+import { queryCount } from './types';
 
 export interface AlgoChatMessage {
     id: number;
@@ -62,12 +63,12 @@ export function listRecentAlgoChatMessages(
     limit: number = 50,
     offset: number = 0,
 ): { messages: AlgoChatMessage[]; total: number } {
-    const countRow = db.query('SELECT COUNT(*) as cnt FROM algochat_messages').get() as { cnt: number };
+    const total = queryCount(db, 'SELECT COUNT(*) as cnt FROM algochat_messages');
     const rows = db.query(
         `SELECT * FROM algochat_messages ORDER BY created_at DESC LIMIT ? OFFSET ?`,
     ).all(limit, offset) as AlgoChatMessageRow[];
 
-    return { messages: rows.map(rowToMessage), total: countRow.cnt };
+    return { messages: rows.map(rowToMessage), total };
 }
 
 export function searchAlgoChatMessages(
@@ -92,7 +93,7 @@ export function searchAlgoChatMessages(
     }
 
     const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
-    const countRow = db.query(`SELECT COUNT(*) as cnt FROM algochat_messages ${where}`).get(...(params as string[])) as { cnt: number };
+    const total = queryCount(db, `SELECT COUNT(*) as cnt FROM algochat_messages ${where}`, ...(params as string[]));
     const limit = Math.min(options.limit ?? 50, 100);
     const offset = options.offset ?? 0;
 
@@ -100,7 +101,7 @@ export function searchAlgoChatMessages(
         `SELECT * FROM algochat_messages ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`,
     ).all(...(params as string[]), limit, offset) as AlgoChatMessageRow[];
 
-    return { messages: rows.map(rowToMessage), total: countRow.cnt };
+    return { messages: rows.map(rowToMessage), total };
 }
 
 // ─── Wallet Summaries ────────────────────────────────────────────────────
@@ -187,13 +188,11 @@ export function getWalletMessages(
     limit: number = 50,
     offset: number = 0,
 ): { messages: AlgoChatMessage[]; total: number } {
-    const countRow = db.query(
-        'SELECT COUNT(*) as cnt FROM algochat_messages WHERE participant = ?'
-    ).get(address) as { cnt: number };
+    const total = queryCount(db, 'SELECT COUNT(*) as cnt FROM algochat_messages WHERE participant = ?', address);
 
     const rows = db.query(
         `SELECT * FROM algochat_messages WHERE participant = ? ORDER BY created_at DESC LIMIT ? OFFSET ?`,
     ).all(address, limit, offset) as AlgoChatMessageRow[];
 
-    return { messages: rows.map(rowToMessage), total: countRow.cnt };
+    return { messages: rows.map(rowToMessage), total };
 }

--- a/server/db/allowlist.ts
+++ b/server/db/allowlist.ts
@@ -1,4 +1,5 @@
 import type { Database } from 'bun:sqlite';
+import { queryCount } from './types';
 
 export interface AllowlistEntry {
     address: string;
@@ -54,6 +55,5 @@ export function removeFromAllowlist(db: Database, address: string): boolean {
 export function isAllowed(db: Database, address: string): boolean {
     const row = db.query('SELECT 1 FROM algochat_allowlist WHERE address = ? LIMIT 1').get(address);
     if (row != null) return true;
-    const count = db.query('SELECT COUNT(*) as cnt FROM algochat_allowlist').get() as { cnt: number };
-    return count.cnt === 0;
+    return queryCount(db, 'SELECT COUNT(*) as cnt FROM algochat_allowlist') === 0;
 }

--- a/server/db/audit.ts
+++ b/server/db/audit.ts
@@ -9,6 +9,7 @@
 import type { Database } from 'bun:sqlite';
 import { getTraceId } from '../observability/trace-context';
 import { createLogger } from '../lib/logger';
+import { queryCount } from './types';
 
 const log = createLogger('Audit');
 
@@ -143,9 +144,7 @@ export function queryAuditLog(db: Database, options: AuditQueryOptions = {}): { 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
     // Count total matching rows
-    const countRow = db.query(
-        `SELECT COUNT(*) as total FROM audit_log ${whereClause}`
-    ).get(...params) as { total: number };
+    const total = queryCount(db, `SELECT COUNT(*) as cnt FROM audit_log ${whereClause}`, ...params);
 
     // Fetch paginated results
     const limit = Math.min(options.limit ?? 50, 500);
@@ -180,6 +179,6 @@ export function queryAuditLog(db: Database, options: AuditQueryOptions = {}): { 
             traceId: r.trace_id,
             ipAddress: r.ip_address,
         })),
-        total: countRow.total,
+        total,
     };
 }

--- a/server/db/github-allowlist.ts
+++ b/server/db/github-allowlist.ts
@@ -1,4 +1,5 @@
 import type { Database } from 'bun:sqlite';
+import { queryCount } from './types';
 
 export interface GitHubAllowlistEntry {
     username: string;
@@ -63,8 +64,7 @@ export function removeFromGitHubAllowlist(db: Database, username: string): boole
 export function isGitHubUserAllowed(db: Database, username: string): boolean {
     const row = db.query('SELECT 1 FROM github_allowlist WHERE username = ? LIMIT 1').get(username.toLowerCase());
     if (row != null) return true;
-    const count = db.query('SELECT COUNT(*) as cnt FROM github_allowlist').get() as { cnt: number };
-    if (count.cnt === 0) {
+    if (queryCount(db, 'SELECT COUNT(*) as cnt FROM github_allowlist') === 0) {
         return process.env.GITHUB_ALLOWLIST_OPEN_MODE === 'true';
     }
     return false;

--- a/server/db/schedules.ts
+++ b/server/db/schedules.ts
@@ -12,6 +12,7 @@ import type {
     ScheduleTriggerEvent,
 } from '../../shared/types';
 import { DEFAULT_TENANT_ID } from '../tenant/types';
+import { queryCount } from './types';
 import { withTenantFilter, validateTenantOwnership } from '../tenant/db-filter';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -261,14 +262,14 @@ export function listExecutionsFiltered(
     const limit = opts.limit ?? 50;
     const offset = opts.offset ?? 0;
 
-    const countRow = db.query(`SELECT COUNT(*) as total FROM schedule_executions ${where}`).get(...params) as { total: number };
+    const total = queryCount(db, `SELECT COUNT(*) as cnt FROM schedule_executions ${where}`, ...params);
     const rows = db.query(
         `SELECT * FROM schedule_executions ${where} ORDER BY started_at DESC LIMIT ? OFFSET ?`
     ).all(...params, limit, offset);
 
     return {
         executions: (rows as Record<string, unknown>[]).map(rowToExecution),
-        total: countRow.total,
+        total,
     };
 }
 

--- a/server/db/types.ts
+++ b/server/db/types.ts
@@ -1,0 +1,58 @@
+/**
+ * Common database type utilities.
+ *
+ * Provides typed helpers for frequent query patterns (counts, existence checks,
+ * pagination) to replace scattered inline type casts.
+ */
+
+import type { Database, SQLQueryBindings } from 'bun:sqlite';
+
+// ─── Count Queries ──────────────────────────────────────────────────────────
+
+/** Row shape for COUNT(*) queries aliased as `cnt`. */
+export interface CountRow { cnt: number }
+
+/**
+ * Execute a COUNT(*) query and return the numeric result.
+ *
+ * Usage:
+ *   const total = queryCount(db, 'SELECT COUNT(*) as cnt FROM agents WHERE active = 1');
+ *   const filtered = queryCount(db, 'SELECT COUNT(*) as cnt FROM sessions WHERE agent_id = ?', agentId);
+ */
+export function queryCount(db: Database, sql: string, ...params: SQLQueryBindings[]): number {
+    const row = db.query(sql).get(...params) as CountRow | null;
+    return row?.cnt ?? 0;
+}
+
+/**
+ * Check if any rows exist matching the query.
+ *
+ * Usage:
+ *   const hasAgent = queryExists(db, 'SELECT COUNT(*) as cnt FROM agents WHERE id = ?', id);
+ */
+export function queryExists(db: Database, sql: string, ...params: SQLQueryBindings[]): boolean {
+    return queryCount(db, sql, ...params) > 0;
+}
+
+// ─── Pagination ─────────────────────────────────────────────────────────────
+
+/** Paginated query result with items and total count. */
+export interface PaginatedResult<T> {
+    items: T[];
+    total: number;
+}
+
+// ─── Common Row Types ───────────────────────────────────────────────────────
+
+/** Row with just a string ID (for SELECT id FROM ...). */
+export interface IdRow { id: string }
+
+/** Row with just a numeric ID. */
+export interface NumericIdRow { id: number }
+
+/** Stats row used by polling service. */
+export interface PollingStatsRow {
+    total: number;
+    active: number;
+    triggers: number;
+}

--- a/server/marketplace/service.ts
+++ b/server/marketplace/service.ts
@@ -19,6 +19,7 @@ import type {
 import { IdentityVerification } from '../reputation/identity-verification';
 import type { VerificationTier } from '../reputation/identity-verification';
 import { createLogger } from '../lib/logger';
+import { queryCount } from '../db/types';
 
 const log = createLogger('Marketplace');
 
@@ -260,9 +261,7 @@ export class MarketplaceService {
             : '';
 
         // Count total
-        const countRow = this.db.query(
-            `SELECT COUNT(*) as total FROM marketplace_listings ml${joinClause} ${where}`,
-        ).get(...values) as { total: number };
+        const total = queryCount(this.db, `SELECT COUNT(*) as cnt FROM marketplace_listings ml${joinClause} ${where}`, ...values);
 
         // Fetch page
         const rows = this.db.query(
@@ -273,7 +272,7 @@ export class MarketplaceService {
 
         return {
             listings: rows.map(recordToListing),
-            total: countRow.total,
+            total,
             limit,
             offset,
         };

--- a/server/mcp/tool-handlers/work.ts
+++ b/server/mcp/tool-handlers/work.ts
@@ -3,6 +3,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { McpToolContext } from './types';
 import { textResult, errorResult } from './types';
 import { createLogger } from '../../lib/logger';
+import { queryCount } from '../../db/types';
 
 const log = createLogger('McpToolHandlers');
 
@@ -10,10 +11,7 @@ const log = createLogger('McpToolHandlers');
 const WORK_TASK_MAX_PER_DAY = parseInt(process.env.WORK_TASK_MAX_PER_DAY ?? '100', 10);
 
 function checkWorkTaskRateLimit(db: Database, agentId: string): boolean {
-    const row = db.query(
-        `SELECT COUNT(*) as count FROM work_tasks WHERE agent_id = ? AND date(created_at) = date('now')`
-    ).get(agentId) as { count: number } | null;
-    return (row?.count ?? 0) < WORK_TASK_MAX_PER_DAY;
+    return queryCount(db, "SELECT COUNT(*) as cnt FROM work_tasks WHERE agent_id = ? AND date(created_at) = date('now')", agentId) < WORK_TASK_MAX_PER_DAY;
 }
 
 export async function handleCreateWorkTask(

--- a/server/performance/collector.ts
+++ b/server/performance/collector.ts
@@ -8,6 +8,7 @@
 import type { Database } from 'bun:sqlite';
 import { statSync } from 'node:fs';
 import { createLogger } from '../lib/logger';
+import { queryCount } from '../db/types';
 
 const log = createLogger('PerfCollector');
 
@@ -206,26 +207,16 @@ export class PerformanceCollector {
         }
 
         // Slow query count regression
-        const slowThisWeek = this.db.query(`
-            SELECT COUNT(*) as count FROM performance_metrics
-            WHERE metric = 'db_slow_query'
-              AND timestamp >= datetime('now', '-7 days')
-        `).get() as { count: number };
+        const slowThisWeekCount = queryCount(this.db, `SELECT COUNT(*) as cnt FROM performance_metrics WHERE metric = 'db_slow_query' AND timestamp >= datetime('now', '-7 days')`);
+        const slowLastWeekCount = queryCount(this.db, `SELECT COUNT(*) as cnt FROM performance_metrics WHERE metric = 'db_slow_query' AND timestamp >= datetime('now', '-14 days') AND timestamp < datetime('now', '-7 days')`);
 
-        const slowLastWeek = this.db.query(`
-            SELECT COUNT(*) as count FROM performance_metrics
-            WHERE metric = 'db_slow_query'
-              AND timestamp >= datetime('now', '-14 days')
-              AND timestamp < datetime('now', '-7 days')
-        `).get() as { count: number };
-
-        if (slowLastWeek.count > 0 && slowThisWeek.count > 0) {
-            const changePercent = ((slowThisWeek.count - slowLastWeek.count) / slowLastWeek.count) * 100;
+        if (slowLastWeekCount > 0 && slowThisWeekCount > 0) {
+            const changePercent = ((slowThisWeekCount - slowLastWeekCount) / slowLastWeekCount) * 100;
             if (changePercent > thresholdPercent) {
                 regressions.push({
                     metric: 'db_slow_query_count',
-                    thisWeekAvg: slowThisWeek.count,
-                    lastWeekAvg: slowLastWeek.count,
+                    thisWeekAvg: slowThisWeekCount,
+                    lastWeekAvg: slowLastWeekCount,
                     changePercent: Math.round(changePercent * 10) / 10,
                     severity: changePercent > 50 ? 'critical' : 'warning',
                 });
@@ -241,22 +232,16 @@ export class PerformanceCollector {
         const regressions = this.detectRegressions();
 
         // Get slow query count for today
-        const slowToday = this.db.query(`
-            SELECT COUNT(*) as count FROM performance_metrics
-            WHERE metric = 'db_slow_query'
-              AND timestamp >= datetime('now', 'start of day')
-        `).get() as { count: number };
+        const slowToday = queryCount(this.db, "SELECT COUNT(*) as cnt FROM performance_metrics WHERE metric = 'db_slow_query' AND timestamp >= datetime('now', 'start of day')");
 
         // Get total metrics count for storage info
-        const totalRows = this.db.query(`
-            SELECT COUNT(*) as count FROM performance_metrics
-        `).get() as { count: number };
+        const metricsTotal = queryCount(this.db, 'SELECT COUNT(*) as cnt FROM performance_metrics');
 
         return {
             snapshot,
             regressions,
-            slowQueriestoday: slowToday.count,
-            metricsStoredTotal: totalRows.count,
+            slowQueriestoday: slowToday,
+            metricsStoredTotal: metricsTotal,
         };
     }
 

--- a/server/polling/service.ts
+++ b/server/polling/service.ts
@@ -37,6 +37,7 @@ import {
     resolveFullRepo,
     type DetectedMention,
 } from './github-searcher';
+import { queryCount } from '../db/types';
 
 const log = createLogger('MentionPoller');
 const TRIGGER_DEDUP_NS = 'polling:triggers';
@@ -499,11 +500,7 @@ export class MentionPollingService {
             log.info('New commits detected on origin/main', { local: localHash.slice(0, 8), remote: remoteHash.slice(0, 8) });
 
             // Check for running sessions — wait for them to finish
-            const running = this.db.query(
-                `SELECT COUNT(*) as count FROM sessions WHERE status = 'running' AND pid IS NOT NULL`
-            ).get() as { count: number } | null;
-
-            const activeCount = running?.count ?? 0;
+            const activeCount = queryCount(this.db, "SELECT COUNT(*) as cnt FROM sessions WHERE status = 'running' AND pid IS NOT NULL");
             if (activeCount > 0) {
                 log.info('Deferring auto-update — waiting for active sessions to finish', { activeCount });
                 return;

--- a/server/process/session-lifecycle.ts
+++ b/server/process/session-lifecycle.ts
@@ -1,5 +1,6 @@
 import type { Database } from 'bun:sqlite';
 import { createLogger } from '../lib/logger';
+import { queryCount } from '../db/types';
 
 const log = createLogger('SessionLifecycle');
 
@@ -277,11 +278,7 @@ export class SessionLifecycleManager {
      * Update the active session count for monitoring
      */
     private updateActiveSessionCount(): void {
-        const result = this.db.query(`
-            SELECT COUNT(*) as count FROM sessions WHERE status IN ('running', 'paused')
-        `).get() as { count: number };
-
-        this.activeSessionCount = result.count;
+        this.activeSessionCount = queryCount(this.db, "SELECT COUNT(*) as cnt FROM sessions WHERE status IN ('running', 'paused')");
     }
 
     /**
@@ -293,7 +290,7 @@ export class SessionLifecycleManager {
         sessionsByStatus: Record<string, number>;
         oldestSessionAge: number;
     } {
-        const totalResult = this.db.query(`SELECT COUNT(*) as count FROM sessions`).get() as { count: number };
+        const totalSessions = queryCount(this.db, 'SELECT COUNT(*) as cnt FROM sessions');
 
         const statusResults = this.db.query(`
             SELECT status, COUNT(*) as count
@@ -312,7 +309,7 @@ export class SessionLifecycleManager {
 
         return {
             activeSessions: this.activeSessionCount,
-            totalSessions: totalResult.count,
+            totalSessions,
             sessionsByStatus,
             oldestSessionAge: oldestResult.oldest ? Date.now() - new Date(oldestResult.oldest + 'Z').getTime() : 0,
         };
@@ -322,13 +319,7 @@ export class SessionLifecycleManager {
      * Check if a new session can be created for a project
      */
     canCreateSession(projectId: string): boolean {
-        const result = this.db.query(`
-            SELECT COUNT(*) as count
-            FROM sessions
-            WHERE project_id = ?
-        `).get(projectId) as { count: number };
-
-        return result.count < this.config.maxSessionsPerProject;
+        return queryCount(this.db, 'SELECT COUNT(*) as cnt FROM sessions WHERE project_id = ?', projectId) < this.config.maxSessionsPerProject;
     }
 
     /**

--- a/server/routes/system-logs.ts
+++ b/server/routes/system-logs.ts
@@ -6,6 +6,7 @@
 import type { Database } from 'bun:sqlite';
 import type { RequestContext } from '../middleware/guards';
 import { json, safeNumParam } from '../lib/response';
+import { queryCount } from '../db/types';
 
 export function handleSystemLogRoutes(req: Request, url: URL, db: Database, _context?: RequestContext): Response | null {
     // GET /api/system-logs — aggregated system logs
@@ -159,11 +160,11 @@ function handleCreditTransactions(db: Database, limit: number, offset: number): 
         session_id: string | null; created_at: string;
     }[];
 
-    const countRow = db.query(`SELECT COUNT(*) as count FROM credit_transactions`).get() as { count: number };
+    const total = queryCount(db, 'SELECT COUNT(*) as cnt FROM credit_transactions');
 
     return json({
         transactions,
-        total: countRow.count,
+        total,
         limit: clampedLimit,
         offset,
     });

--- a/server/scheduler/service.ts
+++ b/server/scheduler/service.ts
@@ -49,6 +49,7 @@ import {
 import type { OutcomeTrackerService } from '../feedback/outcome-tracker';
 import { SystemStateDetector, type SystemStateResult, type SystemStateConfig } from './system-state';
 import { evaluateAction, getAllRules } from './priority-rules';
+import { queryCount } from '../db/types';
 
 const log = createLogger('Scheduler');
 
@@ -214,23 +215,17 @@ export class SchedulerService {
         systemState: SystemStateResult | null;
         priorityRules: ReturnType<typeof getAllRules>;
     } {
-        const activeRow = this.db.query(
-            `SELECT COUNT(*) as count FROM agent_schedules WHERE status = 'active'`
-        ).get() as { count: number };
-        const pausedRow = this.db.query(
-            `SELECT COUNT(*) as count FROM agent_schedules WHERE status = 'paused'`
-        ).get() as { count: number };
-        const failureRow = this.db.query(
-            `SELECT COUNT(*) as count FROM schedule_executions WHERE status = 'failed' AND started_at >= datetime('now', '-24 hours')`
-        ).get() as { count: number };
+        const activeSchedules = queryCount(this.db, "SELECT COUNT(*) as cnt FROM agent_schedules WHERE status = 'active'");
+        const pausedSchedules = queryCount(this.db, "SELECT COUNT(*) as cnt FROM agent_schedules WHERE status = 'paused'");
+        const recentFailures = queryCount(this.db, "SELECT COUNT(*) as cnt FROM schedule_executions WHERE status = 'failed' AND started_at >= datetime('now', '-24 hours')");
 
         return {
             running: this.pollTimer !== null,
-            activeSchedules: activeRow.count,
-            pausedSchedules: pausedRow.count,
+            activeSchedules,
+            pausedSchedules,
             runningExecutions: this.runningExecutions.size,
             maxConcurrent: MAX_CONCURRENT_EXECUTIONS,
-            recentFailures: failureRow.count,
+            recentFailures,
             systemState: this.lastSystemState,
             priorityRules: getAllRules(),
         };

--- a/server/tenant/context.ts
+++ b/server/tenant/context.ts
@@ -8,6 +8,7 @@ import type { Database } from 'bun:sqlite';
 import type { TenantContext, Tenant, TenantRecord, TenantPlan } from './types';
 import { DEFAULT_TENANT_ID, PLAN_LIMITS } from './types';
 import { createLogger } from '../lib/logger';
+import { queryCount } from '../db/types';
 
 const log = createLogger('TenantContext');
 
@@ -182,11 +183,7 @@ export class TenantService {
         if (!tenant) return false;
         if (tenant.maxAgents === -1) return true; // unlimited
 
-        const row = this.db.query(
-            'SELECT COUNT(*) as count FROM agents WHERE tenant_id = ?',
-        ).get(tenantId) as { count: number } | null;
-
-        return (row?.count ?? 0) < tenant.maxAgents;
+        return queryCount(this.db, 'SELECT COUNT(*) as cnt FROM agents WHERE tenant_id = ?', tenantId) < tenant.maxAgents;
     }
 
     /**
@@ -197,10 +194,6 @@ export class TenantService {
         if (!tenant) return false;
         if (tenant.maxConcurrentSessions === -1) return true;
 
-        const row = this.db.query(
-            "SELECT COUNT(*) as count FROM sessions WHERE tenant_id = ? AND status IN ('running', 'idle')",
-        ).get(tenantId) as { count: number } | null;
-
-        return (row?.count ?? 0) < tenant.maxConcurrentSessions;
+        return queryCount(this.db, "SELECT COUNT(*) as cnt FROM sessions WHERE tenant_id = ? AND status IN ('running', 'idle')", tenantId) < tenant.maxConcurrentSessions;
     }
 }

--- a/server/voice/tts.ts
+++ b/server/voice/tts.ts
@@ -3,6 +3,7 @@ import type { VoicePreset } from '../../shared/types';
 import type { TTSOptions, TTSResult } from './types';
 import { createLogger } from '../lib/logger';
 import { ValidationError, ExternalServiceError } from '../lib/errors';
+import { queryCount } from '../db/types';
 
 const log = createLogger('TTS');
 
@@ -105,9 +106,9 @@ export async function synthesizeWithCache(
     ).run(id, textHash, voice, result.audio, result.format, result.durationMs);
 
     // Evict oldest entries if cache exceeds max size
-    const countRow = db.query('SELECT COUNT(*) as cnt FROM voice_cache').get() as { cnt: number };
-    if (countRow.cnt > MAX_VOICE_CACHE_ENTRIES) {
-        const excess = countRow.cnt - MAX_VOICE_CACHE_ENTRIES;
+    const cacheCount = queryCount(db, 'SELECT COUNT(*) as cnt FROM voice_cache');
+    if (cacheCount > MAX_VOICE_CACHE_ENTRIES) {
+        const excess = cacheCount - MAX_VOICE_CACHE_ENTRIES;
         db.query('DELETE FROM voice_cache WHERE id IN (SELECT id FROM voice_cache ORDER BY created_at ASC LIMIT ?)').run(excess);
         log.info('Voice cache evicted old entries', { evicted: excess });
     }

--- a/server/workflow/service.ts
+++ b/server/workflow/service.ts
@@ -32,6 +32,7 @@ import { createSession, getSession } from '../db/sessions';
 import { createLogger } from '../lib/logger';
 import { NotFoundError, ValidationError } from '../lib/errors';
 import { createEventContext, runWithEventContext } from '../observability/event-context';
+import { queryCount } from '../db/types';
 
 const log = createLogger('Workflow');
 
@@ -183,18 +184,14 @@ export class WorkflowService {
         totalWorkflows: number;
         hasMessenger: boolean;
     } {
-        const activeRow = this.db.query(
-            `SELECT COUNT(*) as count FROM workflow_runs WHERE status IN ('running', 'paused')`
-        ).get() as { count: number };
-        const totalRow = this.db.query(
-            `SELECT COUNT(*) as count FROM workflows`
-        ).get() as { count: number };
+        const activeRuns = queryCount(this.db, "SELECT COUNT(*) as cnt FROM workflow_runs WHERE status IN ('running', 'paused')");
+        const totalWorkflows = queryCount(this.db, 'SELECT COUNT(*) as cnt FROM workflows');
 
         return {
             running: this.pollTimer !== null,
-            activeRuns: activeRow.count,
+            activeRuns,
             runningNodes: this.runningNodes.size,
-            totalWorkflows: totalRow.count,
+            totalWorkflows,
             hasMessenger: this.agentMessenger !== null,
         };
     }


### PR DESCRIPTION
## Summary
- Creates `server/db/types.ts` with typed `queryCount()` and `queryExists()` helpers plus common row type interfaces (`CountRow`, `PaginatedResult<T>`, `IdRow`, `NumericIdRow`, `PollingStatsRow`)
- Replaces 35+ scattered inline `as { cnt/count/total: number }` type casts across 22 files with the centralized helper
- Standardizes all count queries to use `cnt` alias for consistency

## Files changed (22 production + test files)
**New:** `server/db/types.ts`
**DB layer:** algochat-messages, agent-messages, allowlist, github-allowlist, agent-memories, audit, schedules
**Services:** scheduler, marketplace, workflow, polling, performance/collector, session-lifecycle, tenant/context, psk-contact-manager, voice/tts
**Routes:** system-logs
**MCP:** tool-handlers/work
**Tests:** dedup, retention, credits, algochat-bridge

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 4492 pass, 0 fail
- [x] `bun run spec:check` — 38 specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)