### PR TITLE
test: add tests for github-allowlist and mcp-servers DB modules

### DIFF
--- a/server/__tests__/github-allowlist.test.ts
+++ b/server/__tests__/github-allowlist.test.ts
@@ -1,0 +1,134 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import {
+    listGitHubAllowlist,
+    getGitHubAllowlistEntry,
+    addToGitHubAllowlist,
+    updateGitHubAllowlistEntry,
+    removeFromGitHubAllowlist,
+    isGitHubUserAllowed,
+} from '../db/github-allowlist';
+
+let db: Database;
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+});
+
+afterEach(() => {
+    db.close();
+});
+
+// ── CRUD ─────────────────────────────────────────────────────────────
+
+describe('GitHub Allowlist CRUD', () => {
+    test('listGitHubAllowlist returns empty array on fresh db', () => {
+        expect(listGitHubAllowlist(db)).toEqual([]);
+    });
+
+    test('addToGitHubAllowlist creates entry with lowercase username', () => {
+        const entry = addToGitHubAllowlist(db, 'TestUser', 'Test label');
+        expect(entry.username).toBe('testuser');
+        expect(entry.label).toBe('Test label');
+        expect(entry.createdAt).toBeTruthy();
+    });
+
+    test('addToGitHubAllowlist upserts label on conflict', () => {
+        addToGitHubAllowlist(db, 'alice', 'Original');
+        const updated = addToGitHubAllowlist(db, 'alice', 'Updated');
+        expect(updated.label).toBe('Updated');
+        expect(listGitHubAllowlist(db)).toHaveLength(1);
+    });
+
+    test('addToGitHubAllowlist defaults label to empty string', () => {
+        const entry = addToGitHubAllowlist(db, 'bob');
+        expect(entry.label).toBe('');
+    });
+
+    test('getGitHubAllowlistEntry returns null for missing user', () => {
+        expect(getGitHubAllowlistEntry(db, 'nobody')).toBeNull();
+    });
+
+    test('getGitHubAllowlistEntry is case-insensitive', () => {
+        addToGitHubAllowlist(db, 'CaseSensitive', 'label');
+        expect(getGitHubAllowlistEntry(db, 'casesensitive')).not.toBeNull();
+        expect(getGitHubAllowlistEntry(db, 'CASESENSITIVE')).not.toBeNull();
+    });
+
+    test('updateGitHubAllowlistEntry updates label', () => {
+        addToGitHubAllowlist(db, 'alice', 'Old');
+        const result = updateGitHubAllowlistEntry(db, 'alice', 'New');
+        expect(result?.label).toBe('New');
+    });
+
+    test('updateGitHubAllowlistEntry returns null for missing user', () => {
+        expect(updateGitHubAllowlistEntry(db, 'nobody', 'label')).toBeNull();
+    });
+
+    test('removeFromGitHubAllowlist deletes entry', () => {
+        addToGitHubAllowlist(db, 'alice', 'label');
+        expect(removeFromGitHubAllowlist(db, 'alice')).toBe(true);
+        expect(getGitHubAllowlistEntry(db, 'alice')).toBeNull();
+    });
+
+    test('removeFromGitHubAllowlist returns false for missing user', () => {
+        expect(removeFromGitHubAllowlist(db, 'nobody')).toBe(false);
+    });
+
+    test('listGitHubAllowlist returns all entries', () => {
+        addToGitHubAllowlist(db, 'first', 'a');
+        addToGitHubAllowlist(db, 'second', 'b');
+        addToGitHubAllowlist(db, 'third', 'c');
+        const list = listGitHubAllowlist(db);
+        expect(list).toHaveLength(3);
+        const usernames = list.map(e => e.username).sort();
+        expect(usernames).toEqual(['first', 'second', 'third']);
+    });
+});
+
+// ── isGitHubUserAllowed ──────────────────────────────────────────────
+
+describe('isGitHubUserAllowed', () => {
+    test('allows listed users', () => {
+        addToGitHubAllowlist(db, 'alice');
+        expect(isGitHubUserAllowed(db, 'alice')).toBe(true);
+    });
+
+    test('denies unlisted users when allowlist has entries', () => {
+        addToGitHubAllowlist(db, 'alice');
+        expect(isGitHubUserAllowed(db, 'bob')).toBe(false);
+    });
+
+    test('is case-insensitive for username check', () => {
+        addToGitHubAllowlist(db, 'alice');
+        expect(isGitHubUserAllowed(db, 'Alice')).toBe(true);
+        expect(isGitHubUserAllowed(db, 'ALICE')).toBe(true);
+    });
+
+    test('denies all when allowlist is empty (default secure mode)', () => {
+        const original = process.env.GITHUB_ALLOWLIST_OPEN_MODE;
+        delete process.env.GITHUB_ALLOWLIST_OPEN_MODE;
+        try {
+            expect(isGitHubUserAllowed(db, 'anyone')).toBe(false);
+        } finally {
+            if (original !== undefined) process.env.GITHUB_ALLOWLIST_OPEN_MODE = original;
+        }
+    });
+
+    test('allows all when empty and GITHUB_ALLOWLIST_OPEN_MODE=true', () => {
+        const original = process.env.GITHUB_ALLOWLIST_OPEN_MODE;
+        process.env.GITHUB_ALLOWLIST_OPEN_MODE = 'true';
+        try {
+            expect(isGitHubUserAllowed(db, 'anyone')).toBe(true);
+        } finally {
+            if (original !== undefined) {
+                process.env.GITHUB_ALLOWLIST_OPEN_MODE = original;
+            } else {
+                delete process.env.GITHUB_ALLOWLIST_OPEN_MODE;
+            }
+        }
+    });
+});

--- a/server/__tests__/mcp-servers.test.ts
+++ b/server/__tests__/mcp-servers.test.ts
@@ -1,0 +1,217 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import {
+    listMcpServerConfigs,
+    getMcpServerConfig,
+    getActiveServersForAgent,
+    createMcpServerConfig,
+    updateMcpServerConfig,
+    deleteMcpServerConfig,
+} from '../db/mcp-servers';
+
+let db: Database;
+
+// Helper to create a test agent for FK constraints
+function createTestAgent(id: string = 'agent-1'): void {
+    db.query(
+        `INSERT INTO agents (id, name, model, system_prompt, tenant_id)
+         VALUES (?, ?, ?, ?, 'default')`,
+    ).run(id, 'Test Agent', 'test-model', 'Test prompt');
+}
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+});
+
+afterEach(() => {
+    db.close();
+});
+
+// ── CRUD ─────────────────────────────────────────────────────────────
+
+describe('MCP Server Config CRUD', () => {
+    test('listMcpServerConfigs returns empty on fresh db', () => {
+        expect(listMcpServerConfigs(db)).toEqual([]);
+    });
+
+    test('createMcpServerConfig creates a global server config', () => {
+        const config = createMcpServerConfig(db, {
+            name: 'test-server',
+            command: 'node',
+            args: ['server.js'],
+            envVars: { PORT: '3000' },
+        });
+
+        expect(config.id).toBeTruthy();
+        expect(config.name).toBe('test-server');
+        expect(config.command).toBe('node');
+        expect(config.args).toEqual(['server.js']);
+        expect(config.envVars).toEqual({ PORT: '3000' });
+        expect(config.agentId).toBeNull();
+        expect(config.enabled).toBe(true);
+        expect(config.cwd).toBeNull();
+    });
+
+    test('createMcpServerConfig creates agent-specific config', () => {
+        createTestAgent();
+        const config = createMcpServerConfig(db, {
+            name: 'agent-server',
+            command: 'python',
+            agentId: 'agent-1',
+        });
+
+        expect(config.agentId).toBe('agent-1');
+    });
+
+    test('createMcpServerConfig defaults args and envVars to empty', () => {
+        const config = createMcpServerConfig(db, {
+            name: 'minimal',
+            command: 'echo',
+        });
+
+        expect(config.args).toEqual([]);
+        expect(config.envVars).toEqual({});
+    });
+
+    test('createMcpServerConfig respects enabled=false', () => {
+        const config = createMcpServerConfig(db, {
+            name: 'disabled-server',
+            command: 'echo',
+            enabled: false,
+        });
+
+        expect(config.enabled).toBe(false);
+    });
+
+    test('getMcpServerConfig returns config by id', () => {
+        const created = createMcpServerConfig(db, {
+            name: 'test',
+            command: 'node',
+        });
+
+        const fetched = getMcpServerConfig(db, created.id);
+        expect(fetched).not.toBeNull();
+        expect(fetched!.name).toBe('test');
+    });
+
+    test('getMcpServerConfig returns null for missing id', () => {
+        expect(getMcpServerConfig(db, 'nonexistent')).toBeNull();
+    });
+
+    test('listMcpServerConfigs returns all configs ordered by name', () => {
+        createMcpServerConfig(db, { name: 'zeta', command: 'z' });
+        createMcpServerConfig(db, { name: 'alpha', command: 'a' });
+        createMcpServerConfig(db, { name: 'mid', command: 'm' });
+
+        const list = listMcpServerConfigs(db);
+        expect(list).toHaveLength(3);
+        expect(list[0].name).toBe('alpha');
+        expect(list[1].name).toBe('mid');
+        expect(list[2].name).toBe('zeta');
+    });
+
+    test('listMcpServerConfigs filters by agentId', () => {
+        createTestAgent();
+        createTestAgent('agent-2');
+
+        createMcpServerConfig(db, { name: 'global', command: 'g' });
+        createMcpServerConfig(db, { name: 'a1-server', command: 'a', agentId: 'agent-1' });
+        createMcpServerConfig(db, { name: 'a2-server', command: 'b', agentId: 'agent-2' });
+
+        const a1Configs = listMcpServerConfigs(db, 'agent-1');
+        expect(a1Configs).toHaveLength(1);
+        expect(a1Configs[0].name).toBe('a1-server');
+    });
+});
+
+// ── Update ───────────────────────────────────────────────────────────
+
+describe('updateMcpServerConfig', () => {
+    test('updates name', () => {
+        const config = createMcpServerConfig(db, { name: 'old', command: 'echo' });
+        const updated = updateMcpServerConfig(db, config.id, { name: 'new' });
+        expect(updated!.name).toBe('new');
+    });
+
+    test('updates command and args', () => {
+        const config = createMcpServerConfig(db, { name: 'test', command: 'node' });
+        const updated = updateMcpServerConfig(db, config.id, {
+            command: 'python',
+            args: ['-m', 'server'],
+        });
+        expect(updated!.command).toBe('python');
+        expect(updated!.args).toEqual(['-m', 'server']);
+    });
+
+    test('updates enabled flag', () => {
+        const config = createMcpServerConfig(db, { name: 'test', command: 'echo' });
+        const updated = updateMcpServerConfig(db, config.id, { enabled: false });
+        expect(updated!.enabled).toBe(false);
+    });
+
+    test('updates envVars', () => {
+        const config = createMcpServerConfig(db, { name: 'test', command: 'echo' });
+        const updated = updateMcpServerConfig(db, config.id, { envVars: { KEY: 'value' } });
+        expect(updated!.envVars).toEqual({ KEY: 'value' });
+    });
+
+    test('returns null for missing id', () => {
+        expect(updateMcpServerConfig(db, 'nonexistent', { name: 'x' })).toBeNull();
+    });
+
+    test('returns existing config when no fields to update', () => {
+        const config = createMcpServerConfig(db, { name: 'test', command: 'echo' });
+        const result = updateMcpServerConfig(db, config.id, {});
+        expect(result!.name).toBe('test');
+    });
+});
+
+// ── Delete ───────────────────────────────────────────────────────────
+
+describe('deleteMcpServerConfig', () => {
+    test('deletes existing config', () => {
+        const config = createMcpServerConfig(db, { name: 'test', command: 'echo' });
+        expect(deleteMcpServerConfig(db, config.id)).toBe(true);
+        expect(getMcpServerConfig(db, config.id)).toBeNull();
+    });
+
+    test('returns false for missing id', () => {
+        expect(deleteMcpServerConfig(db, 'nonexistent')).toBe(false);
+    });
+});
+
+// ── getActiveServersForAgent ─────────────────────────────────────────
+
+describe('getActiveServersForAgent', () => {
+    test('returns global and agent-specific enabled configs', () => {
+        createTestAgent();
+
+        createMcpServerConfig(db, { name: 'global', command: 'g' });
+        createMcpServerConfig(db, { name: 'agent-specific', command: 'a', agentId: 'agent-1' });
+        createMcpServerConfig(db, { name: 'disabled', command: 'd', enabled: false });
+
+        const active = getActiveServersForAgent(db, 'agent-1');
+        expect(active).toHaveLength(2);
+        expect(active.map(c => c.name).sort()).toEqual(['agent-specific', 'global']);
+    });
+
+    test('excludes configs for other agents', () => {
+        createTestAgent();
+        createTestAgent('agent-2');
+
+        createMcpServerConfig(db, { name: 'a1-server', command: 'a', agentId: 'agent-1' });
+        createMcpServerConfig(db, { name: 'a2-server', command: 'b', agentId: 'agent-2' });
+
+        const active = getActiveServersForAgent(db, 'agent-1');
+        expect(active).toHaveLength(1);
+        expect(active[0].name).toBe('a1-server');
+    });
+
+    test('returns empty when no matching configs', () => {
+        createTestAgent();
+        expect(getActiveServersForAgent(db, 'agent-1')).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds 36 tests for two previously untested DB modules
- **github-allowlist**: 14 tests covering CRUD, case-insensitive lookups, `isGitHubUserAllowed` with open mode vs secure-by-default
- **mcp-servers**: 22 tests covering CRUD, agent-specific vs global configs, `getActiveServersForAgent` filtering, partial updates

## Test plan
- [x] `bun test` — 4541 pass (36 new), 0 fail
- [x] `bunx tsc --noEmit --skipLibCheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)