### PR TITLE
security: audit all API endpoints for consistent role enforcement

### DIFF
--- a/server/__tests__/endpoint-rate-limit.test.ts
+++ b/server/__tests__/endpoint-rate-limit.test.ts
@@ -404,3 +404,40 @@ describe('endpointRateLimitGuard integration', () => {
         expect(limiter.check('client', 'GET', '/api/agents', 'public').allowed).toBe(true);
     });
 });
+
+// ---------------------------------------------------------------------------
+// Tenant registration rate limiting
+// ---------------------------------------------------------------------------
+
+describe('tenant registration rate limiting (default config)', () => {
+    let limiter: EndpointRateLimiter;
+
+    beforeEach(() => {
+        limiter = new EndpointRateLimiter(loadEndpointRateLimitConfig());
+    });
+
+    afterEach(() => {
+        limiter.stop();
+    });
+
+    it('blocks public tenant registration after 3 requests', () => {
+        for (let i = 0; i < 3; i++) {
+            const result = limiter.check('attacker', 'POST', '/api/tenants/register', 'public');
+            expect(result.allowed).toBe(true);
+        }
+        const blocked = limiter.check('attacker', 'POST', '/api/tenants/register', 'public');
+        expect(blocked.allowed).toBe(false);
+        expect(blocked.response).not.toBeNull();
+        expect(blocked.response!.status).toBe(429);
+    });
+
+    it('allows different IPs to register independently', () => {
+        for (let i = 0; i < 3; i++) {
+            limiter.check('ip1', 'POST', '/api/tenants/register', 'public');
+        }
+        // ip1 is blocked
+        expect(limiter.check('ip1', 'POST', '/api/tenants/register', 'public').allowed).toBe(false);
+        // ip2 still has budget
+        expect(limiter.check('ip2', 'POST', '/api/tenants/register', 'public').allowed).toBe(true);
+    });
+});

--- a/server/__tests__/guards.test.ts
+++ b/server/__tests__/guards.test.ts
@@ -469,6 +469,32 @@ describe('requiresAdminRole', () => {
         expect(requiresAdminRole('/api/wallets')).toBe(false);
         expect(requiresAdminRole('/api/wallets/ABCD1234')).toBe(false);
     });
+
+    it('returns true for /api/system-logs', () => {
+        expect(requiresAdminRole('/api/system-logs')).toBe(true);
+    });
+
+    it('returns true for /api/system-logs/credit-transactions', () => {
+        expect(requiresAdminRole('/api/system-logs/credit-transactions')).toBe(true);
+    });
+
+    it('returns true for /api/wallets/summary', () => {
+        expect(requiresAdminRole('/api/wallets/summary')).toBe(true);
+    });
+
+    it('returns true for /api/github-allowlist paths', () => {
+        expect(requiresAdminRole('/api/github-allowlist')).toBe(true);
+        expect(requiresAdminRole('/api/github-allowlist/someuser')).toBe(true);
+    });
+
+    it('returns true for /api/performance paths', () => {
+        expect(requiresAdminRole('/api/performance/snapshot')).toBe(true);
+        expect(requiresAdminRole('/api/performance/trends')).toBe(true);
+        expect(requiresAdminRole('/api/performance/regressions')).toBe(true);
+        expect(requiresAdminRole('/api/performance/report')).toBe(true);
+        expect(requiresAdminRole('/api/performance/metrics')).toBe(true);
+        expect(requiresAdminRole('/api/performance/collect')).toBe(true);
+    });
 });
 
 // --- expired API key rejection -----------------------------------------------

--- a/server/middleware/endpoint-rate-limit.ts
+++ b/server/middleware/endpoint-rate-limit.ts
@@ -130,6 +130,15 @@ export function loadEndpointRateLimitConfig(): EndpointRateLimitConfig {
                     admin: { max: 5, windowMs: ONE_MINUTE },
                 },
             },
+            // Tenant registration is public — strict rate limit to prevent abuse
+            {
+                pattern: 'POST /api/tenants/register',
+                tiers: {
+                    public: { max: 3, windowMs: ONE_MINUTE * 5 },
+                    user: { max: 3, windowMs: ONE_MINUTE * 5 },
+                    admin: { max: 10, windowMs: ONE_MINUTE * 5 },
+                },
+            },
         ],
         exemptPaths: ['/api/health', '/webhooks/github', '/ws', '/.well-known/agent-card.json'],
     };

--- a/server/middleware/guards.ts
+++ b/server/middleware/guards.ts
@@ -216,6 +216,11 @@ export const ADMIN_PATHS = new Set([
     '/api/settings/credits',
     '/api/settings/api-key/rotate',
     '/api/settings/api-key/status',
+    // System logs expose escalation queue, work task details, and credit transactions
+    '/api/system-logs',
+    '/api/system-logs/credit-transactions',
+    // Wallet summary exposes all external wallets across tenants
+    '/api/wallets/summary',
 ]);
 
 export function requiresAdminRole(pathname: string): boolean {
@@ -225,5 +230,9 @@ export function requiresAdminRole(pathname: string): boolean {
     if (/^\/api\/wallets\/[^/]+\/credits$/.test(pathname)) return true;
     // Allowlist controls which addresses can interact — admin-only to prevent tenant escalation
     if (pathname.startsWith('/api/allowlist')) return true;
+    // GitHub allowlist controls which GitHub users can trigger work — admin-only
+    if (pathname.startsWith('/api/github-allowlist')) return true;
+    // Performance metrics expose system internals (memory, heap, DB latency, regressions)
+    if (pathname.startsWith('/api/performance')) return true;
     return false;
 }


### PR DESCRIPTION
## Summary

Full security audit of all 34 route handler files against the guard chain. Found and fixed **5 gaps** in role-based access enforcement:

- **`/api/system-logs/*`** — Exposed escalation queue history, work task details, and credit transaction ledger to any authenticated user. Now requires admin role.
- **`/api/performance/*`** — Exposed system internals (memory RSS, heap usage, DB latency, regression detection) to any authenticated user. Now requires admin role.
- **`/api/github-allowlist`** — Was missing from `requiresAdminRole()` — only `/api/allowlist` had a `startsWith` check. Any authenticated user could add/remove GitHub usernames from the authorized list. Now covered by prefix check.
- **`/api/wallets/summary`** — Returned all external wallets across all tenants without restriction. Now requires admin role.
- **`/api/tenants/register`** — Public endpoint (no auth) with only generic rate limiting (60 POST/min). Added strict endpoint-specific rate limit: 3 registrations per 5 minutes per IP.

### What's well-protected (audit confirmed)

- Credit granting (`POST /api/wallets/:addr/credits`) — admin-only ✅
- Allowlist management (`/api/allowlist/*`) — admin-only ✅
- Audit log, operational mode, backup — admin-only ✅
- Tenant member management — owner role required ✅
- Multi-tenant route isolation — all resources filtered by `tenant_id` at DB level ✅
- GitHub/Slack webhooks — HMAC signature validation ✅
- API key validation — timing-safe comparison ✅
- API key rotation — grace period support ✅

### Changes

| File | Change |
|------|--------|
| `server/middleware/guards.ts` | Added 3 entries to `ADMIN_PATHS`, added `github-allowlist` and `performance` prefix checks to `requiresAdminRole()` |
| `server/middleware/endpoint-rate-limit.ts` | Added tenant registration rate limit rule (3/5min per IP) |
| `server/__tests__/guards.test.ts` | 5 new test cases covering all new admin-only paths |
| `server/__tests__/endpoint-rate-limit.test.ts` | 2 new test cases for tenant registration rate limiting |

## Test plan

- [x] All 48 guard tests pass (5 new)
- [x] All 36 endpoint rate limit tests pass (2 new)
- [x] Full suite: 4586 pass, 0 new failures (1 pre-existing logger test)
- [x] TypeScript: `tsc --noEmit` clean
- [x] Verify Angular client still works with admin endpoints (requires login with admin key)

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)