### PR TITLE
docs: fix stale counts and remove nonexistent endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
   <img src="https://img.shields.io/badge/version-0.15.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
-  <img src="https://img.shields.io/badge/runtime-Bun_1.2-f9f1e1?logo=bun" alt="Bun">
+  <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">
   <img src="https://img.shields.io/badge/Angular-21-dd0031?logo=angular" alt="Angular 21">
-  <img src="https://img.shields.io/badge/tests-4417%20unit%20%7C%20348%20E2E-brightgreen" alt="4417 Unit | 348 E2E Tests">
+  <img src="https://img.shields.io/badge/tests-4586%20unit%20%7C%20360%20E2E-brightgreen" alt="4586 Unit | 360 E2E Tests">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>
 </p>
 
@@ -275,7 +275,7 @@ OPENAI_API_KEY=sk-...
 |                                                                 |
 |  +-----------------------------------------------------------+  |
 |  |                    SQLite (bun:sqlite)                     |  |
-|  |  58 migrations | FTS5 search | WAL mode | foreign keys    |  |
+|  |  63 migrations | FTS5 search | WAL mode | foreign keys    |  |
 |  +-----------------------------------------------------------+  |
 +-----------------------------------------------------------------+
 ```
@@ -290,7 +290,7 @@ server/          Bun HTTP + WebSocket server
   billing/       Usage metering and billing
   channels/      Channel adapter interfaces for messaging bridges
   councils/      Council discussion and synthesis engines
-  db/            SQLite schema (58 migrations) and query modules
+  db/            SQLite schema (63 migrations) and query modules
   discord/       Bidirectional Discord bridge (raw WebSocket gateway)
   docs/          OpenAPI generator, MCP tool docs, route registry
   exam/          Model exam system with 18 test cases across 6 categories
@@ -327,9 +327,10 @@ server/          Bun HTTP + WebSocket server
   workflow/      Graph-based DAG workflow orchestration engine
   ws/            WebSocket handlers with pub/sub
 client/          Angular 21 SPA (standalone components, signals)
+cli/             CLI entry point and commands
 shared/          TypeScript types shared between server and client
-deploy/          Docker, docker-compose, systemd, launchd, nginx, caddy, Helm
-e2e/             Playwright end-to-end tests (31 spec files, 348 E2E tests)
+deploy/          Docker, docker-compose, systemd, launchd, nginx, caddy, Helm, K8s
+e2e/             Playwright end-to-end tests (31 spec files, 360 E2E tests)
 ```
 
 ---
@@ -408,15 +409,15 @@ Tools are permission-scoped per agent via skill bundles and agent-level allowlis
 ## Testing
 
 ```bash
-bun test              # 4470+ server tests (~118s)
+bun test              # 4586+ server tests (~120s)
 cd client && npx vitest run   # Angular component tests (~2s)
-bun run test:e2e      # 31 Playwright spec files, 348 tests
+bun run test:e2e      # 31 Playwright spec files, 360 tests
 bun run spec:check    # Validate all module specs in specs/
 ```
 
-**4417 unit tests** covering: API routes, audit logging, authentication, bash security, billing, CLI, credit system, crypto, database migrations, Discord bridge, feedback loop, GitHub tools, health monitoring, marketplace, MCP tool handlers, notifications, multi-model routing, multi-tenant isolation, observability, owner communication, performance metrics, personas, plugins, process lifecycle, rate limiting, reputation, sandbox isolation, scheduling, skill bundles, Slack bridge, Telegram bridge, tenant isolation, usage monitoring, validation, voice TTS/STT, wallet keystore, web search, workflows, work tasks, and Angular components.
+**4586 unit tests** covering: API routes, audit logging, authentication, bash security, billing, CLI, credit system, crypto, database migrations, Discord bridge, feedback loop, GitHub tools, health monitoring, marketplace, MCP tool handlers, notifications, multi-model routing, multi-tenant isolation, observability, owner communication, performance metrics, personas, plugins, process lifecycle, rate limiting, reputation, sandbox isolation, scheduling, skill bundles, Slack bridge, Telegram bridge, tenant isolation, usage monitoring, validation, voice TTS/STT, wallet keystore, web search, workflows, work tasks, and Angular components.
 
-**348 E2E tests** across 31 Playwright spec files covering 198/202 testable API endpoints and all 37 Angular UI routes.
+**360 E2E tests** across 31 Playwright spec files covering 198/202 testable API endpoints and all 37 Angular UI routes.
 
 **38 module specs** in `specs/` with automated validation via `bun run spec:check` — checks YAML frontmatter, required sections, API surface coverage (exported symbols vs documented), file existence, database table references, and dependency graph integrity. Runs in CI on every commit.
 
@@ -428,7 +429,7 @@ bun run spec:check    # Validate all module specs in specs/
 |-------|-----------|
 | Runtime | [Bun](https://bun.sh) — server, package manager, test runner, bundler |
 | Frontend | [Angular 21](https://angular.dev) — standalone components, signals, responsive mobile UI |
-| Database | [SQLite](https://bun.sh/docs/api/sqlite) — WAL mode, FTS5, 58 migrations |
+| Database | [SQLite](https://bun.sh/docs/api/sqlite) — WAL mode, FTS5, 63 migrations |
 | Agent SDK | [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) |
 | Local Models | [Ollama](https://ollama.com) — Qwen, Llama, etc. |
 | Voice | [OpenAI TTS/Whisper](https://platform.openai.com/docs/guides/text-to-speech) — 6 voice presets, STT transcription |
@@ -470,6 +471,8 @@ The `deploy/` directory includes production configurations:
 - `daemon.sh` — cross-platform daemon installer
 - `run-loop.sh` — auto-restart wrapper with update support
 - `nginx/` + `caddy/` — reverse proxy with TLS termination
+- `helm/` — Helm chart for Kubernetes deployment
+- `k8s/` — raw Kubernetes manifests (configmap, ingress, service, statefulset)
 
 ---
 

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -576,11 +576,6 @@
         <h3 class="api-group__title accent-green">Slack</h3>
         <div class="api-table">
           <div class="api-row">
-            <span class="api-method api-method--get">GET</span>
-            <code class="api-path">/api/slack/status</code>
-            <span class="api-desc">Slack bridge connection status</span>
-          </div>
-          <div class="api-row">
             <span class="api-method api-method--post">POST</span>
             <code class="api-path">/slack/events</code>
             <span class="api-desc">Slack event webhook receiver</span>
@@ -900,7 +895,7 @@
   <section class="section" id="database">
     <div class="container">
       <h2 class="section__title">Database Schema</h2>
-      <p class="section__subtitle">SQLite via <code class="accent-cyan">bun:sqlite</code>. Schema version 47. Auto-migrates on startup.</p>
+      <p class="section__subtitle">SQLite via <code class="accent-cyan">bun:sqlite</code>. Schema version 63. Auto-migrates on startup.</p>
 
       <div class="grid grid--3">
         <div class="card card--cyan">


### PR DESCRIPTION
## Summary
- Update migration count 58→63 in README and architecture.html schema version 47→63
- Update test counts: unit 4417→4586, E2E 348→360
- Update Bun badge 1.2→1.3
- Add `cli/` directory and `helm/`/`k8s/` to README structure listings
- Remove stale `GET /api/slack/status` from architecture.html (endpoint never existed in code)

## Context
Full API sync audit found ~80 endpoints undocumented in architecture.html — tracked separately in issue.

## Test plan
- [x] Verify README renders correctly
- [x] Verify architecture.html loads without errors
- [x] CI passes (build, test, CodeQL, E2E, coverage, security scans)

🤖 Generated with [Claude Code](https://claude.com/claude-code)