### PR TITLE
test: add tests for health-snapshots, notifications, and webhooks DB modules

### DIFF
--- a/server/__tests__/health-snapshots.test.ts
+++ b/server/__tests__/health-snapshots.test.ts
@@ -1,0 +1,180 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import {
+    insertHealthSnapshot,
+    listHealthSnapshots,
+    getUptimeStats,
+    pruneHealthSnapshots,
+} from '../db/health-snapshots';
+
+let db: Database;
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+});
+
+afterEach(() => {
+    db.close();
+});
+
+// ── insertHealthSnapshot ─────────────────────────────────────────────
+
+describe('insertHealthSnapshot', () => {
+    test('inserts a minimal snapshot with defaults', () => {
+        const snap = insertHealthSnapshot(db, { status: 'healthy' });
+        expect(snap.id).toBeGreaterThan(0);
+        expect(snap.status).toBe('healthy');
+        expect(snap.responseTimeMs).toBeNull();
+        expect(snap.dependencies).toBeNull();
+        expect(snap.source).toBe('internal');
+        expect(snap.timestamp).toBeTruthy();
+    });
+
+    test('inserts a full snapshot with all fields', () => {
+        const deps = { db: 'ok', redis: 'ok' };
+        const snap = insertHealthSnapshot(db, {
+            status: 'degraded',
+            responseTimeMs: 150,
+            dependencies: deps,
+            source: 'uptime-check',
+        });
+        expect(snap.status).toBe('degraded');
+        expect(snap.responseTimeMs).toBe(150);
+        expect(snap.dependencies).toEqual(deps);
+        expect(snap.source).toBe('uptime-check');
+    });
+
+    test('auto-increments id', () => {
+        const s1 = insertHealthSnapshot(db, { status: 'healthy' });
+        const s2 = insertHealthSnapshot(db, { status: 'unhealthy' });
+        expect(s2.id).toBeGreaterThan(s1.id);
+    });
+});
+
+// ── listHealthSnapshots ──────────────────────────────────────────────
+
+describe('listHealthSnapshots', () => {
+    test('returns empty array for no snapshots', () => {
+        const list = listHealthSnapshots(db);
+        expect(list).toEqual([]);
+    });
+
+    test('returns snapshots in descending timestamp order', () => {
+        insertHealthSnapshot(db, { status: 'healthy' });
+        insertHealthSnapshot(db, { status: 'degraded' });
+        insertHealthSnapshot(db, { status: 'unhealthy' });
+
+        const list = listHealthSnapshots(db);
+        expect(list).toHaveLength(3);
+        // Most recent first
+        expect(list[0].status).toBe('unhealthy');
+        expect(list[2].status).toBe('healthy');
+    });
+
+    test('respects limit parameter', () => {
+        for (let i = 0; i < 10; i++) {
+            insertHealthSnapshot(db, { status: 'healthy' });
+        }
+        const list = listHealthSnapshots(db, { limit: 3 });
+        expect(list).toHaveLength(3);
+    });
+
+    test('filters by since timestamp', () => {
+        // Insert an old snapshot
+        db.query(`INSERT INTO server_health_snapshots (status, source, timestamp)
+                  VALUES ('healthy', 'internal', '2025-01-01T00:00:00Z')`).run();
+        // Insert a recent one
+        insertHealthSnapshot(db, { status: 'degraded' });
+
+        const list = listHealthSnapshots(db, { since: '2026-01-01T00:00:00Z' });
+        expect(list).toHaveLength(1);
+        expect(list[0].status).toBe('degraded');
+    });
+});
+
+// ── getUptimeStats ───────────────────────────────────────────────────
+
+describe('getUptimeStats', () => {
+    test('returns 100% uptime when no snapshots exist', () => {
+        const stats = getUptimeStats(db, '2020-01-01T00:00:00Z');
+        expect(stats.totalChecks).toBe(0);
+        expect(stats.healthyChecks).toBe(0);
+        expect(stats.uptimePercent).toBe(100);
+    });
+
+    test('calculates correct uptime percentages', () => {
+        // 3 healthy, 1 degraded, 1 unhealthy
+        insertHealthSnapshot(db, { status: 'healthy' });
+        insertHealthSnapshot(db, { status: 'healthy' });
+        insertHealthSnapshot(db, { status: 'healthy' });
+        insertHealthSnapshot(db, { status: 'degraded' });
+        insertHealthSnapshot(db, { status: 'unhealthy' });
+
+        const stats = getUptimeStats(db, '2020-01-01T00:00:00Z');
+        expect(stats.totalChecks).toBe(5);
+        expect(stats.healthyChecks).toBe(3);
+        expect(stats.degradedChecks).toBe(1);
+        expect(stats.unhealthyChecks).toBe(1);
+        // healthy + degraded = 4/5 = 80%
+        expect(stats.uptimePercent).toBe(80);
+    });
+
+    test('counts degraded as uptime', () => {
+        insertHealthSnapshot(db, { status: 'degraded' });
+        insertHealthSnapshot(db, { status: 'degraded' });
+
+        const stats = getUptimeStats(db, '2020-01-01T00:00:00Z');
+        expect(stats.uptimePercent).toBe(100);
+    });
+
+    test('respects since filter', () => {
+        db.query(`INSERT INTO server_health_snapshots (status, source, timestamp)
+                  VALUES ('unhealthy', 'internal', '2025-01-01T00:00:00Z')`).run();
+        insertHealthSnapshot(db, { status: 'healthy' });
+
+        const stats = getUptimeStats(db, '2026-01-01T00:00:00Z');
+        expect(stats.totalChecks).toBe(1);
+        expect(stats.healthyChecks).toBe(1);
+        expect(stats.uptimePercent).toBe(100);
+    });
+
+    test('returns period start and end timestamps', () => {
+        insertHealthSnapshot(db, { status: 'healthy' });
+        const stats = getUptimeStats(db, '2020-01-01T00:00:00Z');
+        expect(stats.periodStart).toBeTruthy();
+        expect(stats.periodEnd).toBeTruthy();
+    });
+});
+
+// ── pruneHealthSnapshots ─────────────────────────────────────────────
+
+describe('pruneHealthSnapshots', () => {
+    test('deletes old snapshots', () => {
+        db.query(`INSERT INTO server_health_snapshots (status, source, timestamp)
+                  VALUES ('healthy', 'internal', '2024-01-01T00:00:00Z')`).run();
+        insertHealthSnapshot(db, { status: 'healthy' });
+
+        const deleted = pruneHealthSnapshots(db, 30);
+        expect(deleted).toBe(1);
+
+        const remaining = listHealthSnapshots(db);
+        expect(remaining).toHaveLength(1);
+    });
+
+    test('preserves recent snapshots', () => {
+        insertHealthSnapshot(db, { status: 'healthy' });
+        insertHealthSnapshot(db, { status: 'degraded' });
+
+        const deleted = pruneHealthSnapshots(db, 30);
+        expect(deleted).toBe(0);
+        expect(listHealthSnapshots(db)).toHaveLength(2);
+    });
+
+    test('returns 0 when table is empty', () => {
+        const deleted = pruneHealthSnapshots(db, 1);
+        expect(deleted).toBe(0);
+    });
+});

--- a/server/__tests__/notifications.test.ts
+++ b/server/__tests__/notifications.test.ts
@@ -1,0 +1,263 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import {
+    listChannelsForAgent,
+    upsertChannel,
+    updateChannelEnabled,
+    deleteChannel,
+    getChannelByAgentAndType,
+    createNotification,
+    listNotifications,
+    createDelivery,
+    updateDeliveryStatus,
+    listFailedDeliveries,
+    createQuestionDispatch,
+    listActiveQuestionDispatches,
+    updateQuestionDispatchStatus,
+    markDispatchAnswered,
+    getQuestionDispatchesByQuestionId,
+} from '../db/notifications';
+
+let db: Database;
+const AGENT_ID = 'agent-1';
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+    // Insert a test agent so FK constraints pass
+    db.query(`INSERT INTO agents (id, name, model, system_prompt) VALUES (?, 'TestAgent', 'test', 'test')`).run(AGENT_ID);
+});
+
+afterEach(() => {
+    db.close();
+});
+
+// ── Channel CRUD ─────────────────────────────────────────────────────
+
+describe('notification channels', () => {
+    test('upsertChannel creates a new channel', () => {
+        const ch = upsertChannel(db, AGENT_ID, 'slack', { webhook_url: 'https://hooks.slack.com/x' });
+        expect(ch.id).toBeTruthy();
+        expect(ch.agentId).toBe(AGENT_ID);
+        expect(ch.channelType).toBe('slack');
+        expect(ch.config).toEqual({ webhook_url: 'https://hooks.slack.com/x' });
+        expect(ch.enabled).toBe(true);
+    });
+
+    test('upsertChannel updates config on conflict', () => {
+        upsertChannel(db, AGENT_ID, 'slack', { webhook_url: 'old' });
+        const updated = upsertChannel(db, AGENT_ID, 'slack', { webhook_url: 'new' });
+        expect(updated.config).toEqual({ webhook_url: 'new' });
+    });
+
+    test('upsertChannel can create disabled channel', () => {
+        const ch = upsertChannel(db, AGENT_ID, 'discord', { to: 'a@b.com' }, false);
+        expect(ch.enabled).toBe(false);
+    });
+
+    test('listChannelsForAgent returns channels ordered by type', () => {
+        upsertChannel(db, AGENT_ID, 'slack', {});
+        upsertChannel(db, AGENT_ID, 'discord', {});
+        const list = listChannelsForAgent(db, AGENT_ID);
+        expect(list).toHaveLength(2);
+        expect(list[0].channelType).toBe('discord');
+        expect(list[1].channelType).toBe('slack');
+    });
+
+    test('listChannelsForAgent returns empty for unknown agent', () => {
+        expect(listChannelsForAgent(db, 'unknown')).toEqual([]);
+    });
+
+    test('getChannelByAgentAndType finds channel', () => {
+        upsertChannel(db, AGENT_ID, 'slack', { url: 'x' });
+        const ch = getChannelByAgentAndType(db, AGENT_ID, 'slack');
+        expect(ch).not.toBeNull();
+        expect(ch!.channelType).toBe('slack');
+    });
+
+    test('getChannelByAgentAndType returns null for missing', () => {
+        expect(getChannelByAgentAndType(db, AGENT_ID, 'sms')).toBeNull();
+    });
+
+    test('updateChannelEnabled toggles enabled flag', () => {
+        const ch = upsertChannel(db, AGENT_ID, 'slack', {});
+        expect(ch.enabled).toBe(true);
+
+        const toggled = updateChannelEnabled(db, ch.id, false);
+        expect(toggled).toBe(true);
+
+        const fetched = getChannelByAgentAndType(db, AGENT_ID, 'slack');
+        expect(fetched!.enabled).toBe(false);
+    });
+
+    test('updateChannelEnabled returns false for unknown id', () => {
+        expect(updateChannelEnabled(db, 'nonexistent', true)).toBe(false);
+    });
+
+    test('deleteChannel removes channel', () => {
+        const ch = upsertChannel(db, AGENT_ID, 'slack', {});
+        expect(deleteChannel(db, ch.id)).toBe(true);
+        expect(getChannelByAgentAndType(db, AGENT_ID, 'slack')).toBeNull();
+    });
+
+    test('deleteChannel returns false for unknown id', () => {
+        expect(deleteChannel(db, 'nonexistent')).toBe(false);
+    });
+});
+
+// ── Notification CRUD ────────────────────────────────────────────────
+
+describe('notifications', () => {
+    test('createNotification creates with all fields', () => {
+        const notif = createNotification(db, {
+            agentId: AGENT_ID,
+            sessionId: 'sess-1',
+            title: 'Alert',
+            message: 'Something happened',
+            level: 'warning',
+        });
+        expect(notif.id).toBeTruthy();
+        expect(notif.agentId).toBe(AGENT_ID);
+        expect(notif.sessionId).toBe('sess-1');
+        expect(notif.title).toBe('Alert');
+        expect(notif.message).toBe('Something happened');
+        expect(notif.level).toBe('warning');
+    });
+
+    test('createNotification with minimal fields', () => {
+        const notif = createNotification(db, {
+            agentId: AGENT_ID,
+            message: 'info message',
+            level: 'info',
+        });
+        expect(notif.sessionId).toBeNull();
+        expect(notif.title).toBeNull();
+    });
+
+    test('listNotifications filters by agent', () => {
+        createNotification(db, { agentId: AGENT_ID, message: 'msg1', level: 'info' });
+
+        const agent2 = 'agent-2';
+        db.query(`INSERT INTO agents (id, name, model, system_prompt) VALUES (?, 'A2', 'test', 'test')`).run(agent2);
+        createNotification(db, { agentId: agent2, message: 'msg2', level: 'info' });
+
+        const list = listNotifications(db, AGENT_ID);
+        expect(list).toHaveLength(1);
+        expect(list[0].message).toBe('msg1');
+    });
+
+    test('listNotifications without agent returns all', () => {
+        createNotification(db, { agentId: AGENT_ID, message: 'msg1', level: 'info' });
+        const list = listNotifications(db);
+        expect(list).toHaveLength(1);
+    });
+
+    test('listNotifications respects limit', () => {
+        for (let i = 0; i < 5; i++) {
+            createNotification(db, { agentId: AGENT_ID, message: `msg${i}`, level: 'info' });
+        }
+        expect(listNotifications(db, AGENT_ID, 2)).toHaveLength(2);
+    });
+});
+
+// ── Delivery Tracking ────────────────────────────────────────────────
+
+describe('delivery tracking', () => {
+    test('createDelivery and updateDeliveryStatus lifecycle', () => {
+        upsertChannel(db, AGENT_ID, 'slack', { url: 'x' });
+        const notif = createNotification(db, { agentId: AGENT_ID, message: 'test', level: 'info' });
+
+        const delivery = createDelivery(db, notif.id, 'slack');
+        expect(delivery.notificationId).toBe(notif.id);
+        expect(delivery.channelType).toBe('slack');
+        expect(delivery.status).toBe('pending');
+        expect(delivery.attempts).toBe(0);
+
+        updateDeliveryStatus(db, delivery.id, 'sent', undefined, 'ext-ref-123');
+        // Verify via failed deliveries (sent ones won't show, but the update happened)
+    });
+
+    test('listFailedDeliveries returns retryable deliveries', () => {
+        upsertChannel(db, AGENT_ID, 'slack', { url: 'x' });
+        const notif = createNotification(db, { agentId: AGENT_ID, message: 'test', level: 'error' });
+        const delivery = createDelivery(db, notif.id, 'slack');
+
+        updateDeliveryStatus(db, delivery.id, 'failed', 'timeout');
+
+        const failed = listFailedDeliveries(db, 3);
+        expect(failed).toHaveLength(1);
+        expect(failed[0].error).toBe('timeout');
+        expect(failed[0].notification.message).toBe('test');
+        expect(failed[0].channelConfig).toEqual({ url: 'x' });
+    });
+
+    test('listFailedDeliveries excludes exhausted retries', () => {
+        upsertChannel(db, AGENT_ID, 'slack', { url: 'x' });
+        const notif = createNotification(db, { agentId: AGENT_ID, message: 'test', level: 'error' });
+        const delivery = createDelivery(db, notif.id, 'slack');
+
+        // Fail 3 times
+        updateDeliveryStatus(db, delivery.id, 'failed', 'err1');
+        updateDeliveryStatus(db, delivery.id, 'failed', 'err2');
+        updateDeliveryStatus(db, delivery.id, 'failed', 'err3');
+
+        // maxAttempts = 3, delivery has 3 attempts now
+        const failed = listFailedDeliveries(db, 3);
+        expect(failed).toHaveLength(0);
+    });
+});
+
+// ── Question Dispatch ────────────────────────────────────────────────
+
+describe('question dispatch', () => {
+    test('createQuestionDispatch creates a dispatch', () => {
+        const d = createQuestionDispatch(db, 'q1', 'slack', 'slack-msg-123');
+        expect(d.questionId).toBe('q1');
+        expect(d.channelType).toBe('slack');
+        expect(d.externalRef).toBe('slack-msg-123');
+        expect(d.status).toBe('sent');
+        expect(d.answeredAt).toBeNull();
+    });
+
+    test('listActiveQuestionDispatches returns only sent dispatches', () => {
+        createQuestionDispatch(db, 'q1', 'slack', null);
+        const d2 = createQuestionDispatch(db, 'q2', 'email', null);
+        updateQuestionDispatchStatus(db, d2.id, 'expired');
+
+        const active = listActiveQuestionDispatches(db);
+        expect(active).toHaveLength(1);
+        expect(active[0].questionId).toBe('q1');
+    });
+
+    test('markDispatchAnswered transitions sent→answered', () => {
+        const d = createQuestionDispatch(db, 'q1', 'slack', null);
+        expect(markDispatchAnswered(db, d.id)).toBe(true);
+
+        const dispatches = getQuestionDispatchesByQuestionId(db, 'q1');
+        expect(dispatches[0].status).toBe('answered');
+        expect(dispatches[0].answeredAt).toBeTruthy();
+    });
+
+    test('markDispatchAnswered is idempotent', () => {
+        const d = createQuestionDispatch(db, 'q1', 'slack', null);
+        expect(markDispatchAnswered(db, d.id)).toBe(true);
+        expect(markDispatchAnswered(db, d.id)).toBe(false); // already answered
+    });
+
+    test('markDispatchAnswered rejects expired dispatch', () => {
+        const d = createQuestionDispatch(db, 'q1', 'slack', null);
+        updateQuestionDispatchStatus(db, d.id, 'expired');
+        expect(markDispatchAnswered(db, d.id)).toBe(false);
+    });
+
+    test('getQuestionDispatchesByQuestionId returns all dispatches for question', () => {
+        createQuestionDispatch(db, 'q1', 'slack', null);
+        createQuestionDispatch(db, 'q1', 'email', null);
+        createQuestionDispatch(db, 'q2', 'slack', null);
+
+        const dispatches = getQuestionDispatchesByQuestionId(db, 'q1');
+        expect(dispatches).toHaveLength(2);
+    });
+});

--- a/server/__tests__/webhooks.test.ts
+++ b/server/__tests__/webhooks.test.ts
@@ -1,0 +1,240 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import type { CreateWebhookRegistrationInput } from '../../shared/types';
+import {
+    createWebhookRegistration,
+    getWebhookRegistration,
+    listWebhookRegistrations,
+    findRegistrationsForRepo,
+    updateWebhookRegistration,
+    deleteWebhookRegistration,
+    incrementTriggerCount,
+    createDelivery,
+    getDelivery,
+    listDeliveries,
+    updateDeliveryStatus,
+} from '../db/webhooks';
+
+let db: Database;
+const AGENT_ID = 'agent-1';
+const PROJECT_ID = 'proj-1';
+
+/** Create a registration with sensible defaults. */
+function makeReg(overrides: Partial<CreateWebhookRegistrationInput> = {}) {
+    return createWebhookRegistration(db, {
+        agentId: AGENT_ID,
+        repo: 'org/repo',
+        events: ['issues'],
+        mentionUsername: '@bot',
+        projectId: PROJECT_ID,
+        ...overrides,
+    });
+}
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+    db.query(`INSERT INTO agents (id, name, model, system_prompt) VALUES (?, 'TestAgent', 'test', 'test')`).run(AGENT_ID);
+    db.query(`INSERT INTO projects (id, name, working_dir) VALUES (?, 'TestProject', '/tmp/test')`).run(PROJECT_ID);
+});
+
+afterEach(() => {
+    db.close();
+});
+
+// ── Registration CRUD ────────────────────────────────────────────────
+
+describe('webhook registrations', () => {
+    test('createWebhookRegistration creates with all fields', () => {
+        const reg = makeReg({
+            repo: 'CorvidLabs/corvid-agent',
+            events: ['issues', 'issue_comment'],
+            mentionUsername: '@corvid',
+        });
+        expect(reg.id).toBeTruthy();
+        expect(reg.agentId).toBe(AGENT_ID);
+        expect(reg.repo).toBe('CorvidLabs/corvid-agent');
+        expect(reg.events).toEqual(['issues', 'issue_comment']);
+        expect(reg.mentionUsername).toBe('@corvid');
+        expect(reg.projectId).toBe(PROJECT_ID);
+        expect(reg.status).toBe('active');
+        expect(reg.triggerCount).toBe(0);
+    });
+
+    test('getWebhookRegistration returns registration by id', () => {
+        const reg = makeReg();
+        const fetched = getWebhookRegistration(db, reg.id);
+        expect(fetched).not.toBeNull();
+        expect(fetched!.id).toBe(reg.id);
+    });
+
+    test('getWebhookRegistration returns null for unknown id', () => {
+        expect(getWebhookRegistration(db, 'nonexistent')).toBeNull();
+    });
+
+    test('listWebhookRegistrations returns all registrations', () => {
+        makeReg({ repo: 'org/repo1' });
+        makeReg({ repo: 'org/repo2', events: ['issue_comment'] });
+        const list = listWebhookRegistrations(db);
+        expect(list).toHaveLength(2);
+    });
+
+    test('listWebhookRegistrations filters by agentId', () => {
+        const agent2 = 'agent-2';
+        db.query(`INSERT INTO agents (id, name, model, system_prompt) VALUES (?, 'A2', 'test', 'test')`).run(agent2);
+
+        makeReg({ repo: 'org/repo1' });
+        makeReg({ agentId: agent2, repo: 'org/repo2', mentionUsername: '@bot2' });
+
+        const list = listWebhookRegistrations(db, AGENT_ID);
+        expect(list).toHaveLength(1);
+        expect(list[0].agentId).toBe(AGENT_ID);
+    });
+
+    test('findRegistrationsForRepo returns only active registrations for repo', () => {
+        const r1 = makeReg({ repo: 'org/target' });
+        makeReg({ repo: 'org/other' });
+        updateWebhookRegistration(db, r1.id, { status: 'paused' });
+
+        const found = findRegistrationsForRepo(db, 'org/target');
+        expect(found).toHaveLength(0);
+    });
+
+    test('findRegistrationsForRepo returns active registrations', () => {
+        makeReg({ repo: 'org/target' });
+        const found = findRegistrationsForRepo(db, 'org/target');
+        expect(found).toHaveLength(1);
+    });
+
+    test('updateWebhookRegistration updates fields', () => {
+        const reg = makeReg({ mentionUsername: '@old' });
+        const updated = updateWebhookRegistration(db, reg.id, {
+            events: ['issues', 'issue_comment'],
+            mentionUsername: '@new',
+            status: 'paused',
+        });
+
+        expect(updated).not.toBeNull();
+        expect(updated!.events).toEqual(['issues', 'issue_comment']);
+        expect(updated!.mentionUsername).toBe('@new');
+        expect(updated!.status).toBe('paused');
+    });
+
+    test('updateWebhookRegistration with no changes returns existing', () => {
+        const reg = makeReg();
+        const updated = updateWebhookRegistration(db, reg.id, {});
+        expect(updated!.id).toBe(reg.id);
+    });
+
+    test('updateWebhookRegistration returns null for unknown id', () => {
+        expect(updateWebhookRegistration(db, 'nonexistent', { status: 'paused' })).toBeNull();
+    });
+
+    test('deleteWebhookRegistration removes registration', () => {
+        const reg = makeReg();
+        expect(deleteWebhookRegistration(db, reg.id)).toBe(true);
+        expect(getWebhookRegistration(db, reg.id)).toBeNull();
+    });
+
+    test('deleteWebhookRegistration returns false for unknown id', () => {
+        expect(deleteWebhookRegistration(db, 'nonexistent')).toBe(false);
+    });
+
+    test('incrementTriggerCount increments counter', () => {
+        const reg = makeReg();
+        expect(reg.triggerCount).toBe(0);
+
+        incrementTriggerCount(db, reg.id);
+        incrementTriggerCount(db, reg.id);
+
+        const updated = getWebhookRegistration(db, reg.id)!;
+        expect(updated.triggerCount).toBe(2);
+    });
+});
+
+// ── Delivery Log ─────────────────────────────────────────────────────
+
+describe('webhook deliveries', () => {
+    let regId: string;
+
+    beforeEach(() => {
+        regId = makeReg().id;
+    });
+
+    test('createDelivery creates a delivery record', () => {
+        const d = createDelivery(db, regId, 'issues', 'opened', 'org/repo', 'user1', 'Issue body', 'https://github.com/org/repo/issues/1');
+        expect(d.id).toBeTruthy();
+        expect(d.registrationId).toBe(regId);
+        expect(d.event).toBe('issues');
+        expect(d.action).toBe('opened');
+        expect(d.repo).toBe('org/repo');
+        expect(d.sender).toBe('user1');
+        expect(d.body).toBe('Issue body');
+        expect(d.htmlUrl).toBe('https://github.com/org/repo/issues/1');
+        expect(d.status).toBe('processing');
+        expect(d.sessionId).toBeNull();
+        expect(d.workTaskId).toBeNull();
+        expect(d.result).toBeNull();
+    });
+
+    test('getDelivery returns delivery by id', () => {
+        const d = createDelivery(db, regId, 'issues', 'opened', 'org/repo', 'user1', 'body', 'url');
+        const fetched = getDelivery(db, d.id);
+        expect(fetched).not.toBeNull();
+        expect(fetched!.id).toBe(d.id);
+    });
+
+    test('getDelivery returns null for unknown id', () => {
+        expect(getDelivery(db, 'nonexistent')).toBeNull();
+    });
+
+    test('listDeliveries returns all deliveries', () => {
+        createDelivery(db, regId, 'issues', 'opened', 'org/repo', 'u1', 'b1', 'url1');
+        createDelivery(db, regId, 'issues', 'closed', 'org/repo', 'u2', 'b2', 'url2');
+        const list = listDeliveries(db);
+        expect(list).toHaveLength(2);
+    });
+
+    test('listDeliveries filters by registrationId', () => {
+        const reg2 = makeReg({ repo: 'org/other' });
+        createDelivery(db, regId, 'issues', 'opened', 'org/repo', 'u1', 'b1', 'url1');
+        createDelivery(db, reg2.id, 'issues', 'opened', 'org/other', 'u2', 'b2', 'url2');
+
+        const list = listDeliveries(db, regId);
+        expect(list).toHaveLength(1);
+        expect(list[0].registrationId).toBe(regId);
+    });
+
+    test('listDeliveries respects limit', () => {
+        for (let i = 0; i < 5; i++) {
+            createDelivery(db, regId, 'issues', 'opened', 'org/repo', 'u', `body${i}`, 'url');
+        }
+        expect(listDeliveries(db, regId, 2)).toHaveLength(2);
+    });
+
+    test('updateDeliveryStatus updates status and extras', () => {
+        const d = createDelivery(db, regId, 'issues', 'opened', 'org/repo', 'u1', 'body', 'url');
+        updateDeliveryStatus(db, d.id, 'completed', {
+            result: 'Agent responded',
+            sessionId: 'sess-1',
+            workTaskId: 'wt-1',
+        });
+
+        const updated = getDelivery(db, d.id)!;
+        expect(updated.status).toBe('completed');
+        expect(updated.result).toBe('Agent responded');
+        expect(updated.sessionId).toBe('sess-1');
+        expect(updated.workTaskId).toBe('wt-1');
+    });
+
+    test('updateDeliveryStatus with minimal update', () => {
+        const d = createDelivery(db, regId, 'issues', 'opened', 'org/repo', 'u1', 'body', 'url');
+        updateDeliveryStatus(db, d.id, 'failed');
+
+        const updated = getDelivery(db, d.id)!;
+        expect(updated.status).toBe('failed');
+        expect(updated.sessionId).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

- Adds 61 new tests across 3 previously untested DB modules
- **health-snapshots** (15 tests): insert snapshots, list with since/limit filtering, uptime stats calculation (healthy + degraded = uptime), pruning old snapshots
- **notifications** (25 tests): channel CRUD with upsert-on-conflict, notification creation/listing, delivery tracking with retry logic, question dispatch with idempotent `markDispatchAnswered`
- **webhooks** (21 tests): registration CRUD, `findRegistrationsForRepo` with status filtering, `incrementTriggerCount`, delivery logging with status + extras updates

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 4648 tests pass (61 new)
- [x] `bun run spec:check` — 38 specs, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)