### PR TITLE
fix: add git author identity to LaunchAgent plist

### DIFF
--- a/deploy/com.corvidlabs.corvid-agent.plist
+++ b/deploy/com.corvidlabs.corvid-agent.plist
@@ -24,6 +24,14 @@
         <string>production</string>
         <key>PATH</key>
         <string>__PATH__</string>
+        <key>GIT_AUTHOR_NAME</key>
+        <string>Corvid Agent</string>
+        <key>GIT_AUTHOR_EMAIL</key>
+        <string>95454608+corvid-agent@users.noreply.github.com</string>
+        <key>GIT_COMMITTER_NAME</key>
+        <string>Corvid Agent</string>
+        <key>GIT_COMMITTER_EMAIL</key>
+        <string>95454608+corvid-agent@users.noreply.github.com</string>
     </dict>
 
     <key>RunAtLoad</key>


### PR DESCRIPTION
## Summary
- Adds `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL` to the deploy plist template
- Sets them to `Corvid Agent <95454608+corvid-agent@users.noreply.github.com>` (the correct GitHub noreply address)

## Context
Agent-spawned commits in repos like `corvid-reputation` were showing 3 different author identities:
1. `corvid-agent <corvid-agent.groovy094@passmail.net>` — from GitHub Actions workflow (fixed in corvid-agent/corvid-reputation#1)
2. `Corvid Agent <95454608+corvid-agent@users.noreply.github.com>` — correct identity
3. `corvid-agent <0xOpenBytes@gmail.com>` — from global git config fallback when env vars aren't set

The LaunchAgent plist lacked `GIT_AUTHOR_*` env vars, so `buildSafeEnv()` in `sdk-process.ts` had nothing to forward to child processes. They fell back to the global git config.

Also fixed:
- Global git config updated to correct identity
- Live plist at `~/Library/LaunchAgents/` updated (requires `launchctl unload/load` to take effect)

## Test plan
- [ ] Verify `launchctl unload && launchctl load` picks up the new env vars
- [ ] Next agent work task commit should show correct author identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)