### PR TITLE
security: enforce RBAC on agents, projects, sessions, councils

### DIFF
--- a/server/__tests__/plugins.test.ts
+++ b/server/__tests__/plugins.test.ts
@@ -106,7 +106,7 @@ describe('getPluginCapabilities', () => {
         const granted = caps.find(c => c.capability === 'db:read');
         expect(granted!.granted).toBeTruthy();
         // Raw SQLite returns snake_case column names
-        expect((granted as Record<string, unknown>).granted_at).toBeTruthy();
+        expect((granted as unknown as Record<string, unknown>).granted_at).toBeTruthy();
 
         const denied = caps.find(c => c.capability === 'network:outbound');
         expect(denied!.granted).toBeFalsy();

--- a/server/routes/agents.ts
+++ b/server/routes/agents.ts
@@ -13,6 +13,7 @@ import { buildAgentCardForAgent } from '../a2a/agent-card';
 import { recordAudit } from '../db/audit';
 import { getClientIp } from '../middleware/rate-limit';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 
 export function handleAgentRoutes(
     req: Request,
@@ -30,6 +31,8 @@ export function handleAgentRoutes(
     }
 
     if (path === '/api/agents' && method === 'POST') {
+        const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+        if (denied) return denied;
         return handleCreate(req, db, context, agentWalletService);
     }
 
@@ -42,12 +45,16 @@ export function handleAgentRoutes(
     // Agent fund endpoint
     const fundMatch = path.match(/^\/api\/agents\/([^/]+)\/fund$/);
     if (fundMatch && method === 'POST') {
+        const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+        if (denied) return denied;
         return handleFund(req, fundMatch[1], db, context, agentWalletService);
     }
 
     // Agent invoke endpoint
     const invokeMatch = path.match(/^\/api\/agents\/([^/]+)\/invoke$/);
     if (invokeMatch && method === 'POST') {
+        const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+        if (denied) return denied;
         return handleInvoke(req, invokeMatch[1], db, context, agentMessenger);
     }
 
@@ -65,9 +72,13 @@ export function handleAgentRoutes(
 
     const spendingCapMatch = path.match(/^\/api\/agents\/([^/]+)\/spending-cap$/);
     if (spendingCapMatch && method === 'PUT') {
+        const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+        if (denied) return denied;
         return handleSetSpendingCap(req, spendingCapMatch[1], db, context);
     }
     if (spendingCapMatch && method === 'DELETE') {
+        const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+        if (denied) return denied;
         return handleDeleteSpendingCap(spendingCapMatch[1], db, context);
     }
 
@@ -92,10 +103,14 @@ export function handleAgentRoutes(
     }
 
     if (method === 'PUT') {
+        const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+        if (denied) return denied;
         return handleUpdate(req, db, id, context);
     }
 
     if (method === 'DELETE') {
+        const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+        if (denied) return denied;
         const deleted = deleteAgent(db, id, context.tenantId);
         if (deleted) {
             const actor = context.walletAddress ?? getClientIp(req);

--- a/server/routes/councils.ts
+++ b/server/routes/councils.ts
@@ -13,6 +13,7 @@ import {
 import type { ProcessManager } from '../process/manager';
 import type { AgentMessenger } from '../algochat/agent-messenger';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 import { parseBodyOrThrow, ValidationError, CreateCouncilSchema, UpdateCouncilSchema, LaunchCouncilSchema, CouncilChatSchema } from '../lib/validation';
 import { json, handleRouteError } from '../lib/response';
 import { NotFoundError } from '../lib/errors';
@@ -53,6 +54,10 @@ export function handleCouncilRoutes(
     }
 
     if (path === '/api/councils' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleCreateCouncil(req, db, tenantId);
     }
 
@@ -86,18 +91,34 @@ export function handleCouncilRoutes(
         }
 
         if (action === 'abort' && method === 'POST') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             return handleAbort(db, processManager, launchId);
         }
 
         if (action === 'review' && method === 'POST') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             return handleReview(db, processManager, launchId);
         }
 
         if (action === 'synthesize' && method === 'POST') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             return handleSynthesize(db, processManager, launchId);
         }
 
         if (action === 'chat' && method === 'POST') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             return handleCouncilChat(req, db, processManager, launchId);
         }
     }
@@ -115,15 +136,27 @@ export function handleCouncilRoutes(
             return council ? json(council) : json({ error: 'Not found' }, 404);
         }
         if (method === 'PUT') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             return handleUpdateCouncil(req, db, id, tenantId);
         }
         if (method === 'DELETE') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             const deleted = deleteCouncil(db, id, tenantId);
             return deleted ? json({ ok: true }) : json({ error: 'Not found' }, 404);
         }
     }
 
     if (action === 'launch' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleLaunch(req, db, processManager, id, agentMessenger ?? null);
     }
 

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -7,6 +7,7 @@ import { parseBodyOrThrow, ValidationError, CreateProjectSchema, UpdateProjectSc
 import { createLogger } from '../lib/logger';
 import { json } from '../lib/response';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 
 const log = createLogger('BrowseDirs');
 
@@ -25,6 +26,10 @@ export function handleProjectRoutes(
     }
 
     if (path === '/api/projects' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleCreate(req, db, tenantId);
     }
 
@@ -39,10 +44,18 @@ export function handleProjectRoutes(
     }
 
     if (method === 'PUT') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleUpdate(req, db, id, tenantId);
     }
 
     if (method === 'DELETE') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         const deleted = deleteProject(db, id, tenantId);
         return deleted ? json({ ok: true }) : json({ error: 'Not found' }, 404);
     }

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -14,6 +14,7 @@ import { json } from '../lib/response';
 import { recordAudit } from '../db/audit';
 import { getClientIp } from '../middleware/rate-limit';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 
 const log = createLogger('SessionRoutes');
 
@@ -35,6 +36,10 @@ export async function handleSessionRoutes(
     }
 
     if (path === '/api/sessions' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleCreate(req, db, processManager, tenantId);
     }
 
@@ -50,9 +55,17 @@ export async function handleSessionRoutes(
             return session ? json(session) : json({ error: 'Not found' }, 404);
         }
         if (method === 'PUT') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             return handleUpdate(req, db, id, tenantId);
         }
         if (method === 'DELETE') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             processManager.stopProcess(id);
             const deleted = deleteSession(db, id, tenantId);
             return deleted ? json({ ok: true }) : json({ error: 'Not found' }, 404);
@@ -64,10 +77,18 @@ export async function handleSessionRoutes(
     }
 
     if (action === 'stop' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleStop(req, db, processManager, id, tenantId);
     }
 
     if (action === 'resume' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleResume(req, db, processManager, id, tenantId);
     }
 


### PR DESCRIPTION
## Summary
- Adds `tenantRoleGuard('operator', 'owner')` to all write endpoints (POST/PUT/DELETE) in the 4 core route files
- Routes with optional `RequestContext` use `if (context)` wrapper for single-tenant backward compatibility
- **agents.ts**: 7 endpoints guarded (create, fund, invoke, update, delete, spending-cap set/delete)
- **projects.ts**: 3 endpoints guarded (create, update, delete)
- **sessions.ts**: 5 endpoints guarded (create, update, delete, stop, resume)
- **councils.ts**: 8 endpoints guarded (create, update, delete, launch, abort, review, synthesize, chat)
- Fixes pre-existing tsc error in plugins.test.ts

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] All 4833 tests pass
- [ ] Manual: verify viewer role gets 403 on write endpoints in multi-tenant mode

Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)