### PR TITLE
security: enforce RBAC on schedules, workflows, webhooks, polling, MCP, personas, skills

### DIFF
--- a/server/routes/mcp-servers.ts
+++ b/server/routes/mcp-servers.ts
@@ -1,5 +1,6 @@
 import type { Database } from 'bun:sqlite';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 import {
     listMcpServerConfigs,
     getMcpServerConfig,
@@ -28,18 +29,30 @@ export function handleMcpServerRoutes(
 
     // POST /api/mcp-servers — create config
     if (url.pathname === '/api/mcp-servers' && req.method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleCreate(req, db, tenantId);
     }
 
     // PUT /api/mcp-servers/:id — update config
     const putMatch = url.pathname.match(/^\/api\/mcp-servers\/([^/]+)$/);
     if (putMatch && req.method === 'PUT') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleUpdate(req, db, putMatch[1], tenantId);
     }
 
     // DELETE /api/mcp-servers/:id — delete config
     const deleteMatch = url.pathname.match(/^\/api\/mcp-servers\/([^/]+)$/);
     if (deleteMatch && req.method === 'DELETE') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         const id = deleteMatch[1];
         const deleted = deleteMcpServerConfig(db, id, tenantId);
         if (!deleted) return json({ error: 'MCP server config not found' }, 404);
@@ -49,6 +62,10 @@ export function handleMcpServerRoutes(
     // POST /api/mcp-servers/:id/test — test connection
     const testMatch = url.pathname.match(/^\/api\/mcp-servers\/([^/]+)\/test$/);
     if (testMatch && req.method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleTest(db, testMatch[1], tenantId);
     }
 

--- a/server/routes/mention-polling.ts
+++ b/server/routes/mention-polling.ts
@@ -13,6 +13,7 @@
 import type { Database } from 'bun:sqlite';
 import type { MentionPollingService } from '../polling/service';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 import {
     listMentionPollingConfigs,
     getMentionPollingConfig,
@@ -106,6 +107,10 @@ export function handleMentionPollingRoutes(
 
     // ── Create polling config ──────────────────────────────────────────────
     if (url.pathname === '/api/mention-polling' && req.method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return (async () => {
             try {
                 const data = await parseBodyOrThrow(req, CreateMentionPollingSchema);
@@ -169,6 +174,10 @@ export function handleMentionPollingRoutes(
         }
 
         if (req.method === 'PUT') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             return (async () => {
                 try {
                     const data = await parseBodyOrThrow(req, UpdateMentionPollingSchema);
@@ -182,6 +191,10 @@ export function handleMentionPollingRoutes(
         }
 
         if (req.method === 'DELETE') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             const deleted = deleteMentionPollingConfig(db, id, tenantId);
             if (!deleted) return json({ error: 'Polling config not found' }, 404);
             return json({ ok: true });

--- a/server/routes/personas.ts
+++ b/server/routes/personas.ts
@@ -1,5 +1,6 @@
 import type { Database } from 'bun:sqlite';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 import { getPersona, upsertPersona, deletePersona } from '../db/personas';
 import { getAgent } from '../db/agents';
 import { parseBodyOrThrow, ValidationError, UpsertPersonaSchema } from '../lib/validation';
@@ -28,12 +29,20 @@ export function handlePersonaRoutes(
     // PUT /api/agents/:id/persona
     const putMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/persona$/);
     if (putMatch && req.method === 'PUT') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleUpsert(req, db, putMatch[1], tenantId);
     }
 
     // DELETE /api/agents/:id/persona
     const deleteMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/persona$/);
     if (deleteMatch && req.method === 'DELETE') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         const agentId = deleteMatch[1];
         const agent = getAgent(db, agentId, tenantId);
         if (!agent) return json({ error: 'Agent not found' }, 404);

--- a/server/routes/schedules.ts
+++ b/server/routes/schedules.ts
@@ -1,6 +1,7 @@
 import type { Database } from 'bun:sqlite';
 import type { SchedulerService } from '../scheduler/service';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 import { validateScheduleFrequency } from '../scheduler/service';
 import {
     listSchedules,
@@ -40,6 +41,10 @@ export function handleScheduleRoutes(
 
     // Create schedule
     if (url.pathname === '/api/schedules' && req.method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleCreateSchedule(req, db, tenantId);
     }
 
@@ -53,11 +58,19 @@ export function handleScheduleRoutes(
 
     // Update schedule
     if (scheduleMatch && req.method === 'PUT') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleUpdateSchedule(req, db, scheduleMatch[1], tenantId);
     }
 
     // Delete schedule
     if (scheduleMatch && req.method === 'DELETE') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         const deleted = deleteSchedule(db, scheduleMatch[1], tenantId);
         if (!deleted) return json({ error: 'Schedule not found' }, 404);
         return json({ ok: true });
@@ -93,6 +106,10 @@ export function handleScheduleRoutes(
     // Cancel a running execution
     const cancelMatch = url.pathname.match(/^\/api\/schedule-executions\/([^/]+)\/cancel$/);
     if (cancelMatch && req.method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         if (!schedulerService) return json({ error: 'Scheduler not available' }, 503);
         const execution = schedulerService.cancelExecution(cancelMatch[1]);
         if (!execution) return json({ error: 'Execution not found or not running' }, 404);
@@ -109,12 +126,20 @@ export function handleScheduleRoutes(
 
     // Bulk schedule actions (pause/resume/delete)
     if (url.pathname === '/api/schedules/bulk' && req.method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleBulkAction(req, db);
     }
 
     // Trigger schedule now
     const triggerMatch = url.pathname.match(/^\/api\/schedules\/([^/]+)\/trigger$/);
     if (triggerMatch && req.method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         if (!schedulerService) return json({ error: 'Scheduler not available' }, 503);
         return handleTriggerNow(triggerMatch[1], schedulerService);
     }
@@ -122,6 +147,10 @@ export function handleScheduleRoutes(
     // Approve/deny execution
     const approvalMatch = url.pathname.match(/^\/api\/schedule-executions\/([^/]+)\/resolve$/);
     if (approvalMatch && req.method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleResolveApproval(req, db, approvalMatch[1], schedulerService);
     }
 

--- a/server/routes/skill-bundles.ts
+++ b/server/routes/skill-bundles.ts
@@ -1,5 +1,6 @@
 import type { Database } from 'bun:sqlite';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 import {
     listBundles, getBundle, createBundle, updateBundle, deleteBundle,
     getAgentBundles, assignBundle, unassignBundle,
@@ -29,6 +30,10 @@ export function handleSkillBundleRoutes(
 
     // POST /api/skill-bundles
     if (path === '/api/skill-bundles' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleCreateBundle(req, db);
     }
 
@@ -43,10 +48,18 @@ export function handleSkillBundleRoutes(
         }
 
         if (method === 'PUT') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             return handleUpdateBundle(req, db, id);
         }
 
         if (method === 'DELETE') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             const deleted = deleteBundle(db, id);
             if (!deleted) return json({ error: 'Not found or is a preset bundle' }, 404);
             return json({ ok: true });
@@ -66,12 +79,20 @@ export function handleSkillBundleRoutes(
 
     // POST /api/agents/:id/skills
     if (agentSkillsGet && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleAssignBundle(req, db, agentSkillsGet[1], tenantId);
     }
 
     // DELETE /api/agents/:id/skills/:bundleId
     const agentSkillDelete = path.match(/^\/api\/agents\/([^/]+)\/skills\/([^/]+)$/);
     if (agentSkillDelete && method === 'DELETE') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         const agentId = agentSkillDelete[1];
         const bundleId = agentSkillDelete[2];
         const agent = getAgent(db, agentId, tenantId);
@@ -95,12 +116,20 @@ export function handleSkillBundleRoutes(
 
     // POST /api/projects/:id/skills
     if (projectSkillsGet && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleAssignProjectBundle(req, db, projectSkillsGet[1], tenantId);
     }
 
     // DELETE /api/projects/:id/skills/:bundleId
     const projectSkillDelete = path.match(/^\/api\/projects\/([^/]+)\/skills\/([^/]+)$/);
     if (projectSkillDelete && method === 'DELETE') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         const projectId = projectSkillDelete[1];
         const bundleId = projectSkillDelete[2];
         const project = getProject(db, projectId, tenantId);

--- a/server/routes/webhooks.ts
+++ b/server/routes/webhooks.ts
@@ -15,6 +15,7 @@
 import type { Database } from 'bun:sqlite';
 import type { WebhookService, GitHubWebhookPayload } from '../webhooks/service';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 import {
     listWebhookRegistrations,
     getWebhookRegistration,
@@ -189,6 +190,10 @@ export function handleWebhookRoutes(
 
     // ── Create registration ─────────────────────────────────────────────────
     if (url.pathname === '/api/webhooks' && req.method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return (async () => {
             try {
                 const data = await parseBodyOrThrow(req, CreateWebhookRegistrationSchema);
@@ -225,6 +230,10 @@ export function handleWebhookRoutes(
         }
 
         if (req.method === 'PUT') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             return (async () => {
                 try {
                     const data = await parseBodyOrThrow(req, UpdateWebhookRegistrationSchema);
@@ -238,6 +247,10 @@ export function handleWebhookRoutes(
         }
 
         if (req.method === 'DELETE') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             const deleted = deleteWebhookRegistration(db, id, tenantId);
             if (!deleted) return json({ error: 'Webhook registration not found' }, 404);
             const ip = getClientIp(req);

--- a/server/routes/workflows.ts
+++ b/server/routes/workflows.ts
@@ -1,6 +1,7 @@
 import type { Database } from 'bun:sqlite';
 import type { WorkflowService } from '../workflow/service';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 import {
     listWorkflows,
     getWorkflow,
@@ -39,6 +40,10 @@ export function handleWorkflowRoutes(
 
     // Create workflow
     if (url.pathname === '/api/workflows' && req.method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleCreateWorkflow(req, db, tenantId);
     }
 
@@ -52,11 +57,19 @@ export function handleWorkflowRoutes(
 
     // Update workflow
     if (workflowMatch && req.method === 'PUT') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleUpdateWorkflow(req, db, workflowMatch[1], tenantId);
     }
 
     // Delete workflow
     if (workflowMatch && req.method === 'DELETE') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         const deleted = deleteWorkflow(db, workflowMatch[1], tenantId);
         if (!deleted) return json({ error: 'Workflow not found' }, 404);
         return json({ ok: true });
@@ -65,6 +78,10 @@ export function handleWorkflowRoutes(
     // Trigger workflow execution
     const triggerMatch = url.pathname.match(/^\/api\/workflows\/([^/]+)\/trigger$/);
     if (triggerMatch && req.method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleTriggerWorkflow(req, db, triggerMatch[1], workflowService);
     }
 
@@ -94,6 +111,10 @@ export function handleWorkflowRoutes(
     // Pause/resume/cancel a run
     const runActionMatch = url.pathname.match(/^\/api\/workflow-runs\/([^/]+)\/action$/);
     if (runActionMatch && req.method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleRunAction(req, runActionMatch[1], workflowService);
     }
 


### PR DESCRIPTION
## Summary
- Adds `tenantRoleGuard('operator', 'owner')` to all write endpoints across 7 route files (batch 2 of 3)
- **schedules.ts**: 7 endpoints (create, update, delete, cancel, bulk, trigger, resolve)
- **workflows.ts**: 5 endpoints (create, update, delete, trigger, run action)
- **webhooks.ts**: 3 endpoints (create/update/delete registrations — GitHub receiver excluded since it uses HMAC validation)
- **personas.ts**: 2 endpoints (upsert, delete)
- **skill-bundles.ts**: 7 endpoints (CRUD + agent/project assign/unassign)
- **mcp-servers.ts**: 4 endpoints (create, update, delete, test)
- **mention-polling.ts**: 3 endpoints (create, update, delete)
- Total: 31 write endpoints guarded

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] All 4833 tests pass
- [ ] Manual: verify viewer role gets 403 on write endpoints

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)