### PR TITLE
security: enforce RBAC on settings, billing, sandbox, marketplace, reputation, work-tasks

### DIFF
--- a/server/routes/billing.ts
+++ b/server/routes/billing.ts
@@ -5,6 +5,7 @@ import type { Database } from 'bun:sqlite';
 import type { BillingService } from '../billing/service';
 import type { UsageMeter } from '../billing/meter';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 import { verifyWebhookSignature } from '../billing/stripe';
 import { json, badRequest, notFound, handleRouteError, safeNumParam } from '../lib/response';
 import { parseBodyOrThrow, ValidationError, CreateSubscriptionSchema } from '../lib/validation';
@@ -18,7 +19,7 @@ export function handleBillingRoutes(
     _db: Database,
     billing?: BillingService | null,
     meter?: UsageMeter | null,
-    _context?: RequestContext,
+    context?: RequestContext,
 ): Response | Promise<Response> | null {
     if (!billing) {
         if (!url.pathname.startsWith('/api/billing')) return null;
@@ -37,11 +38,19 @@ export function handleBillingRoutes(
     }
 
     if (path === '/api/billing/subscription' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleCreateSubscription(req, billing);
     }
 
     const cancelMatch = path.match(/^\/api\/billing\/subscription\/([^/]+)\/cancel$/);
     if (cancelMatch && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('owner')(req, url, context);
+            if (denied) return denied;
+        }
         billing.cancelSubscription(cancelMatch[1]);
         return json({ ok: true });
     }

--- a/server/routes/marketplace.ts
+++ b/server/routes/marketplace.ts
@@ -5,6 +5,7 @@ import type { Database } from 'bun:sqlite';
 import { type MarketplaceService, VerificationGateError } from '../marketplace/service';
 import type { MarketplaceFederation } from '../marketplace/federation';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 import type {
     ListingCategory,
     PricingModel,
@@ -18,7 +19,7 @@ export function handleMarketplaceRoutes(
     _db: Database,
     marketplace?: MarketplaceService | null,
     federation?: MarketplaceFederation | null,
-    _context?: RequestContext,
+    context?: RequestContext,
 ): Response | Promise<Response> | null {
     if (!marketplace) {
         // Only match marketplace paths, return null for non-marketplace paths
@@ -59,6 +60,10 @@ export function handleMarketplaceRoutes(
     }
 
     if (path === '/api/marketplace/listings' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleCreateListing(req, marketplace);
     }
 
@@ -72,10 +77,18 @@ export function handleMarketplaceRoutes(
         }
 
         if (method === 'PUT') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             return handleUpdateListing(req, id, marketplace);
         }
 
         if (method === 'DELETE') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             const deleted = marketplace.deleteListing(id);
             return deleted ? json({ ok: true }) : notFound('Listing not found');
         }
@@ -105,6 +118,10 @@ export function handleMarketplaceRoutes(
 
     const reviewDeleteMatch = path.match(/^\/api\/marketplace\/reviews\/([^/]+)$/);
     if (reviewDeleteMatch && method === 'DELETE') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         const deleted = marketplace.deleteReview(reviewDeleteMatch[1]);
         return deleted ? json({ ok: true }) : notFound('Review not found');
     }
@@ -116,15 +133,27 @@ export function handleMarketplaceRoutes(
     }
 
     if (path === '/api/marketplace/federation/instances' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleRegisterInstance(req, federation);
     }
 
     if (path === '/api/marketplace/federation/sync' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleSyncAll(federation);
     }
 
     const instanceMatch = path.match(/^\/api\/marketplace\/federation\/instances\/(.+)$/);
     if (instanceMatch && method === 'DELETE') {
+        if (context) {
+            const denied = tenantRoleGuard('owner')(req, url, context);
+            if (denied) return denied;
+        }
         const removed = federation?.removeInstance(decodeURIComponent(instanceMatch[1]));
         return removed ? json({ ok: true }) : notFound('Instance not found');
     }

--- a/server/routes/reputation.ts
+++ b/server/routes/reputation.ts
@@ -5,6 +5,7 @@ import type { Database } from 'bun:sqlite';
 import type { ReputationScorer } from '../reputation/scorer';
 import type { ReputationAttestation } from '../reputation/attestation';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 import { IdentityVerification, type VerificationTier } from '../reputation/identity-verification';
 import { json, badRequest, notFound, handleRouteError, safeNumParam } from '../lib/response';
 import { parseBodyOrThrow, ValidationError, RecordReputationEventSchema } from '../lib/validation';
@@ -17,7 +18,7 @@ export function handleReputationRoutes(
     _db: Database,
     scorer?: ReputationScorer | null,
     attestation?: ReputationAttestation | null,
-    _context?: RequestContext,
+    context?: RequestContext,
 ): Response | Promise<Response> | null {
     if (!scorer) {
         if (!url.pathname.startsWith('/api/reputation')) return null;
@@ -63,6 +64,10 @@ export function handleReputationRoutes(
 
     // Record event
     if (path === '/api/reputation/events' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleRecordEvent(req, scorer);
     }
 
@@ -94,6 +99,10 @@ export function handleReputationRoutes(
         }
 
         if (method === 'PUT') {
+            if (context) {
+                const denied = tenantRoleGuard('owner')(req, url, context);
+                if (denied) return denied;
+            }
             return handleSetIdentityTier(req, agentId, iv);
         }
     }
@@ -109,6 +118,10 @@ export function handleReputationRoutes(
         }
 
         if (method === 'POST') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             return handleCreateAttestation(agentId, scorer, attestation);
         }
     }

--- a/server/routes/sandbox.ts
+++ b/server/routes/sandbox.ts
@@ -4,6 +4,7 @@
 import type { Database } from 'bun:sqlite';
 import type { SandboxManager } from '../sandbox/manager';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 import { getAgent } from '../db/agents';
 import { getAgentPolicy, setAgentPolicy, removeAgentPolicy, listAgentPolicies } from '../sandbox/policy';
 import { json, notFound, handleRouteError } from '../lib/response';
@@ -46,10 +47,18 @@ export function handleSandboxRoutes(
         }
 
         if (method === 'PUT') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             return handleSetPolicy(req, db, agentId);
         }
 
         if (method === 'DELETE') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
             const removed = removeAgentPolicy(db, agentId);
             return removed ? json({ ok: true }) : notFound('No policy found for agent');
         }
@@ -58,12 +67,20 @@ export function handleSandboxRoutes(
     // Assign container to session
     const assignMatch = path.match(/^\/api\/sandbox\/assign$/);
     if (assignMatch && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleAssign(req, sandboxManager);
     }
 
     // Release container
     const releaseMatch = path.match(/^\/api\/sandbox\/release\/([^/]+)$/);
     if (releaseMatch && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleRelease(releaseMatch[1], sandboxManager);
     }
 

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -7,6 +7,7 @@ import type { Database } from 'bun:sqlite';
 import { json } from '../lib/response';
 import { parseBodyOrThrow, ValidationError, UpdateCreditConfigSchema } from '../lib/validation';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 import {
     rotateApiKey,
     getApiKeyRotationStatus,
@@ -25,11 +26,19 @@ export function handleSettingsRoutes(req: Request, url: URL, db: Database, conte
 
     // PUT /api/settings/credits — update credit config
     if (url.pathname === '/api/settings/credits' && req.method === 'PUT') {
+        if (context) {
+            const denied = tenantRoleGuard('owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleUpdateCreditConfig(req, db);
     }
 
     // POST /api/settings/api-key/rotate — rotate the API key (admin-only, guarded by ADMIN_PATHS)
     if (url.pathname === '/api/settings/api-key/rotate' && req.method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleApiKeyRotate(req, db, authConfig ?? null);
     }
 

--- a/server/routes/work-tasks.ts
+++ b/server/routes/work-tasks.ts
@@ -1,5 +1,6 @@
 import type { WorkTaskService } from '../work/service';
 import type { RequestContext } from '../middleware/guards';
+import { tenantRoleGuard } from '../middleware/guards';
 import { parseBodyOrThrow, ValidationError, CreateWorkTaskSchema } from '../lib/validation';
 import { json, handleRouteError } from '../lib/response';
 
@@ -21,12 +22,20 @@ export function handleWorkTaskRoutes(
 
     // POST /api/work-tasks — create
     if (path === '/api/work-tasks' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleCreate(req, workTaskService, tenantId);
     }
 
     // POST /api/work-tasks/:id/cancel — cancel a running task
     const cancelMatch = path.match(/^\/api\/work-tasks\/([^/]+)\/cancel$/);
     if (cancelMatch && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
         return handleCancel(cancelMatch[1], workTaskService);
     }
 


### PR DESCRIPTION
## Summary
- Adds `tenantRoleGuard` to all write endpoints across 6 route files (batch 3 of 3)
- **settings.ts**: 2 endpoints — owner-only (credit config, API key rotation)
- **billing.ts**: 2 endpoints — owner-only (subscription create/cancel); Stripe webhook excluded (HMAC-validated)
- **sandbox.ts**: 4 endpoints — operator/owner (policy set/remove, container assign/release)
- **marketplace.ts**: 8 endpoints — operator/owner for listings; owner-only for federation management
- **reputation.ts**: 3 endpoints — operator/owner for events/attestation; owner-only for identity tier
- **work-tasks.ts**: 2 endpoints — operator/owner (create, cancel)
- Total: 21 write endpoints guarded
- `plugins.ts` and `allowlist.ts` excluded — no RequestContext (admin-only via ADMIN_PATHS middleware)

Combined with batches 1-2, all write endpoints across all route files now have RBAC enforcement.

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] All 4833 tests pass
- [ ] Manual: verify viewer role gets 403 on write endpoints

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)