### PR TITLE
test: scheduler cron-parser and priority-rules

### DIFF
--- a/server/__tests__/cron-parser.test.ts
+++ b/server/__tests__/cron-parser.test.ts
@@ -1,0 +1,211 @@
+import { describe, test, expect } from 'bun:test';
+import { parseCron, getNextCronDate, describeCron } from '../scheduler/cron-parser';
+
+// ── parseCron ────────────────────────────────────────────────────────
+
+describe('parseCron', () => {
+    test('parses wildcard fields', () => {
+        const cron = parseCron('* * * * *');
+        expect(cron.minute.values.size).toBe(60);
+        expect(cron.hour.values.size).toBe(24);
+        expect(cron.dayOfMonth.values.size).toBe(31);
+        expect(cron.month.values.size).toBe(12);
+        expect(cron.dayOfWeek.values.size).toBe(8); // 0-7
+    });
+
+    test('parses exact values', () => {
+        const cron = parseCron('30 12 15 6 3');
+        expect([...cron.minute.values]).toEqual([30]);
+        expect([...cron.hour.values]).toEqual([12]);
+        expect([...cron.dayOfMonth.values]).toEqual([15]);
+        expect([...cron.month.values]).toEqual([6]);
+        expect([...cron.dayOfWeek.values]).toEqual([3]);
+    });
+
+    test('parses comma-separated lists', () => {
+        const cron = parseCron('0,15,30,45 * * * *');
+        expect([...cron.minute.values].sort((a, b) => a - b)).toEqual([0, 15, 30, 45]);
+    });
+
+    test('parses ranges', () => {
+        const cron = parseCron('* 9-17 * * *');
+        expect([...cron.hour.values].sort((a, b) => a - b)).toEqual([9, 10, 11, 12, 13, 14, 15, 16, 17]);
+    });
+
+    test('parses step values', () => {
+        const cron = parseCron('*/15 * * * *');
+        expect([...cron.minute.values].sort((a, b) => a - b)).toEqual([0, 15, 30, 45]);
+    });
+
+    test('parses range with step', () => {
+        const cron = parseCron('1-30/10 * * * *');
+        expect([...cron.minute.values].sort((a, b) => a - b)).toEqual([1, 11, 21]);
+    });
+
+    test('resolves @hourly preset', () => {
+        const cron = parseCron('@hourly');
+        expect([...cron.minute.values]).toEqual([0]);
+        expect(cron.hour.values.size).toBe(24);
+    });
+
+    test('resolves @daily preset', () => {
+        const cron = parseCron('@daily');
+        expect([...cron.minute.values]).toEqual([0]);
+        expect([...cron.hour.values]).toEqual([0]);
+        expect(cron.dayOfMonth.values.size).toBe(31);
+    });
+
+    test('resolves @weekly preset', () => {
+        const cron = parseCron('@weekly');
+        expect([...cron.minute.values]).toEqual([0]);
+        expect([...cron.hour.values]).toEqual([0]);
+        expect([...cron.dayOfWeek.values]).toEqual([0]);
+    });
+
+    test('resolves @monthly preset', () => {
+        const cron = parseCron('@monthly');
+        expect([...cron.dayOfMonth.values]).toEqual([1]);
+    });
+
+    test('resolves @yearly and @annually to same result', () => {
+        const yearly = parseCron('@yearly');
+        const annually = parseCron('@annually');
+        expect([...yearly.month.values]).toEqual([1]);
+        expect([...annually.month.values]).toEqual([1]);
+        expect([...yearly.dayOfMonth.values]).toEqual([1]);
+        expect([...annually.dayOfMonth.values]).toEqual([1]);
+    });
+
+    test('presets are case-insensitive', () => {
+        const cron = parseCron('@DAILY');
+        expect([...cron.minute.values]).toEqual([0]);
+        expect([...cron.hour.values]).toEqual([0]);
+    });
+
+    test('throws on invalid field count', () => {
+        expect(() => parseCron('* * *')).toThrow('expected 5 fields');
+        expect(() => parseCron('* * * * * *')).toThrow('expected 5 fields');
+    });
+
+    test('handles day-of-week 0 and 7 both as Sunday', () => {
+        const cron = parseCron('* * * * 0,7');
+        expect(cron.dayOfWeek.values.has(0)).toBe(true);
+        expect(cron.dayOfWeek.values.has(7)).toBe(true);
+    });
+});
+
+// ── getNextCronDate ──────────────────────────────────────────────────
+
+describe('getNextCronDate', () => {
+    test('finds next occurrence for every-minute cron', () => {
+        const from = new Date('2026-01-15T10:30:00Z');
+        const next = getNextCronDate('* * * * *', from);
+        expect(next.getMinutes()).toBe(31);
+        expect(next.getHours()).toBe(10);
+    });
+
+    test('finds next hour for hourly cron', () => {
+        const from = new Date('2026-01-15T10:30:00Z');
+        const next = getNextCronDate('0 * * * *', from);
+        expect(next.getMinutes()).toBe(0);
+        expect(next.getHours()).toBe(11);
+    });
+
+    test('finds next day for daily cron', () => {
+        const from = new Date('2026-01-15T10:30:00Z');
+        const next = getNextCronDate('@daily', from);
+        expect(next.getDate()).toBe(16);
+        expect(next.getHours()).toBe(0);
+        expect(next.getMinutes()).toBe(0);
+    });
+
+    test('finds correct day of week', () => {
+        // 2026-01-15 is a Thursday (day 4)
+        const from = new Date('2026-01-15T10:30:00Z');
+        // Next Monday (day 1)
+        const next = getNextCronDate('0 9 * * 1', from);
+        expect(next.getDay()).toBe(1); // Monday
+        expect(next.getHours()).toBe(9);
+    });
+
+    test('finds next month when current month not in schedule', () => {
+        // Schedule for March only
+        const from = new Date('2026-01-15T10:30:00Z');
+        const next = getNextCronDate('0 0 1 3 *', from);
+        expect(next.getMonth()).toBe(2); // March (0-indexed)
+        expect(next.getDate()).toBe(1);
+    });
+
+    test('handles @monthly preset', () => {
+        const from = new Date('2026-01-15T10:30:00Z');
+        const next = getNextCronDate('@monthly', from);
+        expect(next.getDate()).toBe(1);
+        expect(next.getMonth()).toBe(1); // February
+    });
+
+    test('returns seconds and milliseconds as zero', () => {
+        const from = new Date('2026-01-15T10:30:45.123Z');
+        const next = getNextCronDate('* * * * *', from);
+        expect(next.getSeconds()).toBe(0);
+        expect(next.getMilliseconds()).toBe(0);
+    });
+
+    test('uses preset aliases', () => {
+        const from = new Date('2026-01-15T10:30:00Z');
+        const next = getNextCronDate('@hourly', from);
+        expect(next.getMinutes()).toBe(0);
+        expect(next.getHours()).toBe(11);
+    });
+});
+
+// ── describeCron ─────────────────────────────────────────────────────
+
+describe('describeCron', () => {
+    test('describes @hourly', () => {
+        expect(describeCron('@hourly')).toBe('Every hour');
+    });
+
+    test('describes @daily', () => {
+        expect(describeCron('@daily')).toBe('Every day at midnight');
+    });
+
+    test('describes @weekly', () => {
+        expect(describeCron('@weekly')).toBe('Every Sunday at midnight');
+    });
+
+    test('describes @monthly', () => {
+        expect(describeCron('@monthly')).toBe('First day of every month at midnight');
+    });
+
+    test('describes @yearly', () => {
+        expect(describeCron('@yearly')).toBe('January 1st at midnight');
+    });
+
+    test('describes @annually same as @yearly', () => {
+        expect(describeCron('@annually')).toBe('January 1st at midnight');
+    });
+
+    test('describes every minute', () => {
+        expect(describeCron('* * * * *')).toBe('Every minute');
+    });
+
+    test('describes hourly at specific minute', () => {
+        expect(describeCron('30 * * * *')).toBe('Every hour at minute 30');
+    });
+
+    test('describes specific time', () => {
+        expect(describeCron('0 9 * * *')).toBe('At 09:00');
+    });
+
+    test('includes day-of-week when restricted', () => {
+        const desc = describeCron('0 9 * * 1-5');
+        expect(desc).toContain('on');
+        expect(desc).toContain('Mon');
+        expect(desc).toContain('Fri');
+    });
+
+    test('omits day-of-week when all days selected', () => {
+        const desc = describeCron('0 9 * * *');
+        expect(desc).not.toContain('on');
+    });
+});

--- a/server/__tests__/priority-rules.test.ts
+++ b/server/__tests__/priority-rules.test.ts
@@ -1,0 +1,215 @@
+import { describe, test, expect } from 'bun:test';
+import {
+    getActionCategory,
+    evaluateAction,
+    getRulesForState,
+    getAllRules,
+} from '../scheduler/priority-rules';
+import type { SystemState } from '../scheduler/system-state';
+
+// ── getActionCategory ────────────────────────────────────────────────
+
+describe('getActionCategory', () => {
+    test('maps work_task to feature_work', () => {
+        expect(getActionCategory('work_task')).toBe('feature_work');
+    });
+
+    test('maps github_suggest to feature_work', () => {
+        expect(getActionCategory('github_suggest')).toBe('feature_work');
+    });
+
+    test('maps fork_repo to feature_work', () => {
+        expect(getActionCategory('fork_repo')).toBe('feature_work');
+    });
+
+    test('maps review_prs to review', () => {
+        expect(getActionCategory('review_prs')).toBe('review');
+    });
+
+    test('maps codebase_review to maintenance', () => {
+        expect(getActionCategory('codebase_review')).toBe('maintenance');
+    });
+
+    test('maps dependency_audit to maintenance', () => {
+        expect(getActionCategory('dependency_audit')).toBe('maintenance');
+    });
+
+    test('maps improvement_loop to maintenance', () => {
+        expect(getActionCategory('improvement_loop')).toBe('maintenance');
+    });
+
+    test('maps memory_maintenance to maintenance', () => {
+        expect(getActionCategory('memory_maintenance')).toBe('maintenance');
+    });
+
+    test('maps council_launch to communication', () => {
+        expect(getActionCategory('council_launch')).toBe('communication');
+    });
+
+    test('maps send_message to communication', () => {
+        expect(getActionCategory('send_message')).toBe('communication');
+    });
+
+    test('maps reputation_attestation to lightweight', () => {
+        expect(getActionCategory('reputation_attestation')).toBe('lightweight');
+    });
+
+    test('maps outcome_analysis to lightweight', () => {
+        expect(getActionCategory('outcome_analysis')).toBe('lightweight');
+    });
+
+    test('maps star_repo to lightweight', () => {
+        expect(getActionCategory('star_repo')).toBe('lightweight');
+    });
+
+    test('maps custom to feature_work', () => {
+        expect(getActionCategory('custom')).toBe('feature_work');
+    });
+});
+
+// ── evaluateAction ───────────────────────────────────────────────────
+
+describe('evaluateAction', () => {
+    test('healthy state allows all actions', () => {
+        const result = evaluateAction('work_task', ['healthy']);
+        expect(result.decision).toBe('run');
+        expect(result.reasons).toEqual([]);
+    });
+
+    test('ci_broken skips feature_work', () => {
+        const result = evaluateAction('work_task', ['ci_broken']);
+        expect(result.decision).toBe('skip');
+        expect(result.reasons.length).toBeGreaterThan(0);
+    });
+
+    test('ci_broken boosts maintenance', () => {
+        const result = evaluateAction('codebase_review', ['ci_broken']);
+        expect(result.decision).toBe('boost');
+    });
+
+    test('ci_broken boosts review', () => {
+        const result = evaluateAction('review_prs', ['ci_broken']);
+        expect(result.decision).toBe('boost');
+    });
+
+    test('ci_broken runs lightweight normally', () => {
+        const result = evaluateAction('star_repo', ['ci_broken']);
+        expect(result.decision).toBe('run');
+    });
+
+    test('server_degraded skips feature_work', () => {
+        const result = evaluateAction('work_task', ['server_degraded']);
+        expect(result.decision).toBe('skip');
+    });
+
+    test('server_degraded skips communication', () => {
+        const result = evaluateAction('send_message', ['server_degraded']);
+        expect(result.decision).toBe('skip');
+    });
+
+    test('server_degraded boosts lightweight', () => {
+        const result = evaluateAction('star_repo', ['server_degraded']);
+        expect(result.decision).toBe('boost');
+    });
+
+    test('p0_open skips feature_work', () => {
+        const result = evaluateAction('github_suggest', ['p0_open']);
+        expect(result.decision).toBe('skip');
+    });
+
+    test('p0_open boosts maintenance', () => {
+        const result = evaluateAction('dependency_audit', ['p0_open']);
+        expect(result.decision).toBe('boost');
+    });
+
+    test('disk_pressure skips feature_work', () => {
+        const result = evaluateAction('work_task', ['disk_pressure']);
+        expect(result.decision).toBe('skip');
+    });
+
+    test('disk_pressure boosts maintenance', () => {
+        const result = evaluateAction('memory_maintenance', ['disk_pressure']);
+        expect(result.decision).toBe('boost');
+    });
+
+    test('skip takes precedence over boost with multiple states', () => {
+        // ci_broken: skip feature_work, boost maintenance
+        // disk_pressure: skip feature_work, boost maintenance
+        // For maintenance: ci_broken boosts but server_degraded skips
+        const result = evaluateAction('codebase_review', ['ci_broken', 'server_degraded']);
+        expect(result.decision).toBe('skip');
+    });
+
+    test('accumulates reasons from multiple states', () => {
+        const result = evaluateAction('work_task', ['ci_broken', 'p0_open']);
+        expect(result.decision).toBe('skip');
+        expect(result.reasons.length).toBe(2);
+    });
+
+    test('empty states returns run', () => {
+        const result = evaluateAction('work_task', []);
+        expect(result.decision).toBe('run');
+        expect(result.reasons).toEqual([]);
+    });
+
+    test('only healthy state returns run', () => {
+        const result = evaluateAction('work_task', ['healthy']);
+        expect(result.decision).toBe('run');
+        expect(result.reasons).toEqual([]);
+    });
+});
+
+// ── getRulesForState / getAllRules ────────────────────────────────────
+
+describe('getRulesForState', () => {
+    test('returns rule for healthy state', () => {
+        const rule = getRulesForState('healthy');
+        expect(rule.skip).toEqual([]);
+        expect(rule.boost).toEqual([]);
+        expect(rule.reason).toBeTruthy();
+    });
+
+    test('returns rule for ci_broken state', () => {
+        const rule = getRulesForState('ci_broken');
+        expect(rule.skip).toContain('feature_work');
+        expect(rule.boost).toContain('maintenance');
+        expect(rule.boost).toContain('review');
+    });
+
+    test('returns rule for server_degraded state', () => {
+        const rule = getRulesForState('server_degraded');
+        expect(rule.skip).toContain('feature_work');
+        expect(rule.skip).toContain('communication');
+        expect(rule.boost).toContain('lightweight');
+    });
+
+    test('returns rule for p0_open state', () => {
+        const rule = getRulesForState('p0_open');
+        expect(rule.skip).toContain('feature_work');
+        expect(rule.boost).toContain('maintenance');
+    });
+
+    test('returns rule for disk_pressure state', () => {
+        const rule = getRulesForState('disk_pressure');
+        expect(rule.skip).toContain('feature_work');
+        expect(rule.boost).toContain('maintenance');
+    });
+});
+
+describe('getAllRules', () => {
+    test('returns all 5 system states', () => {
+        const rules = getAllRules();
+        const states: SystemState[] = ['healthy', 'ci_broken', 'server_degraded', 'p0_open', 'disk_pressure'];
+        for (const state of states) {
+            expect(rules[state]).toBeTruthy();
+            expect(rules[state].reason).toBeTruthy();
+        }
+    });
+
+    test('returns a copy (not a reference)', () => {
+        const rules1 = getAllRules();
+        const rules2 = getAllRules();
+        expect(rules1).not.toBe(rules2);
+        expect(rules1).toEqual(rules2);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds 70 new tests covering two scheduler modules that previously had zero test coverage
- **cron-parser.test.ts** (37 tests): field parsing (wildcards, ranges, steps, lists), preset aliases (@hourly through @annually), `getNextCronDate` date iteration, `describeCron` human-readable output
- **priority-rules.test.ts** (33 tests): all 14 action type → category mappings, `evaluateAction` for all 5 system states, skip-precedence-over-boost, reason accumulation, `getRulesForState`/`getAllRules`

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] All 4903 tests pass (70 new)

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)