### PR TITLE
test: polling auto-merge and ci-retry modules

### DIFF
--- a/server/__tests__/auto-merge.test.ts
+++ b/server/__tests__/auto-merge.test.ts
@@ -1,0 +1,289 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import { AutoMergeService, type RunGhFn } from '../polling/auto-merge';
+
+let db: Database;
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+});
+
+afterEach(() => {
+    db.close();
+});
+
+function insertPollingConfig(repo: string, username: string, overrides: Record<string, string> = {}) {
+    db.query(`INSERT INTO agents (id, name, model, system_prompt) VALUES ('agent-1', 'TestAgent', 'test', 'test')
+              ON CONFLICT DO NOTHING`).run();
+    db.query(`INSERT INTO projects (id, name, working_dir) VALUES ('proj-1', 'TestProject', '/tmp/test')
+              ON CONFLICT DO NOTHING`).run();
+    db.query(`INSERT INTO mention_polling_configs (id, repo, mention_username, agent_id, project_id, status)
+              VALUES (?, ?, ?, 'agent-1', 'proj-1', ?)`).run(
+        overrides.id ?? crypto.randomUUID(),
+        repo,
+        username,
+        overrides.status ?? 'active',
+    );
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────────
+
+describe('AutoMergeService lifecycle', () => {
+    test('start sets running and stop clears it', () => {
+        const service = new AutoMergeService(db, async () => ({ ok: false, stdout: '', stderr: '' }));
+        service.start();
+        service.stop();
+        // No assertion needed — just verify no throw
+    });
+
+    test('double start is idempotent', () => {
+        const service = new AutoMergeService(db, async () => ({ ok: false, stdout: '', stderr: '' }));
+        service.start();
+        service.start(); // Should not throw or create duplicate timers
+        service.stop();
+    });
+
+    test('double stop is safe', () => {
+        const service = new AutoMergeService(db, async () => ({ ok: false, stdout: '', stderr: '' }));
+        service.start();
+        service.stop();
+        service.stop(); // Should not throw
+    });
+});
+
+// ── checkAll ─────────────────────────────────────────────────────────
+
+describe('AutoMergeService.checkAll', () => {
+    test('does nothing when not running', async () => {
+        let called = false;
+        const service = new AutoMergeService(db, async () => {
+            called = true;
+            return { ok: false, stdout: '', stderr: '' };
+        });
+        await service.checkAll();
+        expect(called).toBe(false);
+    });
+
+    test('does nothing with no active configs', async () => {
+        let called = false;
+        const runGh: RunGhFn = async () => {
+            called = true;
+            return { ok: false, stdout: '', stderr: '' };
+        };
+        const service = new AutoMergeService(db, runGh);
+        (service as any).running = true;
+        await service.checkAll();
+        expect(called).toBe(false);
+    });
+
+    test('deduplicates configs with same repo+username', async () => {
+        insertPollingConfig('org/repo', 'corvid-agent');
+        insertPollingConfig('org/repo', 'corvid-agent');
+
+        const calls: string[][] = [];
+        const runGh: RunGhFn = async (args) => {
+            calls.push(args);
+            return { ok: true, stdout: JSON.stringify({ items: [] }), stderr: '' };
+        };
+
+        const service = new AutoMergeService(db, runGh);
+        (service as any).running = true;
+        await service.checkAll();
+
+        // Should only search once despite two configs
+        expect(calls.length).toBe(1);
+    });
+
+    test('skips inactive configs', async () => {
+        insertPollingConfig('org/repo', 'corvid-agent', { status: 'paused' });
+
+        let called = false;
+        const runGh: RunGhFn = async () => {
+            called = true;
+            return { ok: false, stdout: '', stderr: '' };
+        };
+
+        const service = new AutoMergeService(db, runGh);
+        (service as any).running = true;
+        await service.checkAll();
+        expect(called).toBe(false);
+    });
+
+    test('merges PR when all checks pass', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        const calls: string[][] = [];
+        const runGh: RunGhFn = async (args) => {
+            calls.push(args);
+            const key = args.join(' ');
+            if (key.includes('search/issues')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify({
+                        items: [{ number: 42, html_url: 'https://github.com/CorvidLabs/corvid-agent/pull/42' }],
+                    }),
+                    stderr: '',
+                };
+            }
+            if (key.includes('pr checks')) {
+                return { ok: true, stdout: 'pass', stderr: '' };
+            }
+            if (key.includes('pr merge')) {
+                return { ok: true, stdout: 'Merged', stderr: '' };
+            }
+            return { ok: false, stdout: '', stderr: 'not mocked' };
+        };
+
+        const service = new AutoMergeService(db, runGh);
+        (service as any).running = true;
+        await service.checkAll();
+
+        // Should have made: search, checks, merge
+        expect(calls.length).toBe(3);
+        expect(calls[2].join(' ')).toContain('pr merge');
+        expect(calls[2].join(' ')).toContain('--squash');
+    });
+
+    test('skips PR when checks fail', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        const calls: string[][] = [];
+        const runGh: RunGhFn = async (args) => {
+            calls.push(args);
+            const key = args.join(' ');
+            if (key.includes('search/issues')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify({
+                        items: [{ number: 42, html_url: 'https://github.com/CorvidLabs/corvid-agent/pull/42' }],
+                    }),
+                    stderr: '',
+                };
+            }
+            if (key.includes('pr checks')) {
+                return { ok: true, stdout: 'fail', stderr: '' };
+            }
+            return { ok: false, stdout: '', stderr: '' };
+        };
+
+        const service = new AutoMergeService(db, runGh);
+        (service as any).running = true;
+        await service.checkAll();
+
+        // Should have made: search, checks — no merge
+        expect(calls.length).toBe(2);
+    });
+
+    test('skips PR when no checks exist', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        const calls: string[][] = [];
+        const runGh: RunGhFn = async (args) => {
+            calls.push(args);
+            const key = args.join(' ');
+            if (key.includes('search/issues')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify({
+                        items: [{ number: 42, html_url: 'https://github.com/CorvidLabs/corvid-agent/pull/42' }],
+                    }),
+                    stderr: '',
+                };
+            }
+            if (key.includes('pr checks')) {
+                return { ok: true, stdout: 'none', stderr: '' };
+            }
+            return { ok: false, stdout: '', stderr: '' };
+        };
+
+        const service = new AutoMergeService(db, runGh);
+        (service as any).running = true;
+        await service.checkAll();
+
+        // search + checks, no merge
+        expect(calls.length).toBe(2);
+    });
+
+    test('handles empty search results', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        const calls: string[][] = [];
+        const runGh: RunGhFn = async (args) => {
+            calls.push(args);
+            return { ok: true, stdout: JSON.stringify({ items: [] }), stderr: '' };
+        };
+
+        const service = new AutoMergeService(db, runGh);
+        (service as any).running = true;
+        await service.checkAll();
+
+        // Just the search call, no checks or merges
+        expect(calls.length).toBe(1);
+    });
+
+    test('uses org: qualifier for org-level configs', async () => {
+        insertPollingConfig('CorvidLabs', 'corvid-agent');
+
+        const calls: string[][] = [];
+        const runGh: RunGhFn = async (args) => {
+            calls.push(args);
+            return { ok: true, stdout: JSON.stringify({ items: [] }), stderr: '' };
+        };
+
+        const service = new AutoMergeService(db, runGh);
+        (service as any).running = true;
+        await service.checkAll();
+
+        // org-level config should use org: prefix
+        const searchCall = calls[0].join(' ');
+        expect(searchCall).toContain('org:CorvidLabs');
+    });
+
+    test('continues on merge failure', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        const runGh: RunGhFn = async (args) => {
+            const key = args.join(' ');
+            if (key.includes('search/issues')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify({
+                        items: [
+                            { number: 1, html_url: 'https://github.com/CorvidLabs/corvid-agent/pull/1' },
+                            { number: 2, html_url: 'https://github.com/CorvidLabs/corvid-agent/pull/2' },
+                        ],
+                    }),
+                    stderr: '',
+                };
+            }
+            if (key.includes('pr checks')) {
+                return { ok: true, stdout: 'pass', stderr: '' };
+            }
+            if (key.includes('pr merge')) {
+                return { ok: false, stdout: '', stderr: 'merge conflict' };
+            }
+            return { ok: false, stdout: '', stderr: '' };
+        };
+
+        const service = new AutoMergeService(db, runGh);
+        (service as any).running = true;
+        // Should not throw even when merge fails
+        await service.checkAll();
+    });
+
+    test('handles search API failure gracefully', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        const runGh: RunGhFn = async () => {
+            return { ok: false, stdout: '', stderr: 'API error' };
+        };
+
+        const service = new AutoMergeService(db, runGh);
+        (service as any).running = true;
+        // Should not throw
+        await service.checkAll();
+    });
+});

--- a/server/__tests__/ci-retry.test.ts
+++ b/server/__tests__/ci-retry.test.ts
@@ -1,0 +1,356 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import { CIRetryService, type RunGhFn } from '../polling/ci-retry';
+
+let db: Database;
+const AGENT_ID = 'agent-1';
+const PROJECT_ID = 'proj-1';
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+    db.query(`INSERT INTO agents (id, name, model, system_prompt) VALUES (?, 'TestAgent', 'test', 'test')`).run(AGENT_ID);
+    db.query(`INSERT INTO projects (id, name, working_dir) VALUES (?, 'TestProject', '/tmp/test')`).run(PROJECT_ID);
+});
+
+afterEach(() => {
+    db.close();
+});
+
+function insertPollingConfig(repo: string, username: string, overrides: Record<string, string> = {}) {
+    db.query(`INSERT INTO mention_polling_configs (id, repo, mention_username, agent_id, project_id, status)
+              VALUES (?, ?, ?, ?, ?, ?)`).run(
+        overrides.id ?? crypto.randomUUID(),
+        repo,
+        username,
+        overrides.agentId ?? AGENT_ID,
+        overrides.projectId ?? PROJECT_ID,
+        overrides.status ?? 'active',
+    );
+}
+
+function mockProcessManager() {
+    return {
+        startProcess: () => {},
+        stopProcess: () => {},
+        resumeProcess: () => {},
+    } as any;
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────────
+
+describe('CIRetryService lifecycle', () => {
+    test('start and stop without errors', () => {
+        const service = new CIRetryService(db, mockProcessManager(), async () => ({ ok: false, stdout: '', stderr: '' }));
+        service.start();
+        service.stop();
+    });
+
+    test('double start is idempotent', () => {
+        const service = new CIRetryService(db, mockProcessManager(), async () => ({ ok: false, stdout: '', stderr: '' }));
+        service.start();
+        service.start();
+        service.stop();
+    });
+
+    test('double stop is safe', () => {
+        const service = new CIRetryService(db, mockProcessManager(), async () => ({ ok: false, stdout: '', stderr: '' }));
+        service.start();
+        service.stop();
+        service.stop();
+    });
+});
+
+// ── checkAll ─────────────────────────────────────────────────────────
+
+describe('CIRetryService.checkAll', () => {
+    test('does nothing when not running', async () => {
+        let called = false;
+        const service = new CIRetryService(db, mockProcessManager(), async () => {
+            called = true;
+            return { ok: false, stdout: '', stderr: '' };
+        });
+        await service.checkAll();
+        expect(called).toBe(false);
+    });
+
+    test('does nothing with no active configs', async () => {
+        let called = false;
+        const runGh: RunGhFn = async () => {
+            called = true;
+            return { ok: false, stdout: '', stderr: '' };
+        };
+        const service = new CIRetryService(db, mockProcessManager(), runGh);
+        (service as any).running = true;
+        await service.checkAll();
+        expect(called).toBe(false);
+    });
+
+    test('deduplicates configs with same repo+username', async () => {
+        insertPollingConfig('org/repo', 'corvid-agent');
+        insertPollingConfig('org/repo', 'corvid-agent');
+
+        const calls: string[][] = [];
+        const runGh: RunGhFn = async (args) => {
+            calls.push(args);
+            return { ok: true, stdout: JSON.stringify({ items: [] }), stderr: '' };
+        };
+
+        const service = new CIRetryService(db, mockProcessManager(), runGh);
+        (service as any).running = true;
+        await service.checkAll();
+
+        expect(calls.length).toBe(1);
+    });
+
+    test('spawns fix session for PR with failed CI', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        let sessionStarted = false;
+        const pm = {
+            ...mockProcessManager(),
+            startProcess: () => { sessionStarted = true; },
+        } as any;
+
+        const runGh: RunGhFn = async (args) => {
+            const key = args.join(' ');
+            if (key.includes('search/issues')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify({
+                        items: [{ number: 42, title: 'Fix bug', html_url: 'https://github.com/CorvidLabs/corvid-agent/pull/42' }],
+                    }),
+                    stderr: '',
+                };
+            }
+            if (key.includes('pr checks')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify([
+                        { name: 'lint', state: 'SUCCESS' },
+                        { name: 'test', state: 'FAILURE' },
+                    ]),
+                    stderr: '',
+                };
+            }
+            return { ok: false, stdout: '', stderr: '' };
+        };
+
+        const service = new CIRetryService(db, pm, runGh);
+        (service as any).running = true;
+        await service.checkAll();
+
+        expect(sessionStarted).toBe(true);
+        // Verify a session was created in the DB
+        const sessions = db.query('SELECT name FROM sessions').all() as Array<{ name: string }>;
+        expect(sessions.length).toBe(1);
+        expect(sessions[0].name).toContain('Poll: CorvidLabs/corvid-agent #42');
+    });
+
+    test('skips PR when all checks pass', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        let sessionStarted = false;
+        const pm = {
+            ...mockProcessManager(),
+            startProcess: () => { sessionStarted = true; },
+        } as any;
+
+        const runGh: RunGhFn = async (args) => {
+            const key = args.join(' ');
+            if (key.includes('search/issues')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify({
+                        items: [{ number: 42, title: 'Fix', html_url: 'https://github.com/CorvidLabs/corvid-agent/pull/42' }],
+                    }),
+                    stderr: '',
+                };
+            }
+            if (key.includes('pr checks')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify([
+                        { name: 'lint', state: 'SUCCESS' },
+                        { name: 'test', state: 'SUCCESS' },
+                    ]),
+                    stderr: '',
+                };
+            }
+            return { ok: false, stdout: '', stderr: '' };
+        };
+
+        const service = new CIRetryService(db, pm, runGh);
+        (service as any).running = true;
+        await service.checkAll();
+
+        expect(sessionStarted).toBe(false);
+    });
+
+    test('skips PR when checks are pending', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        let sessionStarted = false;
+        const pm = {
+            ...mockProcessManager(),
+            startProcess: () => { sessionStarted = true; },
+        } as any;
+
+        const runGh: RunGhFn = async (args) => {
+            const key = args.join(' ');
+            if (key.includes('search/issues')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify({
+                        items: [{ number: 42, title: 'Fix', html_url: 'https://github.com/CorvidLabs/corvid-agent/pull/42' }],
+                    }),
+                    stderr: '',
+                };
+            }
+            if (key.includes('pr checks')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify([
+                        { name: 'test', state: 'FAILURE' },
+                        { name: 'build', state: 'PENDING' },
+                    ]),
+                    stderr: '',
+                };
+            }
+            return { ok: false, stdout: '', stderr: '' };
+        };
+
+        const service = new CIRetryService(db, pm, runGh);
+        (service as any).running = true;
+        await service.checkAll();
+
+        expect(sessionStarted).toBe(false);
+    });
+
+    test('enforces cooldown per PR', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        let startCount = 0;
+        const pm = {
+            ...mockProcessManager(),
+            startProcess: () => { startCount++; },
+        } as any;
+
+        const runGh: RunGhFn = async (args) => {
+            const key = args.join(' ');
+            if (key.includes('search/issues')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify({
+                        items: [{ number: 42, title: 'Fix', html_url: 'https://github.com/CorvidLabs/corvid-agent/pull/42' }],
+                    }),
+                    stderr: '',
+                };
+            }
+            if (key.includes('pr checks')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify([
+                        { name: 'test', state: 'FAILURE' },
+                    ]),
+                    stderr: '',
+                };
+            }
+            return { ok: false, stdout: '', stderr: '' };
+        };
+
+        const service = new CIRetryService(db, pm, runGh);
+        (service as any).running = true;
+
+        await service.checkAll();
+        expect(startCount).toBe(1);
+
+        // Delete the created session so it won't be skipped for "existing session" reason
+        db.query('DELETE FROM sessions').run();
+
+        // Second call should be cooldown-blocked
+        await service.checkAll();
+        expect(startCount).toBe(1);
+    });
+
+    test('skips PR with existing running session', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        // Pre-create a running session for this PR
+        db.query(`INSERT INTO sessions (id, project_id, agent_id, name, status, source)
+                  VALUES (?, ?, ?, ?, 'running', 'agent')`).run(
+            crypto.randomUUID(), PROJECT_ID, AGENT_ID,
+            'Poll: CorvidLabs/corvid-agent #42: Fix bug',
+        );
+
+        let sessionStarted = false;
+        const pm = {
+            ...mockProcessManager(),
+            startProcess: () => { sessionStarted = true; },
+        } as any;
+
+        const runGh: RunGhFn = async (args) => {
+            const key = args.join(' ');
+            if (key.includes('search/issues')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify({
+                        items: [{ number: 42, title: 'Fix', html_url: 'https://github.com/CorvidLabs/corvid-agent/pull/42' }],
+                    }),
+                    stderr: '',
+                };
+            }
+            return { ok: false, stdout: '', stderr: '' };
+        };
+
+        const service = new CIRetryService(db, pm, runGh);
+        (service as any).running = true;
+        await service.checkAll();
+
+        expect(sessionStarted).toBe(false);
+    });
+
+    test('handles search API failure gracefully', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        const runGh: RunGhFn = async () => {
+            return { ok: false, stdout: '', stderr: 'API error' };
+        };
+
+        const service = new CIRetryService(db, mockProcessManager(), runGh);
+        (service as any).running = true;
+        await service.checkAll();
+        // Should not throw
+    });
+
+    test('handles empty search results', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        const runGh: RunGhFn = async () => {
+            return { ok: true, stdout: JSON.stringify({ items: [] }), stderr: '' };
+        };
+
+        const service = new CIRetryService(db, mockProcessManager(), runGh);
+        (service as any).running = true;
+        await service.checkAll();
+    });
+
+    test('uses org: qualifier for org-level configs', async () => {
+        insertPollingConfig('CorvidLabs', 'corvid-agent');
+
+        const calls: string[][] = [];
+        const runGh: RunGhFn = async (args) => {
+            calls.push(args);
+            return { ok: true, stdout: JSON.stringify({ items: [] }), stderr: '' };
+        };
+
+        const service = new CIRetryService(db, mockProcessManager(), runGh);
+        (service as any).running = true;
+        await service.checkAll();
+
+        const searchCall = calls[0].join(' ');
+        expect(searchCall).toContain('org:CorvidLabs');
+    });
+});


### PR DESCRIPTION
## Summary
- Adds 28 new tests covering two polling modules that had zero test coverage
- **auto-merge.test.ts** (14 tests): lifecycle management, config deduplication, check status evaluation (pass/fail/none), merge execution, org-level qualifier, error resilience
- **ci-retry.test.ts** (14 tests): lifecycle management, config deduplication, CI failure detection, cooldown enforcement, existing session detection, pending check skip, session spawning

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] All 4931 tests pass (28 new)

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)