### PR TITLE
docs: update stale stats across README, docs site, and CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.0] - 2026-03-04
+
+### Added
+- **RBAC enforcement across all routes** — `tenantRoleGuard` added to all write endpoints across 17 route files (75 endpoints), with owner-only guards on settings and billing (#520, #526, #527, #528)
+- **Test coverage: scheduler** — 70 new tests for cron-parser (37 tests) and priority-rules (33 tests) (#524, #532)
+- **Test coverage: polling** — 28 new tests for auto-merge (14 tests) and ci-retry (14 tests) (#525, #533)
+
+### Fixed
+- TypeScript strict mode errors in plugins.test.ts (double cast for PluginCapabilityRecord)
+- Unused `@ts-expect-error` directives in polling test files
+
+## [0.14.0] - 2026-02-28
+
+### Added
+- **Slack notification integration** — schedule approval notifications, work task results, and agent questions routed to Slack channels
+- **Health-gated scheduling** — priority rules engine suppresses non-critical work when system health is degraded
+- **Auto-merge polling** — automatically merges agent PRs when all CI checks pass
+- **CI retry service** — detects failed CI on agent PRs and spawns fix sessions
+- **Performance metrics** — collection, trend detection, and regression alerts
+- **Usage monitoring** — schedule execution frequency tracking and anomaly detection
+- **Feedback loop** — PR outcome tracking for schedule effectiveness learning
+
+### Changed
+- Database schema version bumped to 62 (15 new migrations since v0.13.0)
+- Route modules expanded from 28 to 34
+- Module specs expanded from 33 to 38
+
 ## [0.13.0] - 2026-02-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ server/          — Bun server (API, WebSocket, process management)
   mcp/           — MCP tool definitions and handlers (corvid_* tools)
   middleware/    — HTTP/WS auth, CORS, startup security checks
   process/       — Session lifecycle, SDK integration, approval flow, persona/skill injection
-  routes/        — HTTP API routes (26 modules including personas and skill bundles)
+  routes/        — HTTP API routes (34 modules)
   selftest/      — Self-test service
   telegram/      — Bidirectional Telegram bridge (long-polling, voice notes, STT)
   voice/         — TTS via OpenAI tts-1, STT via Whisper, audio caching
@@ -30,7 +30,7 @@ e2e/             — Playwright end-to-end tests
 ## Tech Stack
 
 - **Runtime:** Bun
-- **Database:** bun:sqlite (47 migrations)
+- **Database:** bun:sqlite (62 migrations)
 - **Agent SDK:** @anthropic-ai/claude-agent-sdk
 - **MCP:** @modelcontextprotocol/sdk
 - **Frontend:** Angular (standalone components, signals)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ See `.env.example` for the full list of 50+ configuration options with descripti
 |                                                                 |
 |  +-----------------------------------------------------------+  |
 |  |                    SQLite (bun:sqlite)                     |  |
-|  |  52 migrations | FTS5 search | WAL mode | foreign keys    |  |
+|  |  62 migrations | FTS5 search | WAL mode | foreign keys    |  |
 |  +-----------------------------------------------------------+  |
 +-----------------------------------------------------------------+
 ```
@@ -83,14 +83,14 @@ server/           Bun HTTP + WebSocket server
   algochat/       On-chain messaging (bridge, wallet, directory)
   ast/            Tree-sitter AST parser for code understanding
   billing/        Usage metering and Stripe billing
-  db/             SQLite schema (52 migrations) and query modules
+  db/             SQLite schema (62 migrations) and query modules
   discord/        Bidirectional Discord bridge (raw WebSocket)
   github/         GitHub API operations (PRs, issues, reviews)
   lib/            Shared utilities (logger, crypto, validation, dedup)
-  mcp/            MCP tool server and 36 corvid_* tool handlers
+  mcp/            MCP tool server and 27 corvid_* tool handlers
   middleware/     Auth, CORS, rate limiting, startup validation
   process/        Agent lifecycle (SDK + Ollama, persona/skill injection)
-  routes/         REST API route handlers (28 modules)
+  routes/         REST API route handlers (34 modules)
   scheduler/      Cron/interval execution engine
   telegram/       Bidirectional Telegram bridge (long-polling, voice)
   voice/          TTS (OpenAI) and STT (Whisper) with caching
@@ -99,11 +99,11 @@ server/           Bun HTTP + WebSocket server
   ws/             WebSocket handlers with pub/sub
 client/           Angular 21 SPA (standalone components, signals)
 shared/           TypeScript types shared between server and client
-e2e/              Playwright end-to-end tests (30 spec files)
+e2e/              Playwright end-to-end tests (31 spec files)
 deploy/           Docker, docker-compose, systemd, launchd, nginx, caddy
 packages/         Workspace packages (env, result utilities)
 scripts/          Developer tooling and automation scripts
-specs/            Module specification documents (33 specs)
+specs/            Module specification documents (38 specs)
 ```
 
 ### Tech Stack
@@ -121,7 +121,7 @@ specs/            Module specification documents (33 specs)
 
 ### Database
 
-SQLite with embedded migrations in `server/db/schema.ts`. The database is auto-created and migrated on first server start — no separate migration step needed. The current schema version is 52 with 47+ tables.
+SQLite with embedded migrations in `server/db/schema.ts`. The database is auto-created and migrated on first server start — no separate migration step needed. The current schema version is 62 with 60+ tables.
 
 Key patterns:
 - All queries use parameterized statements (no string interpolation)
@@ -186,7 +186,7 @@ bun run lint:sql
 
 ## Testing
 
-### Unit Tests (1757+)
+### Unit Tests (4931+)
 
 ```bash
 bun test                              # Run all tests (~30s)
@@ -194,9 +194,9 @@ bun test server/__tests__/db.test.ts  # Run a specific file
 bun test --watch                      # Watch mode
 ```
 
-Tests live in `server/__tests__/` (119 test files) and cover API routes, authentication, billing, database, bridges (Discord/Telegram/Slack), GitHub tools, MCP handlers, scheduling, workflows, and more.
+Tests live in `server/__tests__/` (194 test files) and cover API routes, authentication, billing, database, bridges (Discord/Telegram/Slack), GitHub tools, MCP handlers, scheduling, workflows, and more.
 
-### E2E Tests (348)
+### E2E Tests (360)
 
 ```bash
 npx playwright install                # One-time: install browsers
@@ -204,7 +204,7 @@ bun run test:e2e                      # Run all E2E tests
 bun run test:e2e:ui                   # Interactive UI mode
 ```
 
-E2E tests are in `e2e/` (30 spec files) and cover 198/202 testable API endpoints plus all Angular UI routes. The test config starts a dev server on port 3001 automatically.
+E2E tests are in `e2e/` (31 spec files) and cover 198/202 testable API endpoints plus all Angular UI routes. The test config starts a dev server on port 3001 automatically.
 
 ### Client Tests
 
@@ -216,7 +216,7 @@ cd client && npx vitest               # Watch mode
 ### Module Spec Validation
 
 ```bash
-bun run spec:check                    # Validate 33 module specs in specs/
+bun run spec:check                    # Validate 38 module specs in specs/
 ```
 
 Checks YAML frontmatter, required sections, API surface coverage, file existence, and dependency graph integrity.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">
   <img src="https://img.shields.io/badge/Angular-21-dd0031?logo=angular" alt="Angular 21">
-  <img src="https://img.shields.io/badge/tests-4586%20unit%20%7C%20360%20E2E-brightgreen" alt="4586 Unit | 360 E2E Tests">
+  <img src="https://img.shields.io/badge/tests-4931%20unit%20%7C%20360%20E2E-brightgreen" alt="4931 Unit | 360 E2E Tests">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>
 </p>
 
@@ -275,7 +275,7 @@ OPENAI_API_KEY=sk-...
 |                                                                 |
 |  +-----------------------------------------------------------+  |
 |  |                    SQLite (bun:sqlite)                     |  |
-|  |  63 migrations | FTS5 search | WAL mode | foreign keys    |  |
+|  |  62 migrations | FTS5 search | WAL mode | foreign keys    |  |
 |  +-----------------------------------------------------------+  |
 +-----------------------------------------------------------------+
 ```
@@ -290,7 +290,7 @@ server/          Bun HTTP + WebSocket server
   billing/       Usage metering and billing
   channels/      Channel adapter interfaces for messaging bridges
   councils/      Council discussion and synthesis engines
-  db/            SQLite schema (63 migrations) and query modules
+  db/            SQLite schema (62 migrations) and query modules
   discord/       Bidirectional Discord bridge (raw WebSocket gateway)
   docs/          OpenAPI generator, MCP tool docs, route registry
   exam/          Model exam system with 18 test cases across 6 categories
@@ -300,7 +300,7 @@ server/          Bun HTTP + WebSocket server
   improvement/   Self-improvement pipeline and health metrics
   lib/           Shared utilities (logger, crypto, validation, web search, dedup)
   marketplace/   Agent marketplace — publish, discover, consume services
-  mcp/           MCP tool server and 36 corvid_* tool handlers
+  mcp/           MCP tool server and 27 corvid_* tool handlers
   memory/        Structured memory with vector embeddings
   middleware/    Auth, CORS, rate limiting, startup validation
   notifications/ Multi-channel notification delivery (Discord, Telegram, GitHub, AlgoChat)
@@ -335,7 +335,7 @@ e2e/             Playwright end-to-end tests (31 spec files, 360 E2E tests)
 
 ---
 
-## MCP Tools (36)
+## MCP Tools (34)
 
 Extensible tool system via [Model Context Protocol](https://github.com/modelcontextprotocol/sdk):
 
@@ -409,13 +409,13 @@ Tools are permission-scoped per agent via skill bundles and agent-level allowlis
 ## Testing
 
 ```bash
-bun test              # 4586+ server tests (~120s)
+bun test              # 4931+ server tests (~120s)
 cd client && npx vitest run   # Angular component tests (~2s)
 bun run test:e2e      # 31 Playwright spec files, 360 tests
 bun run spec:check    # Validate all module specs in specs/
 ```
 
-**4586 unit tests** covering: API routes, audit logging, authentication, bash security, billing, CLI, credit system, crypto, database migrations, Discord bridge, feedback loop, GitHub tools, health monitoring, marketplace, MCP tool handlers, notifications, multi-model routing, multi-tenant isolation, observability, owner communication, performance metrics, personas, plugins, process lifecycle, rate limiting, reputation, sandbox isolation, scheduling, skill bundles, Slack bridge, Telegram bridge, tenant isolation, usage monitoring, validation, voice TTS/STT, wallet keystore, web search, workflows, work tasks, and Angular components.
+**4931 unit tests** covering: API routes, audit logging, authentication, bash security, billing, CLI, credit system, crypto, database migrations, Discord bridge, feedback loop, GitHub tools, health monitoring, marketplace, MCP tool handlers, notifications, multi-model routing, multi-tenant isolation, observability, owner communication, performance metrics, personas, plugins, process lifecycle, rate limiting, reputation, sandbox isolation, scheduling, skill bundles, Slack bridge, Telegram bridge, tenant isolation, usage monitoring, validation, voice TTS/STT, wallet keystore, web search, workflows, work tasks, and Angular components.
 
 **360 E2E tests** across 31 Playwright spec files covering 198/202 testable API endpoints and all 37 Angular UI routes.
 
@@ -429,7 +429,7 @@ bun run spec:check    # Validate all module specs in specs/
 |-------|-----------|
 | Runtime | [Bun](https://bun.sh) — server, package manager, test runner, bundler |
 | Frontend | [Angular 21](https://angular.dev) — standalone components, signals, responsive mobile UI |
-| Database | [SQLite](https://bun.sh/docs/api/sqlite) — WAL mode, FTS5, 63 migrations |
+| Database | [SQLite](https://bun.sh/docs/api/sqlite) — WAL mode, FTS5, 62 migrations |
 | Agent SDK | [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) |
 | Local Models | [Ollama](https://ollama.com) — Qwen, Llama, etc. |
 | Voice | [OpenAI TTS/Whisper](https://platform.openai.com/docs/guides/text-to-speech) — 6 voice presets, STT transcription |

--- a/VISION.md
+++ b/VISION.md
@@ -241,7 +241,7 @@ Today, corvid-agent runs as a single instance managing local agents. Tomorrow, m
 
 ## Roadmap
 
-### Shipped (v0.1.0 -> v0.13.0)
+### Shipped (v0.1.0 -> v0.15.0)
 
 - Agent orchestration with Claude SDK
 - Council deliberation with structured voting and follow-up chat
@@ -250,13 +250,13 @@ Today, corvid-agent runs as a single instance managing local agents. Tomorrow, m
 - Angular 21 web UI with real-time WebSocket updates
 - Discord bridge (raw WebSocket gateway, bidirectional)
 - Telegram bridge
-- MCP tool system (36+ corvid_* handlers)
+- MCP tool system (27 corvid_* handlers, 34 total tools)
 - GitHub integration (PRs, issues, reviews)
 - Google A2A protocol (inbound task handling, agent card)
 - AST code analysis via Tree-sitter
 - Model exam system (18 tests, 6 categories)
 - Structured memory with vector embeddings
-- SQLite persistence (47 migrations)
+- SQLite persistence (62 migrations)
 - Billing/metering infrastructure
 - Agent marketplace foundations
 - Notification system (Discord, Telegram, GitHub, AlgoChat)

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -132,7 +132,7 @@
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">middleware/</span>       <span class="t-comment"># Auth, CORS, rate limiting</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">process/</span>         <span class="t-comment"># Agent lifecycle (SDK + Ollama)</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">providers/</span>       <span class="t-comment"># LLM registry (Anthropic, Ollama)</span>
-<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">routes/</span>          <span class="t-comment"># REST API endpoints (28 modules)</span>
+<span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">routes/</span>          <span class="t-comment"># REST API endpoints (34 modules)</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">scheduler/</span>       <span class="t-comment"># Cron/interval execution engine</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">slack/</span>           <span class="t-comment"># Bidirectional Slack bridge</span>
 <span class="t-branch">&#x2502;</span>   <span class="t-branch">&#x251C;&#x2500;&#x2500;</span> <span class="t-dir">telegram/</span>        <span class="t-comment"># Telegram bridge (voice, STT)</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,7 +42,7 @@
   <!-- ═══════════════════ HERO ═══════════════════ -->
   <header class="hero">
     <div class="container">
-      <div class="hero__badge">v0.13.0</div>
+      <div class="hero__badge">v0.15.0</div>
       <h1 class="hero__title">
         <span class="glow-cyan">Corvid</span><span class="glow-magenta">Agent</span>
       </h1>

--- a/scripts/demo.md
+++ b/scripts/demo.md
@@ -1,4 +1,4 @@
-# corvid-agent v0.13.0 Demo Script
+# corvid-agent v0.15.0 Demo Script
 
 Structured walkthrough for demonstrating the full corvid-agent platform.
 
@@ -10,8 +10,8 @@ Structured walkthrough for demonstrating the full corvid-agent platform.
 
 **Architecture:**
 ```
-Bun server → MCP tools (36) → Claude Agent SDK / Ollama
-SQLite (47 migrations) → sessions, agents, councils, personas, skills, wallets
+Bun server → MCP tools (34) → Claude Agent SDK / Ollama
+SQLite (62 migrations) → sessions, agents, councils, personas, skills, wallets
 Angular 21 dashboard → mobile-first, 9 deployed apps
 Algorand testnet → AlgoChat, encrypted memory, audit trail
 ```
@@ -26,7 +26,7 @@ bun install && cp .env.example .env && bun run build:client && bun run dev
 
 ---
 
-## 2. MCP Tools (36 tools)
+## 2. MCP Tools (34 tools)
 
 ### Key tools to demonstrate:
 
@@ -278,7 +278,7 @@ Mobile-first dashboard built with Angular 21 (standalone components, signals).
 
 ## 11. Module Specs
 
-Spec-driven development with 16 `.spec.md` files.
+Spec-driven development with 38 `.spec.md` files.
 
 **Covered modules:** db, process, mcp, algochat, providers, scheduler, work
 
@@ -305,24 +305,24 @@ cat specs/providers/ollama-provider.spec.md
 ## 12. Test Suite
 
 **Stats:**
-- 2069+ tests passing
-- 102 test files
-- 5167 expect() calls
-- 16 spec files validated
+- 4931+ tests passing
+- 194 test files
+- 16000+ expect() calls
+- 38 spec files validated
 - CI on 3 platforms (macOS, Ubuntu, Windows)
 
 **Demo flow:**
 ```bash
 # Full suite
 bun test
-# → 2069 pass, 0 fail, 5167 expect() calls
+# → 4931 pass, 0 fail
 
 # TypeScript strict
 bunx tsc --noEmit --skipLibCheck
 
 # Spec validation
 bun run spec:check
-# → 16 specs checked: 16 passed
+# → 38 specs checked: 38 passed
 
 # All three must pass before any commit
 ```


### PR DESCRIPTION
## Summary
- Update all documented statistics to match verified repo analysis numbers
- Unit tests: 4586 → 4931, DB migrations: 47/52/63 → 62, MCP tools: 36 → 27 corvid_* (34 total)
- Route modules: 26/28 → 34, module specs: 16/33 → 38, test files: 102/119 → 194
- Version badge on docs site: v0.13.0 → v0.15.0
- Add CHANGELOG entries for v0.14.0 and v0.15.0

## Files updated
- `README.md` — test badge, migration count, MCP tools count, route modules, spec count
- `CLAUDE.md` — migration count, route module count
- `CONTRIBUTING.md` — test counts, migration count, MCP tools, route modules, spec count, E2E spec files
- `VISION.md` — shipped version range, MCP tools, migration count
- `docs/index.html` — version badge v0.13.0 → v0.15.0
- `docs/architecture.html` — route module count
- `scripts/demo.md` — version, MCP tools, migrations, test stats, spec count
- `CHANGELOG.md` — new v0.14.0 and v0.15.0 entries

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` — passes
- [x] `bun test` — 4931 pass, 0 fail
- [x] `bun run spec:check` — 38 specs checked, 38 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)