### PR TITLE
fix(ci): update cosign-installer to current v3 SHA

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,7 +67,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@3454372be43b31757badb472a6eb1a218938bcbf  # v3
+        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9  # v3
 
       - name: Sign Docker image
         env:


### PR DESCRIPTION
## Summary
- The pinned SHA `3454372` for `sigstore/cosign-installer` was force-pushed away upstream
- This broke the Docker Publish and Release workflows on the v0.16.0 tag push
- Updated to current v3 SHA `f713795cb21599bc4e5c4b58cbad1da852d7eeb9`

## After merge
Re-run the Release workflow for v0.16.0 to publish the Docker image:
```
gh workflow run release.yml -f tag=v0.16.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)