### PR TITLE
fix(ci): add id-token permission for cosign in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
   # ── Create GitHub Release ───────────────────────────────────────
   release:


### PR DESCRIPTION
## Summary
- The `docker` job in `release.yml` calls `docker-publish.yml` as a reusable workflow
- `docker-publish.yml` requires `id-token: write` for keyless Cosign signing via Sigstore/Fulcio
- The caller only granted `contents: read` and `packages: write`, causing `startup_failure`
- Added the missing `id-token: write` permission

## After merge
Re-run: `gh workflow run release.yml -f tag=v0.16.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)