### PR TITLE
feat: block all Vapor org repos with wildcard support

### DIFF
--- a/.claude/off-limits-repos.txt
+++ b/.claude/off-limits-repos.txt
@@ -1,10 +1,5 @@
-# Contributor-owned repos — do not create issues, PRs, or commits
-# unless explicitly asked by the repo owner.
-CorvidLabs/rust-server
-CorvidLabs/rust-game
-CorvidLabs/rust-ui
-CorvidLabs/rust-learning
-
 # Projects that reject AI/LLM contributions — do not submit PRs, issues,
 # or any code contributions. They will be closed on sight.
 jellyfin/Swiftfin
+apple/swift-configuration
+vapor/*

--- a/server/__tests__/off-limits.test.ts
+++ b/server/__tests__/off-limits.test.ts
@@ -31,8 +31,15 @@ describe('off-limits repos', () => {
         expect(() => assertRepoAllowed('CorvidLabs/corvid-agent')).not.toThrow();
     });
 
-    test('blocks contributor-owned repos', () => {
-        expect(isRepoOffLimits('CorvidLabs/rust-server')).toBe(true);
-        expect(isRepoOffLimits('CorvidLabs/rust-game')).toBe(true);
+    test('blocks all repos under a wildcard org', () => {
+        expect(isRepoOffLimits('vapor/vapor')).toBe(true);
+        expect(isRepoOffLimits('vapor/fluent')).toBe(true);
+        expect(isRepoOffLimits('vapor/async-kit')).toBe(true);
+        expect(isRepoOffLimits('Vapor/Vapor')).toBe(true);
+    });
+
+    test('wildcard org does not match unrelated repos', () => {
+        expect(isRepoOffLimits('CorvidLabs/corvid-agent')).toBe(false);
+        expect(isRepoOffLimits('vaporware/something')).toBe(false);
     });
 });

--- a/server/github/off-limits.ts
+++ b/server/github/off-limits.ts
@@ -10,32 +10,46 @@ import { resolve } from 'node:path';
 
 const OFF_LIMITS_FILE = resolve(import.meta.dir, '../../.claude/off-limits-repos.txt');
 
-let cachedRepos: Set<string> | null = null;
+interface OffLimitsEntries {
+    exact: Set<string>;
+    orgWildcards: Set<string>;
+}
 
-/** Parse the off-limits file and return lowercased owner/repo entries. */
-function loadOffLimitsRepos(): Set<string> {
-    if (cachedRepos) return cachedRepos;
+let cached: OffLimitsEntries | null = null;
+
+/** Parse the off-limits file, separating exact repos from org/* wildcards. */
+function loadOffLimitsRepos(): OffLimitsEntries {
+    if (cached) return cached;
     try {
         const content = readFileSync(OFF_LIMITS_FILE, 'utf-8');
-        const repos = new Set<string>();
+        const exact = new Set<string>();
+        const orgWildcards = new Set<string>();
         for (const line of content.split('\n')) {
             const trimmed = line.trim();
             if (trimmed && !trimmed.startsWith('#')) {
-                repos.add(trimmed.toLowerCase());
+                const lower = trimmed.toLowerCase();
+                if (lower.endsWith('/*')) {
+                    orgWildcards.add(lower.slice(0, -2));
+                } else {
+                    exact.add(lower);
+                }
             }
         }
-        cachedRepos = repos;
-        return repos;
+        cached = { exact, orgWildcards };
+        return cached;
     } catch {
-        cachedRepos = new Set();
-        return cachedRepos;
+        cached = { exact: new Set(), orgWildcards: new Set() };
+        return cached;
     }
 }
 
 /** Returns true if the repo is on the off-limits blocklist. */
 export function isRepoOffLimits(repo: string): boolean {
-    const repos = loadOffLimitsRepos();
-    return repos.has(repo.toLowerCase());
+    const { exact, orgWildcards } = loadOffLimitsRepos();
+    const lower = repo.toLowerCase();
+    if (exact.has(lower)) return true;
+    const org = lower.split('/')[0];
+    return orgWildcards.has(org);
 }
 
 /**
@@ -50,5 +64,5 @@ export function assertRepoAllowed(repo: string): void {
 
 /** Reset the cache (for testing). */
 export function _resetCache(): void {
-    cachedRepos = null;
+    cached = null;
 }


### PR DESCRIPTION
## Summary

- Adds `vapor/*` org-level wildcard to off-limits blocklist — blocks all repos under the Vapor org
- Adds `apple/swift-configuration` to the blocklist
- Removes old CorvidLabs contributor-owned repo entries (no longer needed)
- Adds org wildcard matching (`owner/*`) to `isRepoOffLimits()` so any repo under a blocked org is automatically blocked

Supersedes #553 — this PR includes the same blocklist changes plus the code to actually enforce the wildcard pattern.

## Test plan

- [x] `bun test server/__tests__/off-limits.test.ts` — 7 pass, 0 fail
- [x] `bunx tsc --noEmit --skipLibCheck` — no type errors
- [x] Verified `vapor/vapor`, `vapor/fluent`, `Vapor/Anything` all blocked
- [x] Verified `vaporware/something` NOT blocked (exact org match, not prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)