### PR TITLE
feat: add repo blocklist with auto-block on PR rejection

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -88,6 +88,11 @@ export const routes: Routes = [
             import('./features/github-allowlist/github-allowlist.component').then((m) => m.GitHubAllowlistComponent),
     },
     {
+        path: 'repo-blocklist',
+        loadComponent: () =>
+            import('./features/repo-blocklist/repo-blocklist.component').then((m) => m.RepoBlocklistComponent),
+    },
+    {
         path: 'wallets',
         loadComponent: () =>
             import('./features/wallets/wallet-viewer.component').then((m) => m.WalletViewerComponent),

--- a/client/src/app/core/services/repo-blocklist.service.ts
+++ b/client/src/app/core/services/repo-blocklist.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { ApiService } from './api.service';
+import { firstValueFrom } from 'rxjs';
+
+export interface RepoBlocklistEntry {
+    repo: string;
+    reason: string;
+    source: 'manual' | 'pr_rejection' | 'daily_review';
+    prUrl: string;
+    tenantId: string;
+    createdAt: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class RepoBlocklistService {
+    private readonly api = inject(ApiService);
+
+    readonly entries = signal<RepoBlocklistEntry[]>([]);
+    readonly loading = signal(false);
+
+    async loadEntries(): Promise<void> {
+        this.loading.set(true);
+        try {
+            const entries = await firstValueFrom(this.api.get<RepoBlocklistEntry[]>('/repo-blocklist'));
+            this.entries.set(entries);
+        } finally {
+            this.loading.set(false);
+        }
+    }
+
+    async addEntry(repo: string, reason?: string): Promise<RepoBlocklistEntry> {
+        const entry = await firstValueFrom(
+            this.api.post<RepoBlocklistEntry>('/repo-blocklist', { repo, reason, source: 'manual' }),
+        );
+        this.entries.update((current) => [entry, ...current]);
+        return entry;
+    }
+
+    async removeEntry(repo: string): Promise<void> {
+        await firstValueFrom(this.api.delete(`/repo-blocklist/${encodeURIComponent(repo)}`));
+        this.entries.update((current) => current.filter((e) => e.repo !== repo));
+    }
+}

--- a/client/src/app/features/repo-blocklist/repo-blocklist.component.ts
+++ b/client/src/app/features/repo-blocklist/repo-blocklist.component.ts
@@ -1,0 +1,154 @@
+import { Component, ChangeDetectionStrategy, inject, OnInit, signal } from '@angular/core';
+import { RepoBlocklistService } from '../../core/services/repo-blocklist.service';
+import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
+
+@Component({
+    selector: 'app-repo-blocklist',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [RelativeTimePipe],
+    template: `
+        <div class="page">
+            <div class="page__header">
+                <h2>
+                    Repo Blocklist
+                    @if (service.entries().length > 0) {
+                        <span class="count">({{ service.entries().length }})</span>
+                    }
+                </h2>
+            </div>
+
+            <div class="add-form">
+                <input
+                    class="input"
+                    type="text"
+                    placeholder="owner/repo or owner/*"
+                    [value]="newRepo()"
+                    (input)="newRepo.set(toInputValue($event))" />
+                <input
+                    class="input input--reason"
+                    type="text"
+                    placeholder="Reason (optional)"
+                    [value]="newReason()"
+                    (input)="newReason.set(toInputValue($event))" />
+                <button
+                    class="btn btn--primary"
+                    [disabled]="!newRepo().trim()"
+                    (click)="add()">Block</button>
+            </div>
+
+            @if (error()) {
+                <p class="error">{{ error() }}</p>
+            }
+
+            @if (service.loading()) {
+                <p>Loading...</p>
+            } @else if (service.entries().length === 0) {
+                <p class="empty">No repos blocklisted. All repos are currently allowed.</p>
+            } @else {
+                <div class="list" role="list">
+                    @for (entry of service.entries(); track entry.repo) {
+                        <div class="list__item" role="listitem">
+                            <div class="list__item-main">
+                                <div class="list__item-repo">{{ entry.repo }}</div>
+                                <div class="list__item-detail">
+                                    <span class="badge badge--{{ entry.source }}">{{ entry.source }}</span>
+                                    @if (entry.reason) {
+                                        <span class="list__item-reason">{{ entry.reason }}</span>
+                                    }
+                                </div>
+                            </div>
+                            <div class="list__item-meta">
+                                <span>{{ entry.createdAt | relativeTime }}</span>
+                                <button class="btn btn--danger btn--small" (click)="remove(entry.repo)">Remove</button>
+                            </div>
+                        </div>
+                    }
+                </div>
+            }
+        </div>
+    `,
+    styles: `
+        .page { padding: 1.5rem; }
+        .page__header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1.5rem; }
+        .page__header h2 { margin: 0; color: var(--text-primary); }
+        .count { color: var(--text-tertiary); font-weight: 400; font-size: 0.85rem; }
+        .add-form { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; }
+        .input {
+            flex: 1; padding: 0.5rem 0.75rem; background: var(--bg-surface); border: 1px solid var(--border);
+            border-radius: var(--radius); color: var(--text-primary); font-family: inherit; font-size: 0.85rem;
+        }
+        .input::placeholder { color: var(--text-tertiary); }
+        .input--reason { max-width: 250px; }
+        .btn {
+            padding: 0.5rem 1rem; border-radius: var(--radius); font-size: 0.8rem; font-weight: 600;
+            cursor: pointer; border: 1px solid; font-family: inherit; text-transform: uppercase; letter-spacing: 0.05em;
+            transition: background 0.15s, box-shadow 0.15s; background: transparent;
+        }
+        .btn:disabled { opacity: 0.4; cursor: default; }
+        .btn--primary { color: var(--accent-cyan); border-color: var(--accent-cyan); }
+        .btn--primary:hover:not(:disabled) { background: var(--accent-cyan-dim); box-shadow: var(--glow-cyan); }
+        .btn--danger { color: var(--accent-red, #f44); border-color: var(--accent-red, #f44); }
+        .btn--danger:hover { background: rgba(255, 68, 68, 0.1); }
+        .btn--small { padding: 0.25rem 0.5rem; font-size: 0.7rem; }
+        .error { color: var(--accent-red, #f44); font-size: 0.85rem; margin-bottom: 1rem; }
+        .empty { color: var(--text-tertiary); }
+        .list { display: flex; flex-direction: column; gap: 0.5rem; }
+        .list__item {
+            display: flex; justify-content: space-between; align-items: center;
+            padding: 1rem; background: var(--bg-surface); border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+        }
+        .list__item-main { flex: 1; min-width: 0; }
+        .list__item-repo { font-family: monospace; font-size: 0.85rem; color: var(--text-primary); }
+        .list__item-detail { display: flex; align-items: center; gap: 0.5rem; margin-top: 0.25rem; }
+        .list__item-reason { font-size: 0.8rem; color: var(--text-secondary); }
+        .badge {
+            font-size: 0.65rem; padding: 0.15rem 0.4rem; border-radius: 3px;
+            text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600;
+        }
+        .badge--manual { color: var(--accent-cyan); border: 1px solid var(--accent-cyan); }
+        .badge--pr_rejection { color: var(--accent-red, #f44); border: 1px solid var(--accent-red, #f44); }
+        .badge--daily_review { color: var(--accent-yellow, #fa0); border: 1px solid var(--accent-yellow, #fa0); }
+        .list__item-meta { display: flex; flex-direction: column; align-items: flex-end; gap: 0.5rem; font-size: 0.75rem; color: var(--text-tertiary); margin-left: 1rem; }
+    `,
+})
+export class RepoBlocklistComponent implements OnInit {
+    protected readonly service = inject(RepoBlocklistService);
+
+    readonly newRepo = signal('');
+    readonly newReason = signal('');
+    readonly error = signal<string | null>(null);
+
+    ngOnInit(): void {
+        this.service.loadEntries();
+    }
+
+    toInputValue(event: Event): string {
+        return (event.target as HTMLInputElement).value;
+    }
+
+    async add(): Promise<void> {
+        const repo = this.newRepo().trim();
+        if (!repo) return;
+        this.error.set(null);
+        try {
+            await this.service.addEntry(repo, this.newReason().trim() || undefined);
+            this.newRepo.set('');
+            this.newReason.set('');
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : 'Failed to add repo';
+            this.error.set(msg);
+        }
+    }
+
+    async remove(repo: string): Promise<void> {
+        if (!confirm(`Remove ${repo} from the repo blocklist?`)) return;
+        this.error.set(null);
+        try {
+            await this.service.removeEntry(repo);
+        } catch {
+            this.error.set('Failed to remove repo');
+            await this.service.loadEntries();
+        }
+    }
+}

--- a/client/src/app/shared/components/sidebar.component.ts
+++ b/client/src/app/shared/components/sidebar.component.ts
@@ -179,6 +179,12 @@ import { filter, Subscription } from 'rxjs';
                     </a>
                 </li>
                 <li>
+                    <a class="sidebar__link" routerLink="/repo-blocklist" routerLinkActive="sidebar__link--active" title="Repo Blocklist">
+                        <span class="sidebar__label">Repo Blocklist</span>
+                        <span class="sidebar__abbr">Bl</span>
+                    </a>
+                </li>
+                <li>
                     <a class="sidebar__link" routerLink="/wallets" routerLinkActive="sidebar__link--active" title="Wallets">
                         <span class="sidebar__label">Wallets</span>
                         <span class="sidebar__abbr">W</span>

--- a/server/__tests__/repo-blocklist.test.ts
+++ b/server/__tests__/repo-blocklist.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import {
+    listRepoBlocklist,
+    addToRepoBlocklist,
+    getRepoBlocklistEntry,
+    removeFromRepoBlocklist,
+    isRepoBlocked,
+} from '../db/repo-blocklist';
+
+let db: Database;
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+});
+
+afterEach(() => {
+    db.close();
+});
+
+// ── CRUD ─────────────────────────────────────────────────────────────
+
+describe('Repo Blocklist CRUD', () => {
+    test('listRepoBlocklist returns empty array on fresh db', () => {
+        expect(listRepoBlocklist(db)).toEqual([]);
+    });
+
+    test('addToRepoBlocklist creates entry with lowercase repo', () => {
+        const entry = addToRepoBlocklist(db, 'Owner/Repo', { reason: 'test', source: 'manual' });
+        expect(entry.repo).toBe('owner/repo');
+        expect(entry.reason).toBe('test');
+        expect(entry.source).toBe('manual');
+        expect(entry.createdAt).toBeTruthy();
+    });
+
+    test('addToRepoBlocklist upserts on conflict', () => {
+        addToRepoBlocklist(db, 'owner/repo', { reason: 'first' });
+        const updated = addToRepoBlocklist(db, 'owner/repo', { reason: 'updated', source: 'pr_rejection' });
+        expect(updated.reason).toBe('updated');
+        expect(updated.source).toBe('pr_rejection');
+        expect(listRepoBlocklist(db)).toHaveLength(1);
+    });
+
+    test('addToRepoBlocklist defaults to manual source', () => {
+        const entry = addToRepoBlocklist(db, 'owner/repo');
+        expect(entry.source).toBe('manual');
+        expect(entry.reason).toBe('');
+    });
+
+    test('getRepoBlocklistEntry returns null for missing repo', () => {
+        expect(getRepoBlocklistEntry(db, 'owner/missing')).toBeNull();
+    });
+
+    test('getRepoBlocklistEntry is case-insensitive', () => {
+        addToRepoBlocklist(db, 'Owner/Repo');
+        expect(getRepoBlocklistEntry(db, 'owner/repo')).not.toBeNull();
+        expect(getRepoBlocklistEntry(db, 'OWNER/REPO')).not.toBeNull();
+    });
+
+    test('removeFromRepoBlocklist deletes entry', () => {
+        addToRepoBlocklist(db, 'owner/repo');
+        expect(removeFromRepoBlocklist(db, 'owner/repo')).toBe(true);
+        expect(getRepoBlocklistEntry(db, 'owner/repo')).toBeNull();
+    });
+
+    test('removeFromRepoBlocklist returns false for missing repo', () => {
+        expect(removeFromRepoBlocklist(db, 'owner/missing')).toBe(false);
+    });
+
+    test('listRepoBlocklist returns all entries ordered by created_at desc', () => {
+        addToRepoBlocklist(db, 'a/one');
+        addToRepoBlocklist(db, 'b/two');
+        addToRepoBlocklist(db, 'c/three');
+        const list = listRepoBlocklist(db);
+        expect(list).toHaveLength(3);
+    });
+
+    test('addToRepoBlocklist stores prUrl', () => {
+        const entry = addToRepoBlocklist(db, 'owner/repo', {
+            prUrl: 'https://github.com/owner/repo/pull/1',
+        });
+        expect(entry.prUrl).toBe('https://github.com/owner/repo/pull/1');
+    });
+});
+
+// ── isRepoBlocked ──────────────────────────────────────────────────
+
+describe('isRepoBlocked', () => {
+    test('returns false when blocklist is empty', () => {
+        expect(isRepoBlocked(db, 'owner/repo')).toBe(false);
+    });
+
+    test('returns true for exact match', () => {
+        addToRepoBlocklist(db, 'owner/repo');
+        expect(isRepoBlocked(db, 'owner/repo')).toBe(true);
+    });
+
+    test('is case-insensitive', () => {
+        addToRepoBlocklist(db, 'Owner/Repo');
+        expect(isRepoBlocked(db, 'owner/repo')).toBe(true);
+        expect(isRepoBlocked(db, 'OWNER/REPO')).toBe(true);
+    });
+
+    test('returns true for org wildcard match', () => {
+        addToRepoBlocklist(db, 'vapor/*');
+        expect(isRepoBlocked(db, 'vapor/vapor')).toBe(true);
+        expect(isRepoBlocked(db, 'vapor/fluent')).toBe(true);
+    });
+
+    test('org wildcard does not match different orgs', () => {
+        addToRepoBlocklist(db, 'vapor/*');
+        expect(isRepoBlocked(db, 'apple/swift')).toBe(false);
+    });
+
+    test('returns false for non-blocked repo', () => {
+        addToRepoBlocklist(db, 'blocked/repo');
+        expect(isRepoBlocked(db, 'other/repo')).toBe(false);
+    });
+
+    test('supports tenant isolation', () => {
+        addToRepoBlocklist(db, 'owner/repo', { tenantId: 'tenant-a' });
+        expect(isRepoBlocked(db, 'owner/repo', 'tenant-a')).toBe(true);
+        expect(isRepoBlocked(db, 'owner/repo', 'tenant-b')).toBe(false);
+        expect(isRepoBlocked(db, 'owner/repo')).toBe(false); // default tenant
+    });
+});

--- a/server/db/migrations/064_repo_blocklist.ts
+++ b/server/db/migrations/064_repo_blocklist.ts
@@ -1,0 +1,27 @@
+/**
+ * Migration 064: Repo blocklist table.
+ *
+ * Prevents the agent from contributing to repos that don't want its help.
+ * Entries can be manual, from PR rejection analysis, or from daily review.
+ */
+
+import { Database } from 'bun:sqlite';
+
+export function up(db: Database): void {
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS repo_blocklist (
+            repo       TEXT NOT NULL,
+            reason     TEXT DEFAULT '',
+            source     TEXT NOT NULL DEFAULT 'manual',
+            pr_url     TEXT DEFAULT '',
+            tenant_id  TEXT DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (repo, tenant_id)
+        )
+    `);
+    db.exec('CREATE INDEX IF NOT EXISTS idx_repo_blocklist_tenant ON repo_blocklist(tenant_id)');
+}
+
+export function down(db: Database): void {
+    db.exec('DROP TABLE IF EXISTS repo_blocklist');
+}

--- a/server/db/repo-blocklist.ts
+++ b/server/db/repo-blocklist.ts
@@ -1,0 +1,107 @@
+/**
+ * Repo blocklist — CRUD operations for the repo_blocklist table.
+ *
+ * Prevents the agent from contributing to repos that don't want its help.
+ * Supports exact repos (owner/name) and org wildcards (owner/*).
+ */
+
+import type { Database } from 'bun:sqlite';
+
+export type BlocklistSource = 'manual' | 'pr_rejection' | 'daily_review';
+
+export interface RepoBlocklistEntry {
+    repo: string;
+    reason: string;
+    source: BlocklistSource;
+    prUrl: string;
+    tenantId: string;
+    createdAt: string;
+}
+
+interface RepoBlocklistRow {
+    repo: string;
+    reason: string;
+    source: string;
+    pr_url: string;
+    tenant_id: string;
+    created_at: string;
+}
+
+function rowToEntry(row: RepoBlocklistRow): RepoBlocklistEntry {
+    return {
+        repo: row.repo,
+        reason: row.reason,
+        source: row.source as BlocklistSource,
+        prUrl: row.pr_url,
+        tenantId: row.tenant_id,
+        createdAt: row.created_at,
+    };
+}
+
+export function listRepoBlocklist(db: Database, tenantId = ''): RepoBlocklistEntry[] {
+    const rows = db.query(
+        'SELECT * FROM repo_blocklist WHERE tenant_id = ? ORDER BY created_at DESC',
+    ).all(tenantId) as RepoBlocklistRow[];
+    return rows.map(rowToEntry);
+}
+
+export function addToRepoBlocklist(
+    db: Database,
+    repo: string,
+    opts?: { reason?: string; source?: BlocklistSource; prUrl?: string; tenantId?: string },
+): RepoBlocklistEntry {
+    const normalized = repo.toLowerCase();
+    const tenantId = opts?.tenantId ?? '';
+    db.query(
+        `INSERT INTO repo_blocklist (repo, reason, source, pr_url, tenant_id)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(repo, tenant_id) DO UPDATE SET
+           reason = excluded.reason,
+           source = excluded.source,
+           pr_url = excluded.pr_url`,
+    ).run(
+        normalized,
+        opts?.reason ?? '',
+        opts?.source ?? 'manual',
+        opts?.prUrl ?? '',
+        tenantId,
+    );
+    return getRepoBlocklistEntry(db, normalized, tenantId)!;
+}
+
+export function getRepoBlocklistEntry(db: Database, repo: string, tenantId = ''): RepoBlocklistEntry | null {
+    const row = db.query(
+        'SELECT * FROM repo_blocklist WHERE repo = ? AND tenant_id = ?',
+    ).get(repo.toLowerCase(), tenantId) as RepoBlocklistRow | null;
+    return row ? rowToEntry(row) : null;
+}
+
+export function removeFromRepoBlocklist(db: Database, repo: string, tenantId = ''): boolean {
+    const result = db.query(
+        'DELETE FROM repo_blocklist WHERE repo = ? AND tenant_id = ?',
+    ).run(repo.toLowerCase(), tenantId);
+    return result.changes > 0;
+}
+
+/**
+ * Check if a repo is blocked. Checks both exact match and org wildcard (owner/*).
+ */
+export function isRepoBlocked(db: Database, repo: string, tenantId = ''): boolean {
+    const normalized = repo.toLowerCase();
+    // Check exact match
+    const exact = db.query(
+        'SELECT 1 FROM repo_blocklist WHERE repo = ? AND tenant_id = ? LIMIT 1',
+    ).get(normalized, tenantId);
+    if (exact) return true;
+
+    // Check org wildcard (e.g. "vapor/*" matches "vapor/vapor")
+    const org = normalized.split('/')[0];
+    if (org) {
+        const wildcard = db.query(
+            'SELECT 1 FROM repo_blocklist WHERE repo = ? AND tenant_id = ? LIMIT 1',
+        ).get(`${org}/*`, tenantId);
+        if (wildcard) return true;
+    }
+
+    return false;
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,6 +1,6 @@
 import { Database } from 'bun:sqlite';
 
-const SCHEMA_VERSION = 63;
+const SCHEMA_VERSION = 64;
 
 const MIGRATIONS: Record<number, string[]> = {
     1: [
@@ -1207,6 +1207,19 @@ const MIGRATIONS: Record<number, string[]> = {
             FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE
         )`,
         `CREATE INDEX IF NOT EXISTS idx_subscription_items_sub ON subscription_items(subscription_id)`,
+    ],
+    64: [
+        // Repo blocklist — prevents agent from contributing to repos that reject its help
+        `CREATE TABLE IF NOT EXISTS repo_blocklist (
+            repo       TEXT NOT NULL,
+            reason     TEXT DEFAULT '',
+            source     TEXT NOT NULL DEFAULT 'manual',
+            pr_url     TEXT DEFAULT '',
+            tenant_id  TEXT DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (repo, tenant_id)
+        )`,
+        `CREATE INDEX IF NOT EXISTS idx_repo_blocklist_tenant ON repo_blocklist(tenant_id)`,
     ],
 };
 

--- a/server/feedback/outcome-tracker.ts
+++ b/server/feedback/outcome-tracker.ts
@@ -19,6 +19,7 @@ import {
     listPrOutcomes,
     getPrOutcomeByWorkTask,
 } from '../db/pr-outcomes';
+import { addToRepoBlocklist, isRepoBlocked } from '../db/repo-blocklist';
 import type { PrOutcome, FailureReason, OutcomeStats } from '../db/pr-outcomes';
 import { getPrState } from '../github/operations';
 import { listWorkTasks } from '../db/work-tasks';
@@ -115,6 +116,11 @@ export class OutcomeTrackerService {
                     updatePrOutcomeState(this.db, pr.id, 'closed', reason);
                     updated++;
                     log.info('PR closed', { repo: pr.repo, prNumber: pr.prNumber, reason });
+
+                    // Auto-block: if this repo has >=2 closed PRs and <30% merge rate, block it
+                    if (reason === 'review_rejection') {
+                        this.checkAutoBlock(pr.repo, pr.prUrl);
+                    }
                 } else {
                     // Still open — check if stale (>14 days without merge)
                     const ageMs = Date.now() - new Date(pr.createdAt).getTime();
@@ -257,6 +263,32 @@ export class OutcomeTrackerService {
     }
 
     // ─── Private ────────────────────────────────────────────────────────────
+
+    /**
+     * Auto-block a repo if it has >=2 closed PRs and <30% merge rate.
+     * Only blocks if not already blocked.
+     */
+    private checkAutoBlock(repo: string, prUrl: string): void {
+        if (isRepoBlocked(this.db, repo)) return;
+
+        const statsByRepo = getOutcomeStatsByRepo(this.db);
+        const stats = statsByRepo[repo];
+        if (!stats) return;
+
+        const closedCount = stats.closed;
+        if (closedCount >= 2 && stats.mergeRate < 0.3) {
+            addToRepoBlocklist(this.db, repo, {
+                reason: `Auto-blocked: ${closedCount} closed PRs, ${(stats.mergeRate * 100).toFixed(0)}% merge rate`,
+                source: 'pr_rejection',
+                prUrl,
+            });
+            log.info('Auto-blocked repo due to repeated PR rejections', {
+                repo,
+                closedCount,
+                mergeRate: stats.mergeRate,
+            });
+        }
+    }
 
     private inferFailureReason(pr: { statusCheckRollup: string | null; reviewDecision: string | null }): FailureReason {
         if (pr.statusCheckRollup && pr.statusCheckRollup.includes('FAILURE')) {

--- a/server/lib/validation.ts
+++ b/server/lib/validation.ts
@@ -249,6 +249,15 @@ export const UpdateGitHubAllowlistSchema = z.object({
     label: z.string({ message: 'label is required' }),
 });
 
+// ─── Repo Blocklist ─────────────────────────────────────────────────────────
+
+export const AddRepoBlocklistSchema = z.object({
+    repo: z.string().min(1, 'repo is required'),
+    reason: z.string().optional(),
+    source: z.enum(['manual', 'pr_rejection', 'daily_review']).optional(),
+    prUrl: z.string().optional(),
+});
+
 // ─── MCP API ──────────────────────────────────────────────────────────────────
 
 export const McpSendMessageSchema = z.object({

--- a/server/mcp/direct-tools.ts
+++ b/server/mcp/direct-tools.ts
@@ -36,6 +36,7 @@ import {
     handleCodeSymbols,
     handleFindReferences,
 } from './tool-handlers';
+import { handleManageRepoBlocklist } from './tool-handlers/repo-blocklist';
 import { buildCodingTools, type CodingToolContext } from './coding-tools';
 import { getAgent } from '../db/agents';
 import type { LlmToolDefinition } from '../providers/types';
@@ -80,6 +81,7 @@ const DEFAULT_ALLOWED_TOOLS = new Set([
     'search_files',
     'corvid_code_symbols',
     'corvid_find_references',
+    'corvid_repo_blocklist',
 ]);
 
 /** Tools blocked during scheduler-initiated sessions. */
@@ -621,6 +623,27 @@ export function buildDirectTools(ctx: McpToolContext | null, codingCtx?: CodingT
                 },
             },
         );
+
+        // ─── Repo Blocklist ──────────────────────────────────────────────
+        tools.push({
+            name: 'corvid_repo_blocklist',
+            description: 'Manage the repo blocklist — repos the agent should not contribute to. Use action="list" to view, "add" to block, "remove" to unblock, "check" to test.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    action: { type: 'string', enum: ['list', 'add', 'remove', 'check'], description: 'What to do' },
+                    repo: { type: 'string', description: 'Repository in owner/name format, or owner/* for org wildcard' },
+                    reason: { type: 'string', description: 'Why this repo is blocked (for add)' },
+                    source: { type: 'string', enum: ['manual', 'pr_rejection', 'daily_review'], description: 'Block source (default: manual)' },
+                },
+                required: ['action'],
+            },
+            handler: async (args) => {
+                const err = validateRequired('corvid_repo_blocklist', args, ['action']);
+                if (err) return err;
+                return unwrapResult(await handleManageRepoBlocklist(ctx, args as Parameters<typeof handleManageRepoBlocklist>[1]));
+            },
+        });
     }
     } // end if (ctx)
 

--- a/server/mcp/sdk-tools.ts
+++ b/server/mcp/sdk-tools.ts
@@ -2,6 +2,7 @@ import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod/v4';
 import type { McpToolContext } from './tool-handlers';
 import { handleSendMessage, handleSaveMemory, handleRecallMemory, handleListAgents, handleCreateWorkTask, handleExtendTimeout, handleCheckCredits, handleGrantCredits, handleCreditConfig, handleManageSchedule, handleManageWorkflow, handleWebSearch, handleDeepResearch, handleDiscoverAgent, handleNotifyOwner, handleAskOwner, handleConfigureNotifications, handleGitHubStarRepo, handleGitHubUnstarRepo, handleGitHubForkRepo, handleGitHubListPrs, handleGitHubCreatePr, handleGitHubReviewPr, handleGitHubCreateIssue, handleGitHubListIssues, handleGitHubRepoInfo, handleGitHubGetPrDiff, handleGitHubCommentOnPr, handleGitHubFollowUser, handleCheckReputation, handleCheckHealthTrends, handlePublishAttestation, handleVerifyAgentReputation, handleInvokeRemoteAgent, handleCodeSymbols, handleFindReferences } from './tool-handlers';
+import { handleManageRepoBlocklist } from './tool-handlers/repo-blocklist';
 import { getAgent } from '../db/agents';
 
 /** Tools available to all agents by default (when mcp_tool_permissions is NULL). */
@@ -40,6 +41,7 @@ const DEFAULT_ALLOWED_TOOLS = new Set([
     'corvid_invoke_remote_agent',
     'corvid_code_symbols',
     'corvid_find_references',
+    'corvid_repo_blocklist',
 ]);
 
 /** Tools that require an explicit grant in mcp_tool_permissions. */
@@ -467,6 +469,21 @@ export function createCorvidMcpServer(ctx: McpToolContext, pluginTools?: ReturnT
                 async (args) => handleFindReferences(ctx, args),
             ),
         ] : []),
+
+        // ─── Repo Blocklist ──────────────────────────────────────────────
+        tool(
+            'corvid_repo_blocklist',
+            'Manage the repo blocklist — repos the agent should not contribute to. ' +
+            'Use action="list" to view blocked repos, "add" to block a repo, "remove" to unblock, "check" to test if blocked. ' +
+            'Supports exact repos (owner/name) and org wildcards (owner/*).',
+            {
+                action: z.enum(['list', 'add', 'remove', 'check']).describe('What to do'),
+                repo: z.string().optional().describe('Repository in owner/name format, or owner/* for org wildcard'),
+                reason: z.string().optional().describe('Why this repo is blocked (for add)'),
+                source: z.enum(['manual', 'pr_rejection', 'daily_review']).optional().describe('Block source (default: manual)'),
+            },
+            async (args) => handleManageRepoBlocklist(ctx, args),
+        ),
     ];
 
     // Merge plugin tools if provided

--- a/server/mcp/tool-handlers/repo-blocklist.ts
+++ b/server/mcp/tool-handlers/repo-blocklist.ts
@@ -1,0 +1,67 @@
+/**
+ * MCP tool handler for managing the repo blocklist.
+ */
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { McpToolContext } from './types';
+import { textResult, errorResult } from './types';
+import {
+    listRepoBlocklist,
+    addToRepoBlocklist,
+    removeFromRepoBlocklist,
+    isRepoBlocked,
+    type BlocklistSource,
+} from '../../db/repo-blocklist';
+
+export async function handleManageRepoBlocklist(
+    ctx: McpToolContext,
+    args: {
+        action: string;
+        repo?: string;
+        reason?: string;
+        source?: string;
+    },
+): Promise<CallToolResult> {
+    const { db } = ctx;
+
+    switch (args.action) {
+        case 'list': {
+            const entries = listRepoBlocklist(db);
+            if (entries.length === 0) {
+                return textResult('Repo blocklist is empty — no repos are blocked.');
+            }
+            const lines = entries.map((e) =>
+                `- ${e.repo} (source: ${e.source})${e.reason ? ` — ${e.reason}` : ''}${e.prUrl ? ` [${e.prUrl}]` : ''}`,
+            );
+            return textResult(`Blocked repos (${entries.length}):\n${lines.join('\n')}`);
+        }
+
+        case 'add': {
+            if (!args.repo) return errorResult('repo is required for action="add"');
+            const entry = addToRepoBlocklist(db, args.repo, {
+                reason: args.reason,
+                source: (args.source as BlocklistSource) || 'manual',
+            });
+            return textResult(`Added ${entry.repo} to blocklist (source: ${entry.source}).`);
+        }
+
+        case 'remove': {
+            if (!args.repo) return errorResult('repo is required for action="remove"');
+            const removed = removeFromRepoBlocklist(db, args.repo);
+            return removed
+                ? textResult(`Removed ${args.repo.toLowerCase()} from blocklist.`)
+                : errorResult(`${args.repo} is not in the blocklist.`);
+        }
+
+        case 'check': {
+            if (!args.repo) return errorResult('repo is required for action="check"');
+            const blocked = isRepoBlocked(db, args.repo);
+            return textResult(blocked
+                ? `${args.repo} IS blocked.`
+                : `${args.repo} is NOT blocked.`);
+        }
+
+        default:
+            return errorResult(`Unknown action "${args.action}". Use list, add, remove, or check.`);
+    }
+}

--- a/server/polling/auto-merge.ts
+++ b/server/polling/auto-merge.ts
@@ -8,6 +8,7 @@
 import type { Database } from 'bun:sqlite';
 import { createLogger } from '../lib/logger';
 import { resolveFullRepo } from './github-searcher';
+import { isRepoBlocked } from '../db/repo-blocklist';
 
 const log = createLogger('AutoMerge');
 
@@ -66,6 +67,10 @@ export class AutoMergeService {
             }
 
             for (const { repo, username } of targets) {
+                if (isRepoBlocked(this.db, repo)) {
+                    log.debug('Skipping auto-merge — repo is blocklisted', { repo });
+                    continue;
+                }
                 await this.mergeForRepo(repo, username);
             }
         } catch (err) {

--- a/server/polling/service.ts
+++ b/server/polling/service.ts
@@ -35,6 +35,7 @@ import { DedupService } from '../lib/dedup';
 import { buildSafeGhEnv } from '../lib/env';
 import { createEventContext, runWithEventContext } from '../observability/event-context';
 import { isGitHubUserAllowed } from '../db/github-allowlist';
+import { isRepoBlocked } from '../db/repo-blocklist';
 import {
     GitHubSearcher,
     filterNewMentions,
@@ -403,6 +404,12 @@ export class MentionPollingService {
 
         // Resolve the actual owner/repo from the mention URL
         const fullRepo = resolveFullRepo(config.repo, mention.htmlUrl);
+
+        // Repo blocklist guard: skip mentions from repos that don't want our contributions
+        if (isRepoBlocked(this.db, fullRepo)) {
+            log.info('Skipping mention — repo is blocklisted', { repo: fullRepo, number: mention.number });
+            return false;
+        }
 
         // Guard: skip only if there's a currently *running* session for the same issue.
         // Idle sessions have finished — follow-up comments are legitimate new work.

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,6 +7,7 @@ import { handleWorkTaskRoutes } from './work-tasks';
 import { handleMcpApiRoutes } from './mcp-api';
 import { handleAllowlistRoutes } from './allowlist';
 import { handleGitHubAllowlistRoutes } from './github-allowlist';
+import { handleRepoBlocklistRoutes } from './repo-blocklist';
 import { handleAnalyticsRoutes } from './analytics';
 import { handleSystemLogRoutes } from './system-logs';
 import { handleSettingsRoutes } from './settings';
@@ -296,6 +297,9 @@ async function handleRoutes(
 
     const githubAllowlistResponse = handleGitHubAllowlistRoutes(req, url, db);
     if (githubAllowlistResponse) return githubAllowlistResponse;
+
+    const repoBlocklistResponse = handleRepoBlocklistRoutes(req, url, db);
+    if (repoBlocklistResponse) return repoBlocklistResponse;
 
     const analyticsResponse = handleAnalyticsRoutes(req, url, db, context);
     if (analyticsResponse) return analyticsResponse;

--- a/server/routes/repo-blocklist.ts
+++ b/server/routes/repo-blocklist.ts
@@ -1,0 +1,52 @@
+import type { Database } from 'bun:sqlite';
+import {
+    listRepoBlocklist,
+    addToRepoBlocklist,
+    removeFromRepoBlocklist,
+} from '../db/repo-blocklist';
+import { parseBodyOrThrow, ValidationError, AddRepoBlocklistSchema } from '../lib/validation';
+import { json } from '../lib/response';
+
+export function handleRepoBlocklistRoutes(
+    req: Request,
+    url: URL,
+    db: Database,
+): Response | Promise<Response> | null {
+    const path = url.pathname;
+    const method = req.method;
+
+    if (path === '/api/repo-blocklist' && method === 'GET') {
+        return json(listRepoBlocklist(db));
+    }
+
+    if (path === '/api/repo-blocklist' && method === 'POST') {
+        return handleAdd(req, db);
+    }
+
+    const match = path.match(/^\/api\/repo-blocklist\/(.+)$/);
+    if (!match) return null;
+
+    const repo = decodeURIComponent(match[1]).toLowerCase();
+
+    if (method === 'DELETE') {
+        const deleted = removeFromRepoBlocklist(db, repo);
+        return deleted ? json({ ok: true }) : json({ error: 'Not found' }, 404);
+    }
+
+    return null;
+}
+
+async function handleAdd(req: Request, db: Database): Promise<Response> {
+    try {
+        const data = await parseBodyOrThrow(req, AddRepoBlocklistSchema);
+        const entry = addToRepoBlocklist(db, data.repo, {
+            reason: data.reason,
+            source: data.source,
+            prUrl: data.prUrl,
+        });
+        return json(entry, 201);
+    } catch (err) {
+        if (err instanceof ValidationError) return json({ error: err.detail }, 400);
+        throw err;
+    }
+}


### PR DESCRIPTION
## Summary

- Add DB-backed repo blocklist (`repo_blocklist` table, migration 064) with tenant isolation
- CRUD module + REST API (`GET/POST/DELETE /api/repo-blocklist`)
- `corvid_repo_blocklist` MCP tool with `list`, `add`, `remove`, `check` actions
- Auto-block repos with >=2 PR rejections and <30% merge rate via OutcomeTrackerService
- Integration: polling service skips blocked repos, auto-merge service skips blocked repos
- Angular UI component with add/remove, source badges, and relative timestamps

## Test plan

- [x] 17 unit tests pass (CRUD, isRepoBlocked with exact/wildcard/tenant isolation)
- [x] Full suite: 4953 pass, 2 pre-existing failures (no regressions)
- [x] TSC clean
- [x] Verify Angular component renders correctly in browser
- [x] Test auto-block trigger by simulating PR rejection outcomes

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)