### PR TITLE
fix: exempt localhost from rate limiting for local dashboard

### DIFF
--- a/server/middleware/guards.ts
+++ b/server/middleware/guards.ts
@@ -77,19 +77,25 @@ export function roleGuard(...allowedRoles: string[]): Guard {
     };
 }
 
+const LOOPBACK_IPS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1', 'localhost']);
+
 export function rateLimitGuard(limiter: RateLimiter): Guard {
     const EXEMPT_PATHS = new Set(['/api/health', '/webhooks/github']);
     return (req: Request, url: URL, context: RequestContext): Response | null => {
         if (EXEMPT_PATHS.has(url.pathname)) return null;
         if (url.pathname === '/ws') return null;
-        const key = context.walletAddress || getClientIp(req);
+        const ip = getClientIp(req);
+        if (!context.walletAddress && LOOPBACK_IPS.has(ip)) return null;
+        const key = context.walletAddress || ip;
         return limiter.check(key, req.method);
     };
 }
 
 export function endpointRateLimitGuard(limiter: EndpointRateLimiter): Guard {
     return (req: Request, url: URL, context: RequestContext): Response | null => {
-        const key = context.walletAddress || getClientIp(req);
+        const ip = getClientIp(req);
+        if (!context.walletAddress && LOOPBACK_IPS.has(ip)) return null;
+        const key = context.walletAddress || ip;
         const tier = resolveTier(context.authenticated, context.role);
         const result: RateLimitResult = limiter.check(key, req.method, url.pathname, tier);
         context.rateLimitHeaders = result.headers;

--- a/server/middleware/rate-limit.ts
+++ b/server/middleware/rate-limit.ts
@@ -280,6 +280,9 @@ export class RateLimiter {
 /** Paths that bypass rate limiting (monitoring probes, webhooks, etc.). */
 const EXEMPT_PATHS = new Set(['/api/health', '/webhooks/github']);
 
+/** Loopback IPs exempt from rate limiting (local dashboard, CLI tools). */
+const LOOPBACK_IPS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1', 'localhost']);
+
 /**
  * Extract the client IP from a Request.
  * Checks X-Forwarded-For first (reverse proxy), then X-Real-IP, falls back to 'unknown'.
@@ -315,8 +318,12 @@ export function checkRateLimit(req: Request, url: URL, limiter: RateLimiter, wal
     // Don't rate-limit WebSocket upgrades
     if (url.pathname === '/ws') return null;
 
+    // Exempt loopback IPs (local dashboard, CLI tools)
+    const ip = getClientIp(req);
+    if (!walletAddress && LOOPBACK_IPS.has(ip)) return null;
+
     // Prefer wallet address as the rate limit key (trust boundary),
     // fall back to IP when no wallet is available
-    const key = walletAddress || getClientIp(req);
+    const key = walletAddress || ip;
     return limiter.check(key, req.method);
 }


### PR DESCRIPTION
## Summary

- Exempts loopback IPs (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`, `localhost`) from both the global and per-endpoint rate limiters
- Fixes the dashboard 429 errors when loading from `localhost:3000` — the dashboard fires ~10 parallel GET requests on page load which exceeds the rate limit window
- Remote clients remain fully rate-limited
- Wallet-keyed requests are still rate-limited regardless of source IP

## Test plan

- [x] `bun test server/__tests__/rate-limit.test.ts server/__tests__/guards.test.ts server/__tests__/endpoint-rate-limit.test.ts` — 100 pass, 0 fail
- [x] `bunx tsc --noEmit --skipLibCheck` — no type errors
- [x] Verified localhost requests bypass rate limiting
- [x] Verified existing tests for remote IP rate limiting still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)