### PR TITLE
docs: add 'At a Glance' stats section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">
   <img src="https://img.shields.io/badge/Angular-21-dd0031?logo=angular" alt="Angular 21">
-  <img src="https://img.shields.io/badge/tests-4931%20unit%20%7C%20360%20E2E-brightgreen" alt="4931 Unit | 360 E2E Tests">
+  <img src="https://img.shields.io/badge/tests-4978%20unit%20%7C%20360%20E2E-brightgreen" alt="4978 Unit | 360 E2E Tests">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>
 </p>
 
@@ -15,6 +15,22 @@
 corvid-agent spawns, orchestrates, and governs autonomous AI agents that do real work — writing code, deliberating decisions, opening PRs, and communicating with other agents through cryptographic channels on Algorand.
 
 See [VISION.md](VISION.md) for architecture, competitive positioning, and long-term roadmap.
+
+## At a Glance
+
+| Metric | Count |
+|--------|-------|
+| Unit tests | **4,978** across 200 files (14,080 assertions) |
+| E2E tests | **360** across 31 Playwright specs |
+| Module specs | **107** with automated validation |
+| MCP tools | **37** corvid_* tool handlers |
+| API endpoints | **~200** across 36 route modules |
+| DB migrations | **64** (74 tables) |
+| Test:code ratio | **1.14×** — more test code than production code |
+
+Cross-platform CI: Ubuntu, macOS, Windows.
+
+---
 
 ## Why This Exists
 
@@ -412,13 +428,13 @@ Tools are permission-scoped per agent via skill bundles and agent-level allowlis
 ## Testing
 
 ```bash
-bun test              # 4931+ server tests (~120s)
+bun test              # 4978+ server tests (~120s)
 cd client && npx vitest run   # Angular component tests (~2s)
 bun run test:e2e      # 31 Playwright spec files, 360 tests
 bun run spec:check    # Validate all module specs in specs/
 ```
 
-**4931 unit tests** covering: API routes, audit logging, authentication, bash security, billing, CLI, credit system, crypto, database migrations, Discord bridge, feedback loop, GitHub tools, health monitoring, marketplace, MCP tool handlers, notifications, multi-model routing, multi-tenant isolation, observability, owner communication, performance metrics, personas, plugins, process lifecycle, rate limiting, reputation, sandbox isolation, scheduling, skill bundles, Slack bridge, Telegram bridge, tenant isolation, usage monitoring, validation, voice TTS/STT, wallet keystore, web search, workflows, work tasks, and Angular components.
+**4978 unit tests** covering: API routes, audit logging, authentication, bash security, billing, CLI, credit system, crypto, database migrations, Discord bridge, feedback loop, GitHub tools, health monitoring, marketplace, MCP tool handlers, notifications, multi-model routing, multi-tenant isolation, observability, owner communication, performance metrics, personas, plugins, process lifecycle, rate limiting, reputation, sandbox isolation, scheduling, skill bundles, Slack bridge, Telegram bridge, tenant isolation, usage monitoring, validation, voice TTS/STT, wallet keystore, web search, workflows, work tasks, and Angular components.
 
 **360 E2E tests** across 31 Playwright spec files covering 198/202 testable API endpoints and all 37 Angular UI routes.
 


### PR DESCRIPTION
## Summary
- Adds a prominent **At a Glance** stats table near the top of README.md with current metrics: 4,978 unit tests, 360 E2E tests, 107 module specs, 37 MCP tools, ~200 API endpoints, 64 migrations, 1.14× test:code ratio
- Updates stale test count references (4931 → 4978) in badge, Testing section header, and body text

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 4,978 pass, 0 fail
- [x] `bun run spec:check` — 107/107 pass

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)