### PR TITLE
docs: fix stale references across 6 documentation files

### DIFF
--- a/docs/decisions/001-autonomous-scheduler.md
+++ b/docs/decisions/001-autonomous-scheduler.md
@@ -82,7 +82,11 @@ The council approved building a **SQLite-backed, prompt-driven autonomous schedu
 
 ---
 
-## Final Schema (Migration 24)
+## Original Schema (Migration 24)
+
+> **Note:** The schema has evolved significantly since this ADR. The current
+> schema version is 64. The SQL below reflects the original design; see
+> `server/db/schema.ts` for the current schema.
 
 ```sql
 -- Scheduled automation definitions (templates)
@@ -90,9 +94,9 @@ CREATE TABLE schedules (
     id                   TEXT PRIMARY KEY,
     name                 TEXT NOT NULL,
     description          TEXT DEFAULT '',
-    action_type          TEXT NOT NULL,        -- star_repos|fork_repos|review_prs|
-                                               -- work_on_repo|suggest_improvements|
-                                               -- council_review|custom
+    action_type          TEXT NOT NULL,        -- star_repo|fork_repo|review_prs|
+                                               -- work_task|github_suggest|
+                                               -- council_launch|custom|...
     cron_expression      TEXT NOT NULL,        -- Standard 5-field cron OR aliases (@daily, @every_6h)
     agent_id             TEXT DEFAULT NULL,    -- Which agent executes (NULL if council-owned)
     council_id           TEXT DEFAULT NULL,    -- Which council owns this (NULL if agent-owned)
@@ -150,16 +154,27 @@ CREATE INDEX idx_schedule_runs_status ON schedule_runs(status);
 
 ---
 
-## Seven Action Types
+## Action Types
+
+> **Note:** Action types evolved during implementation. Names were singularized
+> (`star_repos` → `star_repo`) and 8 new types were added post-ADR.
 
 | Action Type | Description | Default Approval | Session Timeout |
 |-------------|-------------|-------------------|-----------------|
-| `star_repos` | Discover + star repos by topic/criteria | `auto` | 10 min |
-| `fork_repos` | Fork repos for analysis/contribution | `auto` | 10 min |
+| `star_repo` | Discover + star repos by topic/criteria | `auto` | 10 min |
+| `fork_repo` | Fork repos for analysis/contribution | `auto` | 10 min |
 | `review_prs` | Review open PRs, post review comments | `auto` (read-only) | 30 min |
-| `work_on_repo` | Create improvement PRs on core repos | Configurable | 60 min |
-| `suggest_improvements` | Analyze forked repos, propose upstream contributions | `owner_approve` | 30 min |
-| `council_review` | Launch council deliberation on a topic | `auto` (advisory) | 60 min |
+| `work_task` | Create improvement PRs on core repos | Configurable | 60 min |
+| `github_suggest` | Analyze forked repos, propose upstream contributions | `owner_approve` | 30 min |
+| `council_launch` | Launch council deliberation on a topic | `auto` (advisory) | 60 min |
+| `send_message` | Send AlgoChat message | Configurable | 10 min |
+| `codebase_review` | Full codebase review and analysis | `auto` | 60 min |
+| `dependency_audit` | Audit dependencies for updates and vulnerabilities | `auto` | 30 min |
+| `improvement_loop` | Iterative improvement cycle on a repo | Configurable | 60 min |
+| `memory_maintenance` | Maintain and consolidate agent memories | `auto` | 30 min |
+| `reputation_attestation` | Compute and attest reputation scores on-chain | `auto` | 10 min |
+| `outcome_analysis` | Analyze PR and task outcomes | `auto` | 30 min |
+| `daily_review` | Daily self-review with PR outcome analysis | `auto` | 30 min |
 | `custom` | Freeform prompt -- **owner-only creation** | Configurable | 30 min |
 
 ---

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -81,9 +81,9 @@ curl -s http://localhost:3000/api/health | jq .dependencies.database
 Backups should be taken regularly. The backup endpoint:
 
 ```bash
-# Trigger a backup via API
+# Trigger a backup via API (requires ADMIN_API_KEY, not regular API_KEY)
 curl -X POST http://localhost:3000/api/backup \
-  -H "Authorization: Bearer $API_KEY"
+  -H "Authorization: Bearer $ADMIN_API_KEY"
 ```
 
 ## Step 4: Verify All Services

--- a/docs/protected-file-patches.md
+++ b/docs/protected-file-patches.md
@@ -1,9 +1,9 @@
 # Protected File Patches for v1.0
 
-> **Status:** Many of these patches have already been applied as of schema v62.
+> **Status:** Many of these patches have already been applied as of schema v64.
 > Review current code before applying — line numbers and baseline values are
 > approximate and may have shifted. The schema migrations (39-43) below are
-> for reference; actual migrations now extend to v62.
+> for reference; actual migrations now extend to v64.
 
 These patches integrate the Phase 2-4 modules into the protected files.
 Apply them manually in the order shown below.
@@ -545,4 +545,4 @@ bunx tsc --noEmit --skipLibCheck
 bun test
 ```
 
-Both must pass. Current baseline: ~4400+ tests, 0 failures.
+Both must pass. Current baseline: ~4900+ tests, 0 failures.

--- a/docs/security-review-pr336-api-key-auth.md
+++ b/docs/security-review-pr336-api-key-auth.md
@@ -74,19 +74,19 @@ The existing code at line 195 already handles this with more path prefixes
 **Risk**: Medium (CORS regression for non-API routes).
 **Action**: Remove the duplicate check.
 
-### [LOW] L-1: DB_PATH env var is a silent behavior change
+### [LOW] L-1: DB_PATH env var is a silent behavior change — RESOLVED
 
-**Location**: `server/db/connection.ts:29`
+**Location**: `server/db/connection.ts:29` (no longer present)
 
-Setting `DB_PATH` in a non-Docker environment silently changes where the
-database is created. Combined with the volume rename (`db-data` to
-`corvid-data`), existing Docker users could lose data on upgrade.
+The `DB_PATH` env var was removed from `connection.ts` after this review.
+The database path is now determined by convention (`corvid-agent.db` in the
+working directory) without an env-var override.
 
-**Action**: Log when `DB_PATH` overrides the default; document volume migration.
+**Status**: Resolved — the silent behavior change no longer exists.
 
 ### [LOW] L-2: `.env.example` has partial API key prefix
 
-**Location**: `deploy/.env.example:12`
+**Location**: `.env.example` (project root; `deploy/.env.example` no longer exists)
 
 `ANTHROPIC_API_KEY=sk-ant-` may confuse users or leak key format if the
 file is accidentally committed.

--- a/docs/security-triage-2026-03-01.md
+++ b/docs/security-triage-2026-03-01.md
@@ -8,8 +8,8 @@ Triage of open security issues against PR #391 (security hardening batch) and su
 
 **Status:** Fully implemented in PR #391
 
-- `contentLengthGuard()` in `server/middleware/guards.ts:103-115`
-- Wired as first guard in `server/routes/index.ts:199`
+- `contentLengthGuard()` in `server/middleware/guards.ts:109`
+- Wired as first guard in `server/routes/index.ts:206`
 - Rejects POST/PUT/PATCH with Content-Length > 1MB (configurable) with 413
 - GET/HEAD/OPTIONS/DELETE exempted
 - 6 test cases in `server/__tests__/guards.test.ts`
@@ -18,7 +18,7 @@ Triage of open security issues against PR #391 (security hardening batch) and su
 
 **Status:** Fully implemented in PR #391
 
-`instrumentResponse()` in `server/index.ts:433-455` sets on every response:
+`instrumentResponse()` in `server/index.ts:488` sets on every response:
 
 | Header | Value |
 |--------|-------|

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -222,8 +222,10 @@ Trigger a backup via the API:
 
 ```bash
 curl -X POST https://your-corvid-instance.example.com/api/backup \
-  -H "Authorization: Bearer $API_KEY"
+  -H "Authorization: Bearer $ADMIN_API_KEY"
 ```
+
+> **Note:** The `/api/backup` endpoint requires `ADMIN_API_KEY`, not the regular `API_KEY`.
 
 Response:
 
@@ -267,7 +269,7 @@ You can schedule backups with cron:
 
 ```bash
 # Backup every 6 hours
-0 */6 * * * curl -s -X POST http://localhost:3000/api/backup -H "Authorization: Bearer $API_KEY" >> /var/log/corvid-backup.log 2>&1
+0 */6 * * * curl -s -X POST http://localhost:3000/api/backup -H "Authorization: Bearer $ADMIN_API_KEY" >> /var/log/corvid-backup.log 2>&1
 ```
 
 ## Security
@@ -389,7 +391,7 @@ Always create a database backup before upgrading:
 
 ```bash
 curl -X POST http://localhost:3000/api/backup \
-  -H "Authorization: Bearer $API_KEY"
+  -H "Authorization: Bearer $ADMIN_API_KEY"
 ```
 
 ## Additional Deployment Options


### PR DESCRIPTION
## Summary
- **self-hosting.md, incident-response.md**: `/api/backup` examples incorrectly used `$API_KEY` — fixed to `$ADMIN_API_KEY` (endpoint requires admin role per `guards.ts`)
- **protected-file-patches.md**: Updated schema version reference from v62 → v64 and test baseline from ~4400 → ~4900
- **security-triage-2026-03-01.md**: Corrected drifted line numbers (`guards.ts:103→109`, `index.ts:433→488`, `routes/index.ts:199→206`)
- **security-review-pr336-api-key-auth.md**: Marked `DB_PATH` finding as resolved (removed from `connection.ts`), fixed `deploy/.env.example` → `.env.example` path
- **decisions/001-autonomous-scheduler.md**: Updated action types to match implementation (singularized names + 8 new types), added schema drift note (migration 24 → 64)

Closes #572

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` — pre-existing errors only (untracked tool-gating files)
- [x] `bun test` — 5005 pass, 0 fail
- [x] `bun run spec:check` — 107/107 specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)