### PR TITLE
security: add SQL identifier validation to retention pruning

### DIFF
--- a/server/__tests__/retention.test.ts
+++ b/server/__tests__/retention.test.ts
@@ -65,6 +65,31 @@ describe('pruneTable', () => {
         const deleted = pruneTable(db, { table: 'audit_log', timestampColumn: 'timestamp', retentionDays: 180 });
         expect(deleted).toBe(0);
     });
+
+    test('rejects invalid table name (SQL injection attempt)', () => {
+        expect(() =>
+            pruneTable(db, { table: 'audit_log; DROP TABLE agents--', timestampColumn: 'timestamp', retentionDays: 90 }),
+        ).toThrow("invalid table name");
+    });
+
+    test('rejects invalid column name (SQL injection attempt)', () => {
+        expect(() =>
+            pruneTable(db, { table: 'audit_log', timestampColumn: '1; DROP TABLE agents--', retentionDays: 90 }),
+        ).toThrow("invalid column name");
+    });
+
+    test('rejects table name with special characters', () => {
+        expect(() =>
+            pruneTable(db, { table: 'audit-log', timestampColumn: 'timestamp', retentionDays: 90 }),
+        ).toThrow("invalid table name");
+    });
+
+    test('accepts valid SQL identifiers', () => {
+        // Should not throw for valid identifier patterns (may throw for missing table, but not for validation)
+        expect(() =>
+            pruneTable(db, { table: 'audit_log', timestampColumn: 'timestamp', retentionDays: 180 }),
+        ).not.toThrow();
+    });
 });
 
 // ── runRetentionCleanup ──────────────────────────────────────────────

--- a/server/db/retention.ts
+++ b/server/db/retention.ts
@@ -13,6 +13,9 @@ import { createLogger } from '../lib/logger';
 
 const log = createLogger('Retention');
 
+/** Allowlist pattern for valid SQL identifiers (table/column names). */
+const SAFE_SQL_IDENTIFIER = /^[a-z_][a-z0-9_]*$/i;
+
 /** Retention policy for a single table. */
 interface RetentionPolicy {
     table: string;
@@ -39,6 +42,12 @@ const RETENTION_POLICIES: RetentionPolicy[] = [
  * Returns the number of deleted rows.
  */
 export function pruneTable(db: Database, policy: RetentionPolicy): number {
+    if (!SAFE_SQL_IDENTIFIER.test(policy.table)) {
+        throw new Error(`pruneTable: invalid table name '${policy.table}'`);
+    }
+    if (!SAFE_SQL_IDENTIFIER.test(policy.timestampColumn)) {
+        throw new Error(`pruneTable: invalid column name '${policy.timestampColumn}'`);
+    }
     const cutoff = new Date(Date.now() - policy.retentionDays * 24 * 60 * 60 * 1000);
     // daily_spending and agent_daily_spending use date-only format (YYYY-MM-DD)
     const cutoffStr = policy.timestampColumn === 'date'


### PR DESCRIPTION
## Summary
- Adds `SAFE_SQL_IDENTIFIER` allowlist validation to `pruneTable()` in `server/db/retention.ts`
- Prevents SQL injection via table/column name interpolation before they're used in template literals
- Adds 4 tests covering injection attempts, special characters, and valid identifier acceptance

## Context
Proactive security hardening identified via audit. The retention module interpolates `policy.table` and `policy.timestampColumn` into SQL `DELETE` statements. While current values are hardcoded, the comment on line 27 notes "These can be overridden via environment variables if needed" — making this a latent injection vector if policies become configurable.

Uses the same `SAFE_SQL_IDENTIFIER` regex pattern (`/^[a-z_][a-z0-9_]*$/i`) already established in `schema.ts` and 5 migration files.

## Validation
- TSC clean (`bunx tsc --noEmit --skipLibCheck`)
- 13/13 retention tests pass (4 new)
- 107/107 specs pass

## Test plan
- [x] Verify `pruneTable` throws on SQL injection payloads (`; DROP TABLE`)
- [x] Verify `pruneTable` throws on identifiers with special chars (hyphens)
- [x] Verify `pruneTable` accepts valid identifiers without throwing
- [x] Verify existing retention cleanup behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)