### PR TITLE
release: v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.17.0] - 2026-03-06
+
+### Added
+- **Repo blocklist with auto-block on PR rejection** — rejected PRs automatically add repos to the blocklist; org-wide wildcard support (e.g. `vapor/*`); enforced in polling and webhooks (#547, #554, #561, #565)
+- **Branch protection** — script to enable branch protection on unprotected public repos (#560)
+- **Dashboard summary batch endpoint** — `GET /api/dashboard/summary` aggregates agents, sessions, work tasks, and recent activity in a single call (#567)
+- **Schedule management via MCP** — `update` action added to `corvid_manage_schedule` tool (#568)
+- **Daily review schedule action** — automated end-of-day retrospective with PR outcome analysis (#570)
+- **Selective tool gating** — scheduler sessions can restrict which MCP tools are available (#578)
+- **Permission broker** — capability-based security layer for agent actions (#578, #579)
+- **69 module specs** for full server coverage — 109 total specs with automated validation (#552)
+
+### Security
+- **CSP and Permissions-Policy headers** — Content-Security-Policy and Permissions-Policy middleware on all responses (#566)
+- **WebSocket post-connect auth timeout** — 5-second deadline to authenticate after connection (#564)
+- **@hono/node-server authorization bypass patch** — override for GHSA-wc8c-qw6v-h7f6 (#575)
+- **Blocklist enforcement** in polling and webhook handlers (#565)
+
+### Fixed
+- Localhost exempted from rate limiting for local dashboard access (#562, #563)
+- Logger special characters test handles JSON format in production mode (#574)
+- Cosign installer pinned to current v3 SHA; id-token permission for release workflow (#545, #546)
+
+### Changed
+- **Service bootstrap extracted** from `server/index.ts` into `server/bootstrap.ts` — cleaner startup, testable initialization (#579)
+- Architecture docs synced with all 200+ API endpoints and 70 tables (#569)
+- README updated with At a Glance stats section, accurate counts (#573, #576, #577)
+
+### Stats
+- **5,040** unit tests across 202 files (14,118 assertions)
+- **360** E2E tests across 31 Playwright specs
+- **109** module specs with automated validation
+- **37** MCP tools, **~200** API endpoints, **64** migrations, **82** tables
+
 ## [0.16.0] - 2026-03-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.16.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.17.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">
   <img src="https://img.shields.io/badge/Angular-21-dd0031?logo=angular" alt="Angular 21">
-  <img src="https://img.shields.io/badge/tests-4978%20unit%20%7C%20360%20E2E-brightgreen" alt="4978 Unit | 360 E2E Tests">
+  <img src="https://img.shields.io/badge/tests-5040%20unit%20%7C%20360%20E2E-brightgreen" alt="5040 Unit | 360 E2E Tests">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>
 </p>
 
@@ -20,12 +20,12 @@ See [VISION.md](VISION.md) for architecture, competitive positioning, and long-t
 
 | Metric | Count |
 |--------|-------|
-| Unit tests | **4,978** across 200 files (14,080 assertions) |
+| Unit tests | **5,040** across 202 files (14,118 assertions) |
 | E2E tests | **360** across 31 Playwright specs |
-| Module specs | **107** with automated validation |
+| Module specs | **109** with automated validation |
 | MCP tools | **37** corvid_* tool handlers |
 | API endpoints | **~200** across 36 route modules |
-| DB migrations | **64** (74 tables) |
+| DB migrations | **64** (82 tables) |
 | Test:code ratio | **1.14×** — more test code than production code |
 
 Cross-platform CI: Ubuntu, macOS, Windows.

--- a/VISION.md
+++ b/VISION.md
@@ -241,7 +241,7 @@ Today, corvid-agent runs as a single instance managing local agents. Tomorrow, m
 
 ## Roadmap
 
-### Shipped (v0.1.0 -> v0.16.0)
+### Shipped (v0.1.0 -> v0.17.0)
 
 - Agent orchestration with Claude SDK
 - Council deliberation with structured voting and follow-up chat

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,7 +42,7 @@
   <!-- ═══════════════════ HERO ═══════════════════ -->
   <header class="hero">
     <div class="container">
-      <div class="hero__badge">v0.16.0</div>
+      <div class="hero__badge">v0.17.0</div>
       <h1 class="hero__title">
         <span class="glow-cyan">Corvid</span><span class="glow-magenta">Agent</span>
       </h1>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",

--- a/scripts/demo.md
+++ b/scripts/demo.md
@@ -1,4 +1,4 @@
-# corvid-agent v0.16.0 Demo Script
+# corvid-agent v0.17.0 Demo Script
 
 Structured walkthrough for demonstrating the full corvid-agent platform.
 

--- a/server/__tests__/crypto-audit.test.ts
+++ b/server/__tests__/crypto-audit.test.ts
@@ -1,5 +1,5 @@
 /**
- * Crypto audit test suite for v0.16.0 — key rotation, grace periods, and memory wipe.
+ * Crypto audit test suite for v0.17.0 — key rotation, grace periods, and memory wipe.
  *
  * Tests:
  *  - Wallet encryption key rotation (round-trip, old key invalid, atomic write, error recovery)


### PR DESCRIPTION
## v0.17.0 — Security Hardening, Repo Blocklist, Permission Broker

**23 commits** since v0.16.0: 9 features, 4 security fixes, 3 bug fixes.

### Highlights

#### Security
- CSP and Permissions-Policy headers on all responses (#566)
- WebSocket post-connect auth timeout — 5s deadline (#564)
- @hono/node-server authorization bypass patch (GHSA-wc8c-qw6v-h7f6) (#575)
- Blocklist enforcement in polling and webhooks (#565)

#### Features
- Repo blocklist with auto-block on PR rejection + org wildcards (#547, #554, #561)
- Branch protection for public repos (#560)
- Dashboard summary batch endpoint (#567)
- Schedule update via MCP tool (#568)
- Daily review schedule action with PR outcome analysis (#570)
- Selective tool gating for scheduler sessions (#578)
- Permission broker — capability-based security (#578, #579)
- 69 new module specs (109 total) (#552)

#### Infrastructure
- Service bootstrap extracted from server/index.ts (#579)
- Architecture docs synced with 200+ endpoints (#569)

### Stats
- **5,040** unit tests (202 files, 14,118 assertions)
- **360** E2E tests
- **109** module specs
- **82** tables, **64** migrations

### After merge
Tag `v0.17.0` on the merge commit to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)