### PR TITLE
feat: Permission Broker — capability-based agent security (Phase 1)

### DIFF
--- a/server/__tests__/permission-broker.test.ts
+++ b/server/__tests__/permission-broker.test.ts
@@ -1,0 +1,520 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import { migrateUp } from '../db/migrate';
+import { PermissionBroker } from '../permissions/broker';
+import { TOOL_ACTION_MAP } from '../permissions/types';
+
+let db: Database;
+let broker: PermissionBroker;
+const AGENT_ID = 'agent-test-1';
+const AGENT_ID_2 = 'agent-test-2';
+
+beforeEach(async () => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+    await migrateUp(db);
+    db.query(`INSERT INTO agents (id, name, model, system_prompt) VALUES (?, 'TestAgent', 'test', 'test')`).run(AGENT_ID);
+    db.query(`INSERT INTO agents (id, name, model, system_prompt) VALUES (?, 'TestAgent2', 'test', 'test')`).run(AGENT_ID_2);
+    broker = new PermissionBroker(db);
+});
+
+afterEach(() => {
+    db.close();
+});
+
+// ─── TOOL_ACTION_MAP ─────────────────────────────────────────────────────
+
+describe('TOOL_ACTION_MAP', () => {
+    test('maps all standard corvid tools to actions', () => {
+        expect(TOOL_ACTION_MAP['corvid_send_message']).toBe('msg:send');
+        expect(TOOL_ACTION_MAP['corvid_github_create_pr']).toBe('git:create_pr');
+        expect(TOOL_ACTION_MAP['corvid_grant_credits']).toBe('credits:grant');
+        expect(TOOL_ACTION_MAP['corvid_manage_schedule']).toBe('schedule:manage');
+    });
+
+    test('all mapped actions follow namespace:verb format', () => {
+        for (const [_tool, action] of Object.entries(TOOL_ACTION_MAP)) {
+            expect(action).toMatch(/^[a-z]+:[a-z_]+$/);
+        }
+    });
+
+    test('has mappings for GitHub tools', () => {
+        const githubTools = Object.keys(TOOL_ACTION_MAP).filter(t => t.includes('github'));
+        expect(githubTools.length).toBeGreaterThanOrEqual(10);
+    });
+});
+
+// ─── Grant operations ────────────────────────────────────────────────────
+
+describe('grant', () => {
+    test('creates a grant with HMAC signature', async () => {
+        const grant = await broker.grant({
+            agentId: AGENT_ID,
+            action: 'git:create_pr',
+            grantedBy: 'owner',
+            reason: 'PR creation rights',
+        });
+
+        expect(grant.id).toBeGreaterThan(0);
+        expect(grant.agentId).toBe(AGENT_ID);
+        expect(grant.action).toBe('git:create_pr');
+        expect(grant.grantedBy).toBe('owner');
+        expect(grant.signature).toBeTruthy();
+        expect(grant.signature.length).toBe(64); // SHA-256 hex
+        expect(grant.revokedAt).toBeNull();
+        expect(grant.tenantId).toBe('default');
+    });
+
+    test('creates a grant with expiration', async () => {
+        const future = new Date(Date.now() + 3600_000).toISOString();
+        const grant = await broker.grant({
+            agentId: AGENT_ID,
+            action: 'msg:send',
+            grantedBy: 'owner',
+            expiresAt: future,
+        });
+
+        expect(grant.expiresAt).toBe(future);
+    });
+
+    test('creates grants for different tenants', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:read', grantedBy: 'owner', tenantId: 'tenant-a' });
+        await broker.grant({ agentId: AGENT_ID, action: 'git:read', grantedBy: 'owner', tenantId: 'tenant-b' });
+
+        const grantsA = broker.getGrants(AGENT_ID, 'tenant-a');
+        const grantsB = broker.getGrants(AGENT_ID, 'tenant-b');
+        expect(grantsA.length).toBe(1);
+        expect(grantsB.length).toBe(1);
+    });
+
+    test('records audit entry on grant', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:star', grantedBy: 'admin' });
+
+        const auditRow = db.query(
+            `SELECT * FROM audit_log WHERE action = 'permission_grant' ORDER BY id DESC LIMIT 1`
+        ).get() as any;
+        expect(auditRow).toBeTruthy();
+        expect(auditRow.actor).toBe('admin');
+        expect(auditRow.resource_type).toBe('permission');
+    });
+});
+
+// ─── Check operations ────────────────────────────────────────────────────
+
+describe('checkTool', () => {
+    test('denies access when no grants exist', async () => {
+        const result = await broker.checkTool(AGENT_ID, 'corvid_github_create_pr');
+        expect(result.allowed).toBe(false);
+        expect(result.grantId).toBeNull();
+        expect(result.checkMs).toBeGreaterThanOrEqual(0);
+    });
+
+    test('allows access with exact action grant', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:create_pr', grantedBy: 'owner' });
+
+        const result = await broker.checkTool(AGENT_ID, 'corvid_github_create_pr');
+        expect(result.allowed).toBe(true);
+        expect(result.grantId).toBeGreaterThan(0);
+    });
+
+    test('allows access with namespace wildcard grant', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:*', grantedBy: 'owner' });
+
+        const result = await broker.checkTool(AGENT_ID, 'corvid_github_create_pr');
+        expect(result.allowed).toBe(true);
+
+        const result2 = await broker.checkTool(AGENT_ID, 'corvid_github_star_repo');
+        expect(result2.allowed).toBe(true);
+    });
+
+    test('allows access with superuser wildcard', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: '*', grantedBy: 'owner' });
+
+        const result = await broker.checkTool(AGENT_ID, 'corvid_github_create_pr');
+        expect(result.allowed).toBe(true);
+
+        const result2 = await broker.checkTool(AGENT_ID, 'corvid_send_message');
+        expect(result2.allowed).toBe(true);
+    });
+
+    test('denies with wrong namespace wildcard', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'msg:*', grantedBy: 'owner' });
+
+        const result = await broker.checkTool(AGENT_ID, 'corvid_github_create_pr');
+        expect(result.allowed).toBe(false);
+    });
+
+    test('allows tools with no action mapping (unmapped tools)', async () => {
+        const result = await broker.checkTool(AGENT_ID, 'some_unknown_tool');
+        expect(result.allowed).toBe(true);
+        expect(result.reason).toContain('no permission mapping');
+    });
+
+    test('denies access with expired grant', async () => {
+        const past = new Date(Date.now() - 3600_000).toISOString();
+        await broker.grant({
+            agentId: AGENT_ID,
+            action: 'git:create_pr',
+            grantedBy: 'owner',
+            expiresAt: past,
+        });
+
+        const result = await broker.checkTool(AGENT_ID, 'corvid_github_create_pr');
+        expect(result.allowed).toBe(false);
+    });
+
+    test('denies access with revoked grant', async () => {
+        const grant = await broker.grant({ agentId: AGENT_ID, action: 'git:create_pr', grantedBy: 'owner' });
+        broker.revoke({ grantId: grant.id, revokedBy: 'admin' });
+
+        const result = await broker.checkTool(AGENT_ID, 'corvid_github_create_pr');
+        expect(result.allowed).toBe(false);
+    });
+
+    test('records check in permission_checks table', async () => {
+        await broker.checkTool(AGENT_ID, 'corvid_github_create_pr', { sessionId: 'sess-1' });
+
+        const row = db.query(
+            `SELECT * FROM permission_checks WHERE agent_id = ? AND tool_name = ?`
+        ).get(AGENT_ID, 'corvid_github_create_pr') as any;
+        expect(row).toBeTruthy();
+        expect(row.action).toBe('git:create_pr');
+        expect(row.allowed).toBe(0);
+        expect(row.session_id).toBe('sess-1');
+    });
+
+    test('check performance is under 10ms for simple lookups', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:create_pr', grantedBy: 'owner' });
+
+        const result = await broker.checkTool(AGENT_ID, 'corvid_github_create_pr');
+        expect(result.checkMs).toBeLessThan(10);
+    });
+
+    test('respects tenant isolation', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:create_pr', grantedBy: 'owner', tenantId: 'tenant-a' });
+
+        const resultA = await broker.checkTool(AGENT_ID, 'corvid_github_create_pr', { tenantId: 'tenant-a' });
+        expect(resultA.allowed).toBe(true);
+
+        const resultDefault = await broker.checkTool(AGENT_ID, 'corvid_github_create_pr');
+        expect(resultDefault.allowed).toBe(false);
+    });
+});
+
+// ─── checkAction (direct action check) ──────────────────────────────────
+
+describe('checkAction', () => {
+    test('checks a raw action string', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:create_pr', grantedBy: 'owner' });
+
+        const result = await broker.checkAction(AGENT_ID, 'git:create_pr');
+        expect(result.allowed).toBe(true);
+
+        const result2 = await broker.checkAction(AGENT_ID, 'git:fork');
+        expect(result2.allowed).toBe(false);
+    });
+});
+
+// ─── Revoke operations ──────────────────────────────────────────────────
+
+describe('revoke', () => {
+    test('revokes a specific grant by ID', async () => {
+        const grant = await broker.grant({ agentId: AGENT_ID, action: 'git:create_pr', grantedBy: 'owner' });
+
+        const affected = broker.revoke({ grantId: grant.id, revokedBy: 'admin' });
+        expect(affected).toBe(1);
+
+        const grants = broker.getGrants(AGENT_ID);
+        expect(grants.length).toBe(0);
+    });
+
+    test('revokes all grants for an agent + action', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:create_pr', grantedBy: 'owner' });
+        await broker.grant({ agentId: AGENT_ID, action: 'git:create_pr', grantedBy: 'admin' });
+        await broker.grant({ agentId: AGENT_ID, action: 'msg:send', grantedBy: 'owner' });
+
+        const affected = broker.revoke({ agentId: AGENT_ID, action: 'git:create_pr', revokedBy: 'admin' });
+        expect(affected).toBe(2);
+
+        const grants = broker.getGrants(AGENT_ID);
+        expect(grants.length).toBe(1);
+        expect(grants[0].action).toBe('msg:send');
+    });
+
+    test('revokes all grants for an agent (no action specified)', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:create_pr', grantedBy: 'owner' });
+        await broker.grant({ agentId: AGENT_ID, action: 'msg:send', grantedBy: 'owner' });
+
+        const affected = broker.revoke({ agentId: AGENT_ID, revokedBy: 'admin' });
+        expect(affected).toBe(2);
+    });
+
+    test('does not double-revoke', async () => {
+        const grant = await broker.grant({ agentId: AGENT_ID, action: 'git:create_pr', grantedBy: 'owner' });
+        broker.revoke({ grantId: grant.id, revokedBy: 'admin' });
+
+        const affected = broker.revoke({ grantId: grant.id, revokedBy: 'admin' });
+        expect(affected).toBe(0);
+    });
+
+    test('records audit entry on revoke', async () => {
+        const grant = await broker.grant({ agentId: AGENT_ID, action: 'git:star', grantedBy: 'owner' });
+        broker.revoke({ grantId: grant.id, revokedBy: 'security-bot', reason: 'policy change' });
+
+        const auditRow = db.query(
+            `SELECT * FROM audit_log WHERE action = 'permission_revoke' ORDER BY id DESC LIMIT 1`
+        ).get() as any;
+        expect(auditRow).toBeTruthy();
+        expect(auditRow.actor).toBe('security-bot');
+    });
+});
+
+// ─── Emergency revocation ────────────────────────────────────────────────
+
+describe('emergencyRevoke', () => {
+    test('revokes all grants for an agent immediately', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:create_pr', grantedBy: 'owner' });
+        await broker.grant({ agentId: AGENT_ID, action: 'msg:send', grantedBy: 'owner' });
+        await broker.grant({ agentId: AGENT_ID, action: '*', grantedBy: 'owner' });
+
+        const count = broker.emergencyRevoke(AGENT_ID, 'security-team', 'Compromised agent');
+        expect(count).toBe(3);
+
+        const grants = broker.getGrants(AGENT_ID);
+        expect(grants.length).toBe(0);
+    });
+
+    test('does not affect other agents', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:read', grantedBy: 'owner' });
+        await broker.grant({ agentId: AGENT_ID_2, action: 'git:read', grantedBy: 'owner' });
+
+        broker.emergencyRevoke(AGENT_ID, 'security-team', 'Compromised');
+
+        const grants2 = broker.getGrants(AGENT_ID_2);
+        expect(grants2.length).toBe(1);
+    });
+
+    test('records emergency audit entry', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:read', grantedBy: 'owner' });
+        broker.emergencyRevoke(AGENT_ID, 'security-team', 'Compromised');
+
+        const auditRow = db.query(
+            `SELECT * FROM audit_log WHERE action = 'permission_emergency_revoke' ORDER BY id DESC LIMIT 1`
+        ).get() as any;
+        expect(auditRow).toBeTruthy();
+        expect(auditRow.actor).toBe('security-team');
+        expect(JSON.parse(auditRow.detail).revokedCount).toBe(1);
+    });
+});
+
+// ─── getGrants / getGrantHistory ────────────────────────────────────────
+
+describe('getGrants', () => {
+    test('returns only active (non-revoked, non-expired) grants', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:read', grantedBy: 'owner' });
+        const g2 = await broker.grant({ agentId: AGENT_ID, action: 'git:star', grantedBy: 'owner' });
+        await broker.grant({
+            agentId: AGENT_ID,
+            action: 'msg:send',
+            grantedBy: 'owner',
+            expiresAt: new Date(Date.now() - 1000).toISOString(),
+        });
+        broker.revoke({ grantId: g2.id, revokedBy: 'admin' });
+
+        const active = broker.getGrants(AGENT_ID);
+        expect(active.length).toBe(1);
+        expect(active[0].action).toBe('git:read');
+    });
+
+    test('getGrantHistory returns all grants including revoked', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:read', grantedBy: 'owner' });
+        const g2 = await broker.grant({ agentId: AGENT_ID, action: 'git:star', grantedBy: 'owner' });
+        broker.revoke({ grantId: g2.id, revokedBy: 'admin' });
+
+        const history = broker.getGrantHistory(AGENT_ID);
+        expect(history.length).toBe(2);
+    });
+});
+
+// ─── getRequiredAction ──────────────────────────────────────────────────
+
+describe('getRequiredAction', () => {
+    test('returns the action for known tools', () => {
+        expect(broker.getRequiredAction('corvid_github_create_pr')).toBe('git:create_pr');
+        expect(broker.getRequiredAction('corvid_send_message')).toBe('msg:send');
+    });
+
+    test('returns null for unknown tools', () => {
+        expect(broker.getRequiredAction('unknown_tool')).toBeNull();
+    });
+});
+
+// ─── HMAC signature verification ────────────────────────────────────────
+
+describe('HMAC integrity', () => {
+    test('detects tampered grant signature', async () => {
+        const grant = await broker.grant({ agentId: AGENT_ID, action: 'git:create_pr', grantedBy: 'owner' });
+
+        // Tamper with the signature in the DB
+        db.query('UPDATE permission_grants SET signature = ? WHERE id = ?').run('deadbeef'.repeat(8), grant.id);
+
+        const result = await broker.checkTool(AGENT_ID, 'corvid_github_create_pr');
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toContain('invalid HMAC signature');
+    });
+
+    test('detects tampered action in grant', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:create_pr', grantedBy: 'owner' });
+
+        // Tamper with the action in the DB (escalate from git:read to git:create_pr)
+        db.query('UPDATE permission_grants SET action = ? WHERE agent_id = ?').run('git:fork', AGENT_ID);
+
+        // The grant now says git:fork but signature was for git:create_pr — should fail
+        const result = await broker.checkAction(AGENT_ID, 'git:fork');
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toContain('invalid HMAC signature');
+    });
+});
+
+// ─── API routes ─────────────────────────────────────────────────────────
+
+describe('permission routes', () => {
+    // Import the route handler for direct testing
+    const { handlePermissionRoutes } = require('../routes/permissions') as typeof import('../routes/permissions');
+
+    test('GET /api/permissions/actions returns action map', () => {
+        const url = new URL('http://localhost/api/permissions/actions');
+        const req = new Request(url, { method: 'GET' });
+        const res = handlePermissionRoutes(req, url, db);
+        expect(res).toBeTruthy();
+    });
+
+    test('POST /api/permissions/grant creates a grant', async () => {
+        const url = new URL('http://localhost/api/permissions/grant');
+        const req = new Request(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ agent_id: AGENT_ID, action: 'git:read', granted_by: 'test' }),
+        });
+        const res = await handlePermissionRoutes(req, url, db) as Response;
+        expect(res.status).toBe(201);
+
+        const body = await res.json();
+        expect(body.grant.agentId).toBe(AGENT_ID);
+        expect(body.grant.action).toBe('git:read');
+    });
+
+    test('POST /api/permissions/check returns check result', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:read', grantedBy: 'owner' });
+
+        const url = new URL('http://localhost/api/permissions/check');
+        const req = new Request(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ agent_id: AGENT_ID, tool_name: 'corvid_github_list_prs' }),
+        });
+        const res = await handlePermissionRoutes(req, url, db) as Response;
+        expect(res.status).toBe(200);
+
+        const body = await res.json();
+        expect(body.allowed).toBe(true);
+    });
+
+    test('POST /api/permissions/revoke revokes a grant', async () => {
+        const grant = await broker.grant({ agentId: AGENT_ID, action: 'git:read', grantedBy: 'owner' });
+
+        const url = new URL('http://localhost/api/permissions/revoke');
+        const req = new Request(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ grant_id: grant.id, revoked_by: 'test' }),
+        });
+        const res = await handlePermissionRoutes(req, url, db) as Response;
+        expect(res.status).toBe(200);
+
+        const body = await res.json();
+        expect(body.affected).toBe(1);
+    });
+
+    test('POST /api/permissions/emergency-revoke revokes all', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:read', grantedBy: 'owner' });
+        await broker.grant({ agentId: AGENT_ID, action: 'msg:send', grantedBy: 'owner' });
+
+        const url = new URL('http://localhost/api/permissions/emergency-revoke');
+        const req = new Request(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ agent_id: AGENT_ID, revoked_by: 'security', reason: 'test' }),
+        });
+        const res = await handlePermissionRoutes(req, url, db) as Response;
+        expect(res.status).toBe(200);
+
+        const body = await res.json();
+        expect(body.affected).toBe(2);
+        expect(body.emergency).toBe(true);
+    });
+
+    test('GET /api/permissions/:agentId lists grants', async () => {
+        await broker.grant({ agentId: AGENT_ID, action: 'git:read', grantedBy: 'owner' });
+        await broker.grant({ agentId: AGENT_ID, action: 'msg:send', grantedBy: 'owner' });
+
+        const url = new URL(`http://localhost/api/permissions/${AGENT_ID}`);
+        const req = new Request(url, { method: 'GET' });
+        const res = handlePermissionRoutes(req, url, db) as Response;
+        expect(res.status).toBe(200);
+
+        const body = await res.json();
+        expect(body.grants.length).toBe(2);
+        expect(body.count).toBe(2);
+    });
+
+    test('returns 400 for missing required fields', async () => {
+        const url = new URL('http://localhost/api/permissions/grant');
+        const req = new Request(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ agent_id: AGENT_ID }),
+        });
+        const res = await handlePermissionRoutes(req, url, db) as Response;
+        expect(res.status).toBe(400);
+    });
+
+    test('returns null for non-permission paths', () => {
+        const url = new URL('http://localhost/api/other');
+        const req = new Request(url, { method: 'GET' });
+        const res = handlePermissionRoutes(req, url, db);
+        expect(res).toBeNull();
+    });
+});
+
+// ─── Migration ──────────────────────────────────────────────────────────
+
+describe('migration 065', () => {
+    test('permission_grants table exists with correct schema', () => {
+        const info = db.query(`PRAGMA table_info(permission_grants)`).all() as any[];
+        const columns = info.map(r => r.name);
+        expect(columns).toContain('id');
+        expect(columns).toContain('agent_id');
+        expect(columns).toContain('action');
+        expect(columns).toContain('granted_by');
+        expect(columns).toContain('signature');
+        expect(columns).toContain('expires_at');
+        expect(columns).toContain('revoked_at');
+        expect(columns).toContain('tenant_id');
+    });
+
+    test('permission_checks table exists with correct schema', () => {
+        const info = db.query(`PRAGMA table_info(permission_checks)`).all() as any[];
+        const columns = info.map(r => r.name);
+        expect(columns).toContain('id');
+        expect(columns).toContain('agent_id');
+        expect(columns).toContain('tool_name');
+        expect(columns).toContain('action');
+        expect(columns).toContain('allowed');
+        expect(columns).toContain('grant_id');
+        expect(columns).toContain('check_ms');
+        expect(columns).toContain('session_id');
+    });
+});

--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -51,6 +51,7 @@ import { LlmProviderRegistry } from './providers/registry';
 import { AnthropicProvider } from './providers/anthropic/provider';
 import { OllamaProvider } from './providers/ollama/provider';
 import { AstParserService } from './ast/service';
+import { PermissionBroker } from './permissions/broker';
 import { listProjects, createProject } from './db/projects';
 import { initObservability } from './observability/index';
 
@@ -124,6 +125,9 @@ export interface ServiceContainer {
     telegramBridge: TelegramBridge | null;
     discordBridge: DiscordBridge | null;
     slackBridge: SlackBridge | null;
+
+    // Security
+    permissionBroker: PermissionBroker;
 }
 
 /**
@@ -152,6 +156,8 @@ export async function bootstrapServices(db: Database, startTime: number): Promis
     astParserService.init().catch((err) => {
         log.warn('AST parser service failed to initialize', { error: err instanceof Error ? err.message : String(err) });
     });
+
+    const permissionBroker = new PermissionBroker(db);
 
     // ── LLM providers ────────────────────────────────────────────────────
     const providerRegistry = LlmProviderRegistry.getInstance();
@@ -397,5 +403,6 @@ export async function bootstrapServices(db: Database, startTime: number): Promis
         telegramBridge,
         discordBridge,
         slackBridge,
+        permissionBroker,
     };
 }

--- a/server/db/audit.ts
+++ b/server/db/audit.ts
@@ -45,7 +45,10 @@ export type AuditAction =
     | 'webhook_register'
     | 'webhook_delete'
     | 'auth_login'
-    | 'auth_failed';
+    | 'auth_failed'
+    | 'permission_grant'
+    | 'permission_revoke'
+    | 'permission_emergency_revoke';
 
 export interface AuditEntry {
     id: number;

--- a/server/db/migrations/065_permission_broker.ts
+++ b/server/db/migrations/065_permission_broker.ts
@@ -1,0 +1,54 @@
+/**
+ * Migration 065: Permission Broker tables.
+ *
+ * Phase 1 of capability-based security (#557):
+ * - permission_grants: stores action-level capability grants per agent
+ * - permission_checks: audit trail of every permission decision
+ */
+
+import { Database } from 'bun:sqlite';
+
+export function up(db: Database): void {
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS permission_grants (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id    TEXT NOT NULL,
+            action      TEXT NOT NULL,
+            granted_by  TEXT NOT NULL,
+            reason      TEXT DEFAULT '',
+            signature   TEXT NOT NULL DEFAULT '',
+            expires_at  TEXT DEFAULT NULL,
+            revoked_at  TEXT DEFAULT NULL,
+            revoked_by  TEXT DEFAULT NULL,
+            tenant_id   TEXT NOT NULL DEFAULT 'default',
+            created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    `);
+    db.exec('CREATE INDEX IF NOT EXISTS idx_perm_grants_agent ON permission_grants(agent_id)');
+    db.exec('CREATE INDEX IF NOT EXISTS idx_perm_grants_action ON permission_grants(action)');
+    db.exec('CREATE INDEX IF NOT EXISTS idx_perm_grants_tenant ON permission_grants(tenant_id)');
+
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS permission_checks (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id    TEXT NOT NULL,
+            tool_name   TEXT NOT NULL,
+            action      TEXT NOT NULL,
+            allowed     INTEGER NOT NULL DEFAULT 0,
+            grant_id    INTEGER DEFAULT NULL,
+            reason      TEXT DEFAULT '',
+            check_ms    REAL DEFAULT 0,
+            session_id  TEXT DEFAULT NULL,
+            tenant_id   TEXT NOT NULL DEFAULT 'default',
+            checked_at  TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    `);
+    db.exec('CREATE INDEX IF NOT EXISTS idx_perm_checks_agent ON permission_checks(agent_id)');
+    db.exec('CREATE INDEX IF NOT EXISTS idx_perm_checks_tool ON permission_checks(tool_name)');
+    db.exec('CREATE INDEX IF NOT EXISTS idx_perm_checks_tenant ON permission_checks(tenant_id)');
+}
+
+export function down(db: Database): void {
+    db.exec('DROP TABLE IF EXISTS permission_checks');
+    db.exec('DROP TABLE IF EXISTS permission_grants');
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,6 +1,6 @@
 import { Database } from 'bun:sqlite';
 
-const SCHEMA_VERSION = 64;
+const SCHEMA_VERSION = 65;
 
 const MIGRATIONS: Record<number, string[]> = {
     1: [
@@ -1220,6 +1220,41 @@ const MIGRATIONS: Record<number, string[]> = {
             PRIMARY KEY (repo, tenant_id)
         )`,
         `CREATE INDEX IF NOT EXISTS idx_repo_blocklist_tenant ON repo_blocklist(tenant_id)`,
+    ],
+    65: [
+        // Permission Broker — capability-based security for agent actions (#557)
+        `CREATE TABLE IF NOT EXISTS permission_grants (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id    TEXT NOT NULL,
+            action      TEXT NOT NULL,
+            granted_by  TEXT NOT NULL,
+            reason      TEXT DEFAULT '',
+            signature   TEXT NOT NULL DEFAULT '',
+            expires_at  TEXT DEFAULT NULL,
+            revoked_at  TEXT DEFAULT NULL,
+            revoked_by  TEXT DEFAULT NULL,
+            tenant_id   TEXT NOT NULL DEFAULT 'default',
+            created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+        )`,
+        `CREATE INDEX IF NOT EXISTS idx_perm_grants_agent ON permission_grants(agent_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_perm_grants_action ON permission_grants(action)`,
+        `CREATE INDEX IF NOT EXISTS idx_perm_grants_tenant ON permission_grants(tenant_id)`,
+        `CREATE TABLE IF NOT EXISTS permission_checks (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id    TEXT NOT NULL,
+            tool_name   TEXT NOT NULL,
+            action      TEXT NOT NULL,
+            allowed     INTEGER NOT NULL DEFAULT 0,
+            grant_id    INTEGER DEFAULT NULL,
+            reason      TEXT DEFAULT '',
+            check_ms    REAL DEFAULT 0,
+            session_id  TEXT DEFAULT NULL,
+            tenant_id   TEXT NOT NULL DEFAULT 'default',
+            checked_at  TEXT NOT NULL DEFAULT (datetime('now'))
+        )`,
+        `CREATE INDEX IF NOT EXISTS idx_perm_checks_agent ON permission_checks(agent_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_perm_checks_tool ON permission_checks(tool_name)`,
+        `CREATE INDEX IF NOT EXISTS idx_perm_checks_tenant ON permission_checks(tenant_id)`,
     ],
 };
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,6 +28,7 @@ import {
 } from './observability/index';
 import { runWithTraceId } from './observability/trace-context';
 import { handleAuditRoutes } from './routes/audit';
+import { handlePermissionRoutes } from './routes/permissions';
 import { buildAgentCard } from './a2a/agent-card';
 import { extractTenantId } from './tenant/middleware';
 import { DEFAULT_TENANT_ID } from './tenant/types';
@@ -90,6 +91,7 @@ const {
     healthMonitorService,
     reputationVerifier,
     astParserService,
+    permissionBroker,
 } = await bootstrapServices(db, startTime);
 
 async function switchNetwork(network: 'testnet' | 'mainnet'): Promise<void> {
@@ -173,7 +175,7 @@ async function initAlgoChat(): Promise<void> {
         serverMnemonic: algochatConfig.mnemonic,
         network: agentNetworkConfig.network,
     }, workTaskService, schedulerService, workflowService, notificationService, questionDispatcher,
-    reputationScorer, reputationAttestation, reputationVerifier, astParserService);
+    reputationScorer, reputationAttestation, reputationVerifier, astParserService, permissionBroker);
 
     // Forward AlgoChat events to WebSocket clients
     algochatState.bridge.onEvent((participant, content, direction) => {
@@ -283,6 +285,12 @@ const server = Bun.serve<WsData>({
             }
             const auditResponse = handleAuditRoutes(req, url, db);
             if (auditResponse) return instrumentResponse(auditResponse, '/api/audit-log');
+
+            const permResponse = handlePermissionRoutes(req, url, db);
+            if (permResponse) {
+                const resolved = permResponse instanceof Promise ? await permResponse : permResponse;
+                return instrumentResponse(resolved, '/api/permissions');
+            }
         }
 
         // WebSocket upgrade

--- a/server/mcp/tool-handlers/types.ts
+++ b/server/mcp/tool-handlers/types.ts
@@ -12,6 +12,7 @@ import type { ReputationScorer } from '../../reputation/scorer';
 import type { ReputationAttestation } from '../../reputation/attestation';
 import type { ReputationVerifier } from '../../reputation/verifier';
 import type { AstParserService } from '../../ast/service';
+import type { PermissionBroker } from '../../permissions/broker';
 import type { ScheduleActionType } from '../../../shared/types/schedules';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
@@ -65,6 +66,8 @@ export interface McpToolContext {
     resolvedToolPermissions?: string[] | null;
     /** AST parser service for structural code navigation (corvid_code_symbols, corvid_find_references). */
     astParserService?: AstParserService;
+    /** Permission Broker for capability-based action authorization. */
+    permissionBroker?: PermissionBroker;
 }
 
 export function textResult(text: string): CallToolResult {

--- a/server/permissions/broker.ts
+++ b/server/permissions/broker.ts
@@ -1,0 +1,342 @@
+/**
+ * Permission Broker — capability-based security for agent actions.
+ *
+ * Phase 1 (#557): HMAC-signed grants, action-level checks, audit trail,
+ * and emergency revocation. Designed for <10ms permission checks.
+ *
+ * Integration: embedded in the MCP tool server, not a separate service.
+ */
+
+import type { Database } from 'bun:sqlite';
+import { createLogger } from '../lib/logger';
+import { recordAudit, type AuditAction } from '../db/audit';
+import type {
+    PermissionAction,
+    PermissionGrant,
+    PermissionCheckResult,
+    GrantOptions,
+    RevokeOptions,
+} from './types';
+import { TOOL_ACTION_MAP } from './types';
+
+const log = createLogger('PermissionBroker');
+
+/** HMAC secret — from env or a safe default for local dev. */
+function getHmacSecret(): string {
+    return process.env.PERMISSION_HMAC_SECRET || 'corvid-agent-dev-hmac-secret';
+}
+
+/** Sign a grant payload with HMAC-SHA256. */
+async function signGrant(agentId: string, action: string, createdAt: string): Promise<string> {
+    const secret = getHmacSecret();
+    const encoder = new TextEncoder();
+    const key = await crypto.subtle.importKey(
+        'raw',
+        encoder.encode(secret),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign'],
+    );
+    const data = encoder.encode(`${agentId}:${action}:${createdAt}`);
+    const sig = await crypto.subtle.sign('HMAC', key, data);
+    // Convert to hex string
+    return Array.from(new Uint8Array(sig))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+}
+
+/** Verify an HMAC signature on a grant. */
+async function verifySignature(agentId: string, action: string, createdAt: string, signature: string): Promise<boolean> {
+    const expected = await signGrant(agentId, action, createdAt);
+    // Constant-time comparison via subtle.verify would be ideal,
+    // but for hex strings at this length, timing leakage is negligible.
+    return expected === signature;
+}
+
+// ─── DB row shape ────────────────────────────────────────────────────────
+
+interface GrantRow {
+    id: number;
+    agent_id: string;
+    action: string;
+    granted_by: string;
+    reason: string;
+    signature: string;
+    expires_at: string | null;
+    revoked_at: string | null;
+    revoked_by: string | null;
+    tenant_id: string;
+    created_at: string;
+}
+
+function rowToGrant(row: GrantRow): PermissionGrant {
+    return {
+        id: row.id,
+        agentId: row.agent_id,
+        action: row.action,
+        grantedBy: row.granted_by,
+        reason: row.reason,
+        signature: row.signature,
+        expiresAt: row.expires_at,
+        revokedAt: row.revoked_at,
+        revokedBy: row.revoked_by,
+        tenantId: row.tenant_id,
+        createdAt: row.created_at,
+    };
+}
+
+// ─── Permission Broker ───────────────────────────────────────────────────
+
+export class PermissionBroker {
+    constructor(private db: Database) {}
+
+    /**
+     * Check whether an agent is permitted to use a tool.
+     * Returns the decision with timing and audit trail.
+     *
+     * Permission is granted if ANY active (non-expired, non-revoked) grant matches:
+     * 1. Exact action match (e.g. "git:create_pr")
+     * 2. Namespace wildcard (e.g. "git:*")
+     * 3. Superuser wildcard ("*")
+     */
+    async checkTool(
+        agentId: string,
+        toolName: string,
+        opts?: { sessionId?: string; tenantId?: string },
+    ): Promise<PermissionCheckResult> {
+        const start = performance.now();
+        const action = TOOL_ACTION_MAP[toolName];
+        const tenantId = opts?.tenantId ?? 'default';
+
+        // If the tool has no action mapping, it's not gated — allow by default
+        if (!action) {
+            return {
+                allowed: true,
+                grantId: null,
+                reason: `Tool "${toolName}" has no permission mapping — allowed by default`,
+                checkMs: performance.now() - start,
+            };
+        }
+
+        const result = await this.checkAction(agentId, action, tenantId);
+        const checkMs = performance.now() - start;
+
+        // Record the check in the audit trail
+        this.recordCheck(agentId, toolName, action, result.allowed, result.grantId, result.reason, checkMs, opts?.sessionId, tenantId);
+
+        return { ...result, checkMs };
+    }
+
+    /**
+     * Check whether an agent has a grant for a specific action.
+     */
+    async checkAction(
+        agentId: string,
+        action: PermissionAction,
+        tenantId: string = 'default',
+    ): Promise<PermissionCheckResult> {
+        const start = performance.now();
+        const now = new Date().toISOString();
+        const namespace = action.split(':')[0];
+
+        // Query for matching grants: exact action, namespace wildcard, or superuser
+        const rows = this.db.query(`
+            SELECT * FROM permission_grants
+            WHERE agent_id = ?
+              AND tenant_id = ?
+              AND revoked_at IS NULL
+              AND (expires_at IS NULL OR expires_at > ?)
+              AND (action = ? OR action = ? OR action = '*')
+            ORDER BY created_at DESC
+            LIMIT 1
+        `).all(agentId, tenantId, now, action, `${namespace}:*`) as GrantRow[];
+
+        if (rows.length === 0) {
+            return {
+                allowed: false,
+                grantId: null,
+                reason: `No active grant for action "${action}"`,
+                checkMs: performance.now() - start,
+            };
+        }
+
+        const grant = rows[0];
+
+        // Verify HMAC signature integrity
+        const valid = await verifySignature(grant.agent_id, grant.action, grant.created_at, grant.signature);
+        if (!valid) {
+            log.warn('Grant signature verification failed', { grantId: grant.id, agentId, action });
+            return {
+                allowed: false,
+                grantId: grant.id,
+                reason: `Grant #${grant.id} has invalid HMAC signature — possible tampering`,
+                checkMs: performance.now() - start,
+            };
+        }
+
+        return {
+            allowed: true,
+            grantId: grant.id,
+            reason: `Authorized by grant #${grant.id} (action: ${grant.action})`,
+            checkMs: performance.now() - start,
+        };
+    }
+
+    /**
+     * Grant a capability to an agent. Returns the created grant.
+     */
+    async grant(options: GrantOptions): Promise<PermissionGrant> {
+        const { agentId, action, grantedBy, reason = '', expiresAt = null, tenantId = 'default' } = options;
+        const createdAt = new Date().toISOString();
+        const signature = await signGrant(agentId, action, createdAt);
+
+        const result = this.db.query(`
+            INSERT INTO permission_grants (agent_id, action, granted_by, reason, signature, expires_at, tenant_id, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `).run(agentId, action, grantedBy, reason, signature, expiresAt, tenantId, createdAt);
+
+        const grantId = Number(result.lastInsertRowid);
+
+        recordAudit(this.db, 'permission_grant' as AuditAction, grantedBy, 'permission', String(grantId),
+            JSON.stringify({ agentId, action, expiresAt }));
+
+        log.info('Permission granted', { grantId, agentId, action, grantedBy });
+
+        return {
+            id: grantId,
+            agentId,
+            action,
+            grantedBy,
+            reason,
+            signature,
+            expiresAt,
+            revokedAt: null,
+            revokedBy: null,
+            tenantId,
+            createdAt,
+        };
+    }
+
+    /**
+     * Revoke a specific grant or all grants matching agent+action.
+     */
+    revoke(options: RevokeOptions): number {
+        const { grantId, agentId, action, revokedBy, reason, tenantId = 'default' } = options;
+        const revokedAt = new Date().toISOString();
+        let affected = 0;
+
+        if (grantId !== undefined) {
+            // Revoke specific grant
+            const result = this.db.query(`
+                UPDATE permission_grants
+                SET revoked_at = ?, revoked_by = ?
+                WHERE id = ? AND revoked_at IS NULL
+            `).run(revokedAt, revokedBy, grantId);
+            affected = result.changes;
+        } else if (agentId) {
+            // Revoke all matching grants for an agent
+            if (action) {
+                const result = this.db.query(`
+                    UPDATE permission_grants
+                    SET revoked_at = ?, revoked_by = ?
+                    WHERE agent_id = ? AND action = ? AND tenant_id = ? AND revoked_at IS NULL
+                `).run(revokedAt, revokedBy, agentId, action, tenantId);
+                affected = result.changes;
+            } else {
+                // Revoke ALL grants for an agent (emergency revocation)
+                const result = this.db.query(`
+                    UPDATE permission_grants
+                    SET revoked_at = ?, revoked_by = ?
+                    WHERE agent_id = ? AND tenant_id = ? AND revoked_at IS NULL
+                `).run(revokedAt, revokedBy, agentId, tenantId);
+                affected = result.changes;
+            }
+        }
+
+        if (affected > 0) {
+            recordAudit(this.db, 'permission_revoke' as AuditAction, revokedBy, 'permission',
+                grantId ? String(grantId) : agentId ?? '',
+                JSON.stringify({ agentId, action, reason, affected }));
+            log.info('Permission revoked', { grantId, agentId, action, revokedBy, affected });
+        }
+
+        return affected;
+    }
+
+    /**
+     * Emergency revocation — immediately revoke ALL grants for an agent.
+     * Used for compromised agents or security incidents.
+     */
+    emergencyRevoke(agentId: string, revokedBy: string, reason: string): number {
+        const count = this.revoke({ agentId, revokedBy, reason });
+        if (count > 0) {
+            log.warn('EMERGENCY REVOCATION', { agentId, revokedBy, reason, revokedCount: count });
+            recordAudit(this.db, 'permission_emergency_revoke' as AuditAction, revokedBy, 'permission', agentId,
+                JSON.stringify({ reason, revokedCount: count }));
+        }
+        return count;
+    }
+
+    /**
+     * List active grants for an agent.
+     */
+    getGrants(agentId: string, tenantId: string = 'default'): PermissionGrant[] {
+        const now = new Date().toISOString();
+        const rows = this.db.query(`
+            SELECT * FROM permission_grants
+            WHERE agent_id = ? AND tenant_id = ?
+              AND revoked_at IS NULL
+              AND (expires_at IS NULL OR expires_at > ?)
+            ORDER BY created_at DESC
+        `).all(agentId, tenantId, now) as GrantRow[];
+
+        return rows.map(rowToGrant);
+    }
+
+    /**
+     * Get all grants (including revoked/expired) for audit purposes.
+     */
+    getGrantHistory(agentId: string, tenantId: string = 'default', limit: number = 50): PermissionGrant[] {
+        const rows = this.db.query(`
+            SELECT * FROM permission_grants
+            WHERE agent_id = ? AND tenant_id = ?
+            ORDER BY created_at DESC
+            LIMIT ?
+        `).all(agentId, tenantId, limit) as GrantRow[];
+
+        return rows.map(rowToGrant);
+    }
+
+    /**
+     * Get the required action for a tool (for UI/documentation).
+     */
+    getRequiredAction(toolName: string): PermissionAction | null {
+        return TOOL_ACTION_MAP[toolName] ?? null;
+    }
+
+    // ─── Private helpers ─────────────────────────────────────────────────
+
+    private recordCheck(
+        agentId: string,
+        toolName: string,
+        action: string,
+        allowed: boolean,
+        grantId: number | null,
+        reason: string,
+        checkMs: number,
+        sessionId?: string,
+        tenantId: string = 'default',
+    ): void {
+        try {
+            this.db.query(`
+                INSERT INTO permission_checks (agent_id, tool_name, action, allowed, grant_id, reason, check_ms, session_id, tenant_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `).run(agentId, toolName, action, allowed ? 1 : 0, grantId, reason, checkMs, sessionId ?? null, tenantId);
+        } catch (err) {
+            // Never crash the caller — permission check audit is best-effort
+            log.error('Failed to record permission check', {
+                agentId, toolName, error: err instanceof Error ? err.message : String(err),
+            });
+        }
+    }
+}

--- a/server/permissions/index.ts
+++ b/server/permissions/index.ts
@@ -1,0 +1,10 @@
+export { PermissionBroker } from './broker';
+export { TOOL_ACTION_MAP } from './types';
+export type {
+    PermissionAction,
+    PermissionNamespace,
+    PermissionGrant,
+    PermissionCheckResult,
+    GrantOptions,
+    RevokeOptions,
+} from './types';

--- a/server/permissions/types.ts
+++ b/server/permissions/types.ts
@@ -1,0 +1,122 @@
+/**
+ * Permission Broker types — capability-based security for agent actions.
+ *
+ * Actions follow a namespace:verb pattern (e.g. "git:create_pr", "msg:send").
+ * A wildcard ("git:*") grants all actions in a namespace.
+ * The special action "*" grants all capabilities (superuser).
+ */
+
+/** Action namespaces map to MCP tool groups. */
+export type PermissionNamespace =
+    | 'git'       // GitHub operations
+    | 'msg'       // Messaging (AlgoChat, notifications)
+    | 'credits'   // Credit grants/config
+    | 'schedule'  // Schedule management
+    | 'workflow'  // Workflow orchestration
+    | 'work'      // Work task creation
+    | 'search'    // Web search, deep research
+    | 'agent'     // Agent discovery, remote invocation
+    | 'fs'        // File system (coding tools)
+    | 'repo'      // Repo blocklist management
+    | 'reputation' // Reputation system
+    | 'owner';    // Owner communication
+
+/** A permission action string: "namespace:verb", "namespace:*", or "*". */
+export type PermissionAction = string;
+
+/** Maps MCP tool names to their required permission action. */
+export const TOOL_ACTION_MAP: Record<string, PermissionAction> = {
+    // Git/GitHub
+    corvid_github_star_repo: 'git:star',
+    corvid_github_unstar_repo: 'git:unstar',
+    corvid_github_fork_repo: 'git:fork',
+    corvid_github_list_prs: 'git:read',
+    corvid_github_create_pr: 'git:create_pr',
+    corvid_github_review_pr: 'git:review_pr',
+    corvid_github_create_issue: 'git:create_issue',
+    corvid_github_list_issues: 'git:read',
+    corvid_github_repo_info: 'git:read',
+    corvid_github_get_pr_diff: 'git:read',
+    corvid_github_comment_on_pr: 'git:comment',
+    corvid_github_follow_user: 'git:follow',
+    // Messaging
+    corvid_send_message: 'msg:send',
+    corvid_notify_owner: 'owner:notify',
+    corvid_ask_owner: 'owner:ask',
+    corvid_configure_notifications: 'owner:configure',
+    // Credits
+    corvid_grant_credits: 'credits:grant',
+    corvid_credit_config: 'credits:config',
+    corvid_check_credits: 'credits:read',
+    // Scheduling & workflow
+    corvid_manage_schedule: 'schedule:manage',
+    corvid_manage_workflow: 'workflow:manage',
+    corvid_create_work_task: 'work:create',
+    // Search
+    corvid_web_search: 'search:web',
+    corvid_deep_research: 'search:deep',
+    // Agent
+    corvid_list_agents: 'agent:list',
+    corvid_discover_agent: 'agent:discover',
+    corvid_invoke_remote_agent: 'agent:invoke',
+    // Memory
+    corvid_save_memory: 'agent:memory',
+    corvid_recall_memory: 'agent:memory',
+    corvid_extend_timeout: 'agent:extend',
+    // File system (coding tools)
+    corvid_code_symbols: 'fs:read',
+    corvid_find_references: 'fs:read',
+    // Repo blocklist
+    corvid_repo_blocklist: 'repo:manage',
+    // Reputation
+    corvid_check_reputation: 'reputation:read',
+    corvid_check_health_trends: 'reputation:read',
+    corvid_publish_attestation: 'reputation:publish',
+    corvid_verify_agent_reputation: 'reputation:verify',
+};
+
+/** A stored permission grant. */
+export interface PermissionGrant {
+    id: number;
+    agentId: string;
+    action: PermissionAction;
+    grantedBy: string;
+    reason: string;
+    signature: string;
+    expiresAt: string | null;
+    revokedAt: string | null;
+    revokedBy: string | null;
+    tenantId: string;
+    createdAt: string;
+}
+
+/** Result of a permission check. */
+export interface PermissionCheckResult {
+    allowed: boolean;
+    /** The grant that authorized this action (if allowed). */
+    grantId: number | null;
+    /** Human-readable reason for the decision. */
+    reason: string;
+    /** Time taken for the check in ms. */
+    checkMs: number;
+}
+
+/** Options for granting a permission. */
+export interface GrantOptions {
+    agentId: string;
+    action: PermissionAction;
+    grantedBy: string;
+    reason?: string;
+    expiresAt?: string | null;
+    tenantId?: string;
+}
+
+/** Options for revoking permissions. */
+export interface RevokeOptions {
+    grantId?: number;
+    agentId?: string;
+    action?: PermissionAction;
+    revokedBy: string;
+    reason?: string;
+    tenantId?: string;
+}

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -26,6 +26,7 @@ import type { ReputationScorer } from '../reputation/scorer';
 import type { ReputationAttestation } from '../reputation/attestation';
 import type { ReputationVerifier } from '../reputation/verifier';
 import type { AstParserService } from '../ast/service';
+import type { PermissionBroker } from '../permissions/broker';
 import { createCorvidMcpServer } from '../mcp/sdk-tools';
 import type { McpToolContext } from '../mcp/tool-handlers';
 import { recordApiCost } from '../db/spending';
@@ -118,6 +119,7 @@ export class ProcessManager {
     private mcpReputationAttestation: ReputationAttestation | null = null;
     private mcpReputationVerifier: ReputationVerifier | null = null;
     private mcpAstParserService: AstParserService | null = null;
+    private mcpPermissionBroker: PermissionBroker | null = null;
 
     constructor(db: Database) {
         this.db = db;
@@ -156,6 +158,7 @@ export class ProcessManager {
         reputationAttestation?: ReputationAttestation,
         reputationVerifier?: ReputationVerifier,
         astParserService?: AstParserService,
+        permissionBroker?: PermissionBroker,
     ): void {
         this.mcpMessenger = messenger;
         this.mcpDirectory = directory;
@@ -170,6 +173,7 @@ export class ProcessManager {
         this.mcpReputationAttestation = reputationAttestation ?? null;
         this.mcpReputationVerifier = reputationVerifier ?? null;
         this.mcpAstParserService = astParserService ?? null;
+        this.mcpPermissionBroker = permissionBroker ?? null;
         log.info('MCP services registered — agent sessions will receive corvid_* tools');
     }
 
@@ -210,6 +214,7 @@ export class ProcessManager {
             reputationVerifier: this.mcpReputationVerifier ?? undefined,
             resolvedToolPermissions,
             astParserService: this.mcpAstParserService ?? undefined,
+            permissionBroker: this.mcpPermissionBroker ?? undefined,
         };
     }
 

--- a/server/routes/permissions.ts
+++ b/server/routes/permissions.ts
@@ -1,0 +1,137 @@
+/**
+ * Permission Broker API routes — manage capability grants for agents.
+ *
+ * All endpoints require ADMIN_API_KEY authentication (handled by the route guard).
+ *
+ * POST /api/permissions/grant      — Grant a capability to an agent
+ * POST /api/permissions/revoke     — Revoke a specific grant or all grants for an agent
+ * GET  /api/permissions/:agentId   — List active grants for an agent
+ * POST /api/permissions/check      — Check if an agent can use a tool
+ * POST /api/permissions/emergency-revoke — Revoke ALL grants for an agent immediately
+ */
+
+import type { Database } from 'bun:sqlite';
+import { PermissionBroker } from '../permissions/broker';
+import { TOOL_ACTION_MAP } from '../permissions/types';
+import { json, badRequest, notFound } from '../lib/response';
+
+export function handlePermissionRoutes(
+    req: Request,
+    url: URL,
+    db: Database,
+): Response | Promise<Response> | null {
+    if (!url.pathname.startsWith('/api/permissions')) return null;
+
+    const broker = new PermissionBroker(db);
+    const method = req.method;
+
+    // POST /api/permissions/grant
+    if (url.pathname === '/api/permissions/grant' && method === 'POST') {
+        return handleGrant(req, broker);
+    }
+
+    // POST /api/permissions/revoke
+    if (url.pathname === '/api/permissions/revoke' && method === 'POST') {
+        return handleRevoke(req, broker);
+    }
+
+    // POST /api/permissions/emergency-revoke
+    if (url.pathname === '/api/permissions/emergency-revoke' && method === 'POST') {
+        return handleEmergencyRevoke(req, broker);
+    }
+
+    // POST /api/permissions/check
+    if (url.pathname === '/api/permissions/check' && method === 'POST') {
+        return handleCheck(req, broker);
+    }
+
+    // GET /api/permissions/actions — list the action taxonomy
+    if (url.pathname === '/api/permissions/actions' && method === 'GET') {
+        return json({ actions: TOOL_ACTION_MAP });
+    }
+
+    // GET /api/permissions/:agentId — list active grants
+    const agentMatch = url.pathname.match(/^\/api\/permissions\/([^/]+)$/);
+    if (agentMatch && method === 'GET') {
+        const agentId = agentMatch[1];
+        const tenantId = url.searchParams.get('tenant_id') ?? 'default';
+        const includeHistory = url.searchParams.get('history') === 'true';
+
+        const grants = includeHistory
+            ? broker.getGrantHistory(agentId, tenantId)
+            : broker.getGrants(agentId, tenantId);
+
+        return json({ agentId, grants, count: grants.length });
+    }
+
+    return notFound('Permission endpoint not found');
+}
+
+async function handleGrant(req: Request, broker: PermissionBroker): Promise<Response> {
+    const body = await req.json().catch(() => null);
+    if (!body) return badRequest('Invalid JSON body');
+
+    const { agent_id, action, granted_by, reason, expires_at, tenant_id } = body;
+    if (!agent_id || !action) return badRequest('agent_id and action are required');
+
+    const grant = await broker.grant({
+        agentId: agent_id,
+        action,
+        grantedBy: granted_by ?? 'api',
+        reason: reason ?? '',
+        expiresAt: expires_at ?? null,
+        tenantId: tenant_id ?? 'default',
+    });
+
+    return json({ grant }, 201);
+}
+
+async function handleRevoke(req: Request, broker: PermissionBroker): Promise<Response> {
+    const body = await req.json().catch(() => null);
+    if (!body) return badRequest('Invalid JSON body');
+
+    const { grant_id, agent_id, action, revoked_by, reason, tenant_id } = body;
+    if (!grant_id && !agent_id) return badRequest('grant_id or agent_id is required');
+
+    const affected = broker.revoke({
+        grantId: grant_id,
+        agentId: agent_id,
+        action,
+        revokedBy: revoked_by ?? 'api',
+        reason,
+        tenantId: tenant_id ?? 'default',
+    });
+
+    return json({ affected });
+}
+
+async function handleEmergencyRevoke(req: Request, broker: PermissionBroker): Promise<Response> {
+    const body = await req.json().catch(() => null);
+    if (!body) return badRequest('Invalid JSON body');
+
+    const { agent_id, revoked_by, reason } = body;
+    if (!agent_id) return badRequest('agent_id is required');
+
+    const affected = broker.emergencyRevoke(
+        agent_id,
+        revoked_by ?? 'api',
+        reason ?? 'Emergency revocation via API',
+    );
+
+    return json({ affected, emergency: true });
+}
+
+async function handleCheck(req: Request, broker: PermissionBroker): Promise<Response> {
+    const body = await req.json().catch(() => null);
+    if (!body) return badRequest('Invalid JSON body');
+
+    const { agent_id, tool_name, session_id, tenant_id } = body;
+    if (!agent_id || !tool_name) return badRequest('agent_id and tool_name are required');
+
+    const result = await broker.checkTool(agent_id, tool_name, {
+        sessionId: session_id,
+        tenantId: tenant_id ?? 'default',
+    });
+
+    return json({ ...result });
+}


### PR DESCRIPTION
## Summary
- **Phase 1** of capability-based security for agent actions (#557)
- HMAC-SHA256 signed permission grants with action-level granularity
- Maps all 35+ MCP tools to `namespace:verb` actions (`git:create_pr`, `msg:send`, `credits:grant`, etc.)
- Exact match, namespace wildcard (`git:*`), and superuser (`*`) grant types
- Emergency revocation for compromised agents
- Full audit trail in `permission_checks` table
- REST API for grant/revoke/check operations
- Multi-tenant isolation via `tenant_id`
- <10ms permission checks (target met)

## Files changed (12 files, +1249/-3)
- `server/permissions/` — types, broker service, index (new module)
- `server/db/migrations/065_permission_broker.ts` — schema migration
- `server/db/schema.ts` — inline migration for parity
- `server/routes/permissions.ts` — REST API endpoints
- `server/__tests__/permission-broker.test.ts` — 43 tests
- Integration: `bootstrap.ts`, `index.ts`, `manager.ts`, `types.ts`, `audit.ts`

## Test plan
- [x] 43 unit tests covering grant, check, revoke, emergency revoke, HMAC integrity, API routes, migration
- [x] TSC clean (`bunx tsc --noEmit --skipLibCheck`)
- [x] 5094 tests pass, 0 fail (full suite)
- [x] 107/107 specs pass (`bun run spec:check`)
- [x] Migration parity test passes (inline + file-based)

Closes #557 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)