### PR TITLE
feat: add empty states with guided actions across dashboard pages

### DIFF
--- a/client/src/app/features/agents/agent-list.component.ts
+++ b/client/src/app/features/agents/agent-list.component.ts
@@ -5,6 +5,7 @@ import { DecimalPipe } from '@angular/common';
 import { AgentService } from '../../core/services/agent.service';
 import { SessionService } from '../../core/services/session.service';
 import { PersonaService } from '../../core/services/persona.service';
+import { EmptyStateComponent } from '../../shared/components/empty-state.component';
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 import type { Agent } from '../../core/models/agent.model';
 
@@ -20,7 +21,7 @@ interface AgentCard {
 @Component({
     selector: 'app-agent-list',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [RouterLink, FormsModule, DecimalPipe, RelativeTimePipe],
+    imports: [RouterLink, FormsModule, DecimalPipe, EmptyStateComponent, RelativeTimePipe],
     template: `
         <div class="page">
             <div class="page__header">
@@ -76,7 +77,12 @@ interface AgentCard {
             @if (agentService.loading()) {
                 <p class="loading">Loading...</p>
             } @else if (agentService.agents().length === 0) {
-                <p class="empty">No agents configured. Create one to define how Claude behaves.</p>
+                <app-empty-state
+                    icon="\u25C6"
+                    title="No agents configured"
+                    subtitle="Create an agent to define how Claude behaves, what tools it can use, and its permissions."
+                    ctaLabel="+ New Agent"
+                    ctaRoute="/agents/new" />
             } @else if (filteredAgents().length === 0) {
                 <p class="empty">No agents match your filters.</p>
             } @else {

--- a/client/src/app/features/councils/council-list.component.ts
+++ b/client/src/app/features/councils/council-list.component.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy, inject, OnInit, signal, computed } 
 import { RouterLink } from '@angular/router';
 import { CouncilService } from '../../core/services/council.service';
 import { AgentService } from '../../core/services/agent.service';
+import { EmptyStateComponent } from '../../shared/components/empty-state.component';
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 import type { Council, CouncilLaunch } from '../../core/models/council.model';
 
@@ -15,7 +16,7 @@ interface CouncilCard {
 @Component({
     selector: 'app-council-list',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [RouterLink, RelativeTimePipe],
+    imports: [RouterLink, EmptyStateComponent, RelativeTimePipe],
     template: `
         <div class="page">
             <div class="page__header">
@@ -26,7 +27,12 @@ interface CouncilCard {
             @if (councilService.loading()) {
                 <p class="loading">Loading...</p>
             } @else if (councilService.councils().length === 0) {
-                <p class="empty">No councils configured. Create one to run multi-agent deliberations.</p>
+                <app-empty-state
+                    icon="\u25CE"
+                    title="No councils configured"
+                    subtitle="Create a council to run multi-agent deliberations with discussion rounds and synthesis."
+                    ctaLabel="New Council"
+                    ctaRoute="/councils/new" />
             } @else {
                 <div class="council-grid">
                     @for (card of cards(); track card.council.id) {

--- a/client/src/app/features/schedules/schedule-list.component.ts
+++ b/client/src/app/features/schedules/schedule-list.component.ts
@@ -5,13 +5,14 @@ import { SlicePipe } from '@angular/common';
 import { ScheduleService } from '../../core/services/schedule.service';
 import { AgentService } from '../../core/services/agent.service';
 import { NotificationService } from '../../core/services/notification.service';
+import { EmptyStateComponent } from '../../shared/components/empty-state.component';
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 import type { AgentSchedule, ScheduleExecution, ScheduleAction, ScheduleActionType, ScheduleApprovalPolicy, ScheduleTriggerEvent } from '../../core/models/schedule.model';
 
 @Component({
     selector: 'app-schedule-list',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [RouterLink, FormsModule, SlicePipe, RelativeTimePipe],
+    imports: [RouterLink, FormsModule, SlicePipe, EmptyStateComponent, RelativeTimePipe],
     template: `
         <div class="schedules">
             <div class="schedules__header">
@@ -190,10 +191,16 @@ import type { AgentSchedule, ScheduleExecution, ScheduleAction, ScheduleActionTy
 
             @if (scheduleService.loading()) {
                 <p class="loading">Loading schedules...</p>
+            } @else if (scheduleService.schedules().length === 0) {
+                <app-empty-state
+                    icon="\u25F7"
+                    title="No schedules yet"
+                    subtitle="Automate agent tasks like PR reviews, repo starring, and codebase audits on a cron or interval."
+                    ctaLabel="+ New Schedule"
+                    (ctaClick)="showCreateForm.set(true)" />
             } @else if (filteredSchedules().length === 0) {
                 <div class="empty">
-                    <p>No {{ activeFilter() === 'all' ? '' : activeFilter() + ' ' }}schedules found.</p>
-                    <p class="empty-hint">Create a schedule to automate agent tasks like PR reviews, repo starring, and more.</p>
+                    <p>No {{ activeFilter() === 'all' ? '' : activeFilter() + ' ' }}schedules match.</p>
                 </div>
             } @else {
                 <div class="schedule-list">

--- a/client/src/app/features/sessions/session-list.component.ts
+++ b/client/src/app/features/sessions/session-list.component.ts
@@ -5,13 +5,14 @@ import { DecimalPipe, SlicePipe } from '@angular/common';
 import { SessionService } from '../../core/services/session.service';
 import { AgentService } from '../../core/services/agent.service';
 import { StatusBadgeComponent } from '../../shared/components/status-badge.component';
+import { EmptyStateComponent } from '../../shared/components/empty-state.component';
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 import type { Session, SessionStatus, SessionSource } from '../../core/models/session.model';
 
 @Component({
     selector: 'app-session-list',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [RouterLink, FormsModule, StatusBadgeComponent, RelativeTimePipe, DecimalPipe, SlicePipe],
+    imports: [RouterLink, FormsModule, StatusBadgeComponent, EmptyStateComponent, RelativeTimePipe, DecimalPipe, SlicePipe],
     template: `
         <div class="page">
             <div class="page__header">
@@ -61,6 +62,13 @@ import type { Session, SessionStatus, SessionSource } from '../../core/models/se
 
             @if (sessionService.loading()) {
                 <p class="loading">Loading...</p>
+            } @else if (sessionService.sessions().length === 0) {
+                <app-empty-state
+                    icon="\u25C8"
+                    title="No sessions yet"
+                    subtitle="Start a conversation with one of your agents to see it here."
+                    ctaLabel="+ New Conversation"
+                    ctaRoute="/sessions/new" />
             } @else if (filteredSessions().length === 0) {
                 <p class="empty">No conversations match your filters.</p>
             } @else {

--- a/client/src/app/features/work-tasks/work-task-list.component.ts
+++ b/client/src/app/features/work-tasks/work-task-list.component.ts
@@ -4,12 +4,13 @@ import { FormsModule } from '@angular/forms';
 import { WorkTaskService } from '../../core/services/work-task.service';
 import { AgentService } from '../../core/services/agent.service';
 import { NotificationService } from '../../core/services/notification.service';
+import { EmptyStateComponent } from '../../shared/components/empty-state.component';
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 
 @Component({
     selector: 'app-work-task-list',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [RouterLink, FormsModule, RelativeTimePipe],
+    imports: [RouterLink, FormsModule, EmptyStateComponent, RelativeTimePipe],
     template: `
         <div class="tasks">
             <div class="tasks__header">
@@ -63,6 +64,13 @@ import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 
             @if (taskService.loading()) {
                 <p class="loading">Loading work tasks...</p>
+            } @else if (taskService.tasks().length === 0) {
+                <app-empty-state
+                    icon="\u26A1"
+                    title="No work tasks yet"
+                    subtitle="Spawn an agent session to implement code changes, open PRs, and validate builds automatically."
+                    ctaLabel="+ New Task"
+                    (ctaClick)="showCreateForm.set(true)" />
             } @else if (filteredTasks().length === 0) {
                 <div class="empty">
                     <p>No {{ activeFilter() === 'all' ? '' : activeFilter() + ' ' }}work tasks found.</p>

--- a/client/src/app/shared/components/empty-state.component.ts
+++ b/client/src/app/shared/components/empty-state.component.ts
@@ -1,0 +1,88 @@
+import { Component, ChangeDetectionStrategy, input, output } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+    selector: 'app-empty-state',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [RouterLink],
+    template: `
+        <div class="empty-state" role="status">
+            <span class="empty-state__icon" aria-hidden="true">{{ icon() }}</span>
+            <p class="empty-state__title">{{ title() }}</p>
+            @if (subtitle()) {
+                <p class="empty-state__subtitle">{{ subtitle() }}</p>
+            }
+            @if (ctaLabel() && ctaRoute()) {
+                <a class="empty-state__cta" [routerLink]="ctaRoute()">{{ ctaLabel() }}</a>
+            } @else if (ctaLabel()) {
+                <button class="empty-state__cta" (click)="ctaClick.emit()">{{ ctaLabel() }}</button>
+            }
+        </div>
+    `,
+    styles: `
+        .empty-state {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 3rem 1.5rem;
+            text-align: center;
+            border: 1px dashed var(--border-bright);
+            border-radius: var(--radius-lg);
+            background: var(--bg-surface);
+        }
+        .empty-state__icon {
+            font-size: 2.5rem;
+            line-height: 1;
+            margin-bottom: 1rem;
+            color: var(--accent-cyan);
+            text-shadow: var(--glow-cyan);
+        }
+        .empty-state__title {
+            margin: 0 0 0.35rem;
+            font-size: 0.9rem;
+            font-weight: 700;
+            color: var(--text-primary);
+            line-height: 1.4;
+        }
+        .empty-state__subtitle {
+            margin: 0 0 1rem;
+            font-size: 0.75rem;
+            color: var(--text-secondary);
+            line-height: 1.5;
+            max-width: 36ch;
+        }
+        .empty-state__cta {
+            display: inline-block;
+            padding: 0.5rem 1.25rem;
+            border: 1px solid var(--accent-cyan);
+            border-radius: var(--radius);
+            background: var(--accent-cyan-dim);
+            color: var(--accent-cyan);
+            font-size: 0.8rem;
+            font-weight: 600;
+            font-family: inherit;
+            text-decoration: none;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            cursor: pointer;
+            transition: background 0.15s, box-shadow 0.15s;
+        }
+        .empty-state__cta:hover {
+            background: rgba(0, 229, 255, 0.2);
+            box-shadow: var(--glow-cyan);
+        }
+        .empty-state__cta:focus-visible {
+            outline: 2px solid var(--accent-cyan);
+            outline-offset: 2px;
+        }
+    `,
+})
+export class EmptyStateComponent {
+    readonly icon = input.required<string>();
+    readonly title = input.required<string>();
+    readonly subtitle = input<string>('');
+    readonly ctaLabel = input<string>('');
+    readonly ctaRoute = input<string>('');
+    readonly ctaClick = output<void>();
+}


### PR DESCRIPTION
## Summary
- Created shared `EmptyStateComponent` (`client/src/app/shared/components/empty-state.component.ts`) with configurable icon, title, subtitle, and CTA (route link or click handler)
- Added onboarding empty states to all 5 dashboard list pages: **sessions**, **agents**, **schedules**, **councils**, **work-tasks**
- Each page now distinguishes "no data yet" (shows guided empty state with CTA) from "no filter matches" (shows simple text message)
- Uses cyberpunk color palette from #604 (cyan accent, glow effects, dashed border container)
- WCAG AAA compliant — `#e0e0ec` on `#0f1018` = ~14:1, `#00e5ff` on `#0f1018` = ~11:1

| Page | Icon | CTA |
|------|------|-----|
| Sessions | ◈ | + New Conversation → `/sessions/new` |
| Agents | ◆ | + New Agent → `/agents/new` |
| Schedules | ◷ | + New Schedule (opens form) |
| Councils | ◎ | New Council → `/councils/new` |
| Work Tasks | ⚡ | + New Task (opens form) |

Closes #607

## Test plan
- [x] TSC clean (`bunx tsc --noEmit --skipLibCheck`)
- [x] Verify empty states render when no data exists for each page
- [x] Verify CTA buttons navigate/open forms correctly
- [x] Verify filtered-empty still shows simple "no matches" text
- [x] Verify contrast meets WCAG AAA (7:1+) in browser dev tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)