### PR TITLE
feat: sessions page — time grouping, shimmer loading, smart sort

### DIFF
--- a/client/src/app/features/sessions/session-list.component.ts
+++ b/client/src/app/features/sessions/session-list.component.ts
@@ -98,7 +98,7 @@ interface SessionGroup {
                                     <span class="session-table__name" [title]="sessionDisplayName(session)">{{ sessionDisplayName(session) }}</span>
                                     <span class="session-table__agent" [title]="getAgentName(session.agentId)">{{ getAgentName(session.agentId) }}</span>
                                     <span><app-status-badge [status]="session.status" /></span>
-                                    <span class="session-table__cost">${{ session.totalCostUsd | number:'1.2-4' }}</span>
+                                    <span class="session-table__cost">\${{ session.totalCostUsd | number:'1.2-4' }}</span>
                                     <span class="session-table__source">{{ session.source }}</span>
                                     <span class="session-table__time">{{ session.updatedAt | relativeTime }}</span>
                                 </a>


### PR DESCRIPTION
## Summary
- Group sessions by **Today/Yesterday/This Week/Older** for quick scanning
- **Running sessions** sort to top within each group with green left border
- **Shimmer skeleton** loading animation instead of plain "Loading..." text
- Show first 60 chars of prompt as display name (was 40 / raw ID)
- **Title attributes** on truncated text for hover tooltips
- Monospace font for cost column
- Responsive skeleton on mobile breakpoints

## Part of
UI Overhaul Epic #604

## Test plan
- [x] Sessions page loads with shimmer skeleton
- [x] Sessions grouped by time period
- [x] Running sessions appear first with green left border
- [x] Long session names show full text on hover
- [x] Mobile layout hides extra columns and skeletons
- [x] TSC passes

Closes #606