### PR TITLE
security: add dashboard auth middleware with DASHBOARD_API_KEY

### DIFF
--- a/server/__tests__/dashboard-auth-guard.test.ts
+++ b/server/__tests__/dashboard-auth-guard.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { dashboardAuthGuard, createRequestContext } from '../middleware/guards';
+
+function fakeReq(path: string, headers?: Record<string, string>): { req: Request; url: URL } {
+    const url = new URL(`http://localhost:3000${path}`);
+    return { req: new Request(url.toString(), { headers }), url };
+}
+
+describe('dashboardAuthGuard', () => {
+    const originalEnv = process.env.DASHBOARD_API_KEY;
+
+    afterEach(() => {
+        if (originalEnv === undefined) {
+            delete process.env.DASHBOARD_API_KEY;
+        } else {
+            process.env.DASHBOARD_API_KEY = originalEnv;
+        }
+    });
+
+    describe('localhost bypass', () => {
+        it('allows unauthenticated access on 127.0.0.1', () => {
+            process.env.DASHBOARD_API_KEY = 'test-dashboard-key';
+            const guard = dashboardAuthGuard('127.0.0.1');
+            const ctx = createRequestContext();
+            const { req, url } = fakeReq('/api/dashboard/summary');
+            expect(guard(req, url, ctx)).toBeNull();
+        });
+
+        it('allows unauthenticated access on localhost', () => {
+            process.env.DASHBOARD_API_KEY = 'test-dashboard-key';
+            const guard = dashboardAuthGuard('localhost');
+            const ctx = createRequestContext();
+            const { req, url } = fakeReq('/api/dashboard/summary');
+            expect(guard(req, url, ctx)).toBeNull();
+        });
+
+        it('allows unauthenticated access on ::1', () => {
+            process.env.DASHBOARD_API_KEY = 'test-dashboard-key';
+            const guard = dashboardAuthGuard('::1');
+            const ctx = createRequestContext();
+            const { req, url } = fakeReq('/api/dashboard/summary');
+            expect(guard(req, url, ctx)).toBeNull();
+        });
+    });
+
+    describe('non-dashboard paths passthrough', () => {
+        it('ignores non-dashboard paths', () => {
+            process.env.DASHBOARD_API_KEY = 'test-dashboard-key';
+            const guard = dashboardAuthGuard('0.0.0.0');
+            const ctx = createRequestContext();
+            const { req, url } = fakeReq('/api/agents');
+            expect(guard(req, url, ctx)).toBeNull();
+        });
+    });
+
+    describe('already authenticated via API_KEY', () => {
+        it('allows through when context.authenticated is true', () => {
+            process.env.DASHBOARD_API_KEY = 'test-dashboard-key';
+            const guard = dashboardAuthGuard('0.0.0.0');
+            const ctx = createRequestContext();
+            ctx.authenticated = true;
+            const { req, url } = fakeReq('/api/dashboard/summary');
+            expect(guard(req, url, ctx)).toBeNull();
+        });
+    });
+
+    describe('DASHBOARD_API_KEY not set', () => {
+        it('returns 401 when no DASHBOARD_API_KEY and not authenticated on non-localhost', () => {
+            delete process.env.DASHBOARD_API_KEY;
+            const guard = dashboardAuthGuard('0.0.0.0');
+            const ctx = createRequestContext();
+            const { req, url } = fakeReq('/api/dashboard/summary');
+            const res = guard(req, url, ctx);
+            expect(res).not.toBeNull();
+            expect(res!.status).toBe(401);
+        });
+    });
+
+    describe('DASHBOARD_API_KEY set on non-localhost', () => {
+        it('returns 401 when no Authorization header', () => {
+            process.env.DASHBOARD_API_KEY = 'secret-dashboard-key';
+            const guard = dashboardAuthGuard('0.0.0.0');
+            const ctx = createRequestContext();
+            const { req, url } = fakeReq('/api/dashboard/summary');
+            const res = guard(req, url, ctx);
+            expect(res).not.toBeNull();
+            expect(res!.status).toBe(401);
+        });
+
+        it('returns 401 for malformed Authorization header', () => {
+            process.env.DASHBOARD_API_KEY = 'secret-dashboard-key';
+            const guard = dashboardAuthGuard('0.0.0.0');
+            const ctx = createRequestContext();
+            const { req, url } = fakeReq('/api/dashboard/summary', {
+                Authorization: 'Basic abc123',
+            });
+            const res = guard(req, url, ctx);
+            expect(res).not.toBeNull();
+            expect(res!.status).toBe(401);
+        });
+
+        it('returns 403 for invalid dashboard key', () => {
+            process.env.DASHBOARD_API_KEY = 'secret-dashboard-key';
+            const guard = dashboardAuthGuard('0.0.0.0');
+            const ctx = createRequestContext();
+            const { req, url } = fakeReq('/api/dashboard/summary', {
+                Authorization: 'Bearer wrong-key',
+            });
+            const res = guard(req, url, ctx);
+            expect(res).not.toBeNull();
+            expect(res!.status).toBe(403);
+        });
+
+        it('allows valid dashboard key', () => {
+            process.env.DASHBOARD_API_KEY = 'secret-dashboard-key';
+            const guard = dashboardAuthGuard('0.0.0.0');
+            const ctx = createRequestContext();
+            const { req, url } = fakeReq('/api/dashboard/summary', {
+                Authorization: 'Bearer secret-dashboard-key',
+            });
+            const res = guard(req, url, ctx);
+            expect(res).toBeNull();
+            expect(ctx.authenticated).toBe(true);
+        });
+
+        it('works with sub-paths under /api/dashboard', () => {
+            process.env.DASHBOARD_API_KEY = 'secret-dashboard-key';
+            const guard = dashboardAuthGuard('0.0.0.0');
+            const ctx = createRequestContext();
+            const { req, url } = fakeReq('/api/dashboard/other', {
+                Authorization: 'Bearer secret-dashboard-key',
+            });
+            expect(guard(req, url, ctx)).toBeNull();
+        });
+    });
+});

--- a/server/middleware/guards.ts
+++ b/server/middleware/guards.ts
@@ -4,7 +4,7 @@
 
 import type { Database } from 'bun:sqlite';
 import type { AuthConfig } from './auth';
-import { checkHttpAuth } from './auth';
+import { checkHttpAuth, timingSafeEqual } from './auth';
 import type { RateLimiter } from './rate-limit';
 import { getClientIp } from './rate-limit';
 import type { EndpointRateLimiter, RateLimitResult } from './endpoint-rate-limit';
@@ -208,6 +208,65 @@ export function tenantRoleGuard(...roles: TenantRole[]): Guard {
                 headers: { 'Content-Type': 'application/json' },
             });
         }
+        return null;
+    };
+}
+
+/**
+ * Dashboard auth guard — requires DASHBOARD_API_KEY for /api/dashboard/* routes.
+ * Bypassed when BIND_HOST is localhost (127.0.0.1, ::1, localhost).
+ * When the general API_KEY is set and the request already passed authGuard,
+ * this guard is satisfied (defense-in-depth: dashboard is still protected).
+ */
+export function dashboardAuthGuard(bindHost: string): Guard {
+    const dashboardApiKey = process.env.DASHBOARD_API_KEY?.trim() || null;
+    const isLocalhost = bindHost === '127.0.0.1' || bindHost === 'localhost' || bindHost === '::1';
+
+    return (req: Request, url: URL, context: RequestContext): Response | null => {
+        // Only apply to dashboard paths
+        if (!url.pathname.startsWith('/api/dashboard')) return null;
+
+        // Bypass on localhost
+        if (isLocalhost) return null;
+
+        // If already authenticated via general API_KEY, allow through
+        if (context.authenticated) return null;
+
+        // No DASHBOARD_API_KEY configured and not authenticated — block
+        if (!dashboardApiKey) {
+            return new Response(JSON.stringify({ error: 'Dashboard authentication required. Set DASHBOARD_API_KEY or API_KEY.' }), {
+                status: 401,
+                headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer' },
+            });
+        }
+
+        // Check bearer token
+        const authHeader = req.headers.get('Authorization');
+        if (!authHeader) {
+            return new Response(JSON.stringify({ error: 'Dashboard authentication required' }), {
+                status: 401,
+                headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer' },
+            });
+        }
+
+        const match = authHeader.match(/^Bearer\s+(.+)$/i);
+        if (!match) {
+            return new Response(JSON.stringify({ error: 'Invalid Authorization header format. Expected: Bearer <key>' }), {
+                status: 401,
+                headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer' },
+            });
+        }
+
+        if (!timingSafeEqual(match[1], dashboardApiKey)) {
+            log.warn('Rejected dashboard request with invalid DASHBOARD_API_KEY', { path: url.pathname });
+            return new Response(JSON.stringify({ error: 'Invalid dashboard API key' }), {
+                status: 403,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        // Dashboard key is valid — mark as authenticated
+        context.authenticated = true;
         return null;
     };
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -58,6 +58,7 @@ import { RateLimiter, loadRateLimitConfig } from '../middleware/rate-limit';
 import { EndpointRateLimiter, loadEndpointRateLimitConfig } from '../middleware/endpoint-rate-limit';
 import {
     authGuard,
+    dashboardAuthGuard,
     roleGuard,
     rateLimitGuard,
     endpointRateLimitGuard,
@@ -209,6 +210,11 @@ export async function handleRequest(
         tenantGuard(db, tenantService ?? null),
         endpointRateLimitGuard(endpointRateLimiter),
     ];
+
+    // Dashboard-specific auth: requires DASHBOARD_API_KEY on non-localhost
+    if (url.pathname.startsWith('/api/dashboard')) {
+        guards.push(dashboardAuthGuard(config.bindHost));
+    }
 
     // Apply admin role guard for sensitive endpoints
     if (requiresAdminRole(url.pathname)) {


### PR DESCRIPTION
## Summary
- Adds `dashboardAuthGuard` to protect `/api/dashboard/*` endpoints with a dedicated `DASHBOARD_API_KEY` bearer token
- Bypasses auth when `BIND_HOST` is localhost (127.0.0.1, ::1, localhost) for local dev convenience
- Falls through to existing `API_KEY` auth when already authenticated (defense-in-depth)
- Uses timing-safe comparison (`timingSafeEqual`) to prevent side-channel attacks on key validation

## Changes
- `server/middleware/guards.ts` — new `dashboardAuthGuard()` function (+57 LOC)
- `server/routes/index.ts` — wire guard into guard chain for dashboard paths (+5 LOC)
- `server/__tests__/dashboard-auth-guard.test.ts` — 11 new tests covering all auth scenarios

## Test plan
- [x] TSC clean (`bunx tsc --noEmit --skipLibCheck`)
- [x] 5123 tests pass, 0 fail
- [x] 108/108 specs pass
- [x] 11 new dashboard auth guard tests cover: localhost bypass, non-dashboard passthrough, API_KEY fallthrough, missing key, invalid key, valid key, sub-paths

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)