### PR TITLE
fix: deduplicate auto-merge security scan comments

### DIFF
--- a/server/__tests__/auto-merge.test.ts
+++ b/server/__tests__/auto-merge.test.ts
@@ -374,6 +374,45 @@ describe('AutoMergeService.checkAll', () => {
         expect(mergeCall).toBeUndefined();
     });
 
+    test('only posts one comment per PR across multiple checkAll cycles', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        const commentCalls: string[][] = [];
+        const runGh: RunGhFn = async (args) => {
+            const key = args.join(' ');
+            if (key.includes('search/issues')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify({
+                        items: [{ number: 42, html_url: 'https://github.com/CorvidLabs/corvid-agent/pull/42' }],
+                    }),
+                    stderr: '',
+                };
+            }
+            if (key.includes('pr checks')) {
+                return { ok: true, stdout: 'pass', stderr: '' };
+            }
+            if (key.includes('repos/') && key.includes('/pulls/')) {
+                return { ok: true, stdout: '+++ b/server/db/schema.ts\n+// protected file', stderr: '' };
+            }
+            if (key.includes('pr comment')) {
+                commentCalls.push(args);
+                return { ok: true, stdout: '', stderr: '' };
+            }
+            return { ok: false, stdout: '', stderr: '' };
+        };
+
+        const service = new AutoMergeService(db, runGh);
+        (service as any).running = true;
+
+        // Run checkAll three times — should only comment once
+        await service.checkAll();
+        await service.checkAll();
+        await service.checkAll();
+
+        expect(commentCalls.length).toBe(1);
+    });
+
     test('blocks merge when diff has malicious code patterns', async () => {
         insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
 

--- a/server/polling/auto-merge.ts
+++ b/server/polling/auto-merge.ts
@@ -25,6 +25,8 @@ export class AutoMergeService {
     private runGh: RunGhFn;
     private timer: ReturnType<typeof setInterval> | null = null;
     private running = false;
+    /** Track PRs we've already flagged to avoid spamming comments. */
+    private flaggedPRs = new Set<string>();
 
     constructor(db: Database, runGh: RunGhFn) {
         this.db = db;
@@ -173,17 +175,21 @@ export class AutoMergeService {
             }
 
             // All checks pass — run security validation on the diff before merging
+            const prKey = `${prRepo}#${prNumber}`;
             const rejection = await this.validateDiff(prRepo, prNumber);
             if (rejection) {
                 log.warn('Auto-merge blocked by security scan', {
                     repo: prRepo, number: prNumber, reason: rejection,
                 });
-                // Post a review comment explaining why it was blocked
-                await this.runGh([
-                    'pr', 'comment', String(prNumber),
-                    '--repo', prRepo,
-                    '--body', `⚠️ **Auto-merge blocked — security scan failed**\n\n${rejection}\n\nThis PR requires manual review before merging.`,
-                ]);
+                // Only post the comment once per PR to avoid spam
+                if (!this.flaggedPRs.has(prKey)) {
+                    this.flaggedPRs.add(prKey);
+                    await this.runGh([
+                        'pr', 'comment', String(prNumber),
+                        '--repo', prRepo,
+                        '--body', `⚠️ **Auto-merge blocked — security scan failed**\n\n${rejection}\n\nThis PR requires manual review before merging.`,
+                    ]);
+                }
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- AutoMergeService was posting duplicate "security scan failed" comments every 2-minute polling cycle on blocked PRs (e.g. 13 identical comments on PR #613)
- Added `flaggedPRs` Set to track already-commented PRs so each only gets one comment
- Added test verifying that 3 consecutive `checkAll()` cycles produce only 1 comment

## Test plan
- [x] `bun test server/__tests__/auto-merge.test.ts` — 25/25 pass
- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] New test: "only posts one comment per PR across multiple checkAll cycles"

Fixes the comment spam seen on #613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)