### PR TITLE
refactor: deduplicate tenant resolution helpers

### DIFF
--- a/server/algochat/init.ts
+++ b/server/algochat/init.ts
@@ -35,6 +35,7 @@ import { OnChainTransactor } from './on-chain-transactor';
 import { WorkCommandRouter } from './work-command-router';
 import { broadcastAlgoChatMessage } from '../ws/handler';
 import { publishToTenant } from '../events/broadcasting';
+import { resolveAgentTenant } from '../tenant/resolve';
 import { createLogger } from '../lib/logger';
 
 const log = createLogger('AlgoChatInit');
@@ -199,7 +200,7 @@ export function wirePostInit(deps: AlgoChatInitDeps): void {
         algochatState.messenger.onMessageUpdate((message) => {
             const msg = JSON.stringify({ type: 'agent_message_update', message });
             const fromTid = message.fromAgentId
-                ? resolveAgentTenantForBroadcast(deps.db, message.fromAgentId)
+                ? resolveAgentTenant(deps.db, message.fromAgentId)
                 : undefined;
             publishToTenant(deps.server, 'algochat', msg, fromTid);
         });
@@ -225,11 +226,4 @@ export function wirePostInit(deps: AlgoChatInitDeps): void {
     workflowService.start();
     usageMeter.start();
     healthMonitorService.start();
-}
-
-// Internal helper — TODO: deduplicate with broadcasting.ts in a future PR
-function resolveAgentTenantForBroadcast(db: Database, agentId: string): string | undefined {
-    const row = db.query('SELECT tenant_id FROM agents WHERE id = ?').get(agentId) as { tenant_id: string } | null;
-    const tid = row?.tenant_id;
-    return tid && tid !== 'default' ? tid : undefined;
 }

--- a/server/events/broadcasting.ts
+++ b/server/events/broadcasting.ts
@@ -15,7 +15,7 @@ import type { NotificationService } from '../notifications/service';
 import type { ProcessManager } from '../process/manager';
 import { onCouncilStageChange, onCouncilLog, onCouncilDiscussionMessage } from '../routes/councils';
 import { tenantTopic } from '../ws/handler';
-import { DEFAULT_TENANT_ID } from '../tenant/types';
+import { resolveAgentTenant, resolveCouncilTenant } from '../tenant/resolve';
 
 export interface BroadcastDeps {
     server: BunServer;
@@ -27,31 +27,6 @@ export interface BroadcastDeps {
     workflowService: WorkflowService;
     notificationService: NotificationService;
     multiTenant: boolean;
-}
-
-/**
- * Resolve the tenant for an agent (used by event broadcasts).
- * Returns undefined in single-tenant mode (flat topics).
- */
-function resolveAgentTenant(db: Database, multiTenant: boolean, agentId: string): string | undefined {
-    if (!multiTenant) return undefined;
-    const row = db.query('SELECT tenant_id FROM agents WHERE id = ?').get(agentId) as { tenant_id: string } | null;
-    const tid = row?.tenant_id;
-    return tid && tid !== DEFAULT_TENANT_ID ? tid : undefined;
-}
-
-/**
- * Resolve the tenant for a council launch (used by council event broadcasts).
- */
-function resolveCouncilTenant(db: Database, multiTenant: boolean, launchId: string): string | undefined {
-    if (!multiTenant) return undefined;
-    const row = db.query(
-        `SELECT a.tenant_id FROM sessions s
-         JOIN agents a ON s.agent_id = a.id
-         WHERE s.council_launch_id = ? LIMIT 1`,
-    ).get(launchId) as { tenant_id: string } | null;
-    const tid = row?.tenant_id;
-    return tid && tid !== DEFAULT_TENANT_ID ? tid : undefined;
 }
 
 function spreadScheduleEvent(event: { type: string; data: unknown }): Record<string, unknown> {
@@ -95,8 +70,8 @@ export function publishToTenant(server: BunServer, baseTopic: string, data: stri
 export function wireEventBroadcasting(deps: BroadcastDeps): void {
     const { server, db, processManager, schedulerService, webhookService, mentionPollingService, workflowService, notificationService, multiTenant } = deps;
 
-    const resolveAgent = (agentId: string) => resolveAgentTenant(db, multiTenant, agentId);
-    const resolveCouncil = (launchId: string) => resolveCouncilTenant(db, multiTenant, launchId);
+    const resolveAgent = (agentId: string) => resolveAgentTenant(db, agentId, multiTenant);
+    const resolveCouncil = (launchId: string) => resolveCouncilTenant(db, launchId, multiTenant);
     const publish = (baseTopic: string, data: string, tid?: string) => publishToTenant(server, baseTopic, data, tid);
 
     // Wire broadcast function so MCP tools can publish to WS clients

--- a/server/tenant/resolve.ts
+++ b/server/tenant/resolve.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared tenant resolution helpers for broadcasting and event routing.
+ *
+ * Returns `undefined` when the resource belongs to the default tenant
+ * (or when multi-tenant mode is off), so callers can use flat topics.
+ */
+
+import type { Database } from 'bun:sqlite';
+import { DEFAULT_TENANT_ID } from './types';
+
+/**
+ * Resolve the tenant for an agent.
+ *
+ * @param multiTenant - Pass `false` to always return `undefined` (single-tenant shortcut).
+ *                      Defaults to `true` so callers that already filtered can omit it.
+ */
+export function resolveAgentTenant(
+    db: Database,
+    agentId: string,
+    multiTenant = true,
+): string | undefined {
+    if (!multiTenant) return undefined;
+    const row = db.query('SELECT tenant_id FROM agents WHERE id = ?').get(agentId) as { tenant_id: string } | null;
+    const tid = row?.tenant_id;
+    return tid && tid !== DEFAULT_TENANT_ID ? tid : undefined;
+}
+
+/**
+ * Resolve the tenant for a council launch (via its first session's agent).
+ */
+export function resolveCouncilTenant(
+    db: Database,
+    launchId: string,
+    multiTenant = true,
+): string | undefined {
+    if (!multiTenant) return undefined;
+    const row = db.query(
+        `SELECT a.tenant_id FROM sessions s
+         JOIN agents a ON s.agent_id = a.id
+         WHERE s.council_launch_id = ? LIMIT 1`,
+    ).get(launchId) as { tenant_id: string } | null;
+    const tid = row?.tenant_id;
+    return tid && tid !== DEFAULT_TENANT_ID ? tid : undefined;
+}


### PR DESCRIPTION
## Summary
- Extract `resolveAgentTenant()` and `resolveCouncilTenant()` into `server/tenant/resolve.ts`
- Remove duplicate implementations from `server/algochat/init.ts` and `server/events/broadcasting.ts`
- Unified function uses `DEFAULT_TENANT_ID` constant (fixes hardcoded `"default"` in init.ts) and accepts optional `multiTenant` parameter (defaults to `true`)

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 5192 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)