### PR TITLE
fix: prevent duplicate security scan comments and false positives

### DIFF
--- a/server/__tests__/auto-merge.test.ts
+++ b/server/__tests__/auto-merge.test.ts
@@ -317,6 +317,10 @@ describe('AutoMergeService.checkAll', () => {
                 // Diff that modifies a protected file
                 return { ok: true, stdout: '+++ b/server/db/schema.ts\n+// malicious change', stderr: '' };
             }
+            if (key.includes('pr view')) {
+                // No existing security comment
+                return { ok: true, stdout: '', stderr: '' };
+            }
             if (key.includes('pr comment')) {
                 return { ok: true, stdout: '', stderr: '' };
             }
@@ -360,6 +364,9 @@ describe('AutoMergeService.checkAll', () => {
                     stderr: '',
                 };
             }
+            if (key.includes('pr view')) {
+                return { ok: true, stdout: '', stderr: '' };
+            }
             if (key.includes('pr comment')) {
                 return { ok: true, stdout: '', stderr: '' };
             }
@@ -395,6 +402,9 @@ describe('AutoMergeService.checkAll', () => {
             if (key.includes('repos/') && key.includes('/pulls/')) {
                 return { ok: true, stdout: '+++ b/server/db/schema.ts\n+// protected file', stderr: '' };
             }
+            if (key.includes('pr view')) {
+                return { ok: true, stdout: '', stderr: '' };
+            }
             if (key.includes('pr comment')) {
                 commentCalls.push(args);
                 return { ok: true, stdout: '', stderr: '' };
@@ -411,6 +421,83 @@ describe('AutoMergeService.checkAll', () => {
         await service.checkAll();
 
         expect(commentCalls.length).toBe(1);
+    });
+
+    test('skips PR when diff fetch fails (transient error)', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        const calls: string[][] = [];
+        const runGh: RunGhFn = async (args) => {
+            calls.push(args);
+            const key = args.join(' ');
+            if (key.includes('search/issues')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify({
+                        items: [{ number: 42, html_url: 'https://github.com/CorvidLabs/corvid-agent/pull/42' }],
+                    }),
+                    stderr: '',
+                };
+            }
+            if (key.includes('pr checks')) {
+                return { ok: true, stdout: 'pass', stderr: '' };
+            }
+            if (key.includes('repos/') && key.includes('/pulls/')) {
+                // Diff fetch fails (rate limit, network error, etc.)
+                return { ok: false, stdout: '', stderr: 'API rate limit exceeded' };
+            }
+            return { ok: false, stdout: '', stderr: '' };
+        };
+
+        const service = new AutoMergeService(db, runGh);
+        (service as any).running = true;
+        await service.checkAll();
+
+        // Should NOT merge and should NOT comment — just skip
+        const mergeCall = calls.find((c) => c.join(' ').includes('pr merge'));
+        expect(mergeCall).toBeUndefined();
+        const commentCall = calls.find((c) => c.join(' ').includes('pr comment'));
+        expect(commentCall).toBeUndefined();
+    });
+
+    test('does not post duplicate comment if one already exists on the PR', async () => {
+        insertPollingConfig('CorvidLabs/corvid-agent', 'corvid-agent');
+
+        const commentCalls: string[][] = [];
+        const runGh: RunGhFn = async (args) => {
+            const key = args.join(' ');
+            if (key.includes('search/issues')) {
+                return {
+                    ok: true,
+                    stdout: JSON.stringify({
+                        items: [{ number: 42, html_url: 'https://github.com/CorvidLabs/corvid-agent/pull/42' }],
+                    }),
+                    stderr: '',
+                };
+            }
+            if (key.includes('pr checks')) {
+                return { ok: true, stdout: 'pass', stderr: '' };
+            }
+            if (key.includes('repos/') && key.includes('/pulls/')) {
+                return { ok: true, stdout: '+++ b/server/db/schema.ts\n+// protected file', stderr: '' };
+            }
+            if (key.includes('pr view')) {
+                // Simulate an existing security comment from a previous server run
+                return { ok: true, stdout: '⚠️ **Auto-merge blocked — security scan failed**\n\nProtected files', stderr: '' };
+            }
+            if (key.includes('pr comment')) {
+                commentCalls.push(args);
+                return { ok: true, stdout: '', stderr: '' };
+            }
+            return { ok: false, stdout: '', stderr: '' };
+        };
+
+        const service = new AutoMergeService(db, runGh);
+        (service as any).running = true;
+        await service.checkAll();
+
+        // Should NOT post a new comment since one already exists
+        expect(commentCalls.length).toBe(0);
     });
 
     test('blocks merge when diff has malicious code patterns', async () => {
@@ -438,6 +525,9 @@ describe('AutoMergeService.checkAll', () => {
                     stdout: '+++ b/server/routes/new.ts\n+eval("malicious code")',
                     stderr: '',
                 };
+            }
+            if (key.includes('pr view')) {
+                return { ok: true, stdout: '', stderr: '' };
             }
             if (key.includes('pr comment')) {
                 return { ok: true, stdout: '', stderr: '' };
@@ -518,7 +608,7 @@ describe('AutoMergeService.validateDiff', () => {
         expect(result).toContain('Unapproved external domains');
     });
 
-    test('returns error when diff cannot be fetched', async () => {
+    test('returns skip when diff cannot be fetched (transient failure)', async () => {
         const runGh: RunGhFn = async () => ({
             ok: false,
             stdout: '',
@@ -527,7 +617,7 @@ describe('AutoMergeService.validateDiff', () => {
 
         const service = new AutoMergeService(db, runGh);
         const result = await service.validateDiff('CorvidLabs/corvid-agent', 1);
-        expect(result).toContain('Could not retrieve PR diff');
+        expect(result).toBe('skip');
     });
 
     test('catches multiple issues in one diff', async () => {

--- a/server/polling/auto-merge.ts
+++ b/server/polling/auto-merge.ts
@@ -85,9 +85,11 @@ export class AutoMergeService {
 
     /**
      * Validate a PR's diff for security issues before auto-merging.
-     * Returns a rejection reason string if blocked, or null if safe.
+     * Returns: 'skip' if diff couldn't be fetched (retry next cycle),
+     *          a rejection reason string if blocked,
+     *          or null if safe to merge.
      */
-    async validateDiff(repo: string, prNumber: number): Promise<string | null> {
+    async validateDiff(repo: string, prNumber: number): Promise<string | 'skip' | null> {
         // Get the PR diff
         const diffResult = await this.runGh([
             'api', `repos/${repo}/pulls/${prNumber}`,
@@ -95,7 +97,12 @@ export class AutoMergeService {
         ]);
 
         if (!diffResult.ok || !diffResult.stdout.trim()) {
-            return 'Could not retrieve PR diff for security validation';
+            // Transient failure (rate limit, network) — skip this cycle rather than
+            // flagging the PR with a scary comment. We'll retry next cycle.
+            log.debug('Could not retrieve PR diff — skipping security check this cycle', {
+                repo, prNumber, stderr: diffResult.stderr?.slice(0, 200),
+            });
+            return 'skip';
         }
 
         const diff = diffResult.stdout;
@@ -139,6 +146,21 @@ export class AutoMergeService {
     }
 
     /**
+     * Check if we've already posted a security-scan comment on this PR.
+     * Prevents duplicate comments across server restarts.
+     */
+    private async hasSecurityComment(repo: string, prNumber: number): Promise<boolean> {
+        const result = await this.runGh([
+            'pr', 'view', String(prNumber),
+            '--repo', repo,
+            '--json', 'comments',
+            '--jq', '.comments[].body',
+        ]);
+        if (!result.ok) return false;
+        return result.stdout.includes('Auto-merge blocked — security scan failed');
+    }
+
+    /**
      * Auto-merge passing PRs for a specific repo authored by the given username.
      */
     private async mergeForRepo(repo: string, username: string): Promise<void> {
@@ -177,18 +199,26 @@ export class AutoMergeService {
             // All checks pass — run security validation on the diff before merging
             const prKey = `${prRepo}#${prNumber}`;
             const rejection = await this.validateDiff(prRepo, prNumber);
+            if (rejection === 'skip') {
+                log.debug('Skipping PR — diff unavailable this cycle', { repo: prRepo, number: prNumber });
+                continue;
+            }
             if (rejection) {
                 log.warn('Auto-merge blocked by security scan', {
                     repo: prRepo, number: prNumber, reason: rejection,
                 });
-                // Only post the comment once per PR to avoid spam
+                // Only post the comment once per PR — check in-memory set first,
+                // then fall back to checking existing comments on the PR (survives restarts)
                 if (!this.flaggedPRs.has(prKey)) {
+                    const alreadyCommented = await this.hasSecurityComment(prRepo, prNumber);
+                    if (!alreadyCommented) {
+                        await this.runGh([
+                            'pr', 'comment', String(prNumber),
+                            '--repo', prRepo,
+                            '--body', `⚠️ **Auto-merge blocked — security scan failed**\n\n${rejection}\n\nThis PR requires manual review before merging.`,
+                        ]);
+                    }
                     this.flaggedPRs.add(prKey);
-                    await this.runGh([
-                        'pr', 'comment', String(prNumber),
-                        '--repo', prRepo,
-                        '--body', `⚠️ **Auto-merge blocked — security scan failed**\n\n${rejection}\n\nThis PR requires manual review before merging.`,
-                    ]);
                 }
                 continue;
             }


### PR DESCRIPTION
## Summary
- **Transient API failures no longer post scary comments.** When the diff can't be fetched (rate limit, network), `validateDiff()` returns `'skip'` — the PR is silently retried next cycle instead of being flagged with "security scan failed."
- **Dedup survives server restarts.** Before posting a security comment, the service now checks existing PR comments via `gh pr view`. The in-memory Set is still used as a fast path but is no longer the only guard.
- Deleted 2 bogus "could not retrieve PR diff" comments from PR #639 that were caused by GitHub API rate limiting.

## Test plan
- [x] 27 auto-merge tests pass (2 new: transient skip, persistent dedup)
- [x] TSC clean
- [x] Server restarted and healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)