### PR TITLE
feat(ui): wire up toast notifications for async actions

### DIFF
--- a/client/src/app/core/services/notification.service.spec.ts
+++ b/client/src/app/core/services/notification.service.spec.ts
@@ -76,16 +76,42 @@ describe('NotificationService', () => {
     // ──────────────────────────────────────────────
     // Max visible cap
     // ──────────────────────────────────────────────
-    it('should cap visible notifications at 5', () => {
+    it('should cap visible notifications at 3', () => {
+        // Errors now auto-dismiss at 8s, so use fake timers (already set up)
         service.error('One');
         service.error('Two');
         service.error('Three');
         service.error('Four');
-        service.error('Five');
-        service.error('Six');
 
-        // Using error type because it has duration=0 (no auto-dismiss)
         const visible = service.notifications();
-        expect(visible).toHaveLength(5);
+        expect(visible).toHaveLength(3);
+    });
+
+    // ──────────────────────────────────────────────
+    // Error auto-dismiss
+    // ──────────────────────────────────────────────
+    it('should auto-dismiss error notifications after 8s', () => {
+        service.error('Failure');
+        expect(service.notifications()).toHaveLength(1);
+
+        vi.advanceTimersByTime(7999);
+        expect(service.notifications()).toHaveLength(1);
+
+        vi.advanceTimersByTime(1);
+        expect(service.notifications()).toHaveLength(0);
+    });
+
+    // ──────────────────────────────────────────────
+    // Success auto-dismiss
+    // ──────────────────────────────────────────────
+    it('should auto-dismiss success notifications after 4s', () => {
+        service.success('Done');
+        expect(service.notifications()).toHaveLength(1);
+
+        vi.advanceTimersByTime(3999);
+        expect(service.notifications()).toHaveLength(1);
+
+        vi.advanceTimersByTime(1);
+        expect(service.notifications()).toHaveLength(0);
     });
 });

--- a/client/src/app/core/services/notification.service.ts
+++ b/client/src/app/core/services/notification.service.ts
@@ -2,14 +2,14 @@ import { Injectable, signal, computed } from '@angular/core';
 import type { Notification, NotificationType } from '../models/notification.model';
 
 /** Maximum notifications visible at once */
-const MAX_VISIBLE = 5;
+const MAX_VISIBLE = 3;
 
 /** Default auto-dismiss durations by type (ms) */
 const DEFAULT_DURATION: Record<NotificationType, number> = {
-    success: 5000,
-    info: 5000,
+    success: 4000,
+    info: 4000,
     warning: 8000,
-    error: 0, // persistent — user must dismiss
+    error: 8000,
 };
 
 let nextId = 0;

--- a/client/src/app/features/agents/agent-form.component.ts
+++ b/client/src/app/features/agents/agent-form.component.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { AgentService } from '../../core/services/agent.service';
 import { ProjectService } from '../../core/services/project.service';
 import { ApiService } from '../../core/services/api.service';
+import { NotificationService } from '../../core/services/notification.service';
 import type { CreateAgentInput, ProviderInfo } from '../../core/models/agent.model';
 import type { Project } from '../../core/models/project.model';
 import { firstValueFrom } from 'rxjs';
@@ -157,6 +158,7 @@ export class AgentFormComponent implements OnInit {
     private readonly projectService = inject(ProjectService);
     private readonly apiService = inject(ApiService);
     private readonly router = inject(Router);
+    private readonly notify = inject(NotificationService);
 
     readonly id = input<string | undefined>(undefined);
     protected readonly saving = signal(false);
@@ -259,11 +261,15 @@ export class AgentFormComponent implements OnInit {
 
             if (id) {
                 await this.agentService.updateAgent(id, value);
+                this.notify.success('Agent updated');
                 this.router.navigate(['/agents', id]);
             } else {
                 const agent = await this.agentService.createAgent(value);
+                this.notify.success(`Agent '${value.name}' created successfully`);
                 this.router.navigate(['/agents', agent.id]);
             }
+        } catch (e) {
+            this.notify.error('Failed to save agent', String(e));
         } finally {
             this.saving.set(false);
         }

--- a/client/src/app/features/dashboard/dashboard.component.ts
+++ b/client/src/app/features/dashboard/dashboard.component.ts
@@ -12,6 +12,7 @@ import { StatusBadgeComponent } from '../../shared/components/status-badge.compo
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 import { AbsoluteTimePipe } from '../../shared/pipes/absolute-time.pipe';
 import { ApiService } from '../../core/services/api.service';
+import { NotificationService } from '../../core/services/notification.service';
 import { WelcomeWizardComponent } from './welcome-wizard.component';
 import type { ServerWsMessage } from '../../core/models/ws-message.model';
 import type { Agent } from '../../core/models/agent.model';
@@ -455,6 +456,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     protected readonly wsService = inject(WebSocketService);
     private readonly apiService = inject(ApiService);
     private readonly router = inject(Router);
+    private readonly notify = inject(NotificationService);
 
     protected readonly algochatStatus = this.sessionService.algochatStatus;
     protected readonly showWelcome = computed(() =>
@@ -595,6 +597,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
     protected async runSelfTest(): Promise<void> {
         this.selfTestRunning.set(true);
+        this.notify.info('Self-test running...');
         try {
             const result = await firstValueFrom(
                 this.apiService.post<{ sessionId: string }>('/selftest/run', { testType: 'all' }),

--- a/client/src/app/features/sessions/session-launcher.component.ts
+++ b/client/src/app/features/sessions/session-launcher.component.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { ProjectService } from '../../core/services/project.service';
 import { AgentService } from '../../core/services/agent.service';
 import { SessionService } from '../../core/services/session.service';
+import { NotificationService } from '../../core/services/notification.service';
 
 @Component({
     selector: 'app-session-launcher',
@@ -87,6 +88,7 @@ export class SessionLauncherComponent implements OnInit {
     protected readonly projectService = inject(ProjectService);
     protected readonly agentService = inject(AgentService);
     private readonly sessionService = inject(SessionService);
+    private readonly notify = inject(NotificationService);
 
     protected readonly launching = signal(false);
 
@@ -121,7 +123,10 @@ export class SessionLauncherComponent implements OnInit {
                 name: value.name || undefined,
                 initialPrompt: value.initialPrompt || undefined,
             });
+            this.notify.success('Session started');
             this.router.navigate(['/sessions', session.id]);
+        } catch (e) {
+            this.notify.error('Failed to start session', String(e));
         } finally {
             this.launching.set(false);
         }

--- a/client/src/app/features/sessions/session-list.component.ts
+++ b/client/src/app/features/sessions/session-list.component.ts
@@ -8,6 +8,7 @@ import { StatusBadgeComponent } from '../../shared/components/status-badge.compo
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 import { EmptyStateComponent } from '../../shared/components/empty-state.component';
 import { AbsoluteTimePipe } from '../../shared/pipes/absolute-time.pipe';
+import { NotificationService } from '../../core/services/notification.service';
 import type { Session, SessionStatus } from '../../core/models/session.model';
 
 interface SessionGroup {
@@ -227,6 +228,7 @@ interface SessionGroup {
 export class SessionListComponent implements OnInit {
     protected readonly sessionService = inject(SessionService);
     private readonly agentService = inject(AgentService);
+    private readonly notify = inject(NotificationService);
 
     protected searchQuery = '';
     protected sourceFilter = '';
@@ -344,8 +346,17 @@ export class SessionListComponent implements OnInit {
 
     protected async stopAllRunning(): Promise<void> {
         const running = this.sessionService.sessions().filter((s) => s.status === 'running');
+        let stopped = 0;
         for (const s of running) {
-            try { await this.sessionService.stopSession(s.id); } catch {}
+            try {
+                await this.sessionService.stopSession(s.id);
+                stopped++;
+            } catch {
+                this.notify.error(`Failed to stop session ${s.name || s.id.slice(0, 8)}`);
+            }
+        }
+        if (stopped > 0) {
+            this.notify.success(`${stopped} session${stopped > 1 ? 's' : ''} stopped`);
         }
     }
 }

--- a/client/src/app/shared/components/toast-container.component.ts
+++ b/client/src/app/shared/components/toast-container.component.ts
@@ -38,7 +38,7 @@ import type { NotificationType } from '../../core/models/notification.model';
     styles: `
         .toast-container {
             position: fixed;
-            top: 1rem;
+            bottom: 5rem;
             right: 1rem;
             z-index: 10000;
             display: flex;


### PR DESCRIPTION
## Summary
Closes #645

- Wire up `NotificationService` toasts for agent create/update, session start/stop, self-test trigger, and bulk stop-all
- Adjust notification config: max 3 visible (was 5), success auto-dismiss 4s (was 5s), error auto-dismiss 8s (was persistent)
- Move toast container to bottom-right on desktop (above mobile nav)
- Add unit tests for new auto-dismiss timing (error at 8s, success at 4s)

Work tasks and schedules already had toasts — this completes coverage for all listed async actions. API errors are already surfaced via the HTTP error interceptor.

## Test plan
- [x] Verify agent create shows "Agent 'X' created successfully" toast
- [x] Verify agent update shows "Agent updated" toast
- [x] Verify session launch shows "Session started" toast
- [x] Verify stop-all shows "N session(s) stopped" toast
- [x] Verify self-test shows "Self-test running..." info toast
- [x] Verify error toasts auto-dismiss after 8s
- [x] Verify max 3 toasts visible at once
- [x] Verify bottom-right positioning on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)