### PR TITLE
fix(security): prevent log injection in CLI render (CodeQL #281, #282)

### DIFF
--- a/cli/render.ts
+++ b/cli/render.ts
@@ -61,10 +61,10 @@ export class Spinner {
 
 // ─── Sanitization ───────────────────────────────────────────────────────────
 
-/** Strip ANSI escape sequences and other control characters from user-provided strings */
+/** Strip ANSI escape sequences, newlines, and control characters to prevent log injection */
 function sanitize(s: string): string {
     // eslint-disable-next-line no-control-regex
-    return s.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '').replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
+    return s.replace(/[\x00-\x1f\x7f]/g, '').replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
 }
 
 // ─── Output Helpers ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fix log injection vulnerability in `cli/render.ts` `sanitize()` function (CodeQL alerts #281 and #282)
- The regex had gaps that preserved `\n` (0x0a) and `\r` (0x0d), allowing newline injection to forge fake log entries
- Changed `[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]` → `[\x00-\x1f\x7f]` to strip **all** control characters

## Test plan

- [x] 96 existing CLI render tests pass
- [x] TSC clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)