### PR TITLE
Potential fix for code scanning alert no. 281: Log injection

### DIFF
--- a/cli/render.ts
+++ b/cli/render.ts
@@ -63,8 +63,11 @@ export class Spinner {
 
 /** Strip ANSI escape sequences, newlines, and control characters to prevent log injection */
 function sanitize(s: string): string {
-    // eslint-disable-next-line no-control-regex
-    return s.replace(/[\x00-\x1f\x7f]/g, '').replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
+    const input = String(s);
+    // Remove ANSI escape sequences (CSI: ESC [ ... letter)
+    const withoutAnsi = input.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
+    // Allow only safe printable characters; drop control chars and newlines
+    return withoutAnsi.replace(/[^ -~\t]/g, '');
 }
 
 // ─── Output Helpers ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Potential fix for [https://github.com/CorvidLabs/corvid-agent/security/code-scanning/281](https://github.com/CorvidLabs/corvid-agent/security/code-scanning/281)

In general, the fix is to ensure that any user-controlled string passed to logging functions is sanitized so it cannot inject control sequences or new log lines. The project already has a `sanitize` helper, but CodeQL still sees the value as tainted; we can tighten this helper into a whitelist-style filter that only allows safe printable characters and explicitly strips any others. This makes it more obviously safe and may satisfy the static analysis tool.

Concretely, we will modify `sanitize` in `cli/render.ts` to (1) normalize the input to a string, and (2) return only characters in a safe range: basic printable ASCII excluding control characters and DEL, plus standard whitespace except `\r` and `\n` (which we’ll strip). We’ll also keep stripping ANSI CSI escape sequences in case any slip through. This change happens only in `cli/render.ts` lines 64–67; the call sites such as `printError` remain unchanged, so existing behavior (apart from slightly stricter sanitization of pathological inputs) is preserved.

No changes are needed in `cli/commands/demo.ts` or other files, because all flows of untrusted error text already pass through `printError(message)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
