### PR TITLE
fix: sync CLI version with package.json (0.9.0 → 0.19.0)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -38,7 +38,11 @@ function getPositional(index: number): string | undefined {
 
 // ─── Version ────────────────────────────────────────────────────────────────
 
-const VERSION = '0.9.0';
+// Read version from package.json so it stays in sync automatically
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+const pkgPath = join(dirname(new URL(import.meta.url).pathname), '..', 'package.json');
+const VERSION = JSON.parse(readFileSync(pkgPath, 'utf-8')).version as string;
 
 // ─── Help ───────────────────────────────────────────────────────────────────
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- CLI had hardcoded `VERSION = '0.9.0'` — now reads from `package.json` dynamically
- Bumps `package.json` version from `0.18.0` to `0.19.0` to match the v0.19.0 release tag

## Test plan

- [x] TSC clean
- [x] `corvid --version` will now show `0.19.0` after `bun install -g`

🤖 Generated with [Claude Code](https://claude.com/claude-code)