### PR TITLE
feat: add work-intake mode to Discord bridge

### DIFF
--- a/server/__tests__/discord-bridge.test.ts
+++ b/server/__tests__/discord-bridge.test.ts
@@ -4,6 +4,9 @@ import { runMigrations } from '../db/schema';
 import { DiscordBridge } from '../discord/bridge';
 import { GatewayOp } from '../discord/types';
 import type { DiscordBridgeConfig } from '../discord/types';
+import { createAgent } from '../db/agents';
+import { createProject } from '../db/projects';
+import type { WorkTask } from '../../shared/types/work-tasks';
 
 function createMockProcessManager() {
     return {
@@ -13,6 +16,41 @@ function createMockProcessManager() {
         subscribe: mock(() => {}),
         unsubscribe: mock(() => {}),
     } as unknown as import('../process/manager').ProcessManager;
+}
+
+function createMockWorkTaskService() {
+    const completionCallbacks = new Map<string, (task: WorkTask) => void>();
+    return {
+        create: mock(async (input: { description: string; agentId: string }) => ({
+            id: 'task-123',
+            agentId: input.agentId,
+            projectId: 'proj-1',
+            sessionId: null,
+            source: 'discord' as const,
+            sourceId: null,
+            requesterInfo: {},
+            description: input.description,
+            branchName: null,
+            status: 'pending' as const,
+            prUrl: null,
+            summary: null,
+            error: null,
+            originalBranch: null,
+            worktreeDir: null,
+            iterationCount: 0,
+            createdAt: new Date().toISOString(),
+            completedAt: null,
+        })),
+        onComplete: mock((taskId: string, callback: (task: WorkTask) => void) => {
+            completionCallbacks.set(taskId, callback);
+        }),
+        _triggerComplete: (taskId: string, task: WorkTask) => {
+            const cb = completionCallbacks.get(taskId);
+            if (cb) cb(task);
+        },
+    } as unknown as import('../work/service').WorkTaskService & {
+        _triggerComplete: (taskId: string, task: WorkTask) => void;
+    };
 }
 
 let db: Database;
@@ -142,5 +180,353 @@ describe('DiscordBridge', () => {
 
         bridge.stop();
         expect((bridge as unknown as { running: boolean }).running).toBe(false);
+    });
+});
+
+describe('DiscordBridge work_intake mode', () => {
+    test('work_intake mode creates work task from message', async () => {
+        const pm = createMockProcessManager();
+        const wts = createMockWorkTaskService();
+
+        // Seed agent so handleWorkIntake can resolve one
+        createAgent(db, { name: 'TestAgent' });
+
+        const config: DiscordBridgeConfig = {
+            botToken: 'test-token',
+            channelId: 'test-channel',
+            allowedUserIds: [],
+            mode: 'work_intake',
+        };
+        const bridge = new DiscordBridge(db, pm, config, wts as unknown as import('../work/service').WorkTaskService);
+
+        const fetchBodies: unknown[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+            if (init?.body) fetchBodies.push(JSON.parse(String(init.body)));
+            return new Response(JSON.stringify({}), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            await (bridge as unknown as { handleMessage: (msg: unknown) => Promise<void> }).handleMessage({
+                id: 'msg-1',
+                channel_id: 'test-channel',
+                author: { id: 'user-1', username: 'TestUser' },
+                content: 'Fix the login bug',
+                timestamp: new Date().toISOString(),
+            });
+
+            // WorkTaskService.create should have been called
+            expect(wts.create).toHaveBeenCalledTimes(1);
+            const createCall = (wts.create as ReturnType<typeof mock>).mock.calls[0] as unknown[];
+            const input = createCall[0] as { description: string; source: string; sourceId: string };
+            expect(input.description).toBe('Fix the login bug');
+            expect(input.source).toBe('discord');
+            expect(input.sourceId).toBe('msg-1');
+
+            // Should have sent an embed acknowledgment
+            expect(fetchBodies.length).toBeGreaterThanOrEqual(1);
+            const embedBody = fetchBodies.find((b: unknown) => (b as { embeds?: unknown[] }).embeds) as { embeds: Array<{ title: string }> } | undefined;
+            expect(embedBody).toBeDefined();
+            expect(embedBody!.embeds[0].title).toBe('Task Queued');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test('work_intake mode strips bot mentions from description', async () => {
+        const pm = createMockProcessManager();
+        const wts = createMockWorkTaskService();
+
+        createAgent(db, { name: 'TestAgent' });
+
+        const config: DiscordBridgeConfig = {
+            botToken: 'test-token',
+            channelId: 'test-channel',
+            allowedUserIds: [],
+            mode: 'work_intake',
+        };
+        const bridge = new DiscordBridge(db, pm, config, wts as unknown as import('../work/service').WorkTaskService);
+
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async () => {
+            return new Response(JSON.stringify({}), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            await (bridge as unknown as { handleMessage: (msg: unknown) => Promise<void> }).handleMessage({
+                id: 'msg-2',
+                channel_id: 'test-channel',
+                author: { id: 'user-1', username: 'TestUser' },
+                content: '<@!12345678> Fix the login bug',
+                timestamp: new Date().toISOString(),
+            });
+
+            const createCall = (wts.create as ReturnType<typeof mock>).mock.calls[0] as unknown[];
+            const input = createCall[0] as { description: string };
+            expect(input.description).toBe('Fix the login bug');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test('work_intake mode rejects empty description after mention strip', async () => {
+        const pm = createMockProcessManager();
+        const wts = createMockWorkTaskService();
+
+        createAgent(db, { name: 'TestAgent' });
+
+        const config: DiscordBridgeConfig = {
+            botToken: 'test-token',
+            channelId: 'test-channel',
+            allowedUserIds: [],
+            mode: 'work_intake',
+        };
+        const bridge = new DiscordBridge(db, pm, config, wts as unknown as import('../work/service').WorkTaskService);
+
+        const fetchBodies: unknown[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+            if (init?.body) fetchBodies.push(JSON.parse(String(init.body)));
+            return new Response(JSON.stringify({}), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            await (bridge as unknown as { handleMessage: (msg: unknown) => Promise<void> }).handleMessage({
+                id: 'msg-3',
+                channel_id: 'test-channel',
+                author: { id: 'user-1', username: 'TestUser' },
+                content: '<@!12345678>',
+                timestamp: new Date().toISOString(),
+            });
+
+            // Should NOT have created a task
+            expect(wts.create).not.toHaveBeenCalled();
+
+            // Should have sent a "provide a description" message
+            const textBody = fetchBodies.find((b: unknown) => (b as { content?: string }).content) as { content: string } | undefined;
+            expect(textBody).toBeDefined();
+            expect(textBody!.content).toContain('task description');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test('work_intake mode sends completion embed on task finish', async () => {
+        const pm = createMockProcessManager();
+        const wts = createMockWorkTaskService();
+
+        createAgent(db, { name: 'TestAgent' });
+
+        const config: DiscordBridgeConfig = {
+            botToken: 'test-token',
+            channelId: 'test-channel',
+            allowedUserIds: [],
+            mode: 'work_intake',
+        };
+        const bridge = new DiscordBridge(db, pm, config, wts as unknown as import('../work/service').WorkTaskService);
+
+        const fetchBodies: unknown[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+            if (init?.body) fetchBodies.push(JSON.parse(String(init.body)));
+            return new Response(JSON.stringify({}), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            // Create task
+            await (bridge as unknown as { handleMessage: (msg: unknown) => Promise<void> }).handleMessage({
+                id: 'msg-4',
+                channel_id: 'test-channel',
+                author: { id: 'user-1', username: 'TestUser' },
+                content: 'Build the feature',
+                timestamp: new Date().toISOString(),
+            });
+
+            // onComplete should have been registered
+            expect(wts.onComplete).toHaveBeenCalledTimes(1);
+
+            // Simulate task completion
+            fetchBodies.length = 0;
+            (wts as unknown as { _triggerComplete: (id: string, task: WorkTask) => void })._triggerComplete('task-123', {
+                id: 'task-123',
+                agentId: 'agent-1',
+                projectId: 'proj-1',
+                sessionId: 'sess-1',
+                source: 'discord',
+                sourceId: 'msg-4',
+                requesterInfo: {},
+                description: 'Build the feature',
+                branchName: 'agent/test/build-feature',
+                status: 'completed',
+                prUrl: 'https://github.com/test/repo/pull/1',
+                summary: 'Built the feature successfully',
+                error: null,
+                originalBranch: 'main',
+                worktreeDir: null,
+                iterationCount: 1,
+                createdAt: new Date().toISOString(),
+                completedAt: new Date().toISOString(),
+            });
+
+            // Wait for async send
+            await new Promise(resolve => setTimeout(resolve, 50));
+
+            const completionEmbed = fetchBodies.find((b: unknown) => {
+                const body = b as { embeds?: Array<{ title: string }> };
+                return body.embeds?.[0]?.title === 'Task Completed';
+            }) as { embeds: Array<{ title: string; fields?: Array<{ name: string; value: string }> }> } | undefined;
+            expect(completionEmbed).toBeDefined();
+
+            // Should include PR URL in fields
+            const prField = completionEmbed!.embeds[0].fields?.find(f => f.name === 'Pull Request');
+            expect(prField).toBeDefined();
+            expect(prField!.value).toBe('https://github.com/test/repo/pull/1');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test('work_intake mode sends error embed on task failure', async () => {
+        const pm = createMockProcessManager();
+        const wts = createMockWorkTaskService();
+
+        createAgent(db, { name: 'TestAgent' });
+
+        const config: DiscordBridgeConfig = {
+            botToken: 'test-token',
+            channelId: 'test-channel',
+            allowedUserIds: [],
+            mode: 'work_intake',
+        };
+        const bridge = new DiscordBridge(db, pm, config, wts as unknown as import('../work/service').WorkTaskService);
+
+        const fetchBodies: unknown[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+            if (init?.body) fetchBodies.push(JSON.parse(String(init.body)));
+            return new Response(JSON.stringify({}), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            await (bridge as unknown as { handleMessage: (msg: unknown) => Promise<void> }).handleMessage({
+                id: 'msg-5',
+                channel_id: 'test-channel',
+                author: { id: 'user-1', username: 'TestUser' },
+                content: 'Break something',
+                timestamp: new Date().toISOString(),
+            });
+
+            fetchBodies.length = 0;
+            (wts as unknown as { _triggerComplete: (id: string, task: WorkTask) => void })._triggerComplete('task-123', {
+                id: 'task-123',
+                agentId: 'agent-1',
+                projectId: 'proj-1',
+                sessionId: 'sess-1',
+                source: 'discord',
+                sourceId: 'msg-5',
+                requesterInfo: {},
+                description: 'Break something',
+                branchName: null,
+                status: 'failed',
+                prUrl: null,
+                summary: null,
+                error: 'TypeScript compilation failed',
+                originalBranch: 'main',
+                worktreeDir: null,
+                iterationCount: 3,
+                createdAt: new Date().toISOString(),
+                completedAt: new Date().toISOString(),
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 50));
+
+            const failEmbed = fetchBodies.find((b: unknown) => {
+                const body = b as { embeds?: Array<{ title: string }> };
+                return body.embeds?.[0]?.title === 'Task Failed';
+            }) as { embeds: Array<{ title: string; fields?: Array<{ name: string; value: string }> }> } | undefined;
+            expect(failEmbed).toBeDefined();
+
+            const errorField = failEmbed!.embeds[0].fields?.find(f => f.name === 'Error');
+            expect(errorField).toBeDefined();
+            expect(errorField!.value).toContain('TypeScript compilation failed');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test('work_intake mode errors without WorkTaskService', async () => {
+        const pm = createMockProcessManager();
+
+        createAgent(db, { name: 'TestAgent' });
+
+        const config: DiscordBridgeConfig = {
+            botToken: 'test-token',
+            channelId: 'test-channel',
+            allowedUserIds: [],
+            mode: 'work_intake',
+        };
+        // No workTaskService passed
+        const bridge = new DiscordBridge(db, pm, config);
+
+        const fetchBodies: unknown[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+            if (init?.body) fetchBodies.push(JSON.parse(String(init.body)));
+            return new Response(JSON.stringify({}), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            await (bridge as unknown as { handleMessage: (msg: unknown) => Promise<void> }).handleMessage({
+                id: 'msg-6',
+                channel_id: 'test-channel',
+                author: { id: 'user-1', username: 'TestUser' },
+                content: 'Do something',
+                timestamp: new Date().toISOString(),
+            });
+
+            const textBody = fetchBodies.find((b: unknown) => (b as { content?: string }).content) as { content: string } | undefined;
+            expect(textBody).toBeDefined();
+            expect(textBody!.content).toContain('WorkTaskService');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test('chat mode still works with work_intake configured', async () => {
+        const pm = createMockProcessManager();
+        const wts = createMockWorkTaskService();
+
+        createAgent(db, { name: 'TestAgent' });
+        createProject(db, { name: 'TestProject', workingDir: '/tmp/test' });
+
+        const config: DiscordBridgeConfig = {
+            botToken: 'test-token',
+            channelId: 'test-channel',
+            allowedUserIds: [],
+            mode: 'chat',  // explicitly chat mode
+        };
+        const bridge = new DiscordBridge(db, pm, config, wts as unknown as import('../work/service').WorkTaskService);
+
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async () => {
+            return new Response(JSON.stringify({}), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            await (bridge as unknown as { handleMessage: (msg: unknown) => Promise<void> }).handleMessage({
+                id: 'msg-7',
+                channel_id: 'test-channel',
+                author: { id: 'user-1', username: 'TestUser' },
+                content: 'hello there',
+                timestamp: new Date().toISOString(),
+            });
+
+            // In chat mode, WorkTaskService.create should NOT be called
+            expect(wts.create).not.toHaveBeenCalled();
+            // Process manager should start a session
+            expect(pm.startProcess).toHaveBeenCalled();
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
     });
 });

--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -316,13 +316,19 @@ export async function bootstrapServices(db: Database, startTime: number): Promis
 
     let discordBridge: DiscordBridge | null = null;
     if (process.env.DISCORD_BOT_TOKEN && process.env.DISCORD_CHANNEL_ID) {
-        discordBridge = new DiscordBridge(db, processManager, {
-            botToken: process.env.DISCORD_BOT_TOKEN,
-            channelId: process.env.DISCORD_CHANNEL_ID,
-            allowedUserIds: process.env.DISCORD_ALLOWED_USER_IDS
-                ? process.env.DISCORD_ALLOWED_USER_IDS.split(',').map(s => s.trim()).filter(Boolean)
-                : [],
-        });
+        discordBridge = new DiscordBridge(
+            db,
+            processManager,
+            {
+                botToken: process.env.DISCORD_BOT_TOKEN,
+                channelId: process.env.DISCORD_CHANNEL_ID,
+                allowedUserIds: process.env.DISCORD_ALLOWED_USER_IDS
+                    ? process.env.DISCORD_ALLOWED_USER_IDS.split(',').map(s => s.trim()).filter(Boolean)
+                    : [],
+                mode: (process.env.DISCORD_BRIDGE_MODE as 'chat' | 'work_intake') ?? undefined,
+            },
+            workTaskService,
+        );
         discordBridge.start();
         shutdownCoordinator.registerService('DiscordBridge', discordBridge, 20);
         log.info('Discord bridge initialized');

--- a/server/discord/bridge.ts
+++ b/server/discord/bridge.ts
@@ -1,6 +1,7 @@
 import type { Database } from 'bun:sqlite';
 import type { ProcessManager } from '../process/manager';
 import type { SessionSource } from '../../shared/types';
+import type { WorkTaskService } from '../work/service';
 import type {
     DiscordBridgeConfig,
     DiscordGatewayPayload,
@@ -25,6 +26,10 @@ const MAX_MESSAGE_LENGTH = 2000;
  * Bidirectional Discord bridge using raw WebSocket gateway.
  * No external Discord library dependencies.
  *
+ * Supports two modes:
+ * - `chat` (default): Messages route to persistent agent sessions.
+ * - `work_intake`: Messages create async work tasks via WorkTaskService.
+ *
  * Security note: This bridge authenticates via the Discord Gateway WebSocket API
  * using a bot token — it does NOT use the HTTP-based Interactions endpoint.
  * Therefore, Ed25519 request signature validation (X-Signature-Ed25519) is not
@@ -34,6 +39,7 @@ const MAX_MESSAGE_LENGTH = 2000;
 export class DiscordBridge {
     private db: Database;
     private processManager: ProcessManager;
+    private workTaskService: WorkTaskService | null;
     private config: DiscordBridgeConfig;
 
     private ws: WebSocket | null = null;
@@ -55,16 +61,26 @@ export class DiscordBridge {
     private readonly RATE_LIMIT_WINDOW_MS = 60_000;
     private readonly RATE_LIMIT_MAX_MESSAGES = 10;
 
-    constructor(db: Database, processManager: ProcessManager, config: DiscordBridgeConfig) {
+    constructor(
+        db: Database,
+        processManager: ProcessManager,
+        config: DiscordBridgeConfig,
+        workTaskService?: WorkTaskService,
+    ) {
         this.db = db;
         this.processManager = processManager;
         this.config = config;
+        this.workTaskService = workTaskService ?? null;
+    }
+
+    private get mode() {
+        return this.config.mode ?? 'chat';
     }
 
     start(): void {
         if (this.running) return;
         this.running = true;
-        log.info('Discord bridge starting', { channelId: this.config.channelId });
+        log.info('Discord bridge starting', { channelId: this.config.channelId, mode: this.mode });
         this.connect();
     }
 
@@ -357,9 +373,145 @@ export class DiscordBridge {
             return;
         }
 
-        // Route to agent session
-        await this.routeToAgent(data.channel_id, userId, text);
+        // Route based on mode
+        if (this.mode === 'work_intake') {
+            await this.handleWorkIntake(data.channel_id, data.id, userId, text);
+        } else {
+            await this.routeToAgent(data.channel_id, userId, text);
+        }
     }
+
+    // ── Work Intake Mode ─────────────────────────────────────────────────
+
+    private async handleWorkIntake(
+        channelId: string,
+        messageId: string,
+        userId: string,
+        text: string,
+    ): Promise<void> {
+        if (!this.workTaskService) {
+            await this.sendMessage(channelId, 'Work intake mode requires WorkTaskService. Check server configuration.');
+            return;
+        }
+
+        // Strip bot mentions from the task description
+        const description = text.replace(/<@!?\d+>/g, '').trim();
+        if (!description) {
+            await this.sendMessage(channelId, 'Please provide a task description.');
+            return;
+        }
+
+        // Resolve agent
+        const agents = listAgents(this.db);
+        const agent = agents[0];
+        if (!agent) {
+            await this.sendMessage(channelId, 'No agents configured. Create an agent first.');
+            return;
+        }
+
+        try {
+            const task = await this.workTaskService.create({
+                agentId: agent.id,
+                description,
+                source: 'discord',
+                sourceId: messageId,
+                requesterInfo: { discordUserId: userId, channelId, messageId },
+            });
+
+            log.info('Work task created from Discord', { taskId: task.id, userId });
+
+            // Send acknowledgment embed
+            await this.sendEmbed(channelId, {
+                title: 'Task Queued',
+                description: `**${task.id}**\n\n${description.slice(0, 200)}${description.length > 200 ? '...' : ''}`,
+                color: 0x5865f2, // Discord blurple
+                footer: { text: `Status: ${task.status}` },
+            });
+
+            // Subscribe for completion
+            this.workTaskService.onComplete(task.id, (completedTask) => {
+                this.sendTaskResult(channelId, completedTask).catch(err => {
+                    log.error('Failed to send task result to Discord', {
+                        taskId: completedTask.id,
+                        error: err instanceof Error ? err.message : String(err),
+                    });
+                });
+            });
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            log.error('Failed to create work task from Discord', { error: message, userId });
+
+            await this.sendEmbed(channelId, {
+                title: 'Task Failed',
+                description: message.slice(0, 500),
+                color: 0xed4245, // Red
+            });
+        }
+    }
+
+    private async sendTaskResult(channelId: string, task: import('../../shared/types/work-tasks').WorkTask): Promise<void> {
+        if (task.status === 'completed') {
+            const fields: Array<{ name: string; value: string; inline?: boolean }> = [];
+
+            if (task.prUrl) {
+                fields.push({ name: 'Pull Request', value: task.prUrl, inline: false });
+            }
+
+            if (task.summary) {
+                fields.push({ name: 'Summary', value: task.summary.slice(0, 1024), inline: false });
+            }
+
+            await this.sendEmbed(channelId, {
+                title: 'Task Completed',
+                description: task.description.slice(0, 200),
+                color: 0x57f287, // Green
+                fields,
+                footer: { text: `Task: ${task.id}` },
+            });
+        } else if (task.status === 'failed') {
+            await this.sendEmbed(channelId, {
+                title: 'Task Failed',
+                description: task.description.slice(0, 200),
+                color: 0xed4245, // Red
+                fields: task.error
+                    ? [{ name: 'Error', value: task.error.slice(0, 1024), inline: false }]
+                    : [],
+                footer: { text: `Task: ${task.id} | Iterations: ${task.iterationCount}` },
+            });
+        }
+    }
+
+    // ── Discord Embeds ───────────────────────────────────────────────────
+
+    private async sendEmbed(
+        channelId: string,
+        embed: {
+            title: string;
+            description?: string;
+            color?: number;
+            fields?: Array<{ name: string; value: string; inline?: boolean }>;
+            footer?: { text: string };
+        },
+    ): Promise<void> {
+        const response = await fetch(
+            `https://discord.com/api/v10/channels/${channelId}/messages`,
+            {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bot ${this.config.botToken}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ embeds: [embed] }),
+            },
+        );
+
+        if (!response.ok) {
+            const error = await response.text();
+            log.error('Failed to send Discord embed', { status: response.status, error: error.slice(0, 200) });
+        }
+    }
+
+    // ── Chat Mode ────────────────────────────────────────────────────────
 
     private async routeToAgent(channelId: string, userId: string, text: string): Promise<void> {
         let sessionId = this.userSessions.get(userId);
@@ -455,6 +607,8 @@ export class DiscordBridge {
             }
         });
     }
+
+    // ── Messaging ────────────────────────────────────────────────────────
 
     async sendMessage(channelId: string, content: string): Promise<void> {
         // Discord has a 2000 character limit per message

--- a/server/discord/types.ts
+++ b/server/discord/types.ts
@@ -1,7 +1,10 @@
+export type DiscordBridgeMode = 'chat' | 'work_intake';
+
 export interface DiscordBridgeConfig {
     botToken: string;
     channelId: string;
     allowedUserIds: string[];
+    mode?: DiscordBridgeMode;
 }
 
 export interface DiscordGatewayPayload {

--- a/shared/types/work-tasks.ts
+++ b/shared/types/work-tasks.ts
@@ -1,5 +1,5 @@
 export type WorkTaskStatus = 'pending' | 'branching' | 'running' | 'validating' | 'completed' | 'failed';
-export type WorkTaskSource = 'web' | 'algochat' | 'agent';
+export type WorkTaskSource = 'web' | 'algochat' | 'agent' | 'discord';
 
 export interface WorkTask {
     id: string;


### PR DESCRIPTION
## Summary

Implements **Discord bridge work-intake mode** (#523), a P1 v0.17.0 deliverable.

When `DISCORD_BRIDGE_MODE=work_intake`, incoming Discord messages create async work tasks via `WorkTaskService` instead of routing to persistent chat sessions. The bridge:

- Strips bot mentions from task descriptions
- Creates work tasks with `source: 'discord'` and requester metadata
- Sends rich embed acknowledgments (blurple "Task Queued")
- Subscribes for task completion and posts result/error embeds back to the channel
- Falls back gracefully if `WorkTaskService` is not configured

Chat mode (`DISCORD_BRIDGE_MODE=chat` or unset) continues to work exactly as before.

### Changes
- `shared/types/work-tasks.ts` — Add `'discord'` to `WorkTaskSource` union
- `server/discord/types.ts` — Add `DiscordBridgeMode` type and `mode` config field
- `server/discord/bridge.ts` — Work-intake handler, embed messaging, mode routing
- `server/bootstrap.ts` — Wire `workTaskService` and `DISCORD_BRIDGE_MODE` env var
- `server/__tests__/discord-bridge.test.ts` — 7 new tests (13 total)

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — all 13 discord-bridge tests pass (7 new work-intake tests)
- [x] `bun run spec:check` — 111 specs, 0 failures
- [x] Manual: set `DISCORD_BRIDGE_MODE=work_intake` and send a message to verify task creation
- [x] Manual: verify chat mode still works when mode is unset

Closes #523