### PR TITLE
docs: update stale test and spec counts across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">
   <img src="https://img.shields.io/badge/Angular-21-dd0031?logo=angular" alt="Angular 21">
-  <img src="https://img.shields.io/badge/tests-5427%20unit%20%7C%20360%20E2E-brightgreen" alt="5427 Unit | 360 E2E Tests">
+  <img src="https://img.shields.io/badge/tests-5471%20unit%20%7C%20360%20E2E-brightgreen" alt="5471 Unit | 360 E2E Tests">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>
 </p>
 
@@ -20,9 +20,9 @@ See [VISION.md](VISION.md) for architecture, competitive positioning, and long-t
 
 | Metric | Count |
 |--------|-------|
-| Unit tests | **5,427** across 212 files (15,465 assertions) |
+| Unit tests | **5,471** across 214 files (15,544 assertions) |
 | E2E tests | **360** across 31 Playwright specs |
-| Module specs | **111** with automated validation |
+| Module specs | **112** with automated validation |
 | MCP tools | **37** corvid_* tool handlers |
 | API endpoints | **~200** across 38 route modules |
 | DB migrations | **70** (81 tables) |
@@ -442,17 +442,17 @@ Tools are permission-scoped per agent via skill bundles and agent-level allowlis
 ## Testing
 
 ```bash
-bun test              # 5427+ server tests (~120s)
+bun test              # 5471+ server tests (~120s)
 cd client && npx vitest run   # Angular component tests (~2s)
 bun run test:e2e      # 31 Playwright spec files, 360 tests
 bun run spec:check    # Validate all module specs in specs/
 ```
 
-**5427 unit tests** covering: API routes, audit logging, authentication, bash security, billing, CLI, credit system, crypto, database migrations, Discord bridge, feedback loop, GitHub tools, health monitoring, marketplace, MCP tool handlers, notifications, multi-model routing, multi-tenant isolation, observability, owner communication, performance metrics, personas, plugins, process lifecycle, rate limiting, reputation, sandbox isolation, scheduling, skill bundles, Slack bridge, Telegram bridge, tenant isolation, usage monitoring, validation, voice TTS/STT, wallet keystore, web search, workflows, work tasks, and Angular components.
+**5471 unit tests** covering: API routes, audit logging, authentication, bash security, billing, CLI, credit system, crypto, database migrations, Discord bridge, feedback loop, GitHub tools, health monitoring, marketplace, MCP tool handlers, notifications, multi-model routing, multi-tenant isolation, observability, owner communication, performance metrics, personas, plugins, process lifecycle, rate limiting, reputation, sandbox isolation, scheduling, skill bundles, Slack bridge, Telegram bridge, tenant isolation, usage monitoring, validation, voice TTS/STT, wallet keystore, web search, workflows, work tasks, and Angular components.
 
 **360 E2E tests** across 31 Playwright spec files covering 198/202 testable API endpoints and all 37 Angular UI routes.
 
-**111 module specs** in `specs/` with automated validation via `bun run spec:check` — checks YAML frontmatter, required sections, API surface coverage (exported symbols vs documented), file existence, database table references, and dependency graph integrity. Runs in CI on every commit.
+**112 module specs** in `specs/` with automated validation via `bun run spec:check` — checks YAML frontmatter, required sections, API surface coverage (exported symbols vs documented), file existence, database table references, and dependency graph integrity. Runs in CI on every commit.
 
 ---
 

--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -40,7 +40,7 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Database tables | 81 |
 | Database migrations | 70 |
 | MCP tools | 37 corvid_* handlers |
-| Unit tests | 5,427 across 212 files |
+| Unit tests | 5,471 across 214 files |
 | E2E tests | 360 across 31 Playwright specs |
 | Security tests | 232 dedicated |
 | Module specs | 112 .spec.md files |

--- a/docs/external-review-scope.md
+++ b/docs/external-review-scope.md
@@ -9,7 +9,7 @@
 - **Agent SDK**: @anthropic-ai/claude-agent-sdk (Claude AI)
 - **Blockchain**: Algorand (AlgoChat messaging, wallets)
 - **Frontend**: Angular 21 (dashboard)
-- **Tests**: 5427 unit tests, 232 security-specific tests
+- **Tests**: 5471 unit tests, 232 security-specific tests
 
 ## Architecture
 
@@ -78,7 +78,7 @@ Client (Angular) --HTTP/WS--> Bun Server --> SQLite
 2. **Local setup**: `git clone`, `bun install`, `bun run dev` (requires Bun 1.3+)
 3. **Database**: Auto-created on first run, 70 migrations applied automatically
 4. **Environment**: Copy `.env.example` to `.env` — all defaults work for local testing
-5. **Tests**: `bun test` (5427 tests), `bun run spec:check` (111 specs)
+5. **Tests**: `bun test` (5471 tests), `bun run spec:check` (112 specs)
 6. **Key files to review first**: credits.ts, spending.ts, auth.ts, guards.ts, prompt-injection.ts, protected-paths.ts
 7. **Specs**: `specs/` directory has module-level specifications with invariants
 8. **Threat model**: `SECURITY.md` (324 lines, comprehensive)


### PR DESCRIPTION
## Summary
- Update unit test count: 5,427 → 5,471 (across 214 files, was 212; 15,544 assertions, was 15,465)
- Update module spec count: 111 → 112
- Fixes applied in README.md (badge, stats table, test section), docs/deep-dive.md, and docs/external-review-scope.md

Found during full documentation and API sync audit. Also filed #688 for 2 source files missing from spec frontmatter coverage.

## Test plan
- [x] `bun test` — 5471 pass, 0 fail
- [x] `bun run spec:check` — 112 specs, 111 passed, 134 warnings, 0 failed
- [x] @0xLeif review

🤖 Generated with [Claude Code](https://claude.com/claude-code)