### PR TITLE
refactor: extract repo map and symbol extraction into repo-map.ts

### DIFF
--- a/server/work/repo-map.ts
+++ b/server/work/repo-map.ts
@@ -1,0 +1,243 @@
+import { relative } from 'node:path';
+import type { AstParserService } from '../ast/service';
+import type { AstSymbol, FileSymbolIndex } from '../ast/types';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('repo-map');
+
+/** Max lines in the repo map to keep it lightweight. */
+export const REPO_MAP_MAX_LINES = 200;
+
+/** Directories prioritized in repo map ordering (appear first). */
+export const PRIORITY_DIRS = ['src/', 'server/', 'lib/', 'packages/'];
+
+/** Stop words excluded from keyword extraction for symbol search. */
+export const STOP_WORDS = new Set([
+    'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+    'of', 'with', 'by', 'from', 'is', 'it', 'be', 'as', 'was', 'were',
+    'are', 'been', 'has', 'have', 'had', 'do', 'does', 'did', 'will',
+    'would', 'could', 'should', 'may', 'might', 'shall', 'can', 'not',
+    'this', 'that', 'these', 'those', 'if', 'then', 'else', 'when',
+    'up', 'out', 'so', 'no', 'we', 'us', 'our', 'my', 'me', 'i',
+    'add', 'fix', 'update', 'change', 'make', 'use', 'create', 'new',
+    'need', 'want', 'get', 'set', 'all', 'each', 'any', 'into',
+    'also', 'about', 'more', 'some', 'only', 'just', 'than', 'such',
+]);
+
+/**
+ * Priority score for file path ordering in the repo map.
+ * Lower score = higher priority. Source dirs come first, test files last.
+ */
+export function filePathPriority(relPath: string): number {
+    if (relPath.includes('__tests__') || relPath.includes('.test.') || relPath.includes('.spec.')) {
+        return 3;
+    }
+    for (const dir of PRIORITY_DIRS) {
+        if (relPath.startsWith(dir)) return 1;
+    }
+    return 2;
+}
+
+/**
+ * Generate a lightweight repo map showing exported symbols per file,
+ * grouped by directory, with line ranges for each symbol.
+ * Prioritizes source directories over test files and truncates at REPO_MAP_MAX_LINES.
+ * Returns null if AST service is unavailable or indexing fails.
+ */
+export async function generateRepoMap(
+    astParserService: AstParserService,
+    projectDir: string,
+): Promise<string | null> {
+    try {
+        const index = await astParserService.indexProject(projectDir);
+        const RELEVANT_KINDS = new Set(['function', 'class', 'interface', 'type_alias', 'enum', 'variable']);
+
+        // Collect file entries with relative paths
+        const fileEntries: Array<{ relPath: string; fileIndex: FileSymbolIndex }> = [];
+        for (const [filePath, fileIndex] of index.files.entries()) {
+            const relPath = relative(projectDir, filePath).replaceAll('\\', '/');
+            const exported = fileIndex.symbols.filter(
+                (s: AstSymbol) => s.isExported && RELEVANT_KINDS.has(s.kind),
+            );
+            if (exported.length === 0) continue;
+            fileEntries.push({ relPath, fileIndex });
+        }
+
+        if (fileEntries.length === 0) return null;
+
+        // Sort: prioritize source directories, deprioritize test files
+        fileEntries.sort((a, b) => {
+            const aScore = filePathPriority(a.relPath);
+            const bScore = filePathPriority(b.relPath);
+            if (aScore !== bScore) return aScore - bScore;
+            return a.relPath.localeCompare(b.relPath);
+        });
+
+        // Group files by directory
+        const dirGroups = new Map<string, typeof fileEntries>();
+        for (const entry of fileEntries) {
+            const dir = entry.relPath.includes('/')
+                ? entry.relPath.slice(0, entry.relPath.lastIndexOf('/'))
+                : '.';
+            let group = dirGroups.get(dir);
+            if (!group) {
+                group = [];
+                dirGroups.set(dir, group);
+            }
+            group.push(entry);
+        }
+
+        const lines: string[] = [];
+        let lineCount = 0;
+
+        for (const [dir, entries] of dirGroups) {
+            if (lineCount >= REPO_MAP_MAX_LINES) break;
+
+            // Add directory header
+            lines.push(`\n${dir}/`);
+            lineCount++;
+
+            for (const { relPath, fileIndex } of entries) {
+                if (lineCount >= REPO_MAP_MAX_LINES) break;
+
+                const exported = fileIndex.symbols.filter(
+                    (s: AstSymbol) => s.isExported && RELEVANT_KINDS.has(s.kind),
+                );
+
+                const symbolList = exported.map((s: AstSymbol) => {
+                    const kindLabel = s.kind === 'type_alias' ? 'type' : s.kind;
+                    const lineRange = `[${s.startLine}-${s.endLine}]`;
+                    const children = s.children?.filter((c: AstSymbol) => RELEVANT_KINDS.has(c.kind));
+                    if (children && children.length > 0) {
+                        const methods = children.map((c: AstSymbol) =>
+                            `${c.name} [${c.startLine}-${c.endLine}]`,
+                        ).join(', ');
+                        return `${kindLabel} ${s.name} ${lineRange} { ${methods} }`;
+                    }
+                    return `${kindLabel} ${s.name} ${lineRange}`;
+                });
+
+                const fileName = relPath.includes('/')
+                    ? relPath.slice(relPath.lastIndexOf('/') + 1)
+                    : relPath;
+                lines.push(`  ${fileName}: ${symbolList.join(', ')}`);
+                lineCount++;
+            }
+        }
+
+        if (lines.length === 0) return null;
+
+        let result = lines.join('\n') + '\n';
+        if (lineCount >= REPO_MAP_MAX_LINES) {
+            result += `\n  ... truncated (${fileEntries.length} files total)\n`;
+        }
+        return result;
+    } catch (err) {
+        log.warn('Failed to generate repo map', {
+            projectDir,
+            error: err instanceof Error ? err.message : String(err),
+        });
+        return null;
+    }
+}
+
+/**
+ * Extract symbols from the project index that are relevant to the task description.
+ * Tokenizes the description into keywords and searches for matching symbols.
+ * Returns a formatted section showing relevant files/symbols, or null if none found.
+ */
+export function extractRelevantSymbols(
+    astParserService: AstParserService,
+    projectDir: string,
+    description: string,
+): string | null {
+    const keywords = tokenizeDescription(description);
+    if (keywords.length === 0) return null;
+
+    const seen = new Set<string>();
+    const results: AstSymbol[] = [];
+
+    for (const keyword of keywords) {
+        if (results.length >= 20) break;
+        const matches = astParserService.searchSymbols(projectDir, keyword, { limit: 10 });
+        for (const match of matches) {
+            const key = `${match.name}:${match.startLine}`;
+            if (!seen.has(key)) {
+                seen.add(key);
+                results.push(match);
+            }
+            if (results.length >= 20) break;
+        }
+    }
+
+    if (results.length === 0) return null;
+
+    // Group results by file for readability
+    const index = astParserService.getProjectIndex(projectDir);
+    if (!index) return null;
+
+    // Build a reverse lookup: symbol → file path
+    const symbolToFile = new Map<string, string>();
+    for (const [filePath, fileIndex] of index.files.entries()) {
+        for (const sym of fileIndex.symbols) {
+            const relFile = relative(projectDir, filePath).replaceAll('\\', '/');
+            symbolToFile.set(`${sym.name}:${sym.startLine}`, relFile);
+            if (sym.children) {
+                for (const child of sym.children) {
+                    symbolToFile.set(`${child.name}:${child.startLine}`, relFile);
+                }
+            }
+        }
+    }
+
+    const fileGroups = new Map<string, AstSymbol[]>();
+    for (const sym of results) {
+        const file = symbolToFile.get(`${sym.name}:${sym.startLine}`) ?? 'unknown';
+        let group = fileGroups.get(file);
+        if (!group) {
+            group = [];
+            fileGroups.set(file, group);
+        }
+        group.push(sym);
+    }
+
+    const lines: string[] = [];
+    for (const [file, symbols] of fileGroups) {
+        const symDescs = symbols.map((s) => {
+            const kindLabel = s.kind === 'type_alias' ? 'type' : s.kind;
+            return `${kindLabel} ${s.name} [${s.startLine}-${s.endLine}]`;
+        });
+        lines.push(`${file}: ${symDescs.join(', ')}`);
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * Tokenize a task description into meaningful keywords for symbol search.
+ * Splits on word boundaries, filters stop words, and extracts camelCase/PascalCase parts.
+ */
+export function tokenizeDescription(description: string): string[] {
+    const tokens = new Set<string>();
+
+    // Split on non-alphanumeric boundaries
+    const rawTokens = description.split(/[^a-zA-Z0-9]+/).filter(t => t.length > 0);
+
+    for (const token of rawTokens) {
+        const lower = token.toLowerCase();
+        if (lower.length < 3 || STOP_WORDS.has(lower)) continue;
+
+        tokens.add(lower);
+
+        // Split camelCase: 'buildWorkPrompt' → ['build', 'Work', 'Prompt']
+        const camelParts = token.split(/(?=[A-Z])/).filter(p => p.length >= 3);
+        for (const part of camelParts) {
+            const partLower = part.toLowerCase();
+            if (!STOP_WORDS.has(partLower)) {
+                tokens.add(partLower);
+            }
+        }
+    }
+
+    return [...tokens];
+}

--- a/server/work/service.ts
+++ b/server/work/service.ts
@@ -1,4 +1,4 @@
-import { resolve, dirname, relative } from 'node:path';
+import { resolve, dirname } from 'node:path';
 import type { Database } from 'bun:sqlite';
 import type { ProcessManager } from '../process/manager';
 import type { WorkTask, CreateWorkTaskInput } from '../../shared/types';
@@ -22,32 +22,13 @@ import { isRepoOffLimits } from '../github/off-limits';
 import { runBunInstall, runValidation } from './validation';
 import type { AgentMessenger } from '../algochat/agent-messenger';
 import type { AstParserService } from '../ast/service';
-import type { AstSymbol, FileSymbolIndex } from '../ast/types';
+import { generateRepoMap, extractRelevantSymbols } from './repo-map';
 
 const log = createLogger('WorkTaskService');
 
 const PR_URL_REGEX = /https:\/\/github\.com\/[^\s]+\/pull\/\d+/;
 
 const WORK_MAX_ITERATIONS = parseInt(process.env.WORK_MAX_ITERATIONS ?? '3', 10);
-
-/** Max lines in the repo map to keep it lightweight. */
-const REPO_MAP_MAX_LINES = 200;
-
-/** Directories prioritized in repo map ordering (appear first). */
-const PRIORITY_DIRS = ['src/', 'server/', 'lib/', 'packages/'];
-
-/** Stop words excluded from keyword extraction for symbol search. */
-const STOP_WORDS = new Set([
-    'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
-    'of', 'with', 'by', 'from', 'is', 'it', 'be', 'as', 'was', 'were',
-    'are', 'been', 'has', 'have', 'had', 'do', 'does', 'did', 'will',
-    'would', 'could', 'should', 'may', 'might', 'shall', 'can', 'not',
-    'this', 'that', 'these', 'those', 'if', 'then', 'else', 'when',
-    'up', 'out', 'so', 'no', 'we', 'us', 'our', 'my', 'me', 'i',
-    'add', 'fix', 'update', 'change', 'make', 'use', 'create', 'new',
-    'need', 'want', 'get', 'set', 'all', 'each', 'any', 'into',
-    'also', 'about', 'more', 'some', 'only', 'just', 'than', 'such',
-]);
 
 type CompletionCallback = (task: WorkTask) => void;
 
@@ -267,10 +248,14 @@ export class WorkTaskService {
         });
 
         // Generate repo map for structural awareness (best-effort)
-        const repoMap = await this.generateRepoMap(worktreeDir);
+        const repoMap = this.astParserService
+            ? await generateRepoMap(this.astParserService, worktreeDir)
+            : null;
 
         // Extract relevant symbols based on task description keywords
-        const relevantSymbols = this.extractRelevantSymbols(worktreeDir, task.description);
+        const relevantSymbols = this.astParserService
+            ? extractRelevantSymbols(this.astParserService, worktreeDir, task.description)
+            : null;
 
         // Build work prompt
         const prompt = this.buildWorkPrompt(branchName, task.description, repoMap ?? undefined, relevantSymbols ?? undefined);
@@ -644,221 +629,4 @@ ${repoMapSection}${relevantSymbolsSection}
 Important: You MUST create a PR when finished. The PR URL will be captured to report back to the requester.`;
     }
 
-    /**
-     * Generate a lightweight repo map showing exported symbols per file,
-     * grouped by directory, with line ranges for each symbol.
-     * Prioritizes source directories over test files and truncates at REPO_MAP_MAX_LINES.
-     * Returns null if AST service is unavailable or indexing fails.
-     */
-    private async generateRepoMap(projectDir: string): Promise<string | null> {
-        if (!this.astParserService) return null;
-
-        try {
-            const index = await this.astParserService.indexProject(projectDir);
-            const RELEVANT_KINDS = new Set(['function', 'class', 'interface', 'type_alias', 'enum', 'variable']);
-
-            // Collect file entries with relative paths
-            const fileEntries: Array<{ relPath: string; fileIndex: FileSymbolIndex }> = [];
-            for (const [filePath, fileIndex] of index.files.entries()) {
-                const relPath = relative(projectDir, filePath).replaceAll('\\', '/');
-                const exported = fileIndex.symbols.filter(
-                    (s: AstSymbol) => s.isExported && RELEVANT_KINDS.has(s.kind),
-                );
-                if (exported.length === 0) continue;
-                fileEntries.push({ relPath, fileIndex });
-            }
-
-            if (fileEntries.length === 0) return null;
-
-            // Sort: prioritize source directories, deprioritize test files
-            fileEntries.sort((a, b) => {
-                const aScore = this.filePathPriority(a.relPath);
-                const bScore = this.filePathPriority(b.relPath);
-                if (aScore !== bScore) return aScore - bScore;
-                return a.relPath.localeCompare(b.relPath);
-            });
-
-            // Group files by directory
-            const dirGroups = new Map<string, typeof fileEntries>();
-            for (const entry of fileEntries) {
-                const dir = entry.relPath.includes('/')
-                    ? entry.relPath.slice(0, entry.relPath.lastIndexOf('/'))
-                    : '.';
-                let group = dirGroups.get(dir);
-                if (!group) {
-                    group = [];
-                    dirGroups.set(dir, group);
-                }
-                group.push(entry);
-            }
-
-            const lines: string[] = [];
-            let lineCount = 0;
-
-            for (const [dir, entries] of dirGroups) {
-                if (lineCount >= REPO_MAP_MAX_LINES) break;
-
-                // Add directory header
-                lines.push(`\n${dir}/`);
-                lineCount++;
-
-                for (const { relPath, fileIndex } of entries) {
-                    if (lineCount >= REPO_MAP_MAX_LINES) break;
-
-                    const exported = fileIndex.symbols.filter(
-                        (s: AstSymbol) => s.isExported && RELEVANT_KINDS.has(s.kind),
-                    );
-
-                    const symbolList = exported.map((s: AstSymbol) => {
-                        const kindLabel = s.kind === 'type_alias' ? 'type' : s.kind;
-                        const lineRange = `[${s.startLine}-${s.endLine}]`;
-                        const children = s.children?.filter((c: AstSymbol) => RELEVANT_KINDS.has(c.kind));
-                        if (children && children.length > 0) {
-                            const methods = children.map((c: AstSymbol) =>
-                                `${c.name} [${c.startLine}-${c.endLine}]`,
-                            ).join(', ');
-                            return `${kindLabel} ${s.name} ${lineRange} { ${methods} }`;
-                        }
-                        return `${kindLabel} ${s.name} ${lineRange}`;
-                    });
-
-                    const fileName = relPath.includes('/')
-                        ? relPath.slice(relPath.lastIndexOf('/') + 1)
-                        : relPath;
-                    lines.push(`  ${fileName}: ${symbolList.join(', ')}`);
-                    lineCount++;
-                }
-            }
-
-            if (lines.length === 0) return null;
-
-            let result = lines.join('\n') + '\n';
-            if (lineCount >= REPO_MAP_MAX_LINES) {
-                result += `\n  ... truncated (${fileEntries.length} files total)\n`;
-            }
-            return result;
-        } catch (err) {
-            log.warn('Failed to generate repo map', {
-                projectDir,
-                error: err instanceof Error ? err.message : String(err),
-            });
-            return null;
-        }
-    }
-
-    /**
-     * Priority score for file path ordering in the repo map.
-     * Lower score = higher priority. Source dirs come first, test files last.
-     */
-    private filePathPriority(relPath: string): number {
-        // Test files get lowest priority
-        if (relPath.includes('__tests__') || relPath.includes('.test.') || relPath.includes('.spec.')) {
-            return 3;
-        }
-        // Priority source directories
-        for (const dir of PRIORITY_DIRS) {
-            if (relPath.startsWith(dir)) return 1;
-        }
-        return 2;
-    }
-
-    /**
-     * Extract symbols from the project index that are relevant to the task description.
-     * Tokenizes the description into keywords and searches for matching symbols.
-     * Returns a formatted section showing relevant files/symbols, or null if none found.
-     */
-    private extractRelevantSymbols(projectDir: string, description: string): string | null {
-        if (!this.astParserService) return null;
-
-        const keywords = this.tokenizeDescription(description);
-        if (keywords.length === 0) return null;
-
-        const seen = new Set<string>();
-        const results: AstSymbol[] = [];
-
-        for (const keyword of keywords) {
-            if (results.length >= 20) break;
-            const matches = this.astParserService.searchSymbols(projectDir, keyword, { limit: 10 });
-            for (const match of matches) {
-                const key = `${match.name}:${match.startLine}`;
-                if (!seen.has(key)) {
-                    seen.add(key);
-                    results.push(match);
-                }
-                if (results.length >= 20) break;
-            }
-        }
-
-        if (results.length === 0) return null;
-
-        // Group results by file for readability
-        const index = this.astParserService.getProjectIndex(projectDir);
-        if (!index) return null;
-
-        // Build a reverse lookup: symbol → file path
-        const symbolToFile = new Map<string, string>();
-        for (const [filePath, fileIndex] of index.files.entries()) {
-            for (const sym of fileIndex.symbols) {
-                const relFile = relative(projectDir, filePath).replaceAll('\\', '/');
-                symbolToFile.set(`${sym.name}:${sym.startLine}`, relFile);
-                if (sym.children) {
-                    for (const child of sym.children) {
-                        symbolToFile.set(`${child.name}:${child.startLine}`, relFile);
-                    }
-                }
-            }
-        }
-
-        const fileGroups = new Map<string, AstSymbol[]>();
-        for (const sym of results) {
-            const file = symbolToFile.get(`${sym.name}:${sym.startLine}`) ?? 'unknown';
-            let group = fileGroups.get(file);
-            if (!group) {
-                group = [];
-                fileGroups.set(file, group);
-            }
-            group.push(sym);
-        }
-
-        const lines: string[] = [];
-        for (const [file, symbols] of fileGroups) {
-            const symDescs = symbols.map((s) => {
-                const kindLabel = s.kind === 'type_alias' ? 'type' : s.kind;
-                return `${kindLabel} ${s.name} [${s.startLine}-${s.endLine}]`;
-            });
-            lines.push(`${file}: ${symDescs.join(', ')}`);
-        }
-
-        return lines.join('\n');
-    }
-
-    /**
-     * Tokenize a task description into meaningful keywords for symbol search.
-     * Splits on word boundaries, filters stop words, and extracts camelCase/PascalCase parts.
-     */
-    private tokenizeDescription(description: string): string[] {
-        // Split camelCase and PascalCase into parts, then also keep the full token
-        const tokens = new Set<string>();
-
-        // Split on non-alphanumeric boundaries
-        const rawTokens = description.split(/[^a-zA-Z0-9]+/).filter(t => t.length > 0);
-
-        for (const token of rawTokens) {
-            const lower = token.toLowerCase();
-            if (lower.length < 3 || STOP_WORDS.has(lower)) continue;
-
-            tokens.add(lower);
-
-            // Split camelCase: 'buildWorkPrompt' → ['build', 'Work', 'Prompt']
-            const camelParts = token.split(/(?=[A-Z])/).filter(p => p.length >= 3);
-            for (const part of camelParts) {
-                const partLower = part.toLowerCase();
-                if (!STOP_WORDS.has(partLower)) {
-                    tokens.add(partLower);
-                }
-            }
-        }
-
-        return [...tokens];
-    }
 }

--- a/specs/work/work-task-service.spec.md
+++ b/specs/work/work-task-service.spec.md
@@ -5,6 +5,7 @@ status: active
 files:
   - server/work/service.ts
   - server/work/validation.ts
+  - server/work/repo-map.ts
 db_tables:
   - work_tasks
 depends_on:
@@ -160,6 +161,7 @@ Manages the full lifecycle of autonomous work tasks: create a git worktree, spaw
 | `server/db/audit.ts` | `recordAudit` |
 | `server/process/types.ts` | `ClaudeStreamEvent`, `extractContentText` |
 | `server/work/validation.ts` | `runBunInstall`, `runValidation` |
+| `server/work/repo-map.ts` | `generateRepoMap`, `extractRelevantSymbols` |
 
 ### Consumed By
 


### PR DESCRIPTION
## Summary
- Extract `generateRepoMap`, `filePathPriority`, `extractRelevantSymbols`, `tokenizeDescription` and constants (`REPO_MAP_MAX_LINES`, `PRIORITY_DIRS`, `STOP_WORDS`) from `WorkTaskService` into standalone pure functions in `server/work/repo-map.ts`
- Functions now accept `AstParserService` as an explicit parameter instead of using `this.astParserService`
- `server/work/service.ts` drops from 1008 → 776 lines; new `server/work/repo-map.ts` is 243 lines
- Updated `specs/work/work-task-service.spec.md` to include the new file and dependency

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 5471 pass, 0 fail
- [x] `bun run spec:check` — 111/111 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)