### PR TITLE
feat: Telegram bridge work-intake mode

### DIFF
--- a/client/src/app/core/models/work-task.model.ts
+++ b/client/src/app/core/models/work-task.model.ts
@@ -1,5 +1,5 @@
 export type WorkTaskStatus = 'pending' | 'branching' | 'running' | 'validating' | 'completed' | 'failed';
-export type WorkTaskSource = 'web' | 'algochat' | 'agent';
+export type WorkTaskSource = 'web' | 'algochat' | 'agent' | 'discord' | 'telegram';
 
 export interface WorkTask {
     id: string;

--- a/server/__tests__/telegram-bridge.test.ts
+++ b/server/__tests__/telegram-bridge.test.ts
@@ -25,6 +25,8 @@ interface TelegramBridgeInternals {
     callTelegramApi: (method: string, body: Record<string, unknown>) => Promise<{ result: unknown }>;
     downloadFile: (fileId: string) => Promise<Buffer>;
     routeToAgent: (chatId: number, userId: number, text: string, replyTo?: number) => Promise<void>;
+    handleWorkIntake: (chatId: number, userId: number, text: string, replyTo?: number) => Promise<void>;
+    sendTaskResult: (chatId: number, task: import('../../shared/types/work-tasks').WorkTask, replyTo?: number) => Promise<void>;
     sendVoice: (chatId: number, text: string, voicePreset: string, replyTo?: number) => Promise<void>;
     subscribeForResponse: (sessionId: string, chatId: number, replyTo?: number) => void;
 }
@@ -638,5 +640,229 @@ describe('polling', () => {
         await internals(bridge).poll();
         internals(bridge).running = false;
         expect(internals(bridge).offset).toBe(101);
+    });
+});
+
+// ─── Work Intake Mode ──────────────────────────────────────────────────────
+
+describe('TelegramBridge work intake mode', () => {
+    const workIntakeConfig: TelegramBridgeConfig = {
+        ...defaultConfig,
+        mode: 'work_intake',
+    };
+
+    function createMockWorkTaskService() {
+        const completionCallbacks = new Map<string, (task: import('../../shared/types/work-tasks').WorkTask) => void>();
+        return {
+            create: mock(async (input: Record<string, unknown>) => ({
+                id: 'wt-test-001',
+                agentId: input.agentId,
+                projectId: 'proj-1',
+                sessionId: null,
+                source: 'telegram',
+                sourceId: String(input.sourceId ?? ''),
+                requesterInfo: input.requesterInfo ?? {},
+                description: input.description,
+                branchName: null,
+                status: 'pending' as const,
+                prUrl: null,
+                summary: null,
+                error: null,
+                originalBranch: null,
+                worktreeDir: null,
+                iterationCount: 0,
+                createdAt: new Date().toISOString(),
+                completedAt: null,
+            })),
+            onComplete: mock((taskId: string, cb: (task: import('../../shared/types/work-tasks').WorkTask) => void) => {
+                completionCallbacks.set(taskId, cb);
+            }),
+            // Helper for tests to trigger completion
+            _triggerComplete(taskId: string, task: import('../../shared/types/work-tasks').WorkTask) {
+                const cb = completionCallbacks.get(taskId);
+                if (cb) cb(task);
+            },
+        };
+    }
+
+    test('mode switch routes to work intake handler', async () => {
+        const pm = createMockProcessManager();
+        const wts = createMockWorkTaskService();
+        const agent = createAgent(db, { name: 'test-agent' });
+        createProject(db, { name: 'test-proj', workingDir: '/tmp/test' });
+
+        const bridge = new TelegramBridge(db, pm, workIntakeConfig, wts as any);
+        const sent = mockApiCapture(bridge);
+
+        await internals(bridge).handleMessage(makeMessage({
+            from: { id: 42, is_bot: false, first_name: 'User' },
+            text: 'Fix the login bug',
+        }));
+
+        expect(wts.create).toHaveBeenCalledTimes(1);
+        const createArg = (wts.create as any).mock.calls[0][0];
+        expect(createArg.description).toBe('Fix the login bug');
+        expect(createArg.source).toBe('telegram');
+        expect(createArg.agentId).toBe(agent.id);
+        expect(createArg.requesterInfo.telegramUserId).toBe(42);
+        expect(sent).toContain('Task queued: wt-test-001');
+    });
+
+    test('work intake sends error when no WorkTaskService', async () => {
+        const pm = createMockProcessManager();
+        const bridge = new TelegramBridge(db, pm, workIntakeConfig);
+        const sent = mockApiCapture(bridge);
+
+        await internals(bridge).handleMessage(makeMessage({
+            from: { id: 42, is_bot: false, first_name: 'User' },
+            text: 'Do something',
+        }));
+
+        expect(sent).toContain('Work intake mode requires WorkTaskService. Check server configuration.');
+    });
+
+    test('work intake sends error when no agents configured', async () => {
+        const pm = createMockProcessManager();
+        const wts = createMockWorkTaskService();
+        const bridge = new TelegramBridge(db, pm, workIntakeConfig, wts as any);
+        const sent = mockApiCapture(bridge);
+
+        await internals(bridge).handleMessage(makeMessage({
+            from: { id: 42, is_bot: false, first_name: 'User' },
+            text: 'Do something',
+        }));
+
+        expect(sent).toContain('No agents configured. Create an agent first.');
+    });
+
+    test('work intake subscribes for completion', async () => {
+        const pm = createMockProcessManager();
+        const wts = createMockWorkTaskService();
+        createAgent(db, { name: 'test-agent' });
+        createProject(db, { name: 'test-proj', workingDir: '/tmp/test' });
+
+        const bridge = new TelegramBridge(db, pm, workIntakeConfig, wts as any);
+        mockApiCapture(bridge);
+
+        await internals(bridge).handleMessage(makeMessage({
+            from: { id: 42, is_bot: false, first_name: 'User' },
+            text: 'Add dark mode',
+        }));
+
+        expect(wts.onComplete).toHaveBeenCalledTimes(1);
+        expect((wts.onComplete as any).mock.calls[0][0]).toBe('wt-test-001');
+    });
+
+    test('sendTaskResult formats completed task with PR URL', async () => {
+        const pm = createMockProcessManager();
+        const bridge = new TelegramBridge(db, pm, workIntakeConfig);
+        const sent = mockApiCapture(bridge);
+
+        await internals(bridge).sendTaskResult(12345, {
+            id: 'wt-001',
+            agentId: 'a1',
+            projectId: 'p1',
+            sessionId: null,
+            source: 'telegram',
+            sourceId: null,
+            requesterInfo: {},
+            description: 'Test',
+            branchName: 'feat/test',
+            status: 'completed',
+            prUrl: 'https://github.com/org/repo/pull/1',
+            summary: 'Added dark mode toggle',
+            error: null,
+            originalBranch: 'main',
+            worktreeDir: null,
+            iterationCount: 1,
+            createdAt: new Date().toISOString(),
+            completedAt: new Date().toISOString(),
+        });
+
+        expect(sent.length).toBe(1);
+        expect(sent[0]).toContain('Task completed!');
+        expect(sent[0]).toContain('https://github.com/org/repo/pull/1');
+        expect(sent[0]).toContain('Added dark mode toggle');
+    });
+
+    test('sendTaskResult formats failed task', async () => {
+        const pm = createMockProcessManager();
+        const bridge = new TelegramBridge(db, pm, workIntakeConfig);
+        const sent = mockApiCapture(bridge);
+
+        await internals(bridge).sendTaskResult(12345, {
+            id: 'wt-001',
+            agentId: 'a1',
+            projectId: 'p1',
+            sessionId: null,
+            source: 'telegram',
+            sourceId: null,
+            requesterInfo: {},
+            description: 'Test',
+            branchName: null,
+            status: 'failed',
+            prUrl: null,
+            summary: null,
+            error: 'Build failed: type errors',
+            originalBranch: 'main',
+            worktreeDir: null,
+            iterationCount: 1,
+            createdAt: new Date().toISOString(),
+            completedAt: new Date().toISOString(),
+        });
+
+        expect(sent.length).toBe(1);
+        expect(sent[0]).toContain('Task failed');
+        expect(sent[0]).toContain('Build failed: type errors');
+    });
+
+    test('work intake handles create failure gracefully', async () => {
+        const pm = createMockProcessManager();
+        const wts = createMockWorkTaskService();
+        wts.create = mock(async () => { throw new Error('Active task already exists for this project'); });
+        createAgent(db, { name: 'test-agent' });
+        createProject(db, { name: 'test-proj', workingDir: '/tmp/test' });
+
+        const bridge = new TelegramBridge(db, pm, workIntakeConfig, wts as any);
+        const sent = mockApiCapture(bridge);
+
+        await internals(bridge).handleMessage(makeMessage({
+            from: { id: 42, is_bot: false, first_name: 'User' },
+            text: 'Do something',
+        }));
+
+        expect(sent.some(m => m.includes('Task failed'))).toBe(true);
+        expect(sent.some(m => m.includes('Active task already exists'))).toBe(true);
+    });
+
+    test('chat mode still works when mode is chat', async () => {
+        const pm = createMockProcessManager();
+        createAgent(db, { name: 'test-agent' });
+        createProject(db, { name: 'test-proj', workingDir: '/tmp/test' });
+
+        const chatConfig: TelegramBridgeConfig = { ...defaultConfig, mode: 'chat' };
+        const bridge = new TelegramBridge(db, pm, chatConfig);
+        mockApiCapture(bridge);
+
+        await internals(bridge).handleMessage(makeMessage({
+            from: { id: 42, is_bot: false, first_name: 'User' },
+            text: 'Hello',
+        }));
+
+        // Should have started a process (chat mode behavior)
+        expect(pm.startProcess).toHaveBeenCalledTimes(1);
+    });
+
+    test('commands still work in work intake mode', async () => {
+        const pm = createMockProcessManager();
+        const bridge = new TelegramBridge(db, pm, workIntakeConfig);
+        const sent = mockApiCapture(bridge);
+
+        await internals(bridge).handleMessage(makeMessage({
+            from: { id: 42, is_bot: false, first_name: 'User' },
+            text: '/start',
+        }));
+
+        expect(sent).toContain('Connected to corvid-agent. Send a message to talk to an agent.');
     });
 });

--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -304,11 +304,17 @@ export async function bootstrapServices(db: Database, startTime: number): Promis
     // ── Communication bridges (opt-in via env vars) ──────────────────────
     let telegramBridge: TelegramBridge | null = null;
     if (process.env.TELEGRAM_BOT_TOKEN && process.env.TELEGRAM_CHAT_ID) {
-        telegramBridge = new TelegramBridge(db, processManager, {
-            botToken: process.env.TELEGRAM_BOT_TOKEN,
-            chatId: process.env.TELEGRAM_CHAT_ID,
-            allowedUserIds: (process.env.TELEGRAM_ALLOWED_USER_IDS ?? '').split(',').map(s => s.trim()).filter(Boolean),
-        });
+        telegramBridge = new TelegramBridge(
+            db,
+            processManager,
+            {
+                botToken: process.env.TELEGRAM_BOT_TOKEN,
+                chatId: process.env.TELEGRAM_CHAT_ID,
+                allowedUserIds: (process.env.TELEGRAM_ALLOWED_USER_IDS ?? '').split(',').map(s => s.trim()).filter(Boolean),
+                mode: (process.env.TELEGRAM_BRIDGE_MODE as 'chat' | 'work_intake') ?? undefined,
+            },
+            workTaskService,
+        );
         telegramBridge.start();
         shutdownCoordinator.registerService('TelegramBridge', telegramBridge, 20);
         log.info('Telegram bridge initialized');

--- a/server/telegram/bridge.ts
+++ b/server/telegram/bridge.ts
@@ -1,7 +1,9 @@
 import type { Database } from 'bun:sqlite';
 import type { ProcessManager } from '../process/manager';
+import type { WorkTaskService } from '../work/service';
 import type { TelegramBridgeConfig, TelegramUpdate, TelegramMessage, TelegramFile } from './types';
 import type { SessionSource } from '../../shared/types';
+import type { WorkTask } from '../../shared/types/work-tasks';
 import { getAgent, listAgents } from '../db/agents';
 import { createSession, getSession } from '../db/sessions';
 import { listProjects } from '../db/projects';
@@ -23,6 +25,7 @@ const POLL_TIMEOUT = 30; // Long-polling timeout in seconds
 export class TelegramBridge {
     private db: Database;
     private processManager: ProcessManager;
+    private workTaskService: WorkTaskService | null;
     private config: TelegramBridgeConfig;
     private offset = 0;
     private pollTimer: ReturnType<typeof setTimeout> | null = null;
@@ -36,10 +39,15 @@ export class TelegramBridge {
     private readonly RATE_LIMIT_WINDOW_MS = 60_000;
     private readonly RATE_LIMIT_MAX_MESSAGES = 10;
 
-    constructor(db: Database, processManager: ProcessManager, config: TelegramBridgeConfig) {
+    constructor(db: Database, processManager: ProcessManager, config: TelegramBridgeConfig, workTaskService?: WorkTaskService) {
         this.db = db;
         this.processManager = processManager;
         this.config = config;
+        this.workTaskService = workTaskService ?? null;
+    }
+
+    private get mode() {
+        return this.config.mode ?? 'chat';
     }
 
     start(): void {
@@ -196,9 +204,78 @@ export class TelegramBridge {
             return;
         }
 
-        // Route to agent session
-        await this.routeToAgent(message.chat.id, userId, text, message.message_id);
+        // Route based on mode
+        if (this.mode === 'work_intake') {
+            await this.handleWorkIntake(message.chat.id, userId, text, message.message_id);
+        } else {
+            await this.routeToAgent(message.chat.id, userId, text, message.message_id);
+        }
     }
+
+    // ── Work Intake Mode ─────────────────────────────────────────────────
+
+    private async handleWorkIntake(chatId: number, userId: number, text: string, replyTo?: number): Promise<void> {
+        if (!this.workTaskService) {
+            await this.sendText(chatId, 'Work intake mode requires WorkTaskService. Check server configuration.');
+            return;
+        }
+
+        const description = text.trim();
+        if (!description) {
+            await this.sendText(chatId, 'Please provide a task description.');
+            return;
+        }
+
+        // Resolve agent
+        const agents = listAgents(this.db);
+        const agent = agents[0];
+        if (!agent) {
+            await this.sendText(chatId, 'No agents configured. Create an agent first.');
+            return;
+        }
+
+        try {
+            const task = await this.workTaskService.create({
+                agentId: agent.id,
+                description,
+                source: 'telegram',
+                sourceId: String(replyTo ?? ''),
+                requesterInfo: { telegramUserId: userId, chatId, messageId: replyTo },
+            });
+
+            log.info('Work task created from Telegram', { taskId: task.id, userId });
+
+            // Send acknowledgment
+            await this.sendText(chatId, `Task queued: ${task.id}`, replyTo);
+
+            // Subscribe for completion
+            this.workTaskService.onComplete(task.id, (completedTask) => {
+                this.sendTaskResult(chatId, completedTask, replyTo).catch(err => {
+                    log.error('Failed to send task result to Telegram', {
+                        taskId: completedTask.id,
+                        error: err instanceof Error ? err.message : String(err),
+                    });
+                });
+            });
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            log.error('Failed to create work task from Telegram', { error: message, userId });
+            await this.sendText(chatId, `Task failed: ${message.slice(0, 500)}`, replyTo);
+        }
+    }
+
+    private async sendTaskResult(chatId: number, task: WorkTask, replyTo?: number): Promise<void> {
+        if (task.status === 'completed') {
+            const parts = ['Task completed!'];
+            if (task.prUrl) parts.push(`PR: ${task.prUrl}`);
+            if (task.summary) parts.push(task.summary.slice(0, 3000));
+            await this.sendText(chatId, parts.join('\n'), replyTo);
+        } else {
+            await this.sendText(chatId, `Task failed: ${(task.error ?? 'Unknown error').slice(0, 1000)}`, replyTo);
+        }
+    }
+
+    // ── Chat Mode ────────────────────────────────────────────────────────
 
     private async routeToAgent(chatId: number, userId: number, text: string, replyTo?: number): Promise<void> {
         let sessionId = this.userSessions.get(userId);

--- a/server/telegram/types.ts
+++ b/server/telegram/types.ts
@@ -1,7 +1,10 @@
+export type TelegramBridgeMode = 'chat' | 'work_intake';
+
 export interface TelegramBridgeConfig {
     botToken: string;
     chatId: string;
     allowedUserIds: string[];
+    mode?: TelegramBridgeMode;
 }
 
 export interface TelegramUpdate {

--- a/shared/types/work-tasks.ts
+++ b/shared/types/work-tasks.ts
@@ -1,5 +1,5 @@
 export type WorkTaskStatus = 'pending' | 'branching' | 'running' | 'validating' | 'completed' | 'failed';
-export type WorkTaskSource = 'web' | 'algochat' | 'agent' | 'discord';
+export type WorkTaskSource = 'web' | 'algochat' | 'agent' | 'discord' | 'telegram';
 
 export interface WorkTask {
     id: string;


### PR DESCRIPTION
## Summary
- Adds `TELEGRAM_BRIDGE_MODE=work_intake` mode to the Telegram bridge (#522)
- Incoming messages create async work tasks via `WorkTaskService.create()` instead of persistent chat sessions
- Task acknowledgment sent immediately; result/error sent back on completion
- Voice notes in work-intake mode transcribe via STT and use the transcript as task description
- Chat mode (`TELEGRAM_BRIDGE_MODE=chat`, default) is unchanged
- Adds `'telegram'` to `WorkTaskSource` union type

## Files changed
- `shared/types/work-tasks.ts` — added `'telegram'` to source union
- `client/src/app/core/models/work-task.model.ts` — synced client model
- `server/telegram/types.ts` — added `TelegramBridgeMode` type and `mode` config field
- `server/telegram/bridge.ts` — added `WorkTaskService` dependency, mode switch, `handleWorkIntake()` and `sendTaskResult()` methods
- `server/bootstrap.ts` — passes `TELEGRAM_BRIDGE_MODE` and `workTaskService` to bridge constructor
- `server/__tests__/telegram-bridge.test.ts` — 9 new tests for work intake mode

## Test plan
- [x] tsc clean
- [x] All 53 Telegram bridge tests pass (44 existing + 9 new)
- [x] CI passes

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)