### PR TITLE
fix: resolve CodeQL log-injection alerts #283 and #284

### DIFF
--- a/cli/render.ts
+++ b/cli/render.ts
@@ -66,8 +66,10 @@ function sanitize(s: string): string {
     const input = String(s);
     // Remove ANSI escape sequences (CSI: ESC [ ... letter)
     const withoutAnsi = input.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
-    // Allow only safe printable characters; drop control chars and newlines
-    return withoutAnsi.replace(/[^ -~\t]/g, '');
+    // Strip newlines/carriage returns explicitly (CodeQL log-injection barrier)
+    const noNewlines = withoutAnsi.replace(/[\r\n]/g, '');
+    // Drop remaining control characters outside safe printable ASCII + tab
+    return noNewlines.replace(/[^ -~\t]/g, '');
 }
 
 // ─── Output Helpers ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- CodeQL couldn't statically determine that `[^ -~\t]` strips `\r\n`
- Added explicit `replace(/[\r\n]/g, '')` step as a recognized sanitizer barrier
- Same `sanitize()` function, just split into two steps so CodeQL can trace it

Resolves CodeQL alerts #283 and #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)