### PR TITLE
feat: add governance tier to council edit UI

### DIFF
--- a/client/src/app/core/models/council.model.ts
+++ b/client/src/app/core/models/council.model.ts
@@ -1,3 +1,5 @@
+export type CouncilOnChainMode = 'off' | 'attestation' | 'full';
+
 export interface Council {
     id: string;
     name: string;
@@ -5,6 +7,7 @@ export interface Council {
     chairmanAgentId: string | null;
     agentIds: string[];
     discussionRounds: number;
+    onChainMode: CouncilOnChainMode;
     createdAt: string;
     updatedAt: string;
 }
@@ -15,6 +18,7 @@ export interface CreateCouncilInput {
     agentIds: string[];
     chairmanAgentId?: string;
     discussionRounds?: number;
+    onChainMode?: CouncilOnChainMode;
 }
 
 export interface UpdateCouncilInput {
@@ -23,6 +27,7 @@ export interface UpdateCouncilInput {
     agentIds?: string[];
     chairmanAgentId?: string | null;
     discussionRounds?: number;
+    onChainMode?: CouncilOnChainMode;
 }
 
 export type CouncilStage = 'responding' | 'discussing' | 'reviewing' | 'synthesizing' | 'complete';

--- a/client/src/app/features/councils/council-detail.component.ts
+++ b/client/src/app/features/councils/council-detail.component.ts
@@ -35,6 +35,8 @@ import type { Council, CouncilLaunch } from '../../core/models/council.model';
                         <dd>{{ chairmanName() || 'None' }}</dd>
                         <dt>Discussion Rounds</dt>
                         <dd>{{ c.discussionRounds }}</dd>
+                        <dt>Governance Tier</dt>
+                        <dd>{{ c.onChainMode }}</dd>
                         <dt>Created</dt>
                         <dd>{{ c.createdAt | relativeTime }}</dd>
                     </dl>

--- a/client/src/app/features/councils/council-form.component.ts
+++ b/client/src/app/features/councils/council-form.component.ts
@@ -58,6 +58,16 @@ import type { Agent } from '../../core/models/agent.model';
                 </div>
 
                 <div class="form__field">
+                    <label for="onChainMode" class="form__label">Governance Tier</label>
+                    <select id="onChainMode" formControlName="onChainMode" class="form__input">
+                        <option value="off">Off</option>
+                        <option value="attestation">Attestation</option>
+                        <option value="full">Full</option>
+                    </select>
+                    <p class="form__hint">Controls on-chain recording: off (local only), attestation (hash on-chain), or full (all data on-chain).</p>
+                </div>
+
+                <div class="form__field">
                     <label for="chairman" class="form__label">Chairman (optional)</label>
                     <select #chairmanSelect id="chairman" class="form__input" (change)="onChairmanChange($event)">
                         <option value="">None</option>
@@ -125,6 +135,7 @@ export class CouncilFormComponent implements OnInit {
         name: ['', Validators.required],
         description: [''],
         discussionRounds: [2, [Validators.min(0), Validators.max(10)]],
+        onChainMode: ['full' as 'off' | 'attestation' | 'full'],
     });
 
     protected get selectedAgentsList(): () => Agent[] {
@@ -147,6 +158,7 @@ export class CouncilFormComponent implements OnInit {
                 name: council.name,
                 description: council.description,
                 discussionRounds: council.discussionRounds ?? 2,
+                onChainMode: council.onChainMode ?? 'full',
             });
             this.selectedAgentIds.set(new Set(council.agentIds));
             this.chairmanId.set(council.chairmanAgentId ?? '');
@@ -186,6 +198,7 @@ export class CouncilFormComponent implements OnInit {
                     name: value.name,
                     description: value.description,
                     discussionRounds: value.discussionRounds,
+                    onChainMode: value.onChainMode,
                     agentIds,
                     chairmanAgentId: chairmanAgentId ?? null,
                 });
@@ -195,6 +208,7 @@ export class CouncilFormComponent implements OnInit {
                     name: value.name,
                     description: value.description,
                     discussionRounds: value.discussionRounds,
+                    onChainMode: value.onChainMode,
                     agentIds,
                     chairmanAgentId,
                 });


### PR DESCRIPTION
## Summary
- Adds `onChainMode` (governance tier) field to the council edit/create form, detail view, and client TypeScript model
- The council edit UI already supported editing members, chairman, and discussion rounds — this fills the last gap
- Server PUT endpoint and DB layer already handle `onChainMode`, so no backend changes needed

## Changes
- `client/src/app/core/models/council.model.ts` — added `CouncilOnChainMode` type and `onChainMode` to `Council`, `CreateCouncilInput`, `UpdateCouncilInput`
- `client/src/app/features/councils/council-form.component.ts` — added governance tier `<select>` with off/attestation/full options, wired into form group and submit logic
- `client/src/app/features/councils/council-detail.component.ts` — displays governance tier in council info panel

## Test plan
- [x] Navigate to Councils → click a council → verify "Governance Tier" appears in the detail info
- [x] Click "Edit" → verify governance tier dropdown shows current value
- [x] Change governance tier → Save → verify detail page reflects the change
- [x] Create a new council → verify governance tier defaults to "full"

Closes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)