### PR TITLE
refactor: extract scheduler service into handler modules

### DIFF
--- a/server/scheduler/execution.ts
+++ b/server/scheduler/execution.ts
@@ -1,0 +1,183 @@
+/**
+ * Execution lifecycle — wraps action handler dispatch with error handling,
+ * failure tracking, notifications, and repo lock management.
+ */
+import type { Database } from 'bun:sqlite';
+import type {
+    AgentSchedule,
+    ScheduleAction,
+    ScheduleActionType,
+    ScheduleExecution,
+} from '../../shared/types';
+import {
+    updateExecutionStatus,
+    getExecution,
+    updateSchedule,
+    getSchedule,
+} from '../db/schedules';
+import { releaseAllLocks } from '../db/repo-locks';
+import { createLogger } from '../lib/logger';
+import type { AgentMessenger } from '../algochat/agent-messenger';
+
+import type { HandlerContext } from './handlers/types';
+import {
+    execStarRepos,
+    execForkRepos,
+    execReviewPrs,
+    execGithubSuggest,
+    execWorkTask,
+    execCouncilLaunch,
+    execSendMessage,
+    execCodebaseReview,
+    execDependencyAudit,
+    execImprovementLoop,
+    execMemoryMaintenance,
+    execReputationAttestation,
+    execOutcomeAnalysis,
+    execDailyReview,
+    execStatusCheckin,
+    execCustom,
+} from './handlers';
+
+const log = createLogger('Scheduler');
+const MAX_CONSECUTIVE_FAILURES = 5;
+
+const BROADCAST_ACTION_TYPES: ScheduleActionType[] = [
+    'work_task', 'council_launch', 'daily_review', 'review_prs',
+    'github_suggest', 'codebase_review', 'dependency_audit',
+    'improvement_loop', 'custom', 'status_checkin',
+];
+
+/** Dispatch an action to its handler. */
+async function dispatchAction(
+    hctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+    action: ScheduleAction,
+    db: Database,
+): Promise<void> {
+    switch (action.type) {
+        case 'star_repo':              await execStarRepos(hctx, executionId, action); break;
+        case 'fork_repo':              await execForkRepos(hctx, executionId, action); break;
+        case 'review_prs':             await execReviewPrs(hctx, executionId, schedule, action); break;
+        case 'work_task':              await execWorkTask(hctx, executionId, schedule, action); break;
+        case 'council_launch':         await execCouncilLaunch(hctx, executionId, schedule, action); break;
+        case 'send_message':           await execSendMessage(hctx, executionId, schedule, action); break;
+        case 'github_suggest':         await execGithubSuggest(hctx, executionId, schedule, action); break;
+        case 'codebase_review':        await execCodebaseReview(hctx, executionId, schedule, action); break;
+        case 'dependency_audit':       await execDependencyAudit(hctx, executionId, schedule, action); break;
+        case 'improvement_loop':       await execImprovementLoop(hctx, executionId, schedule, action); break;
+        case 'memory_maintenance':     await execMemoryMaintenance(hctx, executionId, schedule); break;
+        case 'reputation_attestation': await execReputationAttestation(hctx, executionId, schedule); break;
+        case 'outcome_analysis':       await execOutcomeAnalysis(hctx, executionId, schedule); break;
+        case 'daily_review':           execDailyReview(hctx, executionId, schedule); break;
+        case 'status_checkin':         await execStatusCheckin(hctx, executionId, schedule); break;
+        case 'custom':                 await execCustom(hctx, executionId, schedule, action); break;
+        default:
+            updateExecutionStatus(db, executionId, 'failed', {
+                result: `Unknown action type: ${action.type}`,
+            });
+    }
+}
+
+export interface RunActionDeps {
+    db: Database;
+    agentMessenger: AgentMessenger | null;
+    runningExecutions: Set<string>;
+    consecutiveFailures: Map<string, number>;
+    emit: (event: { type: string; data: unknown }) => void;
+}
+
+/**
+ * Execute an action with full lifecycle management:
+ * dispatch → error handling → lock cleanup → failure tracking → notifications.
+ */
+export async function runAction(
+    deps: RunActionDeps,
+    hctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+    action: ScheduleAction,
+): Promise<void> {
+    deps.runningExecutions.add(executionId);
+
+    try {
+        await dispatchAction(hctx, executionId, schedule, action, deps.db);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.error('Schedule action failed', { executionId, actionType: action.type, error: message });
+        updateExecutionStatus(deps.db, executionId, 'failed', { result: message });
+    } finally {
+        releaseAllLocks(deps.db, executionId);
+        deps.runningExecutions.delete(executionId);
+
+        const updated = getExecution(deps.db, executionId);
+        if (updated) {
+            deps.emit({ type: 'schedule_execution_update', data: updated });
+
+            const resultSnippet = updated.result ? updated.result.slice(0, 200) : '';
+            if (updated.status === 'completed') {
+                notifyScheduleEvent(deps, schedule, 'completed',
+                    `Schedule "${schedule.name}" completed (${action.type}): ${resultSnippet}`);
+                broadcastScheduleResult(deps.agentMessenger, schedule.agentId, action.type, resultSnippet);
+            } else if (updated.status === 'failed') {
+                notifyScheduleEvent(deps, schedule, 'failed',
+                    `Schedule "${schedule.name}" FAILED (${action.type}): ${resultSnippet}`);
+            }
+
+            trackConsecutiveFailures(deps, schedule, updated);
+        }
+    }
+}
+
+function trackConsecutiveFailures(
+    deps: RunActionDeps,
+    schedule: AgentSchedule,
+    execution: ScheduleExecution,
+): void {
+    if (execution.status === 'failed') {
+        const count = (deps.consecutiveFailures.get(schedule.id) ?? 0) + 1;
+        deps.consecutiveFailures.set(schedule.id, count);
+        if (count >= MAX_CONSECUTIVE_FAILURES) {
+            log.warn('Auto-pausing schedule after consecutive failures', {
+                scheduleId: schedule.id, failures: count,
+            });
+            updateSchedule(deps.db, schedule.id, { status: 'paused' });
+            deps.consecutiveFailures.delete(schedule.id);
+            const pausedSchedule = getSchedule(deps.db, schedule.id);
+            if (pausedSchedule) deps.emit({ type: 'schedule_update', data: pausedSchedule });
+        }
+    } else if (execution.status === 'completed') {
+        deps.consecutiveFailures.delete(schedule.id);
+    }
+}
+
+function broadcastScheduleResult(
+    agentMessenger: AgentMessenger | null,
+    agentId: string,
+    actionType: ScheduleActionType,
+    summary: string,
+): void {
+    if (!agentMessenger) return;
+    if (!BROADCAST_ACTION_TYPES.includes(actionType)) return;
+    const msg = `[SCHEDULE:${actionType}] ${summary.slice(0, 200)}`;
+    agentMessenger.sendOnChainToSelf(agentId, msg).catch(() => {});
+}
+
+function notifyScheduleEvent(
+    deps: RunActionDeps,
+    schedule: AgentSchedule,
+    event: 'started' | 'completed' | 'failed',
+    message: string,
+): void {
+    if (!schedule.notifyAddress || !deps.agentMessenger) return;
+    deps.agentMessenger.sendNotificationToAddress(
+        schedule.agentId, schedule.notifyAddress,
+        `[schedule:${event}] ${message}`,
+    ).catch((err) => {
+        log.debug('Schedule notification send failed', {
+            scheduleId: schedule.id, notifyAddress: schedule.notifyAddress,
+            error: err instanceof Error ? err.message : String(err),
+        });
+    });
+}

--- a/server/scheduler/handlers/council.ts
+++ b/server/scheduler/handlers/council.ts
@@ -1,0 +1,72 @@
+/**
+ * Council and messaging schedule action handlers: council_launch, send_message.
+ */
+import type { AgentSchedule, ScheduleAction } from '../../../shared/types';
+import { updateExecutionStatus } from '../../db/schedules';
+import { launchCouncil } from '../../routes/councils';
+import type { HandlerContext } from './types';
+
+export async function execCouncilLaunch(
+    ctx: HandlerContext,
+    executionId: string,
+    _schedule: AgentSchedule,
+    action: ScheduleAction,
+): Promise<void> {
+    if (!action.councilId || !action.projectId || !action.description) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', {
+            result: 'councilId, projectId, and description are required for council_launch',
+        });
+        return;
+    }
+
+    try {
+        const result = launchCouncil(
+            ctx.db,
+            ctx.processManager,
+            action.councilId,
+            action.projectId,
+            action.description,
+            ctx.agentMessenger,
+        );
+        updateExecutionStatus(ctx.db, executionId, 'completed', {
+            result: `Council launched: ${result.launchId} (${result.sessionIds.length} agents)`,
+        });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: message });
+    }
+}
+
+export async function execSendMessage(
+    ctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+    action: ScheduleAction,
+): Promise<void> {
+    if (!action.toAgentId || !action.message) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', {
+            result: 'toAgentId and message are required for send_message',
+        });
+        return;
+    }
+
+    if (!ctx.agentMessenger) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'Agent messenger not available' });
+        return;
+    }
+
+    try {
+        const { response, threadId } = await ctx.agentMessenger.invokeAndWait({
+            fromAgentId: schedule.agentId,
+            toAgentId: action.toAgentId,
+            content: action.message,
+        });
+
+        updateExecutionStatus(ctx.db, executionId, 'completed', {
+            result: `Message sent. Response: ${response.slice(0, 500)}... [thread: ${threadId}]`,
+        });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: message });
+    }
+}

--- a/server/scheduler/handlers/github.ts
+++ b/server/scheduler/handlers/github.ts
@@ -1,0 +1,180 @@
+/**
+ * GitHub-related schedule action handlers: star_repo, fork_repo, review_prs, github_suggest.
+ */
+import type { AgentSchedule, ScheduleAction } from '../../../shared/types';
+import { updateExecutionStatus } from '../../db/schedules';
+import { getAgent } from '../../db/agents';
+import { createSession } from '../../db/sessions';
+import * as github from '../../github/operations';
+import type { HandlerContext } from './types';
+
+export async function execStarRepos(
+    ctx: HandlerContext,
+    executionId: string,
+    action: ScheduleAction,
+): Promise<void> {
+    if (!action.repos?.length) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'No repos specified' });
+        return;
+    }
+
+    const results: string[] = [];
+    for (const repo of action.repos) {
+        const r = await github.starRepo(repo);
+        results.push(r.message);
+    }
+
+    updateExecutionStatus(ctx.db, executionId, 'completed', {
+        result: results.join('\n'),
+    });
+}
+
+export async function execForkRepos(
+    ctx: HandlerContext,
+    executionId: string,
+    action: ScheduleAction,
+): Promise<void> {
+    if (!action.repos?.length) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'No repos specified' });
+        return;
+    }
+
+    const results: string[] = [];
+    for (const repo of action.repos) {
+        const r = await github.forkRepo(repo);
+        results.push(r.message);
+    }
+
+    updateExecutionStatus(ctx.db, executionId, 'completed', {
+        result: results.join('\n'),
+    });
+}
+
+export async function execReviewPrs(
+    ctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+    action: ScheduleAction,
+): Promise<void> {
+    if (!action.repos?.length) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'No repos specified' });
+        return;
+    }
+
+    const tenantId = ctx.resolveScheduleTenantId(schedule.agentId);
+    const agent = getAgent(ctx.db, schedule.agentId, tenantId);
+    if (!agent) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'Agent not found' });
+        return;
+    }
+
+    const maxPrs = action.maxPrs ?? 5;
+    const results: string[] = [];
+
+    for (const repo of action.repos) {
+        const prList = await github.listOpenPrs(repo, maxPrs);
+        if (!prList.ok) {
+            results.push(`${repo}: Failed to list PRs — ${prList.error}`);
+            continue;
+        }
+
+        if (prList.prs.length === 0) {
+            results.push(`${repo}: No open PRs`);
+            continue;
+        }
+
+        // Create a session for the agent to review the PRs
+        const prSummary = prList.prs.map((pr) =>
+            `- #${pr.number}: "${pr.title}" by ${pr.author} (+${pr.additions}/-${pr.deletions}, ${pr.changedFiles} files)`
+        ).join('\n');
+
+        const prompt = `You are reviewing open pull requests for ${repo}.\n\n` +
+            `## Open PRs\n${prSummary}\n\n` +
+            `## Instructions\n` +
+            `1. BEFORE reviewing each PR, check if you (corvid-agent) have already left a review comment:\n` +
+            `   \`gh pr view <number> --repo ${repo} --json comments --jq '.comments[] | select(.author.login == "corvid-agent") | .createdAt'\`\n` +
+            `   If you already commented AND there are no new commits since your last comment, SKIP that PR.\n` +
+            `   Only re-review if there are new commits since your last review.\n` +
+            `2. For PRs that need review, use \`gh pr diff <number> --repo ${repo}\` to review the changes.\n` +
+            `3. Analyze code quality, potential issues, and improvements.\n` +
+            `4. Leave ONE concise review comment. Do not leave multiple comments on the same PR.\n` +
+            `5. Summarize your review findings at the end.`;
+
+        const projectId = action.projectId ?? agent.defaultProjectId;
+        if (!projectId) {
+            results.push(`${repo}: No project configured for agent`);
+            continue;
+        }
+
+        const session = createSession(ctx.db, {
+            projectId,
+            agentId: schedule.agentId,
+            name: `Scheduled PR Review: ${repo}`,
+            initialPrompt: prompt,
+            source: 'agent',
+        }, tenantId);
+
+        updateExecutionStatus(ctx.db, executionId, 'running', { sessionId: session.id });
+        ctx.processManager.startProcess(session, prompt, { schedulerMode: true, schedulerActionType: action.type });
+        results.push(`${repo}: Reviewing ${prList.prs.length} PR(s) in session ${session.id}`);
+    }
+
+    // Mark completed (the session may still be running)
+    updateExecutionStatus(ctx.db, executionId, 'completed', {
+        result: results.join('\n'),
+    });
+}
+
+export async function execGithubSuggest(
+    ctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+    action: ScheduleAction,
+): Promise<void> {
+    if (!action.repos?.length) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'No repos specified' });
+        return;
+    }
+
+    const tenantId = ctx.resolveScheduleTenantId(schedule.agentId);
+    const agent = getAgent(ctx.db, schedule.agentId, tenantId);
+    if (!agent) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'Agent not found' });
+        return;
+    }
+
+    const projectId = action.projectId ?? agent.defaultProjectId;
+    if (!projectId) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'No project configured for agent' });
+        return;
+    }
+
+    // Create a session for the agent to analyze repos and suggest improvements
+    const repoList = action.repos.join(', ');
+    const prompt = `You are analyzing the following repositories for potential improvements: ${repoList}\n\n` +
+        `## Instructions\n` +
+        `1. For each repo, examine the codebase structure, README, issues, and recent PRs.\n` +
+        `2. Identify potential improvements: documentation, code quality, performance, testing, CI/CD.\n` +
+        `3. Prioritize suggestions by impact and feasibility.\n` +
+        `4. For each suggestion, provide a clear description of the change.\n` +
+        (action.autoCreatePr
+            ? `5. If you have high-confidence suggestions, create work tasks using corvid_create_work_task.\n`
+            : `5. Summarize your findings — do NOT create PRs automatically.\n`) +
+        `\nBe thorough but focused. Quality over quantity.`;
+
+    const session = createSession(ctx.db, {
+        projectId,
+        agentId: schedule.agentId,
+        name: `Scheduled Suggestions: ${repoList.slice(0, 50)}`,
+        initialPrompt: prompt,
+        source: 'agent',
+    }, tenantId);
+
+    updateExecutionStatus(ctx.db, executionId, 'running', { sessionId: session.id });
+    ctx.processManager.startProcess(session, prompt, { schedulerMode: true, schedulerActionType: action.type });
+
+    updateExecutionStatus(ctx.db, executionId, 'completed', {
+        result: `Analysis session started: ${session.id}`,
+        sessionId: session.id,
+    });
+}

--- a/server/scheduler/handlers/improvement.ts
+++ b/server/scheduler/handlers/improvement.ts
@@ -1,0 +1,47 @@
+/**
+ * Improvement loop schedule action handler.
+ */
+import type { AgentSchedule, ScheduleAction } from '../../../shared/types';
+import { updateExecutionStatus } from '../../db/schedules';
+import { getAgent } from '../../db/agents';
+import type { HandlerContext } from './types';
+
+export async function execImprovementLoop(
+    ctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+    action: ScheduleAction,
+): Promise<void> {
+    if (!ctx.improvementLoopService) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'Improvement loop service not configured' });
+        return;
+    }
+
+    const tenantId = ctx.resolveScheduleTenantId(schedule.agentId);
+    const agent = getAgent(ctx.db, schedule.agentId, tenantId);
+    if (!agent) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'Agent not found' });
+        return;
+    }
+
+    const projectId = action.projectId ?? agent.defaultProjectId;
+    if (!projectId) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'No project configured for agent' });
+        return;
+    }
+
+    updateExecutionStatus(ctx.db, executionId, 'running');
+
+    const result = await ctx.improvementLoopService.run(schedule.agentId, projectId, {
+        maxTasks: action.maxImprovementTasks ?? 3,
+        focusArea: action.focusArea,
+    });
+
+    updateExecutionStatus(ctx.db, executionId, 'completed', {
+        result: `Improvement loop session started: ${result.sessionId}. ` +
+            `Health: ${result.health.tscErrorCount} tsc errors, ${result.health.testFailureCount} test failures. ` +
+            `Reputation: ${result.reputationScore} (${result.trustLevel}). ` +
+            `Max tasks: ${result.maxTasksAllowed}.`,
+        sessionId: result.sessionId,
+    });
+}

--- a/server/scheduler/handlers/index.ts
+++ b/server/scheduler/handlers/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Barrel export for all scheduler action handlers.
+ */
+export { execStarRepos, execForkRepos, execReviewPrs, execGithubSuggest } from './github';
+export { execWorkTask } from './work-task';
+export { execCouncilLaunch, execSendMessage } from './council';
+export { execCodebaseReview, execDependencyAudit } from './review';
+export { execImprovementLoop } from './improvement';
+export {
+    execMemoryMaintenance,
+    execReputationAttestation,
+    execOutcomeAnalysis,
+    execDailyReview,
+    execStatusCheckin,
+    execCustom,
+} from './maintenance';
+export type { HandlerContext } from './types';

--- a/server/scheduler/handlers/maintenance.ts
+++ b/server/scheduler/handlers/maintenance.ts
@@ -1,0 +1,200 @@
+/**
+ * Maintenance schedule action handlers: memory_maintenance, reputation_attestation,
+ * outcome_analysis, daily_review, status_checkin, custom.
+ */
+import type { AgentSchedule, ScheduleAction } from '../../../shared/types';
+import { updateExecutionStatus } from '../../db/schedules';
+import { getAgent } from '../../db/agents';
+import { createSession } from '../../db/sessions';
+import { summarizeOldMemories } from '../../memory/summarizer';
+import type { HandlerContext } from './types';
+
+export async function execMemoryMaintenance(
+    ctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+): Promise<void> {
+    try {
+        const archived = summarizeOldMemories(ctx.db, schedule.agentId, 30);
+        updateExecutionStatus(ctx.db, executionId, 'completed', {
+            result: `Memory maintenance completed: ${archived} memories archived and summarized.`,
+        });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: message });
+    }
+}
+
+export async function execReputationAttestation(
+    ctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+): Promise<void> {
+    if (!ctx.reputationScorer || !ctx.reputationAttestation) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', {
+            result: 'Reputation services not configured',
+        });
+        return;
+    }
+
+    try {
+        const score = ctx.reputationScorer.computeScore(schedule.agentId);
+        const hash = await ctx.reputationAttestation.createAttestation(score);
+
+        // Attempt on-chain publish via agent messenger
+        let txid: string | null = null;
+        if (ctx.agentMessenger) {
+            try {
+                const note = `corvid-reputation:${schedule.agentId}:${hash}`;
+                txid = await ctx.agentMessenger.sendOnChainToSelf(schedule.agentId, note);
+                if (txid) {
+                    ctx.reputationAttestation.publishOnChain(
+                        schedule.agentId, hash, async () => txid!,
+                    );
+                }
+            } catch {
+                // On-chain publish is best-effort
+            }
+        }
+
+        ctx.reputationScorer.setAttestationHash(schedule.agentId, hash);
+
+        updateExecutionStatus(ctx.db, executionId, 'completed', {
+            result: `Attestation created: hash=${hash.slice(0, 16)}... score=${score.overallScore} trust=${score.trustLevel}${txid ? ` txid=${txid}` : ' (off-chain)'}`,
+        });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: message });
+    }
+}
+
+export async function execOutcomeAnalysis(
+    ctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+): Promise<void> {
+    if (!ctx.outcomeTrackerService) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', {
+            result: 'Outcome tracker service not configured',
+        });
+        return;
+    }
+
+    try {
+        const checkResult = await ctx.outcomeTrackerService.checkOpenPrs();
+        const analysis = ctx.outcomeTrackerService.analyzeWeekly(schedule.agentId);
+        ctx.outcomeTrackerService.saveAnalysisToMemory(schedule.agentId, analysis);
+
+        const summary = [
+            `Checked ${checkResult.checked} open PRs (${checkResult.updated} updated).`,
+            `Merge rate: ${(analysis.overall.mergeRate * 100).toFixed(0)}% (${analysis.overall.merged}/${analysis.overall.total}).`,
+            `Work tasks: ${analysis.workTaskStats.completed}/${analysis.workTaskStats.total} succeeded.`,
+            analysis.topInsights.length > 0 ? `Insights: ${analysis.topInsights[0]}` : '',
+        ].filter(Boolean).join(' ');
+
+        updateExecutionStatus(ctx.db, executionId, 'completed', { result: summary });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: message });
+    }
+}
+
+export function execDailyReview(
+    ctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+): void {
+    if (!ctx.dailyReviewService) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', {
+            result: 'Daily review service not configured',
+        });
+        return;
+    }
+
+    try {
+        const result = ctx.dailyReviewService.run(schedule.agentId);
+        const summary = [
+            `Executions: ${result.executions.completed} completed, ${result.executions.failed} failed (${result.executions.total} total).`,
+            `PRs: ${result.prs.opened} opened, ${result.prs.merged} merged, ${result.prs.closed} closed.`,
+            `Health: ${result.health.uptimePercent}% uptime (${result.health.snapshotCount} snapshots).`,
+            result.observations.length > 0 ? `Observations: ${result.observations.join('; ')}` : '',
+        ].filter(Boolean).join(' ');
+
+        updateExecutionStatus(ctx.db, executionId, 'completed', { result: summary });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: message });
+    }
+}
+
+export async function execStatusCheckin(
+    ctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+): Promise<void> {
+    try {
+        const state = await ctx.systemStateDetector.evaluate();
+        const agent = getAgent(ctx.db, schedule.agentId);
+        const agentName = agent?.name ?? schedule.agentId.slice(0, 8);
+
+        const summary = [
+            `Agent: ${agentName}`,
+            `System: ${state.states.join(', ') || 'nominal'}`,
+            `Schedules running: ${ctx.runningExecutions.size}`,
+        ].join(' | ');
+
+        // Broadcast status to AlgoChat
+        if (ctx.agentMessenger) {
+            await ctx.agentMessenger.sendOnChainToSelf(
+                schedule.agentId,
+                `[STATUS_CHECKIN] ${summary}`,
+            );
+        }
+
+        updateExecutionStatus(ctx.db, executionId, 'completed', { result: summary });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: message });
+    }
+}
+
+export async function execCustom(
+    ctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+    action: ScheduleAction,
+): Promise<void> {
+    if (!action.prompt) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'No prompt provided for custom action' });
+        return;
+    }
+
+    const tenantId = ctx.resolveScheduleTenantId(schedule.agentId);
+    const agent = getAgent(ctx.db, schedule.agentId, tenantId);
+    if (!agent) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'Agent not found' });
+        return;
+    }
+
+    const projectId = action.projectId ?? agent.defaultProjectId;
+    if (!projectId) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'No project configured for agent' });
+        return;
+    }
+
+    const session = createSession(ctx.db, {
+        projectId,
+        agentId: schedule.agentId,
+        name: `Scheduled Custom: ${action.prompt.slice(0, 50)}`,
+        initialPrompt: action.prompt,
+        source: 'agent',
+    }, tenantId);
+
+    updateExecutionStatus(ctx.db, executionId, 'running', { sessionId: session.id });
+    ctx.processManager.startProcess(session, action.prompt, { schedulerMode: true, schedulerActionType: action.type });
+
+    updateExecutionStatus(ctx.db, executionId, 'completed', {
+        result: `Custom action session started: ${session.id}`,
+        sessionId: session.id,
+    });
+}

--- a/server/scheduler/handlers/review.ts
+++ b/server/scheduler/handlers/review.ts
@@ -1,0 +1,103 @@
+/**
+ * Codebase review and dependency audit schedule action handlers.
+ */
+import type { AgentSchedule, ScheduleAction } from '../../../shared/types';
+import { updateExecutionStatus } from '../../db/schedules';
+import { getAgent } from '../../db/agents';
+import { createSession } from '../../db/sessions';
+import type { HandlerContext } from './types';
+
+export async function execCodebaseReview(
+    ctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+    action: ScheduleAction,
+): Promise<void> {
+    const tenantId = ctx.resolveScheduleTenantId(schedule.agentId);
+    const agent = getAgent(ctx.db, schedule.agentId, tenantId);
+    if (!agent) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'Agent not found' });
+        return;
+    }
+
+    const projectId = action.projectId ?? agent.defaultProjectId;
+    if (!projectId) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'No project configured for agent' });
+        return;
+    }
+
+    const prompt = `You are performing an automated codebase review.\n\n` +
+        `## Instructions\n` +
+        `1. Run \`bun x tsc --noEmit 2>&1\` and collect any TypeScript errors.\n` +
+        `2. Run \`bun test 2>&1 | tail -50\` and collect any test failures.\n` +
+        `3. Search for TODO, FIXME, and HACK comments in the source code.\n` +
+        `4. Identify files over 500 lines that may need refactoring.\n` +
+        `5. Prioritize findings by severity (type errors > test failures > code smells).\n` +
+        `6. Create 1-3 work tasks via corvid_create_work_task for the most impactful fixes.\n` +
+        `7. Use corvid_notify_owner to report a summary of findings and created tasks.\n\n` +
+        `${action.description ? `Context: ${action.description}\n\n` : ''}` +
+        `Focus on actionable improvements. Quality over quantity.`;
+
+    const session = createSession(ctx.db, {
+        projectId,
+        agentId: schedule.agentId,
+        name: `Scheduled Codebase Review`,
+        initialPrompt: prompt,
+        source: 'agent',
+    }, tenantId);
+
+    updateExecutionStatus(ctx.db, executionId, 'running', { sessionId: session.id });
+    ctx.processManager.startProcess(session, prompt, { schedulerMode: true, schedulerActionType: action.type });
+
+    updateExecutionStatus(ctx.db, executionId, 'completed', {
+        result: `Codebase review session started: ${session.id}`,
+        sessionId: session.id,
+    });
+}
+
+export async function execDependencyAudit(
+    ctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+    action: ScheduleAction,
+): Promise<void> {
+    const tenantId = ctx.resolveScheduleTenantId(schedule.agentId);
+    const agent = getAgent(ctx.db, schedule.agentId, tenantId);
+    if (!agent) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'Agent not found' });
+        return;
+    }
+
+    const projectId = action.projectId ?? agent.defaultProjectId;
+    if (!projectId) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'No project configured for agent' });
+        return;
+    }
+
+    const prompt = `You are performing an automated dependency audit.\n\n` +
+        `## Instructions\n` +
+        `1. Check for outdated dependencies: \`bun outdated 2>&1\` (or \`npm outdated 2>&1\` as fallback).\n` +
+        `2. Check for known vulnerabilities: \`bun audit 2>&1\` (or \`npm audit 2>&1\` as fallback).\n` +
+        `3. Review \`package.json\` for pinning issues (exact versions vs ranges).\n` +
+        `4. Identify any deprecated or unmaintained packages.\n` +
+        `5. Create work tasks via corvid_create_work_task for critical updates (security vulnerabilities, major version bumps).\n` +
+        `6. Use corvid_notify_owner to report a summary of findings and recommendations.\n\n` +
+        `${action.description ? `Context: ${action.description}\n\n` : ''}` +
+        `Prioritize security fixes over feature updates.`;
+
+    const session = createSession(ctx.db, {
+        projectId,
+        agentId: schedule.agentId,
+        name: `Scheduled Dependency Audit`,
+        initialPrompt: prompt,
+        source: 'agent',
+    }, tenantId);
+
+    updateExecutionStatus(ctx.db, executionId, 'running', { sessionId: session.id });
+    ctx.processManager.startProcess(session, prompt, { schedulerMode: true, schedulerActionType: action.type });
+
+    updateExecutionStatus(ctx.db, executionId, 'completed', {
+        result: `Dependency audit session started: ${session.id}`,
+        sessionId: session.id,
+    });
+}

--- a/server/scheduler/handlers/types.ts
+++ b/server/scheduler/handlers/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared context passed to all scheduler action handlers.
+ */
+import type { Database } from 'bun:sqlite';
+import type { ProcessManager } from '../../process/manager';
+import type { WorkTaskService } from '../../work/service';
+import type { AutonomousLoopService } from '../../improvement/service';
+import type { AgentMessenger } from '../../algochat/agent-messenger';
+import type { ReputationScorer } from '../../reputation/scorer';
+import type { ReputationAttestation } from '../../reputation/attestation';
+import type { OutcomeTrackerService } from '../../feedback/outcome-tracker';
+import type { DailyReviewService } from '../../improvement/daily-review';
+import type { SystemStateDetector } from '../system-state';
+
+export interface HandlerContext {
+    db: Database;
+    processManager: ProcessManager;
+    workTaskService: WorkTaskService | null;
+    agentMessenger: AgentMessenger | null;
+    improvementLoopService: AutonomousLoopService | null;
+    reputationScorer: ReputationScorer | null;
+    reputationAttestation: ReputationAttestation | null;
+    outcomeTrackerService: OutcomeTrackerService | null;
+    dailyReviewService: DailyReviewService | null;
+    systemStateDetector: SystemStateDetector;
+    runningExecutions: Set<string>;
+    resolveScheduleTenantId(agentId: string): string;
+}

--- a/server/scheduler/handlers/work-task.ts
+++ b/server/scheduler/handlers/work-task.ts
@@ -1,0 +1,41 @@
+/**
+ * Work task schedule action handler.
+ */
+import type { AgentSchedule, ScheduleAction } from '../../../shared/types';
+import { updateExecutionStatus } from '../../db/schedules';
+import type { HandlerContext } from './types';
+
+export async function execWorkTask(
+    ctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+    action: ScheduleAction,
+): Promise<void> {
+    if (!ctx.workTaskService) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'Work task service not available' });
+        return;
+    }
+
+    if (!action.description) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: 'No description provided' });
+        return;
+    }
+
+    try {
+        const task = await ctx.workTaskService.create({
+            agentId: schedule.agentId,
+            description: action.description,
+            projectId: action.projectId,
+            source: 'agent',
+        });
+
+        updateExecutionStatus(ctx.db, executionId, 'completed', {
+            result: `Work task created: ${task.id} (branch: ${task.branchName ?? 'pending'})`,
+            workTaskId: task.id,
+            sessionId: task.sessionId ?? undefined,
+        });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: message });
+    }
+}

--- a/server/scheduler/orchestration.ts
+++ b/server/scheduler/orchestration.ts
@@ -1,0 +1,138 @@
+/**
+ * Per-action orchestration checks: health gating, approval workflows, repo locking.
+ *
+ * These are evaluated before dispatching each action in a schedule tick.
+ */
+import type { Database } from 'bun:sqlite';
+import type {
+    AgentSchedule,
+    ScheduleAction,
+    ScheduleActionType,
+    ScheduleExecution,
+} from '../../shared/types';
+import {
+    updateExecutionStatus,
+    getExecution,
+} from '../db/schedules';
+import { acquireRepoLock, releaseAllLocks } from '../db/repo-locks';
+import { recordAudit } from '../db/audit';
+import { createLogger } from '../lib/logger';
+import type { NotificationService } from '../notifications/service';
+import { evaluateAction } from './priority-rules';
+import type { SystemStateResult } from './system-state';
+
+const log = createLogger('Scheduler');
+
+type EmitFn = (event: { type: string; data: unknown }) => void;
+
+const DESTRUCTIVE_ACTIONS: ScheduleActionType[] = [
+    'work_task', 'github_suggest', 'fork_repo',
+    'codebase_review', 'dependency_audit', 'improvement_loop',
+];
+
+export function needsApproval(schedule: AgentSchedule, action: ScheduleAction): boolean {
+    if (schedule.approvalPolicy === 'auto') return false;
+    if (schedule.approvalPolicy === 'owner_approve') return DESTRUCTIVE_ACTIONS.includes(action.type);
+    return true; // council_approve
+}
+
+export function resolveActionRepos(action: ScheduleAction): string[] {
+    const repos: string[] = [];
+    if (action.repos?.length) repos.push(...action.repos);
+    if (action.projectId && !action.repos?.length) repos.push(`project:${action.projectId}`);
+    return repos;
+}
+
+export function shouldSkipByHealthGate(
+    db: Database,
+    schedule: AgentSchedule,
+    execution: ScheduleExecution,
+    action: ScheduleAction,
+    lastSystemState: SystemStateResult | null,
+    emit: EmitFn,
+): boolean {
+    if (!lastSystemState) return false;
+    const gate = evaluateAction(action.type, lastSystemState.states);
+    if (gate.decision !== 'skip') return false;
+
+    log.info('Action skipped by health gate', {
+        scheduleId: schedule.id, executionId: execution.id,
+        actionType: action.type, reasons: gate.reasons,
+    });
+    updateExecutionStatus(db, execution.id, 'cancelled', {
+        result: `Skipped by health gate: ${gate.reasons.join('; ')}`,
+    });
+    const gatedExec = getExecution(db, execution.id);
+    if (gatedExec) emit({ type: 'schedule_execution_update', data: gatedExec });
+    recordAudit(db, 'schedule_skip', schedule.agentId, 'schedule_execution', execution.id,
+        `Action ${action.type} skipped by health gate: ${gate.reasons.join('; ')}`);
+    return true;
+}
+
+export function handleApprovalIfNeeded(
+    db: Database,
+    schedule: AgentSchedule,
+    execution: ScheduleExecution,
+    action: ScheduleAction,
+    notificationService: NotificationService | null,
+    emit: EmitFn,
+): boolean {
+    if (!needsApproval(schedule, action)) return false;
+
+    updateExecutionStatus(db, execution.id, 'awaiting_approval');
+    const updated = getExecution(db, execution.id);
+    emit({
+        type: 'schedule_approval_request',
+        data: {
+            executionId: execution.id, scheduleId: schedule.id,
+            agentId: schedule.agentId, actionType: action.type,
+            description: action.description ?? `${action.type} on ${action.repos?.join(', ') ?? 'N/A'}`,
+        },
+    });
+    if (updated) emit({ type: 'schedule_execution_update', data: updated });
+
+    if (notificationService) {
+        const desc = action.description ?? `${action.type} on ${action.repos?.join(', ') ?? 'N/A'}`;
+        notificationService.notify({
+            agentId: schedule.agentId,
+            title: `Approval needed: ${schedule.name}`,
+            message: `Schedule "${schedule.name}" wants to run ${action.type}:\n${desc}\n\nApprove in the dashboard.`,
+            level: 'warning',
+        }).catch(err => log.warn('Approval notification failed', {
+            scheduleId: schedule.id, error: err instanceof Error ? err.message : String(err),
+        }));
+    }
+    return true;
+}
+
+export function handleRepoLocking(
+    db: Database,
+    schedule: AgentSchedule,
+    execution: ScheduleExecution,
+    action: ScheduleAction,
+    emit: EmitFn,
+): boolean {
+    const repos = resolveActionRepos(action);
+    if (repos.length === 0) return false;
+
+    const acquired: string[] = [];
+    for (const repo of repos) {
+        if (acquireRepoLock(db, repo, execution.id, schedule.id, action.type)) {
+            acquired.push(repo);
+        } else {
+            if (acquired.length > 0) releaseAllLocks(db, execution.id);
+            log.info('Action skipped — repo locked', {
+                scheduleId: schedule.id, executionId: execution.id, actionType: action.type, blockedRepo: repo,
+            });
+            updateExecutionStatus(db, execution.id, 'cancelled', {
+                result: `Repo "${repo}" is locked by another schedule execution`,
+            });
+            const skipped = getExecution(db, execution.id);
+            if (skipped) emit({ type: 'schedule_execution_update', data: skipped });
+            recordAudit(db, 'schedule_skip', schedule.agentId, 'schedule_execution', execution.id,
+                `Action ${action.type} skipped: repo "${repo}" locked`);
+            return true;
+        }
+    }
+    return false;
+}

--- a/server/scheduler/service.ts
+++ b/server/scheduler/service.ts
@@ -3,6 +3,9 @@
  *
  * Polls for due schedules every 30 seconds, executes their actions,
  * and manages approval workflows for PR submissions.
+ *
+ * Action execution is delegated to focused handler modules in ./handlers/.
+ * Execution lifecycle (dispatch, error handling, notifications) lives in ./execution.ts.
  */
 
 import type { Database } from 'bun:sqlite';
@@ -14,13 +17,7 @@ import type { AgentMessenger } from '../algochat/agent-messenger';
 import type { ReputationScorer } from '../reputation/scorer';
 import type { ReputationAttestation } from '../reputation/attestation';
 import type { NotificationService } from '../notifications/service';
-import { summarizeOldMemories } from '../memory/summarizer';
-import type {
-    AgentSchedule,
-    ScheduleAction,
-    ScheduleExecution,
-    ScheduleActionType,
-} from '../../shared/types';
+import type { AgentSchedule, ScheduleAction, ScheduleExecution } from '../../shared/types';
 import {
     listDueSchedules,
     updateScheduleLastRun,
@@ -33,30 +30,29 @@ import {
     resolveScheduleApproval,
 } from '../db/schedules';
 import { getAgent } from '../db/agents';
-import { createSession } from '../db/sessions';
 import { DEFAULT_TENANT_ID } from '../tenant/types';
-import * as github from '../github/operations';
-import { launchCouncil } from '../routes/councils';
 import { getNextCronDate } from './cron-parser';
 import { createLogger } from '../lib/logger';
 import { NotFoundError, ValidationError } from '../lib/errors';
 import { recordAudit } from '../db/audit';
 import { createEventContext, runWithEventContext } from '../observability/event-context';
-import {
-    acquireRepoLock,
-    releaseAllLocks,
-    cleanExpiredLocks,
-} from '../db/repo-locks';
+import { cleanExpiredLocks } from '../db/repo-locks';
 import type { OutcomeTrackerService } from '../feedback/outcome-tracker';
 import type { DailyReviewService } from '../improvement/daily-review';
 import { SystemStateDetector, type SystemStateResult, type SystemStateConfig } from './system-state';
-import { evaluateAction, getAllRules } from './priority-rules';
+import { getAllRules } from './priority-rules';
+import type { HandlerContext } from './handlers/types';
+import { runAction, type RunActionDeps } from './execution';
+import {
+    shouldSkipByHealthGate,
+    handleApprovalIfNeeded,
+    handleRepoLocking,
+} from './orchestration';
 
 const log = createLogger('Scheduler');
 
-const POLL_INTERVAL_MS = 30_000; // Check for due schedules every 30s
+const POLL_INTERVAL_MS = 30_000;
 const MAX_CONCURRENT_EXECUTIONS = 2;
-const MAX_CONSECUTIVE_FAILURES = 5;
 const MIN_SCHEDULE_INTERVAL_MS = 300_000; // 5 minutes
 
 type ScheduleEventCallback = (event: {
@@ -66,7 +62,6 @@ type ScheduleEventCallback = (event: {
 
 /**
  * Validate that a schedule doesn't fire more often than every 5 minutes.
- * Throws an Error if the schedule is too frequent.
  */
 export function validateScheduleFrequency(cronExpression?: string | null, intervalMs?: number | null): void {
     if (intervalMs !== undefined && intervalMs !== null) {
@@ -127,124 +122,60 @@ export class SchedulerService {
         this.systemStateDetector = new SystemStateDetector(db, systemStateConfig);
     }
 
-    /** Update the agent messenger (set after async AlgoChat init). */
-    setAgentMessenger(messenger: AgentMessenger): void {
-        this.agentMessenger = messenger;
-    }
+    // ─── Dependency setters ──────────────────────────────────────────────────
 
-    /** Set the improvement loop service (set after service initialization). */
-    setImprovementLoopService(service: AutonomousLoopService): void {
-        this.improvementLoopService = service;
-    }
-
-    /** Set reputation services (for attestation publishing schedule). */
+    setAgentMessenger(messenger: AgentMessenger): void { this.agentMessenger = messenger; }
+    setImprovementLoopService(service: AutonomousLoopService): void { this.improvementLoopService = service; }
     setReputationServices(scorer: ReputationScorer, attestation: ReputationAttestation): void {
         this.reputationScorer = scorer;
         this.reputationAttestation = attestation;
     }
+    setOutcomeTrackerService(service: OutcomeTrackerService): void { this.outcomeTrackerService = service; }
+    setDailyReviewService(service: DailyReviewService): void { this.dailyReviewService = service; }
+    setNotificationService(service: NotificationService): void { this.notificationService = service; }
+    setHealthCheck(fn: () => Promise<{ status: string }>): void { this.systemStateDetector.setHealthCheck(fn); }
 
-    /** Set outcome tracker service (for outcome_analysis schedule action). */
-    setOutcomeTrackerService(service: OutcomeTrackerService): void {
-        this.outcomeTrackerService = service;
-    }
+    // ─── Public API ──────────────────────────────────────────────────────────
 
-    /** Set daily review service (for daily_review schedule action). */
-    setDailyReviewService(service: DailyReviewService): void {
-        this.dailyReviewService = service;
-    }
+    async getSystemState(): Promise<SystemStateResult> { return this.systemStateDetector.evaluate(); }
+    getLastSystemState(): SystemStateResult | null { return this.lastSystemState; }
 
-    /** Set notification service (for approval request notifications). */
-    setNotificationService(service: NotificationService): void {
-        this.notificationService = service;
-    }
-
-    /**
-     * Resolve the tenant ID for a scheduled agent.
-     * Queries the agents table for the tenant_id column.
-     * Returns DEFAULT_TENANT_ID if the agent is not found.
-     */
-    private resolveScheduleTenantId(agentId: string): string {
-        const row = this.db.query(
-            'SELECT tenant_id FROM agents WHERE id = ?',
-        ).get(agentId) as { tenant_id: string } | null;
-        return row?.tenant_id ?? DEFAULT_TENANT_ID;
-    }
-
-    /** Set health check function for system state detection. */
-    setHealthCheck(fn: () => Promise<{ status: string }>): void {
-        this.systemStateDetector.setHealthCheck(fn);
-    }
-
-    /** Get the current system state (for health endpoint / dashboard). */
-    async getSystemState(): Promise<SystemStateResult> {
-        return this.systemStateDetector.evaluate();
-    }
-
-    /** Get the last cached system state (synchronous, may be null on first call). */
-    getLastSystemState(): SystemStateResult | null {
-        return this.lastSystemState;
-    }
-
-    /** Start the scheduler polling loop. */
     start(): void {
         if (this.pollTimer) return;
         log.info('Scheduler started', { pollIntervalMs: POLL_INTERVAL_MS });
-
-        // Initialize next_run_at for schedules that don't have one yet
         this.initializeNextRuns();
-
         this.pollTimer = setInterval(() => { this.tickPromise = this.tick(); }, POLL_INTERVAL_MS);
-        // Run once immediately
         this.tickPromise = this.tick();
     }
 
-    /** Stop the scheduler and wait for any in-flight tick to finish. */
     async stop(): Promise<void> {
-        if (this.pollTimer) {
-            clearInterval(this.pollTimer);
-            this.pollTimer = null;
-        }
-        if (this.tickPromise) {
-            await this.tickPromise.catch(() => {});
-            this.tickPromise = null;
-        }
+        if (this.pollTimer) { clearInterval(this.pollTimer); this.pollTimer = null; }
+        if (this.tickPromise) { await this.tickPromise.catch(() => {}); this.tickPromise = null; }
         log.info('Scheduler stopped');
     }
 
-    /** Get scheduler stats for the health endpoint. */
     getStats(): {
-        running: boolean;
-        activeSchedules: number;
-        pausedSchedules: number;
-        runningExecutions: number;
-        maxConcurrent: number;
-        recentFailures: number;
-        systemState: SystemStateResult | null;
-        priorityRules: ReturnType<typeof getAllRules>;
+        running: boolean; activeSchedules: number; pausedSchedules: number;
+        runningExecutions: number; maxConcurrent: number; recentFailures: number;
+        systemState: SystemStateResult | null; priorityRules: ReturnType<typeof getAllRules>;
     } {
-        const activeSchedules = queryCount(this.db, "SELECT COUNT(*) as cnt FROM agent_schedules WHERE status = 'active'");
-        const pausedSchedules = queryCount(this.db, "SELECT COUNT(*) as cnt FROM agent_schedules WHERE status = 'paused'");
-        const recentFailures = queryCount(this.db, "SELECT COUNT(*) as cnt FROM schedule_executions WHERE status = 'failed' AND started_at >= datetime('now', '-24 hours')");
-
         return {
             running: this.pollTimer !== null,
-            activeSchedules,
-            pausedSchedules,
+            activeSchedules: queryCount(this.db, "SELECT COUNT(*) as cnt FROM agent_schedules WHERE status = 'active'"),
+            pausedSchedules: queryCount(this.db, "SELECT COUNT(*) as cnt FROM agent_schedules WHERE status = 'paused'"),
             runningExecutions: this.runningExecutions.size,
             maxConcurrent: MAX_CONCURRENT_EXECUTIONS,
-            recentFailures,
+            recentFailures: queryCount(this.db, "SELECT COUNT(*) as cnt FROM schedule_executions WHERE status = 'failed' AND started_at >= datetime('now', '-24 hours')"),
             systemState: this.lastSystemState,
             priorityRules: getAllRules(),
         };
     }
 
-    /** Subscribe to schedule events (for WebSocket broadcast). */
     onEvent(callback: ScheduleEventCallback): () => void {
         this.eventCallbacks.add(callback);
         return () => this.eventCallbacks.delete(callback);
     }
 
-    /** Manually trigger a schedule to run now (ignoring cron/interval timing). */
     async triggerNow(scheduleId: string): Promise<void> {
         const schedule = getSchedule(this.db, scheduleId);
         if (!schedule) throw new NotFoundError('Schedule', scheduleId);
@@ -252,108 +183,69 @@ export class SchedulerService {
         await this.executeSchedule(schedule);
     }
 
-    /** Cancel a running execution. Returns the cancelled execution or null if not cancellable. */
     cancelExecution(executionId: string): ScheduleExecution | null {
         const execution = getExecution(this.db, executionId);
         if (!execution || execution.status !== 'running') return null;
-
-        // Stop the process if a session exists
         if (execution.sessionId) {
-            try {
-                this.processManager.stopProcess(execution.sessionId);
-            } catch {
-                // Best-effort stop
-            }
+            try { this.processManager.stopProcess(execution.sessionId); } catch { /* best-effort */ }
         }
-
-        // Remove from running set
         this.runningExecutions.delete(executionId);
-
-        // Update status
-        updateExecutionStatus(this.db, executionId, 'cancelled', {
-            result: 'Cancelled by user',
-        });
-
+        updateExecutionStatus(this.db, executionId, 'cancelled', { result: 'Cancelled by user' });
         const updated = getExecution(this.db, executionId);
-        if (updated) {
-            this.emit({ type: 'schedule_execution_update', data: updated });
-        }
+        if (updated) this.emit({ type: 'schedule_execution_update', data: updated });
         return updated;
     }
 
-    /** Resolve an approval request for a schedule execution. */
     resolveApproval(executionId: string, approved: boolean): ScheduleExecution | null {
         const execution = resolveScheduleApproval(this.db, executionId, approved);
         if (!execution) return null;
-
-        this.emit({
-            type: 'schedule_execution_update',
-            data: execution,
-        });
-
-        // If approved, actually execute the action
+        this.emit({ type: 'schedule_execution_update', data: execution });
         if (approved) {
             const schedule = getSchedule(this.db, execution.scheduleId);
-            if (schedule) {
-                this.executeApprovedAction(execution, schedule);
-            }
+            if (schedule) this.executeApprovedAction(execution, schedule);
         }
-
         return execution;
     }
 
     // ─── Internal ────────────────────────────────────────────────────────────
 
+    private resolveScheduleTenantId(agentId: string): string {
+        const row = this.db.query('SELECT tenant_id FROM agents WHERE id = ?')
+            .get(agentId) as { tenant_id: string } | null;
+        return row?.tenant_id ?? DEFAULT_TENANT_ID;
+    }
+
     private initializeNextRuns(): void {
         const schedules = this.db.query(
             `SELECT * FROM agent_schedules WHERE status = 'active' AND next_run_at IS NULL`
         ).all() as Record<string, unknown>[];
-
         for (const row of schedules) {
-            const id = row.id as string;
-            const cronExpr = row.cron_expression as string | null;
-            const intervalMs = row.interval_ms as number | null;
-
-            const nextRun = this.calculateNextRun(cronExpr, intervalMs);
-            if (nextRun) {
-                updateScheduleNextRun(this.db, id, nextRun);
-            }
+            const nextRun = this.calculateNextRun(row.cron_expression as string | null, row.interval_ms as number | null);
+            if (nextRun) updateScheduleNextRun(this.db, row.id as string, nextRun);
         }
     }
 
     private async tick(): Promise<void> {
-        // Clean expired repo locks on each tick
         cleanExpiredLocks(this.db);
-        if (this.runningExecutions.size >= MAX_CONCURRENT_EXECUTIONS) {
-            log.debug('Max concurrent executions reached, skipping tick');
-            return;
+        if (this.runningExecutions.size >= MAX_CONCURRENT_EXECUTIONS) return;
+
+        try { this.lastSystemState = await this.systemStateDetector.evaluate(); }
+        catch (err) {
+            log.warn('System state evaluation failed', { error: err instanceof Error ? err.message : String(err) });
         }
 
-
-        // Evaluate system state (cached with ~60s TTL)
-        try {
-            this.lastSystemState = await this.systemStateDetector.evaluate();
-        } catch (err) {
-            log.warn('System state evaluation failed, proceeding with last known state', {
-                error: err instanceof Error ? err.message : String(err),
-            });
-        }
         const dueSchedules = listDueSchedules(this.db);
         if (dueSchedules.length === 0) return;
-
         log.info(`Processing ${dueSchedules.length} due schedule(s)`);
 
         for (const schedule of dueSchedules) {
             if (this.runningExecutions.size >= MAX_CONCURRENT_EXECUTIONS) break;
-
-            // Check if max executions reached
             if (schedule.maxExecutions !== null && schedule.executionCount >= schedule.maxExecutions) {
                 updateSchedule(this.db, schedule.id, { status: 'completed' });
                 const updated = getSchedule(this.db, schedule.id);
                 if (updated) this.emit({ type: 'schedule_update', data: updated });
                 continue;
             }
-
             await this.executeSchedule(schedule);
         }
     }
@@ -361,910 +253,90 @@ export class SchedulerService {
     private async executeSchedule(schedule: AgentSchedule): Promise<void> {
         const ctx = createEventContext('scheduler');
         return runWithEventContext(ctx, async () => {
-        const tenantId = this.resolveScheduleTenantId(schedule.agentId);
-        const agent = getAgent(this.db, schedule.agentId, tenantId);
-        if (!agent) {
-            log.warn('Schedule agent not found', { scheduleId: schedule.id, agentId: schedule.agentId });
-            return;
-        }
+            const tenantId = this.resolveScheduleTenantId(schedule.agentId);
+            const agent = getAgent(this.db, schedule.agentId, tenantId);
+            if (!agent) { log.warn('Schedule agent not found', { scheduleId: schedule.id, agentId: schedule.agentId }); return; }
 
-        // Update last run and calculate next run
-        updateScheduleLastRun(this.db, schedule.id);
-        const nextRun = this.calculateNextRun(schedule.cronExpression, schedule.intervalMs);
-        updateScheduleNextRun(this.db, schedule.id, nextRun);
+            updateScheduleLastRun(this.db, schedule.id);
+            updateScheduleNextRun(this.db, schedule.id, this.calculateNextRun(schedule.cronExpression, schedule.intervalMs));
+            const updatedSchedule = getSchedule(this.db, schedule.id);
+            if (updatedSchedule) this.emit({ type: 'schedule_update', data: updatedSchedule });
 
-        // Emit schedule update
-        const updatedSchedule = getSchedule(this.db, schedule.id);
-        if (updatedSchedule) this.emit({ type: 'schedule_update', data: updatedSchedule });
+            for (const action of schedule.actions) {
+                if (this.runningExecutions.size >= MAX_CONCURRENT_EXECUTIONS) break;
 
-        // Execute each action in the schedule
-        for (const action of schedule.actions) {
-            if (this.runningExecutions.size >= MAX_CONCURRENT_EXECUTIONS) break;
+                const execution = createExecution(this.db, schedule.id, schedule.agentId,
+                    action.type, action as unknown as Record<string, unknown>,
+                    { actions: schedule.actions, approvalPolicy: schedule.approvalPolicy,
+                      cronExpression: schedule.cronExpression, intervalMs: schedule.intervalMs });
+                this.emit({ type: 'schedule_execution_update', data: execution });
+                recordAudit(this.db, 'schedule_execute', schedule.agentId,
+                    'schedule_execution', execution.id,
+                    `Executing action: ${action.type} for schedule "${schedule.name}"`);
 
-            const configSnapshot = {
-                actions: schedule.actions,
-                approvalPolicy: schedule.approvalPolicy,
-                cronExpression: schedule.cronExpression,
-                intervalMs: schedule.intervalMs,
-            };
+                const emitFn = (e: { type: string; data: unknown }) => this.emit(e);
+                if (shouldSkipByHealthGate(this.db, schedule, execution, action, this.lastSystemState, emitFn)) continue;
+                if (handleApprovalIfNeeded(this.db, schedule, execution, action, this.notificationService, emitFn)) continue;
+                if (handleRepoLocking(this.db, schedule, execution, action, emitFn)) continue;
 
-            const execution = createExecution(
-                this.db,
-                schedule.id,
-                schedule.agentId,
-                action.type,
-                action as unknown as Record<string, unknown>,
-                configSnapshot,
-            );
-
-            this.emit({ type: 'schedule_execution_update', data: execution });
-
-            // Audit log the schedule execution
-            recordAudit(
-                this.db,
-                'schedule_execute',
-                schedule.agentId,
-                'schedule_execution',
-                execution.id,
-                `Executing action: ${action.type} for schedule "${schedule.name}"`,
-            );
-
-            // Health gate: check if system state allows this action
-            if (this.lastSystemState) {
-                const gate = evaluateAction(action.type, this.lastSystemState.states);
-                if (gate.decision === 'skip') {
-                    log.info('Action skipped by health gate', {
-                        scheduleId: schedule.id,
-                        executionId: execution.id,
-                        actionType: action.type,
-                        systemStates: this.lastSystemState.states,
-                        reasons: gate.reasons,
-                    });
-                    updateExecutionStatus(this.db, execution.id, 'cancelled', {
-                        result: `Skipped by health gate: ${gate.reasons.join('; ')}`,
-                    });
-                    const gatedExec = getExecution(this.db, execution.id);
-                    if (gatedExec) this.emit({ type: 'schedule_execution_update', data: gatedExec });
-                    recordAudit(
-                        this.db,
-                        'schedule_skip',
-                        schedule.agentId,
-                        'schedule_execution',
-                        execution.id,
-                        `Action ${action.type} skipped by health gate: ${gate.reasons.join('; ')}`,
-                    );
-                    continue;
-                }
+                this.notifyScheduleEvent(schedule, 'started', `Schedule "${schedule.name}" started: ${action.type}`);
+                runAction(this.buildRunActionDeps(), this.buildHandlerContext(), execution.id, schedule, action);
             }
-
-            // Check if this action needs approval
-            if (this.needsApproval(schedule, action)) {
-                updateExecutionStatus(this.db, execution.id, 'awaiting_approval');
-                const updated = getExecution(this.db, execution.id);
-                this.emit({
-                    type: 'schedule_approval_request',
-                    data: {
-                        executionId: execution.id,
-                        scheduleId: schedule.id,
-                        agentId: schedule.agentId,
-                        actionType: action.type,
-                        description: action.description ?? `${action.type} on ${action.repos?.join(', ') ?? 'N/A'}`,
-                    },
-                });
-                if (updated) this.emit({ type: 'schedule_execution_update', data: updated });
-
-                // Push approval notification to all configured channels
-                if (this.notificationService) {
-                    const desc = action.description ?? `${action.type} on ${action.repos?.join(', ') ?? 'N/A'}`;
-                    this.notificationService.notify({
-                        agentId: schedule.agentId,
-                        title: `Approval needed: ${schedule.name}`,
-                        message: `Schedule "${schedule.name}" wants to run ${action.type}:\n${desc}\n\nApprove in the dashboard.`,
-                        level: 'warning',
-                    }).catch(err => log.warn('Approval notification failed', {
-                        scheduleId: schedule.id,
-                        error: err instanceof Error ? err.message : String(err),
-                    }));
-                }
-
-                continue;
-            }
-
-            // Repo coordination: acquire locks before executing
-            const lockResult = this.acquireActionLocks(action, execution.id, schedule.id);
-            if (!lockResult.acquired) {
-                log.info('Action skipped — repo locked', {
-                    scheduleId: schedule.id,
-                    executionId: execution.id,
-                    actionType: action.type,
-                    blockedRepo: lockResult.blockedRepo,
-                });
-                updateExecutionStatus(this.db, execution.id, 'cancelled', {
-                    result: `Repo "${lockResult.blockedRepo}" is locked by another schedule execution`,
-                });
-                const skippedExec = getExecution(this.db, execution.id);
-                if (skippedExec) this.emit({ type: 'schedule_execution_update', data: skippedExec });
-                recordAudit(
-                    this.db,
-                    'schedule_skip',
-                    schedule.agentId,
-                    'schedule_execution',
-                    execution.id,
-                    `Action ${action.type} skipped: repo "${lockResult.blockedRepo}" locked`,
-                );
-                continue;
-            }
-
-            // Notify start
-            this.notifyScheduleEvent(schedule, 'started', `Schedule "${schedule.name}" started: ${action.type}`);
-
-            // Execute immediately
-            this.runAction(execution.id, schedule, action);
-        }
-        }); // runWithEventContext
+        });
     }
 
-    private needsApproval(schedule: AgentSchedule, action: ScheduleAction): boolean {
-        if (schedule.approvalPolicy === 'auto') return false;
-
-        // Actions that modify external repos always need approval unless auto
-        const destructiveActions: ScheduleActionType[] = [
-            'work_task',
-            'github_suggest',
-            'fork_repo',
-            'codebase_review',
-            'dependency_audit',
-            'improvement_loop',
-        ];
-
-        if (schedule.approvalPolicy === 'owner_approve') {
-            return destructiveActions.includes(action.type);
-        }
-
-        // council_approve: all actions need approval
-        return true;
+    private buildHandlerContext(): HandlerContext {
+        return {
+            db: this.db, processManager: this.processManager,
+            workTaskService: this.workTaskService, agentMessenger: this.agentMessenger,
+            improvementLoopService: this.improvementLoopService,
+            reputationScorer: this.reputationScorer, reputationAttestation: this.reputationAttestation,
+            outcomeTrackerService: this.outcomeTrackerService, dailyReviewService: this.dailyReviewService,
+            systemStateDetector: this.systemStateDetector, runningExecutions: this.runningExecutions,
+            resolveScheduleTenantId: (agentId: string) => this.resolveScheduleTenantId(agentId),
+        };
     }
 
-
-    /**
-     * Resolve the target repos for an action.
-     */
-    private resolveActionRepos(action: ScheduleAction): string[] {
-        const repos: string[] = [];
-        if (action.repos?.length) {
-            repos.push(...action.repos);
-        }
-        if (action.projectId && !action.repos?.length) {
-            repos.push(`project:${action.projectId}`);
-        }
-        return repos;
-    }
-
-    /**
-     * Attempt to acquire locks on all repos targeted by an action.
-     */
-    private acquireActionLocks(
-        action: ScheduleAction,
-        executionId: string,
-        scheduleId: string,
-    ): { acquired: boolean; blockedRepo?: string } {
-        const repos = this.resolveActionRepos(action);
-        if (repos.length === 0) return { acquired: true };
-        const acquired: string[] = [];
-        for (const repo of repos) {
-            if (acquireRepoLock(this.db, repo, executionId, scheduleId, action.type)) {
-                acquired.push(repo);
-            } else {
-                if (acquired.length > 0) releaseAllLocks(this.db, executionId);
-                return { acquired: false, blockedRepo: repo };
-            }
-        }
-        return { acquired: true };
-    }
-
-    private async runAction(executionId: string, schedule: AgentSchedule, action: ScheduleAction): Promise<void> {
-        this.runningExecutions.add(executionId);
-
-        try {
-            switch (action.type) {
-                case 'star_repo':
-                    await this.execStarRepos(executionId, action);
-                    break;
-                case 'fork_repo':
-                    await this.execForkRepos(executionId, action);
-                    break;
-                case 'review_prs':
-                    await this.execReviewPrs(executionId, schedule, action);
-                    break;
-                case 'work_task':
-                    await this.execWorkTask(executionId, schedule, action);
-                    break;
-                case 'council_launch':
-                    await this.execCouncilLaunch(executionId, schedule, action);
-                    break;
-                case 'send_message':
-                    await this.execSendMessage(executionId, schedule, action);
-                    break;
-                case 'github_suggest':
-                    await this.execGithubSuggest(executionId, schedule, action);
-                    break;
-                case 'codebase_review':
-                    await this.execCodebaseReview(executionId, schedule, action);
-                    break;
-                case 'dependency_audit':
-                    await this.execDependencyAudit(executionId, schedule, action);
-                    break;
-                case 'improvement_loop':
-                    await this.execImprovementLoop(executionId, schedule, action);
-                    break;
-                case 'memory_maintenance':
-                    await this.execMemoryMaintenance(executionId, schedule);
-                    break;
-                case 'reputation_attestation':
-                    await this.execReputationAttestation(executionId, schedule);
-                    break;
-                case 'outcome_analysis':
-                    await this.execOutcomeAnalysis(executionId, schedule);
-                    break;
-                case 'daily_review':
-                    await this.execDailyReview(executionId, schedule);
-                    break;
-                case 'status_checkin':
-                    await this.execStatusCheckin(executionId, schedule);
-                    break;
-                case 'custom':
-                    await this.execCustom(executionId, schedule, action);
-                    break;
-                default:
-                    updateExecutionStatus(this.db, executionId, 'failed', {
-                        result: `Unknown action type: ${action.type}`,
-                    });
-            }
-        } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            log.error('Schedule action failed', { executionId, actionType: action.type, error: message });
-            updateExecutionStatus(this.db, executionId, 'failed', { result: message });
-        } finally {
-            // Release any repo locks held by this execution
-            releaseAllLocks(this.db, executionId);
-
-            this.runningExecutions.delete(executionId);
-            const updated = getExecution(this.db, executionId);
-            if (updated) {
-                this.emit({ type: 'schedule_execution_update', data: updated });
-
-                // Notify completion/failure
-                const resultSnippet = updated.result ? updated.result.slice(0, 200) : '';
-                if (updated.status === 'completed') {
-                    this.notifyScheduleEvent(schedule, 'completed',
-                        `Schedule "${schedule.name}" completed (${action.type}): ${resultSnippet}`);
-                    // Broadcast to AlgoChat-enabled peers for non-trivial action types
-                    this.broadcastScheduleResult(schedule.agentId, action.type, resultSnippet);
-                } else if (updated.status === 'failed') {
-                    this.notifyScheduleEvent(schedule, 'failed',
-                        `Schedule "${schedule.name}" FAILED (${action.type}): ${resultSnippet}`);
-                }
-
-                // Track consecutive failures for auto-pause
-                if (updated.status === 'failed') {
-                    const count = (this.consecutiveFailures.get(schedule.id) ?? 0) + 1;
-                    this.consecutiveFailures.set(schedule.id, count);
-
-                    if (count >= MAX_CONSECUTIVE_FAILURES) {
-                        log.warn('Auto-pausing schedule after consecutive failures', {
-                            scheduleId: schedule.id,
-                            failures: count,
-                        });
-                        updateSchedule(this.db, schedule.id, { status: 'paused' });
-                        this.consecutiveFailures.delete(schedule.id);
-                        const pausedSchedule = getSchedule(this.db, schedule.id);
-                        if (pausedSchedule) this.emit({ type: 'schedule_update', data: pausedSchedule });
-                    }
-                } else if (updated.status === 'completed') {
-                    this.consecutiveFailures.delete(schedule.id);
-                }
-            }
-        }
+    private buildRunActionDeps(): RunActionDeps {
+        return {
+            db: this.db, agentMessenger: this.agentMessenger,
+            runningExecutions: this.runningExecutions,
+            consecutiveFailures: this.consecutiveFailures,
+            emit: (event) => this.emit(event),
+        };
     }
 
     private async executeApprovedAction(execution: ScheduleExecution, schedule: AgentSchedule): Promise<void> {
         const action = execution.actionInput as unknown as ScheduleAction;
-        // Re-set status to running
         updateExecutionStatus(this.db, execution.id, 'running');
         const updated = getExecution(this.db, execution.id);
         if (updated) this.emit({ type: 'schedule_execution_update', data: updated });
-
-        await this.runAction(execution.id, schedule, action);
+        await runAction(this.buildRunActionDeps(), this.buildHandlerContext(), execution.id, schedule, action);
     }
-
-    // ─── Action Executors ────────────────────────────────────────────────────
-
-    private async execStarRepos(executionId: string, action: ScheduleAction): Promise<void> {
-        if (!action.repos?.length) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'No repos specified' });
-            return;
-        }
-
-        const results: string[] = [];
-        for (const repo of action.repos) {
-            const r = await github.starRepo(repo);
-            results.push(r.message);
-        }
-
-        updateExecutionStatus(this.db, executionId, 'completed', {
-            result: results.join('\n'),
-        });
-    }
-
-    private async execForkRepos(executionId: string, action: ScheduleAction): Promise<void> {
-        if (!action.repos?.length) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'No repos specified' });
-            return;
-        }
-
-        const results: string[] = [];
-        for (const repo of action.repos) {
-            const r = await github.forkRepo(repo);
-            results.push(r.message);
-        }
-
-        updateExecutionStatus(this.db, executionId, 'completed', {
-            result: results.join('\n'),
-        });
-    }
-
-    private async execReviewPrs(executionId: string, schedule: AgentSchedule, action: ScheduleAction): Promise<void> {
-        if (!action.repos?.length) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'No repos specified' });
-            return;
-        }
-
-        const tenantId = this.resolveScheduleTenantId(schedule.agentId);
-        const agent = getAgent(this.db, schedule.agentId, tenantId);
-        if (!agent) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'Agent not found' });
-            return;
-        }
-
-        const maxPrs = action.maxPrs ?? 5;
-        const results: string[] = [];
-
-        for (const repo of action.repos) {
-            const prList = await github.listOpenPrs(repo, maxPrs);
-            if (!prList.ok) {
-                results.push(`${repo}: Failed to list PRs — ${prList.error}`);
-                continue;
-            }
-
-            if (prList.prs.length === 0) {
-                results.push(`${repo}: No open PRs`);
-                continue;
-            }
-
-            // Create a session for the agent to review the PRs
-            const prSummary = prList.prs.map((pr) =>
-                `- #${pr.number}: "${pr.title}" by ${pr.author} (+${pr.additions}/-${pr.deletions}, ${pr.changedFiles} files)`
-            ).join('\n');
-
-            const prompt = `You are reviewing open pull requests for ${repo}.\n\n` +
-                `## Open PRs\n${prSummary}\n\n` +
-                `## Instructions\n` +
-                `1. BEFORE reviewing each PR, check if you (corvid-agent) have already left a review comment:\n` +
-                `   \`gh pr view <number> --repo ${repo} --json comments --jq '.comments[] | select(.author.login == "corvid-agent") | .createdAt'\`\n` +
-                `   If you already commented AND there are no new commits since your last comment, SKIP that PR.\n` +
-                `   Only re-review if there are new commits since your last review.\n` +
-                `2. For PRs that need review, use \`gh pr diff <number> --repo ${repo}\` to review the changes.\n` +
-                `3. Analyze code quality, potential issues, and improvements.\n` +
-                `4. Leave ONE concise review comment. Do not leave multiple comments on the same PR.\n` +
-                `5. Summarize your review findings at the end.`;
-
-            const projectId = action.projectId ?? agent.defaultProjectId;
-            if (!projectId) {
-                results.push(`${repo}: No project configured for agent`);
-                continue;
-            }
-
-            const session = createSession(this.db, {
-                projectId,
-                agentId: schedule.agentId,
-                name: `Scheduled PR Review: ${repo}`,
-                initialPrompt: prompt,
-                source: 'agent',
-            }, tenantId);
-
-            updateExecutionStatus(this.db, executionId, 'running', { sessionId: session.id });
-            this.processManager.startProcess(session, prompt, { schedulerMode: true, schedulerActionType: action.type });
-            results.push(`${repo}: Reviewing ${prList.prs.length} PR(s) in session ${session.id}`);
-        }
-
-        // Mark completed (the session may still be running)
-        updateExecutionStatus(this.db, executionId, 'completed', {
-            result: results.join('\n'),
-        });
-    }
-
-    private async execWorkTask(executionId: string, schedule: AgentSchedule, action: ScheduleAction): Promise<void> {
-        if (!this.workTaskService) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'Work task service not available' });
-            return;
-        }
-
-        if (!action.description) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'No description provided' });
-            return;
-        }
-
-        try {
-            const task = await this.workTaskService.create({
-                agentId: schedule.agentId,
-                description: action.description,
-                projectId: action.projectId,
-                source: 'agent',
-            });
-
-            updateExecutionStatus(this.db, executionId, 'completed', {
-                result: `Work task created: ${task.id} (branch: ${task.branchName ?? 'pending'})`,
-                workTaskId: task.id,
-                sessionId: task.sessionId ?? undefined,
-            });
-        } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            updateExecutionStatus(this.db, executionId, 'failed', { result: message });
-        }
-    }
-
-    private async execCouncilLaunch(executionId: string, _schedule: AgentSchedule, action: ScheduleAction): Promise<void> {
-        if (!action.councilId || !action.projectId || !action.description) {
-            updateExecutionStatus(this.db, executionId, 'failed', {
-                result: 'councilId, projectId, and description are required for council_launch',
-            });
-            return;
-        }
-
-        try {
-            const result = launchCouncil(
-                this.db,
-                this.processManager,
-                action.councilId,
-                action.projectId,
-                action.description,
-                this.agentMessenger,
-            );
-            updateExecutionStatus(this.db, executionId, 'completed', {
-                result: `Council launched: ${result.launchId} (${result.sessionIds.length} agents)`,
-            });
-        } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            updateExecutionStatus(this.db, executionId, 'failed', { result: message });
-        }
-    }
-
-    private async execSendMessage(executionId: string, schedule: AgentSchedule, action: ScheduleAction): Promise<void> {
-        if (!action.toAgentId || !action.message) {
-            updateExecutionStatus(this.db, executionId, 'failed', {
-                result: 'toAgentId and message are required for send_message',
-            });
-            return;
-        }
-
-        if (!this.agentMessenger) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'Agent messenger not available' });
-            return;
-        }
-
-        try {
-            const { response, threadId } = await this.agentMessenger.invokeAndWait({
-                fromAgentId: schedule.agentId,
-                toAgentId: action.toAgentId,
-                content: action.message,
-            });
-
-            updateExecutionStatus(this.db, executionId, 'completed', {
-                result: `Message sent. Response: ${response.slice(0, 500)}... [thread: ${threadId}]`,
-            });
-        } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            updateExecutionStatus(this.db, executionId, 'failed', { result: message });
-        }
-    }
-
-    private async execGithubSuggest(executionId: string, schedule: AgentSchedule, action: ScheduleAction): Promise<void> {
-        if (!action.repos?.length) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'No repos specified' });
-            return;
-        }
-
-        const tenantId = this.resolveScheduleTenantId(schedule.agentId);
-        const agent = getAgent(this.db, schedule.agentId, tenantId);
-        if (!agent) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'Agent not found' });
-            return;
-        }
-
-        const projectId = action.projectId ?? agent.defaultProjectId;
-        if (!projectId) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'No project configured for agent' });
-            return;
-        }
-
-        // Create a session for the agent to analyze repos and suggest improvements
-        const repoList = action.repos.join(', ');
-        const prompt = `You are analyzing the following repositories for potential improvements: ${repoList}\n\n` +
-            `## Instructions\n` +
-            `1. For each repo, examine the codebase structure, README, issues, and recent PRs.\n` +
-            `2. Identify potential improvements: documentation, code quality, performance, testing, CI/CD.\n` +
-            `3. Prioritize suggestions by impact and feasibility.\n` +
-            `4. For each suggestion, provide a clear description of the change.\n` +
-            (action.autoCreatePr
-                ? `5. If you have high-confidence suggestions, create work tasks using corvid_create_work_task.\n`
-                : `5. Summarize your findings — do NOT create PRs automatically.\n`) +
-            `\nBe thorough but focused. Quality over quantity.`;
-
-        const session = createSession(this.db, {
-            projectId,
-            agentId: schedule.agentId,
-            name: `Scheduled Suggestions: ${repoList.slice(0, 50)}`,
-            initialPrompt: prompt,
-            source: 'agent',
-        }, tenantId);
-
-        updateExecutionStatus(this.db, executionId, 'running', { sessionId: session.id });
-        this.processManager.startProcess(session, prompt, { schedulerMode: true, schedulerActionType: action.type });
-
-        updateExecutionStatus(this.db, executionId, 'completed', {
-            result: `Analysis session started: ${session.id}`,
-            sessionId: session.id,
-        });
-    }
-
-    private async execCodebaseReview(executionId: string, schedule: AgentSchedule, action: ScheduleAction): Promise<void> {
-        const tenantId = this.resolveScheduleTenantId(schedule.agentId);
-        const agent = getAgent(this.db, schedule.agentId, tenantId);
-        if (!agent) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'Agent not found' });
-            return;
-        }
-
-        const projectId = action.projectId ?? agent.defaultProjectId;
-        if (!projectId) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'No project configured for agent' });
-            return;
-        }
-
-        const prompt = `You are performing an automated codebase review.\n\n` +
-            `## Instructions\n` +
-            `1. Run \`bun x tsc --noEmit 2>&1\` and collect any TypeScript errors.\n` +
-            `2. Run \`bun test 2>&1 | tail -50\` and collect any test failures.\n` +
-            `3. Search for TODO, FIXME, and HACK comments in the source code.\n` +
-            `4. Identify files over 500 lines that may need refactoring.\n` +
-            `5. Prioritize findings by severity (type errors > test failures > code smells).\n` +
-            `6. Create 1-3 work tasks via corvid_create_work_task for the most impactful fixes.\n` +
-            `7. Use corvid_notify_owner to report a summary of findings and created tasks.\n\n` +
-            `${action.description ? `Context: ${action.description}\n\n` : ''}` +
-            `Focus on actionable improvements. Quality over quantity.`;
-
-        const session = createSession(this.db, {
-            projectId,
-            agentId: schedule.agentId,
-            name: `Scheduled Codebase Review`,
-            initialPrompt: prompt,
-            source: 'agent',
-        }, tenantId);
-
-        updateExecutionStatus(this.db, executionId, 'running', { sessionId: session.id });
-        this.processManager.startProcess(session, prompt, { schedulerMode: true, schedulerActionType: action.type });
-
-        updateExecutionStatus(this.db, executionId, 'completed', {
-            result: `Codebase review session started: ${session.id}`,
-            sessionId: session.id,
-        });
-    }
-
-    private async execDependencyAudit(executionId: string, schedule: AgentSchedule, action: ScheduleAction): Promise<void> {
-        const tenantId = this.resolveScheduleTenantId(schedule.agentId);
-        const agent = getAgent(this.db, schedule.agentId, tenantId);
-        if (!agent) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'Agent not found' });
-            return;
-        }
-
-        const projectId = action.projectId ?? agent.defaultProjectId;
-        if (!projectId) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'No project configured for agent' });
-            return;
-        }
-
-        const prompt = `You are performing an automated dependency audit.\n\n` +
-            `## Instructions\n` +
-            `1. Check for outdated dependencies: \`bun outdated 2>&1\` (or \`npm outdated 2>&1\` as fallback).\n` +
-            `2. Check for known vulnerabilities: \`bun audit 2>&1\` (or \`npm audit 2>&1\` as fallback).\n` +
-            `3. Review \`package.json\` for pinning issues (exact versions vs ranges).\n` +
-            `4. Identify any deprecated or unmaintained packages.\n` +
-            `5. Create work tasks via corvid_create_work_task for critical updates (security vulnerabilities, major version bumps).\n` +
-            `6. Use corvid_notify_owner to report a summary of findings and recommendations.\n\n` +
-            `${action.description ? `Context: ${action.description}\n\n` : ''}` +
-            `Prioritize security fixes over feature updates.`;
-
-        const session = createSession(this.db, {
-            projectId,
-            agentId: schedule.agentId,
-            name: `Scheduled Dependency Audit`,
-            initialPrompt: prompt,
-            source: 'agent',
-        }, tenantId);
-
-        updateExecutionStatus(this.db, executionId, 'running', { sessionId: session.id });
-        this.processManager.startProcess(session, prompt, { schedulerMode: true, schedulerActionType: action.type });
-
-        updateExecutionStatus(this.db, executionId, 'completed', {
-            result: `Dependency audit session started: ${session.id}`,
-            sessionId: session.id,
-        });
-    }
-
-    private async execImprovementLoop(executionId: string, schedule: AgentSchedule, action: ScheduleAction): Promise<void> {
-        if (!this.improvementLoopService) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'Improvement loop service not configured' });
-            return;
-        }
-
-        const tenantId = this.resolveScheduleTenantId(schedule.agentId);
-        const agent = getAgent(this.db, schedule.agentId, tenantId);
-        if (!agent) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'Agent not found' });
-            return;
-        }
-
-        const projectId = action.projectId ?? agent.defaultProjectId;
-        if (!projectId) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'No project configured for agent' });
-            return;
-        }
-
-        updateExecutionStatus(this.db, executionId, 'running');
-
-        const result = await this.improvementLoopService.run(schedule.agentId, projectId, {
-            maxTasks: action.maxImprovementTasks ?? 3,
-            focusArea: action.focusArea,
-        });
-
-        updateExecutionStatus(this.db, executionId, 'completed', {
-            result: `Improvement loop session started: ${result.sessionId}. ` +
-                `Health: ${result.health.tscErrorCount} tsc errors, ${result.health.testFailureCount} test failures. ` +
-                `Reputation: ${result.reputationScore} (${result.trustLevel}). ` +
-                `Max tasks: ${result.maxTasksAllowed}.`,
-            sessionId: result.sessionId,
-        });
-    }
-
-    private async execCustom(executionId: string, schedule: AgentSchedule, action: ScheduleAction): Promise<void> {
-        if (!action.prompt) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'No prompt provided for custom action' });
-            return;
-        }
-
-        const tenantId = this.resolveScheduleTenantId(schedule.agentId);
-        const agent = getAgent(this.db, schedule.agentId, tenantId);
-        if (!agent) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'Agent not found' });
-            return;
-        }
-
-        const projectId = action.projectId ?? agent.defaultProjectId;
-        if (!projectId) {
-            updateExecutionStatus(this.db, executionId, 'failed', { result: 'No project configured for agent' });
-            return;
-        }
-
-        const session = createSession(this.db, {
-            projectId,
-            agentId: schedule.agentId,
-            name: `Scheduled Custom: ${action.prompt.slice(0, 50)}`,
-            initialPrompt: action.prompt,
-            source: 'agent',
-        }, tenantId);
-
-        updateExecutionStatus(this.db, executionId, 'running', { sessionId: session.id });
-        this.processManager.startProcess(session, action.prompt, { schedulerMode: true, schedulerActionType: action.type });
-
-        updateExecutionStatus(this.db, executionId, 'completed', {
-            result: `Custom action session started: ${session.id}`,
-            sessionId: session.id,
-        });
-    }
-
-    private async execMemoryMaintenance(executionId: string, schedule: AgentSchedule): Promise<void> {
-        try {
-            const archived = summarizeOldMemories(this.db, schedule.agentId, 30);
-            updateExecutionStatus(this.db, executionId, 'completed', {
-                result: `Memory maintenance completed: ${archived} memories archived and summarized.`,
-            });
-        } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            updateExecutionStatus(this.db, executionId, 'failed', { result: message });
-        }
-    }
-
-    private async execReputationAttestation(executionId: string, schedule: AgentSchedule): Promise<void> {
-        if (!this.reputationScorer || !this.reputationAttestation) {
-            updateExecutionStatus(this.db, executionId, 'failed', {
-                result: 'Reputation services not configured',
-            });
-            return;
-        }
-
-        try {
-            const score = this.reputationScorer.computeScore(schedule.agentId);
-            const hash = await this.reputationAttestation.createAttestation(score);
-
-            // Attempt on-chain publish via agent messenger
-            let txid: string | null = null;
-            if (this.agentMessenger) {
-                try {
-                    const note = `corvid-reputation:${schedule.agentId}:${hash}`;
-                    txid = await this.agentMessenger.sendOnChainToSelf(schedule.agentId, note);
-                    if (txid) {
-                        this.reputationAttestation.publishOnChain(
-                            schedule.agentId, hash, async () => txid!,
-                        );
-                    }
-                } catch {
-                    // On-chain publish is best-effort
-                }
-            }
-
-            this.reputationScorer.setAttestationHash(schedule.agentId, hash);
-
-            updateExecutionStatus(this.db, executionId, 'completed', {
-                result: `Attestation created: hash=${hash.slice(0, 16)}... score=${score.overallScore} trust=${score.trustLevel}${txid ? ` txid=${txid}` : ' (off-chain)'}`,
-            });
-        } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            updateExecutionStatus(this.db, executionId, 'failed', { result: message });
-        }
-    }
-
-
-    private async execOutcomeAnalysis(executionId: string, schedule: AgentSchedule): Promise<void> {
-        if (!this.outcomeTrackerService) {
-            updateExecutionStatus(this.db, executionId, 'failed', {
-                result: 'Outcome tracker service not configured',
-            });
-            return;
-        }
-
-        try {
-            const checkResult = await this.outcomeTrackerService.checkOpenPrs();
-            const analysis = this.outcomeTrackerService.analyzeWeekly(schedule.agentId);
-            this.outcomeTrackerService.saveAnalysisToMemory(schedule.agentId, analysis);
-
-            const summary = [
-                `Checked ${checkResult.checked} open PRs (${checkResult.updated} updated).`,
-                `Merge rate: ${(analysis.overall.mergeRate * 100).toFixed(0)}% (${analysis.overall.merged}/${analysis.overall.total}).`,
-                `Work tasks: ${analysis.workTaskStats.completed}/${analysis.workTaskStats.total} succeeded.`,
-                analysis.topInsights.length > 0 ? `Insights: ${analysis.topInsights[0]}` : '',
-            ].filter(Boolean).join(' ');
-
-            updateExecutionStatus(this.db, executionId, 'completed', { result: summary });
-        } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            updateExecutionStatus(this.db, executionId, 'failed', { result: message });
-        }
-    }
-
-    private execDailyReview(executionId: string, schedule: AgentSchedule): void {
-        if (!this.dailyReviewService) {
-            updateExecutionStatus(this.db, executionId, 'failed', {
-                result: 'Daily review service not configured',
-            });
-            return;
-        }
-
-        try {
-            const result = this.dailyReviewService.run(schedule.agentId);
-            const summary = [
-                `Executions: ${result.executions.completed} completed, ${result.executions.failed} failed (${result.executions.total} total).`,
-                `PRs: ${result.prs.opened} opened, ${result.prs.merged} merged, ${result.prs.closed} closed.`,
-                `Health: ${result.health.uptimePercent}% uptime (${result.health.snapshotCount} snapshots).`,
-                result.observations.length > 0 ? `Observations: ${result.observations.join('; ')}` : '',
-            ].filter(Boolean).join(' ');
-
-            updateExecutionStatus(this.db, executionId, 'completed', { result: summary });
-        } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            updateExecutionStatus(this.db, executionId, 'failed', { result: message });
-        }
-    }
-
-    private async execStatusCheckin(executionId: string, schedule: AgentSchedule): Promise<void> {
-        try {
-            const state = await this.systemStateDetector.evaluate();
-            const agent = getAgent(this.db, schedule.agentId);
-            const agentName = agent?.name ?? schedule.agentId.slice(0, 8);
-
-            const summary = [
-                `Agent: ${agentName}`,
-                `System: ${state.states.join(', ') || 'nominal'}`,
-                `Schedules running: ${this.runningExecutions.size}`,
-            ].join(' | ');
-
-            // Broadcast status to AlgoChat
-            if (this.agentMessenger) {
-                await this.agentMessenger.sendOnChainToSelf(
-                    schedule.agentId,
-                    `[STATUS_CHECKIN] ${summary}`,
-                );
-            }
-
-            updateExecutionStatus(this.db, executionId, 'completed', { result: summary });
-        } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            updateExecutionStatus(this.db, executionId, 'failed', { result: message });
-        }
-    }
-
-    // ─── Cron helpers ────────────────────────────────────────────────────────
 
     private calculateNextRun(cronExpression: string | null, intervalMs: number | null): string | null {
         if (cronExpression) {
-            try {
-                const next = getNextCronDate(cronExpression);
-                return next.toISOString();
-            } catch (err) {
-                log.warn('Invalid cron expression', { cronExpression, error: String(err) });
-                return null;
-            }
+            try { return getNextCronDate(cronExpression).toISOString(); }
+            catch (err) { log.warn('Invalid cron expression', { cronExpression, error: String(err) }); return null; }
         }
-
-        if (intervalMs && intervalMs > 0) {
-            return new Date(Date.now() + intervalMs).toISOString();
-        }
-
+        if (intervalMs && intervalMs > 0) return new Date(Date.now() + intervalMs).toISOString();
         return null;
     }
 
     private emit(event: { type: string; data: unknown }): void {
         for (const cb of this.eventCallbacks) {
-            try {
-                cb(event as Parameters<ScheduleEventCallback>[0]);
-            } catch (err) {
-                log.error('Schedule event callback error', { error: err instanceof Error ? err.message : String(err) });
-            }
+            try { cb(event as Parameters<ScheduleEventCallback>[0]); }
+            catch (err) { log.error('Schedule event callback error', { error: err instanceof Error ? err.message : String(err) }); }
         }
     }
 
-    /** Broadcast schedule result to AlgoChat-enabled peer agents (fire-and-forget). */
-    private broadcastScheduleResult(agentId: string, actionType: ScheduleActionType, summary: string): void {
-        if (!this.agentMessenger) return;
-
-        // Only broadcast for meaningful action types
-        const broadcastTypes: ScheduleActionType[] = [
-            'work_task', 'council_launch', 'daily_review', 'review_prs',
-            'github_suggest', 'codebase_review', 'dependency_audit',
-            'improvement_loop', 'custom', 'status_checkin',
-        ];
-        if (!broadcastTypes.includes(actionType)) return;
-
-        const msg = `[SCHEDULE:${actionType}] ${summary.slice(0, 200)}`;
-        this.agentMessenger.sendOnChainToSelf(agentId, msg).catch(() => {});
-    }
-
-    /** Send best-effort on-chain notification to the schedule's notifyAddress. */
-    private notifyScheduleEvent(
-        schedule: AgentSchedule,
-        event: 'started' | 'completed' | 'failed',
-        message: string,
-    ): void {
+    private notifyScheduleEvent(schedule: AgentSchedule, event: 'started' | 'completed' | 'failed', message: string): void {
         if (!schedule.notifyAddress || !this.agentMessenger) return;
-
         this.agentMessenger.sendNotificationToAddress(
-            schedule.agentId,
-            schedule.notifyAddress,
-            `[schedule:${event}] ${message}`,
+            schedule.agentId, schedule.notifyAddress, `[schedule:${event}] ${message}`,
         ).catch((err) => {
             log.debug('Schedule notification send failed', {
-                scheduleId: schedule.id,
-                notifyAddress: schedule.notifyAddress,
+                scheduleId: schedule.id, notifyAddress: schedule.notifyAddress,
                 error: err instanceof Error ? err.message : String(err),
             });
         });


### PR DESCRIPTION
## Summary
- Refactored `server/scheduler/service.ts` from **1272 LOC → 344 LOC** (73% reduction)
- Extracted 16 action executors into 6 focused handler files under `server/scheduler/handlers/`
- Moved execution lifecycle (dispatch, error handling, failure tracking, notifications) to `server/scheduler/execution.ts`
- Moved per-action orchestration (health gating, approval workflows, repo locking) to `server/scheduler/orchestration.ts`
- Service remains the facade: scheduling loop, public API, dependency wiring

### New files
| File | Purpose |
|------|---------|
| `handlers/types.ts` | Shared `HandlerContext` interface |
| `handlers/github.ts` | star_repo, fork_repo, review_prs, github_suggest |
| `handlers/work-task.ts` | work_task |
| `handlers/council.ts` | council_launch, send_message |
| `handlers/review.ts` | codebase_review, dependency_audit |
| `handlers/improvement.ts` | improvement_loop |
| `handlers/maintenance.ts` | memory, reputation, outcome, daily_review, status_checkin, custom |
| `execution.ts` | Action dispatch + lifecycle (error handling, lock cleanup, failure tracking) |
| `orchestration.ts` | Health gate, approval, repo locking checks |

Closes #749

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` — passes clean
- [x] `bun test server/__tests__/scheduler.test.ts server/__tests__/scheduler-service.test.ts` — 107 pass, 0 fail
- [x] `bun test` — 5704 pass, 0 fail (full suite)
- [x] No behavioral changes — all handler logic is verbatim extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)