### PR TITLE
feat: Telegram bridge hardening — poll backoff + dedup

### DIFF
--- a/server/__tests__/telegram-bridge.test.ts
+++ b/server/__tests__/telegram-bridge.test.ts
@@ -9,6 +9,7 @@ import type { ClaudeStreamEvent } from '../process/types';
 import { createAgent } from '../db/agents';
 import { createProject } from '../db/projects';
 import { createSession, updateSession } from '../db/sessions';
+import { DedupService } from '../lib/dedup';
 
 // ─── Test-only interface to access private members without `as any` ─────────
 
@@ -16,6 +17,8 @@ import { createSession, updateSession } from '../db/sessions';
 interface TelegramBridgeInternals {
     running: boolean;
     offset: number;
+    consecutiveErrors: number;
+    dedup: DedupService;
     userSessions: Map<number, string>;
     userMessageTimestamps: Map<number, number[]>;
     poll: () => Promise<void>;
@@ -105,6 +108,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    DedupService.resetGlobal();
     db.close();
 });
 
@@ -864,5 +868,111 @@ describe('TelegramBridge work intake mode', () => {
         }));
 
         expect(sent).toContain('Connected to corvid-agent. Send a message to talk to an agent.');
+    });
+});
+
+// ─── Poll Backoff ──────────────────────────────────────────────────────────
+
+describe('poll backoff on errors', () => {
+    test('consecutiveErrors increments on poll failure', async () => {
+        const pm = createMockProcessManager();
+        const bridge = new TelegramBridge(db, pm, defaultConfig);
+        internals(bridge).running = true;
+        internals(bridge).callTelegramApi = mock(async () => { throw new Error('Network error'); });
+        await internals(bridge).poll();
+        internals(bridge).running = false;
+        expect(internals(bridge).consecutiveErrors).toBe(1);
+    });
+
+    test('consecutiveErrors resets on successful poll', async () => {
+        const pm = createMockProcessManager();
+        const bridge = new TelegramBridge(db, pm, defaultConfig);
+        internals(bridge).running = true;
+        internals(bridge).consecutiveErrors = 5;
+        internals(bridge).callTelegramApi = mock(async () => ({ result: [] }));
+        await internals(bridge).poll();
+        internals(bridge).running = false;
+        expect(internals(bridge).consecutiveErrors).toBe(0);
+    });
+
+    test('backoff delay increases exponentially', async () => {
+        const pm = createMockProcessManager();
+        const bridge = new TelegramBridge(db, pm, defaultConfig);
+        internals(bridge).running = false; // prevent scheduled follow-up
+        internals(bridge).callTelegramApi = mock(async () => { throw new Error('fail'); });
+
+        // Simulate 3 consecutive errors
+        internals(bridge).running = true;
+        await internals(bridge).poll();
+        internals(bridge).running = false;
+        expect(internals(bridge).consecutiveErrors).toBe(1);
+
+        internals(bridge).running = true;
+        await internals(bridge).poll();
+        internals(bridge).running = false;
+        expect(internals(bridge).consecutiveErrors).toBe(2);
+
+        internals(bridge).running = true;
+        await internals(bridge).poll();
+        internals(bridge).running = false;
+        expect(internals(bridge).consecutiveErrors).toBe(3);
+    });
+
+    test('backoff delay is capped at 30 seconds', () => {
+        // Verify the formula: min(500 * 2^n, 30000)
+        // At n=10: 500 * 1024 = 512000, capped to 30000
+        const delay = Math.min(500 * Math.pow(2, 10), 30_000);
+        expect(delay).toBe(30_000);
+    });
+});
+
+// ─── Update Deduplication ──────────────────────────────────────────────────
+
+describe('update deduplication', () => {
+    test('skips duplicate update_ids', async () => {
+        const pm = createMockProcessManager();
+        const bridge = new TelegramBridge(db, pm, defaultConfig);
+        bridge.start();
+        bridge.stop(); // registers dedup namespace via start()
+
+        const handled: TelegramMessage[] = [];
+        internals(bridge).handleMessage = mock(async (msg: TelegramMessage) => { handled.push(msg); });
+
+        const message = makeMessage({ from: { id: 100, is_bot: false, first_name: 'User' }, text: 'hello' });
+        await internals(bridge).handleUpdate({ update_id: 555, message });
+        await internals(bridge).handleUpdate({ update_id: 555, message }); // duplicate
+        expect(handled).toHaveLength(1);
+    });
+
+    test('processes distinct update_ids', async () => {
+        const pm = createMockProcessManager();
+        const bridge = new TelegramBridge(db, pm, defaultConfig);
+        bridge.start();
+        bridge.stop();
+
+        const handled: TelegramMessage[] = [];
+        internals(bridge).handleMessage = mock(async (msg: TelegramMessage) => { handled.push(msg); });
+
+        const msg1 = makeMessage({ from: { id: 100, is_bot: false, first_name: 'User' }, text: 'first' });
+        const msg2 = makeMessage({ from: { id: 100, is_bot: false, first_name: 'User' }, text: 'second' });
+        await internals(bridge).handleUpdate({ update_id: 100, message: msg1 });
+        await internals(bridge).handleUpdate({ update_id: 101, message: msg2 });
+        expect(handled).toHaveLength(2);
+    });
+
+    test('dedup prevents reprocessing after poll error recovery', async () => {
+        const pm = createMockProcessManager();
+        const bridge = new TelegramBridge(db, pm, defaultConfig);
+        bridge.start();
+        bridge.stop();
+
+        const handled: TelegramMessage[] = [];
+        internals(bridge).handleMessage = mock(async (msg: TelegramMessage) => { handled.push(msg); });
+
+        // Simulate: first poll processes update 200, then poll error occurs,
+        // recovery re-fetches update 200 (offset didn't advance for some reason)
+        await internals(bridge).handleUpdate({ update_id: 200, message: makeMessage({ from: { id: 100, is_bot: false, first_name: 'User' }, text: 'msg' }) });
+        await internals(bridge).handleUpdate({ update_id: 200, message: makeMessage({ from: { id: 100, is_bot: false, first_name: 'User' }, text: 'msg' }) });
+        expect(handled).toHaveLength(1);
     });
 });

--- a/server/telegram/bridge.ts
+++ b/server/telegram/bridge.ts
@@ -13,10 +13,14 @@ import { createLogger } from '../lib/logger';
 import { ExternalServiceError, NotFoundError } from '../lib/errors';
 import { scanForInjection } from '../lib/prompt-injection';
 import { recordAudit } from '../db/audit';
+import { DedupService } from '../lib/dedup';
 
 const log = createLogger('TelegramBridge');
 
 const POLL_TIMEOUT = 30; // Long-polling timeout in seconds
+const TELEGRAM_DEDUP_NS = 'telegram:updates';
+const BASE_POLL_DELAY_MS = 500;
+const MAX_POLL_DELAY_MS = 30_000;
 
 /**
  * Bidirectional Telegram bridge.
@@ -30,6 +34,8 @@ export class TelegramBridge {
     private offset = 0;
     private pollTimer: ReturnType<typeof setTimeout> | null = null;
     private running = false;
+    private consecutiveErrors = 0;
+    private dedup = DedupService.global();
 
     // Map Telegram userId → active sessionId
     private userSessions: Map<number, string> = new Map();
@@ -53,6 +59,7 @@ export class TelegramBridge {
     start(): void {
         if (this.running) return;
         this.running = true;
+        this.dedup.register(TELEGRAM_DEDUP_NS, { maxSize: 1000, ttlMs: 300_000 }); // 5 min TTL
         log.info('Telegram bridge started', { chatId: this.config.chatId });
         this.poll();
     }
@@ -69,20 +76,24 @@ export class TelegramBridge {
     private async poll(): Promise<void> {
         if (!this.running) return;
 
+        let delay = BASE_POLL_DELAY_MS;
         try {
             const updates = await this.getUpdates();
+            this.consecutiveErrors = 0;
             for (const update of updates) {
                 this.offset = update.update_id + 1;
                 await this.handleUpdate(update);
             }
         } catch (err) {
+            this.consecutiveErrors++;
+            delay = Math.min(BASE_POLL_DELAY_MS * Math.pow(2, this.consecutiveErrors), MAX_POLL_DELAY_MS);
             const message = err instanceof Error ? err.message : String(err);
-            log.error('Telegram poll error', { error: message });
+            log.error('Telegram poll error', { error: message, attempt: this.consecutiveErrors, retryMs: delay });
         }
 
         // Schedule next poll
         if (this.running) {
-            this.pollTimer = setTimeout(() => this.poll(), 500);
+            this.pollTimer = setTimeout(() => this.poll(), delay);
         }
     }
 
@@ -97,6 +108,12 @@ export class TelegramBridge {
     }
 
     private async handleUpdate(update: TelegramUpdate): Promise<void> {
+        const dedupKey = String(update.update_id);
+        if (this.dedup.isDuplicate(TELEGRAM_DEDUP_NS, dedupKey)) {
+            log.debug('Skipping duplicate Telegram update', { updateId: update.update_id });
+            return;
+        }
+
         if (update.message) {
             await this.handleMessage(update.message);
         }


### PR DESCRIPTION
## Summary

- Adds **exponential backoff** to Telegram long-poll error recovery (500ms base, 30s cap) — previously retried at fixed 500ms regardless of failure count
- Integrates **DedupService** (`telegram:updates` namespace) to skip already-processed `update_id`s, preventing duplicate message handling after poll error recovery
- Adds 7 new tests covering backoff behavior and dedup edge cases

Partial progress on #631 (bridge hardening) — addresses the Telegram sub-tasks:
> Telegram bridge: exponential backoff on long-poll failures, dedup incoming updates by `update_id`

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test server/__tests__/telegram-bridge.test.ts` — 60/60 pass
- [x] `bun test` — 5,711/5,711 pass
- [x] `bun run spec:check` — 111/111 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)