### PR TITLE
fix(security): sanitize error messages in WS and AlgoChat handlers

### DIFF
--- a/server/__tests__/work-command-router.test.ts
+++ b/server/__tests__/work-command-router.test.ts
@@ -185,8 +185,7 @@ describe('handleSlashCommand()', () => {
         await new Promise((r) => setTimeout(r, 50));
 
         expect(responses.length).toBe(1);
-        expect(responses[0]).toContain('Work task error');
-        expect(responses[0]).toContain('git worktree error');
+        expect(responses[0]).toContain('Work task creation failed');
     });
 });
 

--- a/server/algochat/command-handler.ts
+++ b/server/algochat/command-handler.ts
@@ -317,7 +317,8 @@ export class CommandHandler {
 
             case '/council': {
                 this.handleCouncilCommand(participant, parts, respond).catch((err) => {
-                    respond(`Council error: ${err instanceof Error ? err.message : String(err)}`);
+                    log.error('Council command error', { error: err instanceof Error ? err.message : String(err) });
+                    respond('Council operation failed. Check server logs for details.');
                 });
                 return true;
             }

--- a/server/algochat/work-command-router.ts
+++ b/server/algochat/work-command-router.ts
@@ -19,6 +19,9 @@ import {
     getAgentMessage,
 } from '../db/agent-messages';
 import { ValidationError, NotFoundError } from '../lib/errors';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('WorkCommandRouter');
 
 /** Parameters for handling an agent-to-agent [WORK] request. */
 export interface AgentWorkRequestParams {
@@ -103,7 +106,8 @@ export class WorkCommandRouter {
                 }
             });
         }).catch((err) => {
-            respond(`Work task error: ${err instanceof Error ? err.message : String(err)}`);
+            log.error('Slash command work task error', { error: err instanceof Error ? err.message : String(err) });
+            respond('Work task creation failed. Check server logs for details.');
         });
     }
 
@@ -178,7 +182,7 @@ export class WorkCommandRouter {
             };
         } catch (err) {
             updateAgentMessageStatus(this.db, agentMessage.id, 'failed', {
-                response: `Work task error: ${err instanceof Error ? err.message : String(err)}`,
+                response: 'Work task creation failed',
                 errorCode: 'WORK_TASK_ERROR',
             });
             emitMessageUpdate(agentMessage.id);

--- a/server/ws/handler.ts
+++ b/server/ws/handler.ts
@@ -342,7 +342,8 @@ function handleClientMessage(
                     ws.send(JSON.stringify(serverMsg));
                 }
             }).catch((err) => {
-                sendError(ws, `Chat error: ${err instanceof Error ? err.message : String(err)}`);
+                log.error('Chat error', { error: err instanceof Error ? err.message : String(err) });
+                sendError(ws, 'Chat request failed', undefined, 'CHAT_ERROR');
             });
             break;
         }
@@ -393,7 +394,8 @@ function handleClientMessage(
                     processManager.subscribe(result.sessionId, invokeCallback);
                 }
             }).catch((err) => {
-                sendError(ws, `Invoke error: ${err instanceof Error ? err.message : String(err)}`);
+                log.error('Agent invoke error', { error: err instanceof Error ? err.message : String(err) });
+                sendError(ws, 'Agent invocation failed', undefined, 'INVOKE_ERROR');
             });
             break;
         }
@@ -428,7 +430,8 @@ function handleClientMessage(
                     safeSend(ws, updateMsg);
                 });
             }).catch((err) => {
-                sendError(ws, `Work task error: ${err instanceof Error ? err.message : String(err)}`);
+                log.error('Work task error', { error: err instanceof Error ? err.message : String(err) });
+                sendError(ws, 'Work task creation failed', undefined, 'WORK_TASK_ERROR');
             });
             break;
         }
@@ -461,7 +464,8 @@ function handleClientMessage(
                 };
                 safeSend(ws, balanceMsg);
             }).catch((err) => {
-                sendError(ws, `Reward error: ${err instanceof Error ? err.message : String(err)}`);
+                log.error('Agent reward error', { error: err instanceof Error ? err.message : String(err) });
+                sendError(ws, 'Agent reward failed', undefined, 'REWARD_ERROR');
             });
             break;
         }


### PR DESCRIPTION
## Summary
- Sanitize 7 error message exposure points across WebSocket handler, WorkCommandRouter, and CommandHandler
- Raw `err.message` strings were being sent directly to clients (WebSocket, AlgoChat on-chain, agent messages DB)
- Now returns generic error messages with error codes; full details logged server-side only
- Prevents information disclosure of internal paths, service names, and implementation details

## Files Changed
- `server/ws/handler.ts` — 4 catch blocks sanitized (chat, invoke, work task, reward)
- `server/algochat/work-command-router.ts` — 2 error paths sanitized (slash command, agent work request)
- `server/algochat/command-handler.ts` — 1 catch block sanitized (council command)
- `server/__tests__/work-command-router.test.ts` — Updated assertion to match new generic message

## Addresses
- #750 (stack trace / error message exposure — P0)

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` — passes
- [x] `bun test` on affected test files — 85 tests pass
- [x] `bun run spec:check` — 111/111 passed


🤖 Generated with [Claude Code](https://claude.com/claude-code)