### PR TITLE
spec: document all 17 remaining undocumented exports

### DIFF
--- a/specs/algochat/config.spec.md
+++ b/specs/algochat/config.spec.md
@@ -29,6 +29,7 @@ Loads and caches AlgoChat configuration from environment variables. Handles Algo
 |----------|-----------|---------|-------------|
 | `loadAlgoChatConfig` | `()` | `AlgoChatConfig` | Load config from env vars (cached after first call) |
 | `parseOwnerAddresses` | `(network: AlgoChatNetwork)` | `Set<string>` | Parse and validate ALGOCHAT_OWNER_ADDRESSES. Exported for testing |
+| `_resetConfigCache` | `()` | `void` | Reset the cached config singleton (test-only) |
 
 ## Invariants
 
@@ -120,3 +121,4 @@ Loads and caches AlgoChat configuration from environment variables. Handles Algo
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-02-19 | corvid-agent | Initial spec |
+| 2026-03-08 | corvid-agent | Documented `_resetConfigCache` test helper |

--- a/specs/db/work-tasks.spec.md
+++ b/specs/db/work-tasks.spec.md
@@ -26,6 +26,8 @@ Provides CRUD, query, and lifecycle operations for work tasks -- autonomous agen
 | `getWorkTaskBySessionId` | `db: Database, sessionId: string` | `WorkTask \| null` | Retrieves a work task by its associated session ID (no tenant filter) |
 | `updateWorkTaskStatus` | `db: Database, id: string, status: WorkTaskStatus, extra?: { sessionId?: string; branchName?: string; prUrl?: string; summary?: string; error?: string; originalBranch?: string; worktreeDir?: string; iterationCount?: number }` | `void` | Updates a work task's status and optionally sets associated metadata fields; auto-sets completed_at when status is 'completed' or 'failed' |
 | `cleanupStaleWorkTasks` | `db: Database` | `WorkTask[]` | Marks all active tasks (branching/running/validating) as failed with error 'Interrupted by server restart'; returns the affected tasks for branch restoration; runs in a transaction |
+| `resetWorkTaskForRetry` | `db: Database, id: string` | `void` | Reset a failed work task back to pending for retry; clears session_id, branch_name, worktree_dir, error, completed_at and resets iteration_count to 0 |
+| `getActiveWorkTasks` | `db: Database` | `WorkTask[]` | Return all work tasks currently in an active state (branching, running, validating) |
 | `listWorkTasks` | `db: Database, agentId?: string, tenantId?: string` | `WorkTask[]` | Lists work tasks, optionally filtered by agent ID, ordered by created_at DESC |
 
 ### Exported Types
@@ -118,3 +120,4 @@ Provides CRUD, query, and lifecycle operations for work tasks -- autonomous agen
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-03-04 | corvid-agent | Initial spec |
+| 2026-03-08 | corvid-agent | Documented `resetWorkTaskForRetry` and `getActiveWorkTasks` |

--- a/specs/github/github.spec.md
+++ b/specs/github/github.spec.md
@@ -49,6 +49,7 @@ Provides GitHub operations via the `gh` CLI (stars, forks, PRs, issues, reviews,
 | `closeIssue` | `repo: string, issueNumber: number` | `Promise<{ ok: boolean; error?: string }>` | Closes a GitHub issue |
 | `addIssueComment` | `repo: string, issueNumber: number, body: string` | `Promise<{ ok: boolean; error?: string }>` | Adds a comment on a GitHub issue |
 | `getPrState` | `repo: string, prNumber: number` | `Promise<{ ok: boolean; pr?: PrViewResult; error?: string }>` | Gets the state of a PR (open/closed/merged, checks, review decision) |
+| `searchOpenPrsForIssue` | `repo: string, issueNumber: number` | `Promise<{ ok: boolean; prs: PullRequest[]; error?: string }>` | Searches open PRs for references to a given issue number (`#NNN` in title or body). Used to deduplicate before creating new work |
 | `isGitHubConfigured` | (none) | `boolean` | Returns true if GH_TOKEN is set in the environment |
 
 ### Exported Types
@@ -124,3 +125,4 @@ Provides GitHub operations via the `gh` CLI (stars, forks, PRs, issues, reviews,
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-03-04 | corvid-agent | Initial spec |
+| 2026-03-08 | corvid-agent | Documented `searchOpenPrsForIssue` |

--- a/specs/lib/infra.spec.md
+++ b/specs/lib/infra.spec.md
@@ -145,6 +145,8 @@ Core infrastructure utilities providing structured logging, environment safety, 
 | `DeviceAuthorizeSchema` | Auth Flow | Validates device authorization: `userCode`, `tenantId`, `email`, `approve` (all required). |
 | `PSKContactNicknameSchema` | PSK Contacts | Validates PSK contact: `nickname` (required). |
 | `CreditGrantSchema` | Wallet Credits | Validates credit grant: `amount` (positive finite number), optional `reference`. |
+| `CastVoteSchema` | Councils | Validates council vote: `agentId` (required), `vote` (approve/reject/abstain), optional `reason`. |
+| `HumanApprovalSchema` | Councils | Validates human approval: `approvedBy` (required). |
 
 ### Re-exports (validation.ts)
 | Export | Source | Description |
@@ -229,3 +231,4 @@ Core infrastructure utilities providing structured logging, environment safety, 
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-03-04 | corvid-agent | Initial spec |
+| 2026-03-08 | corvid-agent | Documented `CastVoteSchema` and `HumanApprovalSchema` Zod schemas |

--- a/specs/routes/routes.spec.md
+++ b/specs/routes/routes.spec.md
@@ -123,12 +123,20 @@ Each route module exports a handler function with the signature `(req, url, db, 
 | `onCouncilDiscussionMessage` | `(launchId, callback)` | `void` | Subscribe to council discussion messages |
 | `onCouncilAgentError` | `(cb: (error: CouncilAgentError) => void)` | `() => void` | Subscribe to council agent error events. Returns an unsubscribe function. |
 
+### Exported Constants (councils.ts re-exports)
+
+| Constant | Type | Description |
+|----------|------|-------------|
+| `HEARTBEAT_INTERVAL_MS` | `number` (30,000) | Periodic re-check interval for missed session exits during council wait |
+| `SAFETY_TIMEOUT_MS` | `number` (600,000) | Safety net timeout when all sessions appear dead but pending set is non-empty |
+
 ### Exported Types (councils.ts re-exports)
 
 | Type | Description |
 |------|-------------|
 | `LaunchCouncilResult` | Result of launching a council deliberation |
 | `WaitForSessionsResult` | Result of waiting for council sessions |
+| `WaitForSessionsOptions` | Optional overrides for internal timing: `{ heartbeatMs?, safetyTimeoutMs? }` (primarily for testing) |
 
 ### Exported Types (mcp-api.ts)
 
@@ -622,3 +630,4 @@ Every request passes through these stages in order:
 |------|--------|--------|
 | 2026-02-20 | corvid-agent | Initial spec |
 | 2026-02-21 | corvid-agent | Add POST /api/reputation/scores for bulk recompute; update GET /scores description to reflect auto-compute behavior |
+| 2026-03-08 | corvid-agent | Documented council re-exports: `HEARTBEAT_INTERVAL_MS`, `SAFETY_TIMEOUT_MS`, `WaitForSessionsOptions` |

--- a/specs/telegram/bridge.spec.md
+++ b/specs/telegram/bridge.spec.md
@@ -48,7 +48,8 @@ Bidirectional Telegram bot bridge that routes Telegram messages to agent session
 
 | Type | Description |
 |------|-------------|
-| `TelegramBridgeConfig` | `{ botToken: string; chatId: string; allowedUserIds: string[] }` |
+| `TelegramBridgeMode` | Union type `'chat' \| 'work_intake'` — controls whether the bridge routes messages to chat sessions or work task intake |
+| `TelegramBridgeConfig` | `{ botToken: string; chatId: string; allowedUserIds: string[]; mode?: TelegramBridgeMode }` |
 | `TelegramUpdate` | Telegram update object with optional `message` and `callback_query` |
 | `TelegramMessage` | Message with `from`, `chat`, optional `text`, optional `voice` |
 | `TelegramUser` | `{ id: number; is_bot: boolean; first_name: string; username?: string }` |
@@ -168,3 +169,4 @@ Bidirectional Telegram bot bridge that routes Telegram messages to agent session
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-02-20 | corvid-agent | Initial spec |
+| 2026-03-08 | corvid-agent | Documented `TelegramBridgeMode` type, updated `TelegramBridgeConfig` to include optional `mode` field |

--- a/specs/work/work-task-service.spec.md
+++ b/specs/work/work-task-service.spec.md
@@ -34,6 +34,23 @@ Manages the full lifecycle of autonomous work tasks: create a git worktree, spaw
 | `runBunInstall` | `(cwd: string)` | `Promise<void>` | Run `bun install --frozen-lockfile --ignore-scripts`, retrying without `--frozen-lockfile` on failure |
 | `runValidation` | `(workingDir: string)` | `Promise<{ passed: boolean; output: string }>` | Full validation pipeline: install deps, tsc, tests, security/governance scans |
 
+### Exported Constants (server/work/repo-map.ts)
+
+| Constant | Type | Description |
+|----------|------|-------------|
+| `REPO_MAP_MAX_LINES` | `number` (200) | Max lines in the generated repo map to keep it lightweight |
+| `PRIORITY_DIRS` | `string[]` | Directories prioritized in repo map ordering (`src/`, `server/`, `lib/`, `packages/`) |
+| `STOP_WORDS` | `Set<string>` | Stop words excluded from keyword extraction for symbol search |
+
+### Exported Functions (server/work/repo-map.ts)
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `filePathPriority` | `(relPath: string)` | `number` | Priority score for file path ordering (1=source dirs, 2=other, 3=test files) |
+| `generateRepoMap` | `(astParserService: AstParserService, projectDir: string)` | `Promise<string \| null>` | Generate a lightweight repo map showing exported symbols per file, grouped by directory. Returns null if AST service unavailable or no exported symbols found |
+| `extractRelevantSymbols` | `(repoMap: string, description: string)` | `string` | Extract symbols from the repo map that are relevant to a task description using keyword matching |
+| `tokenizeDescription` | `(description: string)` | `string[]` | Tokenize a task description into lowercase keywords, filtering out stop words and short tokens |
+
 #### WorkTaskService Constructor
 
 | Parameter | Type | Description |
@@ -211,3 +228,4 @@ Manages the full lifecycle of autonomous work tasks: create a git worktree, spaw
 | 2026-02-20 | corvid-agent | Updated invariant #6 and behavioral example: PR creation now falls back to service-level `createPrFallback()` (fixes #182) |
 | 2026-03-06 | corvid-agent | Added AlgoChat notifications for work task lifecycle events |
 | 2026-03-07 | corvid-agent | Extracted `runValidation` and `runBunInstall` into `server/work/validation.ts` |
+| 2026-03-08 | corvid-agent | Documented repo-map.ts exports: constants, `generateRepoMap`, `extractRelevantSymbols`, `tokenizeDescription`, `filePathPriority` |


### PR DESCRIPTION
## Summary
- Documents all 17 remaining undocumented exports across 7 spec files, reducing spec warnings from 17 to **0**
- Covers repo-map functions/constants, council re-exports, Zod schemas, DB functions, and type exports
- Refs #591

## Files changed
| Spec file | Exports added |
|-----------|---------------|
| `specs/work/work-task-service.spec.md` | 7 — repo-map.ts constants (`REPO_MAP_MAX_LINES`, `PRIORITY_DIRS`, `STOP_WORDS`) and functions (`filePathPriority`, `generateRepoMap`, `extractRelevantSymbols`, `tokenizeDescription`) |
| `specs/routes/routes.spec.md` | 3 — `HEARTBEAT_INTERVAL_MS`, `SAFETY_TIMEOUT_MS`, `WaitForSessionsOptions` |
| `specs/lib/infra.spec.md` | 2 — `CastVoteSchema`, `HumanApprovalSchema` |
| `specs/db/work-tasks.spec.md` | 2 — `resetWorkTaskForRetry`, `getActiveWorkTasks` |
| `specs/algochat/config.spec.md` | 1 — `_resetConfigCache` |
| `specs/github/github.spec.md` | 1 — `searchOpenPrsForIssue` |
| `specs/telegram/bridge.spec.md` | 1 — `TelegramBridgeMode` |

## Test plan
- [x] `bun run spec:check` — 111/111 passed, **0 warnings**, 0 failed
- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 5724 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)