### PR TITLE
fix: remove duplicate properties in playwright config

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -22,7 +22,6 @@ export default defineConfig({
             use: { ...devices['Desktop Chrome'] },
         },
     ],
-    globalTeardown: './e2e/global-teardown.ts',
     webServer: {
         command: 'bun run dev',
         url: `${E2E_BASE}/api/health`,
@@ -36,7 +35,6 @@ export default defineConfig({
             ENABLED_PROVIDERS: 'anthropic,ollama', // Prevent auto-restrict to ollama-only in CI
             API_KEY: 'e2e-test-key',     // Auth key for client-side + server-side auth gates
             ADMIN_API_KEY: 'e2e-test-key', // Same key for admin endpoints in E2E
-            DATABASE_PATH: 'e2e-test.db', // Isolate E2E data from production DB
         },
     },
 });


### PR DESCRIPTION
## Summary
- Remove duplicate `globalTeardown` property (lines 8 and 25 — kept first occurrence)
- Remove duplicate `DATABASE_PATH` env var (lines 33 and 39 — kept first occurrence with original comment)

Resolves the last 2 open CodeQL alerts (#286, #285) on the repository.

Closes #750

## Test plan
- [x] All 5,724 unit tests pass (0 failures)
- [x] Playwright config validated — no functional change (duplicates were identical values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)