### PR TITLE
test: add coverage for wait-sessions, tenant middleware, plugin permissions

### DIFF
--- a/server/__tests__/plugin-permissions.test.ts
+++ b/server/__tests__/plugin-permissions.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for plugin permissions — capability validation, grant/revoke lifecycle,
+ * and sandbox enforcement.
+ *
+ * Uses in-memory SQLite with the plugin_capabilities schema.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import {
+    isValidCapability,
+    validateCapabilities,
+    getGrantedCapabilities,
+    grantCapability,
+    revokeCapability,
+    grantAllCapabilities,
+    hasCapability,
+} from '../plugins/permissions';
+
+function createTestDb(): Database {
+    const db = new Database(':memory:');
+    db.exec('PRAGMA journal_mode = WAL');
+
+    db.exec(`
+        CREATE TABLE plugin_capabilities (
+            plugin_name TEXT NOT NULL,
+            capability TEXT NOT NULL,
+            granted INTEGER NOT NULL DEFAULT 0,
+            granted_at TEXT,
+            PRIMARY KEY (plugin_name, capability)
+        )
+    `);
+
+    return db;
+}
+
+describe('plugins/permissions', () => {
+    let db: Database;
+
+    beforeEach(() => {
+        db = createTestDb();
+    });
+
+    describe('isValidCapability', () => {
+        it('accepts all defined capabilities', () => {
+            expect(isValidCapability('db:read')).toBe(true);
+            expect(isValidCapability('network:outbound')).toBe(true);
+            expect(isValidCapability('fs:project-dir')).toBe(true);
+            expect(isValidCapability('agent:read')).toBe(true);
+            expect(isValidCapability('session:read')).toBe(true);
+        });
+
+        it('rejects unknown capabilities', () => {
+            expect(isValidCapability('db:write')).toBe(false);
+            expect(isValidCapability('network:inbound')).toBe(false);
+            expect(isValidCapability('fs:root')).toBe(false);
+            expect(isValidCapability('')).toBe(false);
+            expect(isValidCapability('admin:all')).toBe(false);
+        });
+    });
+
+    describe('validateCapabilities', () => {
+        it('separates valid from invalid capabilities', () => {
+            const result = validateCapabilities([
+                'db:read',
+                'fs:root',
+                'network:outbound',
+                'unknown',
+            ]);
+            expect(result.valid).toEqual(['db:read', 'network:outbound']);
+            expect(result.invalid).toEqual(['fs:root', 'unknown']);
+        });
+
+        it('returns all valid when input is clean', () => {
+            const result = validateCapabilities(['db:read', 'agent:read']);
+            expect(result.valid).toEqual(['db:read', 'agent:read']);
+            expect(result.invalid).toEqual([]);
+        });
+
+        it('returns all invalid for unknown capabilities', () => {
+            const result = validateCapabilities(['foo', 'bar']);
+            expect(result.valid).toEqual([]);
+            expect(result.invalid).toEqual(['foo', 'bar']);
+        });
+
+        it('handles empty input', () => {
+            const result = validateCapabilities([]);
+            expect(result.valid).toEqual([]);
+            expect(result.invalid).toEqual([]);
+        });
+    });
+
+    describe('grantCapability / hasCapability', () => {
+        it('grants a capability that can be checked', () => {
+            grantCapability(db, 'my-plugin', 'db:read');
+            expect(hasCapability(db, 'my-plugin', 'db:read')).toBe(true);
+        });
+
+        it('returns false for ungranted capability', () => {
+            expect(hasCapability(db, 'my-plugin', 'db:read')).toBe(false);
+        });
+
+        it('returns false for different plugin', () => {
+            grantCapability(db, 'plugin-a', 'db:read');
+            expect(hasCapability(db, 'plugin-b', 'db:read')).toBe(false);
+        });
+
+        it('idempotent — granting twice does not error', () => {
+            grantCapability(db, 'my-plugin', 'db:read');
+            grantCapability(db, 'my-plugin', 'db:read');
+            expect(hasCapability(db, 'my-plugin', 'db:read')).toBe(true);
+        });
+    });
+
+    describe('revokeCapability', () => {
+        it('revokes a previously granted capability', () => {
+            grantCapability(db, 'my-plugin', 'network:outbound');
+            expect(hasCapability(db, 'my-plugin', 'network:outbound')).toBe(true);
+
+            revokeCapability(db, 'my-plugin', 'network:outbound');
+            expect(hasCapability(db, 'my-plugin', 'network:outbound')).toBe(false);
+        });
+
+        it('revoking non-existent capability does not error', () => {
+            // Should not throw
+            revokeCapability(db, 'no-plugin', 'db:read');
+        });
+
+        it('can re-grant after revocation', () => {
+            grantCapability(db, 'my-plugin', 'db:read');
+            revokeCapability(db, 'my-plugin', 'db:read');
+            expect(hasCapability(db, 'my-plugin', 'db:read')).toBe(false);
+
+            grantCapability(db, 'my-plugin', 'db:read');
+            expect(hasCapability(db, 'my-plugin', 'db:read')).toBe(true);
+        });
+    });
+
+    describe('grantAllCapabilities', () => {
+        it('grants multiple capabilities at once', () => {
+            grantAllCapabilities(db, 'multi-plugin', ['db:read', 'agent:read', 'session:read']);
+
+            expect(hasCapability(db, 'multi-plugin', 'db:read')).toBe(true);
+            expect(hasCapability(db, 'multi-plugin', 'agent:read')).toBe(true);
+            expect(hasCapability(db, 'multi-plugin', 'session:read')).toBe(true);
+            expect(hasCapability(db, 'multi-plugin', 'network:outbound')).toBe(false);
+        });
+
+        it('handles empty array', () => {
+            grantAllCapabilities(db, 'empty-plugin', []);
+            expect(getGrantedCapabilities(db, 'empty-plugin')).toEqual([]);
+        });
+    });
+
+    describe('getGrantedCapabilities', () => {
+        it('returns all granted capabilities for a plugin', () => {
+            grantCapability(db, 'p1', 'db:read');
+            grantCapability(db, 'p1', 'network:outbound');
+            grantCapability(db, 'p1', 'fs:project-dir');
+
+            const caps = getGrantedCapabilities(db, 'p1');
+            expect(caps).toContain('db:read');
+            expect(caps).toContain('network:outbound');
+            expect(caps).toContain('fs:project-dir');
+            expect(caps.length).toBe(3);
+        });
+
+        it('excludes revoked capabilities', () => {
+            grantCapability(db, 'p1', 'db:read');
+            grantCapability(db, 'p1', 'network:outbound');
+            revokeCapability(db, 'p1', 'db:read');
+
+            const caps = getGrantedCapabilities(db, 'p1');
+            expect(caps).toEqual(['network:outbound']);
+        });
+
+        it('returns empty array for unknown plugin', () => {
+            expect(getGrantedCapabilities(db, 'unknown')).toEqual([]);
+        });
+
+        it('isolates capabilities between plugins', () => {
+            grantCapability(db, 'p1', 'db:read');
+            grantCapability(db, 'p2', 'network:outbound');
+
+            expect(getGrantedCapabilities(db, 'p1')).toEqual(['db:read']);
+            expect(getGrantedCapabilities(db, 'p2')).toEqual(['network:outbound']);
+        });
+    });
+});

--- a/server/__tests__/tenant-middleware.test.ts
+++ b/server/__tests__/tenant-middleware.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for tenant middleware — extractTenantId, registerApiKey, revokeApiKey.
+ *
+ * Validates multi-tenant isolation: API key resolution, header extraction,
+ * mismatch rejection (403), and single-tenant bypass.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { extractTenantId, registerApiKey, revokeApiKey } from '../tenant/middleware';
+import { TenantService } from '../tenant/context';
+
+function createTestDb(): Database {
+    const db = new Database(':memory:');
+    db.exec('PRAGMA journal_mode = WAL');
+
+    // Minimal schema for tenant middleware tests
+    db.exec(`
+        CREATE TABLE tenants (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            slug TEXT NOT NULL UNIQUE,
+            owner_email TEXT NOT NULL,
+            stripe_customer_id TEXT,
+            plan TEXT NOT NULL DEFAULT 'free',
+            max_agents INTEGER NOT NULL DEFAULT 3,
+            max_concurrent_sessions INTEGER NOT NULL DEFAULT 2,
+            sandbox_enabled INTEGER NOT NULL DEFAULT 0,
+            status TEXT NOT NULL DEFAULT 'active',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    `);
+
+    db.exec(`
+        CREATE TABLE api_keys (
+            key_hash TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            label TEXT NOT NULL DEFAULT 'default',
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    `);
+
+    return db;
+}
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+    return new Request('http://localhost/test', { headers });
+}
+
+describe('tenant/middleware', () => {
+    let db: Database;
+
+    beforeEach(() => {
+        db = createTestDb();
+    });
+
+    describe('extractTenantId — single-tenant mode', () => {
+        it('returns default context regardless of headers', () => {
+            const service = new TenantService(db, false);
+            const req = makeRequest({ 'x-tenant-id': 'some-tenant' });
+
+            const result = extractTenantId(req, db, service);
+            expect(result).not.toBeInstanceOf(Response);
+            expect((result as any).tenantId).toBe('default');
+        });
+
+        it('returns enterprise plan in single-tenant mode', () => {
+            const service = new TenantService(db, false);
+            const result = extractTenantId(makeRequest(), db, service);
+            expect((result as any).plan).toBe('enterprise');
+        });
+    });
+
+    describe('extractTenantId — multi-tenant mode', () => {
+        let service: TenantService;
+
+        beforeEach(() => {
+            service = new TenantService(db, true);
+        });
+
+        it('resolves tenant from X-Tenant-ID header', () => {
+            const req = makeRequest({ 'x-tenant-id': 'tenant-abc' });
+            const result = extractTenantId(req, db, service);
+
+            expect(result).not.toBeInstanceOf(Response);
+            expect((result as any).tenantId).toBe('tenant-abc');
+        });
+
+        it('resolves tenant from API key (Bearer token)', () => {
+            const apiKey = 'test-api-key-12345';
+            registerApiKey(db, 'tenant-from-key', apiKey, 'test-key');
+
+            const req = makeRequest({ authorization: `Bearer ${apiKey}` });
+            const result = extractTenantId(req, db, service);
+
+            expect(result).not.toBeInstanceOf(Response);
+            expect((result as any).tenantId).toBe('tenant-from-key');
+        });
+
+        it('API key takes precedence over header when they agree', () => {
+            const apiKey = 'matching-key-67890';
+            registerApiKey(db, 'tenant-x', apiKey);
+
+            const req = makeRequest({
+                authorization: `Bearer ${apiKey}`,
+                'x-tenant-id': 'tenant-x',
+            });
+            const result = extractTenantId(req, db, service);
+
+            expect(result).not.toBeInstanceOf(Response);
+            expect((result as any).tenantId).toBe('tenant-x');
+        });
+
+        it('returns 403 when API key tenant and header tenant disagree', () => {
+            const apiKey = 'conflict-key-11111';
+            registerApiKey(db, 'tenant-a', apiKey);
+
+            const req = makeRequest({
+                authorization: `Bearer ${apiKey}`,
+                'x-tenant-id': 'tenant-b',
+            });
+            const result = extractTenantId(req, db, service);
+
+            expect(result).toBeInstanceOf(Response);
+            const resp = result as Response;
+            expect(resp.status).toBe(403);
+        });
+
+        it('returns 403 with JSON error body on mismatch', async () => {
+            const apiKey = 'mismatch-key-22222';
+            registerApiKey(db, 'alpha', apiKey);
+
+            const req = makeRequest({
+                authorization: `Bearer ${apiKey}`,
+                'x-tenant-id': 'beta',
+            });
+            const resp = extractTenantId(req, db, service) as Response;
+            const body = await resp.json();
+            expect(body.error).toContain('does not match');
+        });
+
+        it('falls back to default tenant when no header or API key', () => {
+            const result = extractTenantId(makeRequest(), db, service);
+            expect(result).not.toBeInstanceOf(Response);
+            expect((result as any).tenantId).toBe('default');
+        });
+
+        it('ignores non-Bearer auth headers', () => {
+            const req = makeRequest({
+                authorization: 'Basic dXNlcjpwYXNz',
+                'x-tenant-id': 'tenant-via-header',
+            });
+            const result = extractTenantId(req, db, service);
+
+            expect(result).not.toBeInstanceOf(Response);
+            expect((result as any).tenantId).toBe('tenant-via-header');
+        });
+
+        it('handles unknown API key gracefully (falls through to header)', () => {
+            const req = makeRequest({
+                authorization: 'Bearer unknown-key',
+                'x-tenant-id': 'fallback-tenant',
+            });
+            const result = extractTenantId(req, db, service);
+
+            expect(result).not.toBeInstanceOf(Response);
+            expect((result as any).tenantId).toBe('fallback-tenant');
+        });
+    });
+
+    describe('registerApiKey', () => {
+        it('registers a key that can be resolved', () => {
+            const service = new TenantService(db, true);
+            const apiKey = 'register-test-key';
+            registerApiKey(db, 'my-tenant', apiKey, 'my-label');
+
+            const req = makeRequest({ authorization: `Bearer ${apiKey}` });
+            const result = extractTenantId(req, db, service);
+            expect((result as any).tenantId).toBe('my-tenant');
+        });
+
+        it('overwrites existing key on re-register (INSERT OR REPLACE)', () => {
+            const apiKey = 'overwrite-key';
+            registerApiKey(db, 'old-tenant', apiKey);
+            registerApiKey(db, 'new-tenant', apiKey);
+
+            const service = new TenantService(db, true);
+            const req = makeRequest({ authorization: `Bearer ${apiKey}` });
+            const result = extractTenantId(req, db, service);
+            expect((result as any).tenantId).toBe('new-tenant');
+        });
+    });
+
+    describe('revokeApiKey', () => {
+        it('returns true when key existed', () => {
+            const apiKey = 'revoke-me';
+            registerApiKey(db, 'some-tenant', apiKey);
+            expect(revokeApiKey(db, apiKey)).toBe(true);
+        });
+
+        it('returns false when key did not exist', () => {
+            expect(revokeApiKey(db, 'nonexistent-key')).toBe(false);
+        });
+
+        it('key is no longer resolvable after revocation', () => {
+            const service = new TenantService(db, true);
+            const apiKey = 'revoked-key';
+            registerApiKey(db, 'tenant-z', apiKey);
+            revokeApiKey(db, apiKey);
+
+            const req = makeRequest({ authorization: `Bearer ${apiKey}` });
+            const result = extractTenantId(req, db, service);
+            // Should fall through to default since key is revoked
+            expect((result as any).tenantId).toBe('default');
+        });
+    });
+});

--- a/server/__tests__/wait-sessions.test.ts
+++ b/server/__tests__/wait-sessions.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for waitForSessions — heartbeat polling, safety timeout, and
+ * subscribe-first race condition prevention.
+ *
+ * Uses a minimal mock ProcessManager to exercise all branches without
+ * real subprocesses.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { waitForSessions } from '../lib/wait-sessions';
+import type { EventCallback } from '../process/interfaces';
+
+// ── Mock ProcessManager ──────────────────────────────────────────────────
+
+type SubscribeFn = (sessionId: string, callback: EventCallback) => void;
+
+interface MockProcessManager {
+    subscribe: SubscribeFn;
+    unsubscribe: (sessionId: string, callback: EventCallback) => void;
+    isRunning: (sessionId: string) => boolean;
+    /** Simulate a session exit event. */
+    simulateExit: (sessionId: string) => void;
+    /** Set a session's running state. */
+    setRunning: (sessionId: string, running: boolean) => void;
+}
+
+function createMockProcessManager(): MockProcessManager {
+    const runningState = new Map<string, boolean>();
+    const subscribers = new Map<string, Set<EventCallback>>();
+
+    return {
+        subscribe(sessionId: string, callback: EventCallback) {
+            if (!subscribers.has(sessionId)) {
+                subscribers.set(sessionId, new Set());
+            }
+            subscribers.get(sessionId)!.add(callback);
+        },
+
+        unsubscribe(sessionId: string, callback: EventCallback) {
+            subscribers.get(sessionId)?.delete(callback);
+        },
+
+        isRunning(sessionId: string): boolean {
+            return runningState.get(sessionId) ?? false;
+        },
+
+        simulateExit(sessionId: string) {
+            runningState.set(sessionId, false);
+            const cbs = subscribers.get(sessionId);
+            if (cbs) {
+                for (const cb of cbs) {
+                    cb(sessionId, { type: 'session_exited' } as any);
+                }
+            }
+        },
+
+        setRunning(sessionId: string, running: boolean) {
+            runningState.set(sessionId, running);
+        },
+    };
+}
+
+describe('waitForSessions', () => {
+    let pm: MockProcessManager;
+
+    beforeEach(() => {
+        pm = createMockProcessManager();
+    });
+
+    it('resolves immediately when session list is empty', async () => {
+        const result = await waitForSessions(pm as any, []);
+        expect(result.completed).toEqual([]);
+        expect(result.timedOut).toEqual([]);
+    });
+
+    it('resolves immediately when all sessions already exited', async () => {
+        pm.setRunning('s1', false);
+        pm.setRunning('s2', false);
+
+        const result = await waitForSessions(pm as any, ['s1', 's2']);
+        expect(result.completed).toContain('s1');
+        expect(result.completed).toContain('s2');
+        expect(result.timedOut).toEqual([]);
+    });
+
+    it('completes when sessions exit via event subscription', async () => {
+        pm.setRunning('s1', true);
+        pm.setRunning('s2', true);
+
+        const promise = waitForSessions(pm as any, ['s1', 's2'], 5000);
+
+        // Simulate exits after a short delay
+        setTimeout(() => pm.simulateExit('s1'), 10);
+        setTimeout(() => pm.simulateExit('s2'), 20);
+
+        const result = await promise;
+        expect(result.completed).toContain('s1');
+        expect(result.completed).toContain('s2');
+        expect(result.timedOut).toEqual([]);
+    });
+
+    it('reports timed-out sessions when timeout fires', async () => {
+        pm.setRunning('s1', true);
+        pm.setRunning('s2', true);
+
+        // Very short timeout — sessions never exit
+        const result = await waitForSessions(pm as any, ['s1', 's2'], 50, {
+            heartbeatMs: 99999, // disable heartbeat from interfering
+            safetyTimeoutMs: 99999,
+        });
+
+        expect(result.timedOut.length).toBe(2);
+        expect(result.timedOut).toContain('s1');
+        expect(result.timedOut).toContain('s2');
+    });
+
+    it('catches missed exits via heartbeat polling', async () => {
+        pm.setRunning('s1', true);
+
+        const promise = waitForSessions(pm as any, ['s1'], 5000, {
+            heartbeatMs: 30, // Fast heartbeat for testing
+            safetyTimeoutMs: 99999,
+        });
+
+        // Silently mark as not running without emitting event
+        // (simulates a missed exit event — the exact race condition heartbeat catches)
+        setTimeout(() => pm.setRunning('s1', false), 10);
+
+        const result = await promise;
+        expect(result.completed).toContain('s1');
+        expect(result.timedOut).toEqual([]);
+    });
+
+    it('safety timeout auto-advances when all pending sessions are dead', async () => {
+        pm.setRunning('s1', true);
+
+        const promise = waitForSessions(pm as any, ['s1'], 10000, {
+            heartbeatMs: 99999, // disable heartbeat
+            safetyTimeoutMs: 50, // fast safety timeout for testing
+        });
+
+        // Mark session dead without event (heartbeat disabled too)
+        pm.setRunning('s1', false);
+
+        const result = await promise;
+        expect(result.completed).toContain('s1');
+        expect(result.timedOut).toEqual([]);
+    });
+
+    it('handles mixed completed and timed-out sessions', async () => {
+        pm.setRunning('s1', true);
+        pm.setRunning('s2', true);
+
+        const promise = waitForSessions(pm as any, ['s1', 's2'], 100, {
+            heartbeatMs: 99999,
+            safetyTimeoutMs: 99999,
+        });
+
+        // Only s1 exits
+        setTimeout(() => pm.simulateExit('s1'), 10);
+
+        const result = await promise;
+        expect(result.completed).toContain('s1');
+        expect(result.timedOut).toContain('s2');
+    });
+
+    it('catches silently-stopped sessions via heartbeat', async () => {
+        pm.setRunning('s1', true);
+
+        const promise = waitForSessions(pm as any, ['s1'], 5000, {
+            heartbeatMs: 20,
+        });
+
+        // Mark session as stopped without emitting an event
+        setTimeout(() => pm.setRunning('s1', false), 10);
+
+        const result = await promise;
+        expect(result.completed).toContain('s1');
+    });
+
+    it('unsubscribes all callbacks on completion', async () => {
+        pm.setRunning('s1', false);
+
+        let unsubscribeCalled = false;
+        const originalUnsubscribe = pm.unsubscribe;
+        pm.unsubscribe = (sid, cb) => {
+            unsubscribeCalled = true;
+            originalUnsubscribe.call(pm, sid, cb);
+        };
+
+        await waitForSessions(pm as any, ['s1']);
+        expect(unsubscribeCalled).toBe(true);
+    });
+
+    it('uses default timeout when none specified', async () => {
+        // Just verify it doesn't throw when no timeout given
+        pm.setRunning('s1', false);
+        const result = await waitForSessions(pm as any, ['s1']);
+        expect(result.completed).toContain('s1');
+    });
+});


### PR DESCRIPTION
## Summary
- Add 44 new tests (82 assertions) covering three previously untested security-sensitive modules
- **`server/lib/wait-sessions.ts`**: heartbeat polling, safety timeout, subscribe-first race condition prevention, mixed completed/timed-out sessions, cleanup verification
- **`server/tenant/middleware.ts`**: multi-tenant isolation — API key resolution, X-Tenant-ID header extraction, mismatch 403 rejection, single-tenant bypass, key register/revoke lifecycle
- **`server/plugins/permissions.ts`**: capability validation, grant/revoke lifecycle, plugin isolation, idempotent operations, bulk grant

## Test plan
- [x] All 44 tests pass (`bun test`)
- [x] TypeScript compiles clean (`tsc --noEmit --skipLibCheck`)
- [x] Spec check passes (112/112)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)