### PR TITLE
feat: bridge delivery receipt tracking (#631)

### DIFF
--- a/server/__tests__/delivery-tracker.test.ts
+++ b/server/__tests__/delivery-tracker.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { DeliveryTracker } from '../lib/delivery-tracker';
+
+describe('DeliveryTracker', () => {
+    let tracker: DeliveryTracker;
+
+    beforeEach(() => {
+        tracker = new DeliveryTracker();
+    });
+
+    // ── sendWithReceipt ─────────────────────────────────────────────────
+
+    describe('sendWithReceipt', () => {
+        it('records successful delivery', async () => {
+            const { receipt } = await tracker.sendWithReceipt('discord', async () => 'ok', false);
+
+            expect(receipt.platform).toBe('discord');
+            expect(receipt.success).toBe(true);
+            expect(receipt.attempts).toBe(1);
+            expect(receipt.error).toBeUndefined();
+        });
+
+        it('records failed delivery', async () => {
+            await expect(
+                tracker.sendWithReceipt('telegram', async () => {
+                    throw new Error('API down');
+                }, false),
+            ).rejects.toThrow('API down');
+
+            const metrics = tracker.getMetrics('telegram');
+            expect(metrics.failure).toBe(1);
+            expect(metrics.recentFailures).toHaveLength(1);
+            expect(metrics.recentFailures[0].error).toBe('API down');
+        });
+
+        it('returns the result of the send function', async () => {
+            const { result } = await tracker.sendWithReceipt('slack', async () => 42, false);
+            expect(result).toBe(42);
+        });
+
+        it('retries on failure when retry is enabled', async () => {
+            let attempts = 0;
+            const { receipt } = await tracker.sendWithReceipt(
+                'discord',
+                async () => {
+                    attempts++;
+                    if (attempts < 2) throw new Error('transient');
+                    return 'ok';
+                },
+                { maxAttempts: 3, baseDelayMs: 10 },
+            );
+
+            expect(receipt.success).toBe(true);
+            expect(receipt.attempts).toBe(2);
+            expect(attempts).toBe(2);
+        });
+
+        it('records failure after all retries exhausted', async () => {
+            await expect(
+                tracker.sendWithReceipt(
+                    'telegram',
+                    async () => { throw new Error('persistent'); },
+                    { maxAttempts: 2, baseDelayMs: 10 },
+                ),
+            ).rejects.toThrow('persistent');
+
+            const metrics = tracker.getMetrics('telegram');
+            expect(metrics.failure).toBe(1);
+            expect(metrics.total).toBe(1);
+        });
+    });
+
+    // ── Metrics ─────────────────────────────────────────────────────────
+
+    describe('getMetrics', () => {
+        it('returns zero metrics for unused platform', () => {
+            const metrics = tracker.getMetrics('slack');
+            expect(metrics.total).toBe(0);
+            expect(metrics.success).toBe(0);
+            expect(metrics.failure).toBe(0);
+            expect(metrics.successRate).toBe(1);
+            expect(metrics.recentFailures).toEqual([]);
+        });
+
+        it('computes correct success rate', async () => {
+            // 3 successes, 1 failure
+            for (let i = 0; i < 3; i++) {
+                await tracker.sendWithReceipt('discord', async () => 'ok', false);
+            }
+            try {
+                await tracker.sendWithReceipt('discord', async () => { throw new Error('fail'); }, false);
+            } catch { /* expected */ }
+
+            const metrics = tracker.getMetrics('discord');
+            expect(metrics.total).toBe(4);
+            expect(metrics.success).toBe(3);
+            expect(metrics.failure).toBe(1);
+            expect(metrics.successRate).toBe(0.75);
+        });
+
+        it('limits recent failures to 10', async () => {
+            for (let i = 0; i < 15; i++) {
+                try {
+                    await tracker.sendWithReceipt('slack', async () => { throw new Error(`fail-${i}`); }, false);
+                } catch { /* expected */ }
+            }
+
+            const metrics = tracker.getMetrics('slack');
+            expect(metrics.recentFailures).toHaveLength(10);
+            // Should keep the most recent 10
+            expect(metrics.recentFailures[0].error).toBe('fail-5');
+            expect(metrics.recentFailures[9].error).toBe('fail-14');
+        });
+    });
+
+    describe('getAllMetrics', () => {
+        it('returns metrics for all platforms', async () => {
+            await tracker.sendWithReceipt('discord', async () => 'ok', false);
+            await tracker.sendWithReceipt('telegram', async () => 'ok', false);
+
+            const all = tracker.getAllMetrics();
+            expect(all.discord.total).toBe(1);
+            expect(all.telegram.total).toBe(1);
+            expect(all.slack.total).toBe(0);
+        });
+    });
+
+    describe('reset', () => {
+        it('clears all metrics', async () => {
+            await tracker.sendWithReceipt('discord', async () => 'ok', false);
+            tracker.reset();
+
+            const metrics = tracker.getMetrics('discord');
+            expect(metrics.total).toBe(0);
+        });
+    });
+});

--- a/server/__tests__/routes-bridge-delivery.test.ts
+++ b/server/__tests__/routes-bridge-delivery.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'bun:test';
+import { handleBridgeDeliveryRoutes } from '../routes/bridge-delivery';
+
+describe('GET /api/bridges/delivery', () => {
+    it('returns delivery metrics', () => {
+        const req = new Request('http://localhost/api/bridges/delivery', { method: 'GET' });
+        const url = new URL(req.url);
+        const response = handleBridgeDeliveryRoutes(req, url);
+
+        expect(response).not.toBeNull();
+        expect(response!.status).toBe(200);
+    });
+
+    it('returns null for non-matching paths', () => {
+        const req = new Request('http://localhost/api/bridges/other', { method: 'GET' });
+        const url = new URL(req.url);
+        expect(handleBridgeDeliveryRoutes(req, url)).toBeNull();
+    });
+
+    it('returns null for non-GET methods', () => {
+        const req = new Request('http://localhost/api/bridges/delivery', { method: 'POST' });
+        const url = new URL(req.url);
+        expect(handleBridgeDeliveryRoutes(req, url)).toBeNull();
+    });
+
+    it('response body has all platform keys', async () => {
+        const req = new Request('http://localhost/api/bridges/delivery', { method: 'GET' });
+        const url = new URL(req.url);
+        const response = handleBridgeDeliveryRoutes(req, url)!;
+        const body = await response.json() as Record<string, unknown>;
+
+        expect(body).toHaveProperty('discord');
+        expect(body).toHaveProperty('telegram');
+        expect(body).toHaveProperty('slack');
+    });
+});

--- a/server/discord/bridge.ts
+++ b/server/discord/bridge.ts
@@ -18,6 +18,7 @@ import { createLogger } from '../lib/logger';
 import { scanForInjection } from '../lib/prompt-injection';
 import { extractContentText } from '../process/types';
 import { recordAudit } from '../db/audit';
+import { getDeliveryTracker, type DeliveryTracker } from '../lib/delivery-tracker';
 
 const log = createLogger('DiscordBridge');
 
@@ -74,6 +75,7 @@ export class DiscordBridge {
     private userMessageTimestamps: Map<string, number[]> = new Map();
     private readonly RATE_LIMIT_WINDOW_MS = 60_000;
     private readonly RATE_LIMIT_MAX_MESSAGES = 10;
+    private delivery: DeliveryTracker = getDeliveryTracker();
 
     constructor(
         db: Database,
@@ -636,21 +638,28 @@ export class DiscordBridge {
             footer?: { text: string };
         },
     ): Promise<void> {
-        const response = await fetch(
-            `https://discord.com/api/v10/channels/${channelId}/messages`,
-            {
-                method: 'POST',
-                headers: {
-                    'Authorization': `Bot ${this.config.botToken}`,
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({ embeds: [embed] }),
-            },
-        );
+        try {
+            await this.delivery.sendWithReceipt('discord', async () => {
+                const response = await fetch(
+                    `https://discord.com/api/v10/channels/${channelId}/messages`,
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Authorization': `Bot ${this.config.botToken}`,
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({ embeds: [embed] }),
+                    },
+                );
 
-        if (!response.ok) {
-            const error = await response.text();
-            log.error('Failed to send Discord embed', { status: response.status, error: error.slice(0, 200) });
+                if (!response.ok) {
+                    const error = await response.text();
+                    log.error('Failed to send Discord embed', { status: response.status, error: error.slice(0, 200) });
+                    throw new Error(`Discord embed failed: ${response.status}`);
+                }
+            });
+        } catch {
+            // Error already logged by DeliveryTracker
         }
     }
 
@@ -754,24 +763,31 @@ export class DiscordBridge {
     ): Promise<void> {
         assertSnowflake(channelId, 'channel ID');
         assertSnowflake(replyToMessageId, 'message ID');
-        const response = await fetch(
-            `https://discord.com/api/v10/channels/${encodeURIComponent(channelId)}/messages`,
-            {
-                method: 'POST',
-                headers: {
-                    'Authorization': `Bot ${this.config.botToken}`,
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    embeds: [embed],
-                    message_reference: { message_id: replyToMessageId },
-                }),
-            },
-        );
+        try {
+            await this.delivery.sendWithReceipt('discord', async () => {
+                const response = await fetch(
+                    `https://discord.com/api/v10/channels/${encodeURIComponent(channelId)}/messages`,
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Authorization': `Bot ${this.config.botToken}`,
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({
+                            embeds: [embed],
+                            message_reference: { message_id: replyToMessageId },
+                        }),
+                    },
+                );
 
-        if (!response.ok) {
-            const error = await response.text();
-            log.error('Failed to send Discord reply embed', { status: response.status, error: error.slice(0, 200) });
+                if (!response.ok) {
+                    const error = await response.text();
+                    log.error('Failed to send Discord reply embed', { status: response.status, error: error.slice(0, 200) });
+                    throw new Error(`Discord reply embed failed: ${response.status}`);
+                }
+            });
+        } catch {
+            // Error already logged by DeliveryTracker
         }
     }
 
@@ -1020,21 +1036,28 @@ export class DiscordBridge {
         }
 
         for (const chunk of chunks) {
-            const response = await fetch(
-                `https://discord.com/api/v10/channels/${channelId}/messages`,
-                {
-                    method: 'POST',
-                    headers: {
-                        'Authorization': `Bot ${this.config.botToken}`,
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({ content: chunk }),
-                },
-            );
+            try {
+                await this.delivery.sendWithReceipt('discord', async () => {
+                    const response = await fetch(
+                        `https://discord.com/api/v10/channels/${channelId}/messages`,
+                        {
+                            method: 'POST',
+                            headers: {
+                                'Authorization': `Bot ${this.config.botToken}`,
+                                'Content-Type': 'application/json',
+                            },
+                            body: JSON.stringify({ content: chunk }),
+                        },
+                    );
 
-            if (!response.ok) {
-                const error = await response.text();
-                log.error('Failed to send Discord message', { status: response.status, error: error.slice(0, 200) });
+                    if (!response.ok) {
+                        const error = await response.text();
+                        log.error('Failed to send Discord message', { status: response.status, error: error.slice(0, 200) });
+                        throw new Error(`Discord sendMessage failed: ${response.status}`);
+                    }
+                });
+            } catch {
+                // Error already logged by DeliveryTracker
             }
         }
     }

--- a/server/lib/delivery-tracker.ts
+++ b/server/lib/delivery-tracker.ts
@@ -1,0 +1,150 @@
+/**
+ * Delivery receipt tracker for outbound bridge messages.
+ *
+ * Tracks success/failure of messages sent to external platforms
+ * (Discord, Telegram, Slack) and provides per-platform metrics.
+ */
+
+import { createLogger } from './logger';
+import { withRetry, type RetryOptions } from './resilience';
+
+const log = createLogger('DeliveryTracker');
+
+export type DeliveryPlatform = 'discord' | 'telegram' | 'slack';
+
+export interface DeliveryReceipt {
+    platform: DeliveryPlatform;
+    success: boolean;
+    timestamp: number;
+    error?: string;
+    /** How many attempts were needed (1 = first try succeeded) */
+    attempts: number;
+}
+
+export interface DeliveryMetrics {
+    total: number;
+    success: number;
+    failure: number;
+    successRate: number;
+    /** Recent failures (last 10) */
+    recentFailures: Array<{ timestamp: number; error: string }>;
+}
+
+const DEFAULT_RETRY: RetryOptions = {
+    maxAttempts: 2,
+    baseDelayMs: 500,
+    maxDelayMs: 5_000,
+    multiplier: 2,
+};
+
+const MAX_RECENT_FAILURES = 10;
+const METRICS_WINDOW_MS = 3_600_000; // 1 hour
+
+export class DeliveryTracker {
+    private receipts: Map<DeliveryPlatform, DeliveryReceipt[]> = new Map();
+
+    /**
+     * Send a message with delivery tracking and optional retry.
+     * Returns the delivery receipt.
+     */
+    async sendWithReceipt<T>(
+        platform: DeliveryPlatform,
+        sendFn: () => Promise<T>,
+        retryOptions?: RetryOptions | false,
+    ): Promise<{ result: T; receipt: DeliveryReceipt }> {
+        const startTime = Date.now();
+        let attempts = 0;
+
+        const doRetry = retryOptions !== false;
+        const retryOpts = typeof retryOptions === 'object' ? retryOptions : DEFAULT_RETRY;
+
+        try {
+            let result: T;
+            if (doRetry) {
+                let attemptCount = 0;
+                result = await withRetry(async () => {
+                    attemptCount++;
+                    return sendFn();
+                }, retryOpts);
+                attempts = attemptCount;
+            } else {
+                attempts = 1;
+                result = await sendFn();
+            }
+
+            const receipt: DeliveryReceipt = {
+                platform,
+                success: true,
+                timestamp: startTime,
+                attempts,
+            };
+            this.record(receipt);
+            return { result, receipt };
+        } catch (err) {
+            const errorMsg = err instanceof Error ? err.message : String(err);
+            const receipt: DeliveryReceipt = {
+                platform,
+                success: false,
+                timestamp: startTime,
+                error: errorMsg,
+                attempts: doRetry ? (retryOpts.maxAttempts ?? 3) : 1,
+            };
+            this.record(receipt);
+            log.warn('Delivery failed', { platform, error: errorMsg, attempts: receipt.attempts });
+            throw err;
+        }
+    }
+
+    private record(receipt: DeliveryReceipt): void {
+        const list = this.receipts.get(receipt.platform) ?? [];
+        list.push(receipt);
+        // Prune receipts older than metrics window
+        const cutoff = Date.now() - METRICS_WINDOW_MS;
+        const pruned = list.filter(r => r.timestamp >= cutoff);
+        this.receipts.set(receipt.platform, pruned);
+    }
+
+    getMetrics(platform: DeliveryPlatform): DeliveryMetrics {
+        const cutoff = Date.now() - METRICS_WINDOW_MS;
+        const list = (this.receipts.get(platform) ?? []).filter(r => r.timestamp >= cutoff);
+
+        const total = list.length;
+        const success = list.filter(r => r.success).length;
+        const failure = total - success;
+
+        const recentFailures = list
+            .filter(r => !r.success && r.error)
+            .slice(-MAX_RECENT_FAILURES)
+            .map(r => ({ timestamp: r.timestamp, error: r.error! }));
+
+        return {
+            total,
+            success,
+            failure,
+            successRate: total > 0 ? success / total : 1,
+            recentFailures,
+        };
+    }
+
+    getAllMetrics(): Record<DeliveryPlatform, DeliveryMetrics> {
+        return {
+            discord: this.getMetrics('discord'),
+            telegram: this.getMetrics('telegram'),
+            slack: this.getMetrics('slack'),
+        };
+    }
+
+    reset(): void {
+        this.receipts.clear();
+    }
+}
+
+/** Global singleton */
+let globalTracker: DeliveryTracker | null = null;
+
+export function getDeliveryTracker(): DeliveryTracker {
+    if (!globalTracker) {
+        globalTracker = new DeliveryTracker();
+    }
+    return globalTracker;
+}

--- a/server/openapi/route-registry.ts
+++ b/server/openapi/route-registry.ts
@@ -549,6 +549,16 @@ export const routes: RouteEntry[] = [
         auth: 'required',
     },
 
+    // ── Bridge Delivery ───────────────────────────────────────────────────
+    {
+        method: 'GET', path: '/api/bridges/delivery',
+        summary: 'Bridge delivery metrics',
+        description: 'Returns delivery receipt metrics (success/failure counts and rates) for all bridge platforms (Discord, Telegram, Slack).',
+        tags: ['Bridges'],
+        auth: 'required',
+        responses: { 200: { description: 'Per-platform delivery metrics' } },
+    },
+
     // ── Security Overview ─────────────────────────────────────────────────
     {
         method: 'GET', path: '/api/security/overview',

--- a/server/routes/bridge-delivery.ts
+++ b/server/routes/bridge-delivery.ts
@@ -1,0 +1,19 @@
+/**
+ * Bridge delivery metrics route.
+ *
+ *   GET /api/bridges/delivery — Delivery receipt metrics for all bridge platforms.
+ */
+
+import { json } from '../lib/response';
+import { getDeliveryTracker } from '../lib/delivery-tracker';
+
+export function handleBridgeDeliveryRoutes(
+    req: Request,
+    url: URL,
+): Response | null {
+    if (req.method !== 'GET') return null;
+    if (url.pathname !== '/api/bridges/delivery') return null;
+
+    const tracker = getDeliveryTracker();
+    return json(tracker.getAllMetrics());
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -34,6 +34,7 @@ import { handleUsageRoutes } from './usage';
 import { handleFeedbackRoutes } from './feedback';
 import { handleOnboardingRoutes } from './onboarding';
 import { handleSecurityOverviewRoutes } from './security-overview';
+import { handleBridgeDeliveryRoutes } from './bridge-delivery';
 import type { ProcessManager } from '../process/manager';
 import type { SchedulerService } from '../scheduler/service';
 import type { WebhookService } from '../webhooks/service';
@@ -316,6 +317,9 @@ async function handleRoutes(
 
     const securityOverviewResponse = handleSecurityOverviewRoutes(req, url, db);
     if (securityOverviewResponse) return securityOverviewResponse;
+
+    const bridgeDeliveryResponse = handleBridgeDeliveryRoutes(req, url);
+    if (bridgeDeliveryResponse) return bridgeDeliveryResponse;
 
     const dashboardResponse = handleDashboardRoutes(req, url, db, context);
     if (dashboardResponse) return dashboardResponse;

--- a/server/slack/bridge.ts
+++ b/server/slack/bridge.ts
@@ -12,6 +12,7 @@ import { listProjects } from '../db/projects';
 import { createLogger } from '../lib/logger';
 import { DedupService } from '../lib/dedup';
 import { timingSafeEqual } from '../middleware/auth';
+import { getDeliveryTracker, type DeliveryTracker } from '../lib/delivery-tracker';
 
 const log = createLogger('SlackBridge');
 
@@ -37,6 +38,7 @@ export class SlackBridge {
     private readonly RATE_LIMIT_MAX_MESSAGES = 10;
 
     private dedup = DedupService.global();
+    private delivery: DeliveryTracker = getDeliveryTracker();
 
     constructor(db: Database, processManager: ProcessManager, config: SlackBridgeConfig) {
         this.db = db;
@@ -320,23 +322,31 @@ export class SlackBridge {
                 body.thread_ts = threadTs;
             }
 
-            const response = await fetch('https://slack.com/api/chat.postMessage', {
-                method: 'POST',
-                headers: {
-                    'Authorization': `Bearer ${this.config.botToken}`,
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(body),
-            });
+            try {
+                await this.delivery.sendWithReceipt('slack', async () => {
+                    const response = await fetch('https://slack.com/api/chat.postMessage', {
+                        method: 'POST',
+                        headers: {
+                            'Authorization': `Bearer ${this.config.botToken}`,
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify(body),
+                    });
 
-            if (!response.ok) {
-                const error = await response.text();
-                log.error('Failed to send Slack message', { status: response.status, error: error.slice(0, 200) });
-            } else {
-                const data = await response.json() as { ok: boolean; error?: string };
-                if (!data.ok) {
-                    log.error('Slack API error', { error: data.error });
-                }
+                    if (!response.ok) {
+                        const error = await response.text();
+                        log.error('Failed to send Slack message', { status: response.status, error: error.slice(0, 200) });
+                        throw new Error(`Slack sendMessage failed: ${response.status}`);
+                    } else {
+                        const data = await response.json() as { ok: boolean; error?: string };
+                        if (!data.ok) {
+                            log.error('Slack API error', { error: data.error });
+                            throw new Error(`Slack API error: ${data.error}`);
+                        }
+                    }
+                });
+            } catch {
+                // Error already logged by DeliveryTracker
             }
         }
     }

--- a/server/telegram/bridge.ts
+++ b/server/telegram/bridge.ts
@@ -14,6 +14,7 @@ import { ExternalServiceError, NotFoundError } from '../lib/errors';
 import { scanForInjection } from '../lib/prompt-injection';
 import { recordAudit } from '../db/audit';
 import { DedupService } from '../lib/dedup';
+import { getDeliveryTracker, type DeliveryTracker } from '../lib/delivery-tracker';
 
 const log = createLogger('TelegramBridge');
 
@@ -36,6 +37,7 @@ export class TelegramBridge {
     private running = false;
     private consecutiveErrors = 0;
     private dedup = DedupService.global();
+    private delivery: DeliveryTracker = getDeliveryTracker();
 
     // Map Telegram userId → active sessionId
     private userSessions: Map<number, string> = new Map();
@@ -426,12 +428,18 @@ export class TelegramBridge {
         }
 
         for (const chunk of chunks) {
-            await this.callTelegramApi('sendMessage', {
-                chat_id: chatId,
-                text: chunk,
-                parse_mode: 'Markdown',
-                ...(replyTo ? { reply_to_message_id: replyTo } : {}),
-            });
+            try {
+                await this.delivery.sendWithReceipt('telegram', () =>
+                    this.callTelegramApi('sendMessage', {
+                        chat_id: chatId,
+                        text: chunk,
+                        parse_mode: 'Markdown',
+                        ...(replyTo ? { reply_to_message_id: replyTo } : {}),
+                    }),
+                );
+            } catch {
+                // Error already logged by DeliveryTracker and callTelegramApi
+            }
         }
     }
 
@@ -447,15 +455,18 @@ export class TelegramBridge {
         formData.append('voice', new Blob([new Uint8Array(result.audio)], { type: 'audio/mpeg' }), 'voice.mp3');
         if (replyTo) formData.append('reply_to_message_id', String(replyTo));
 
-        const response = await fetch(
-            `https://api.telegram.org/bot${this.config.botToken}/sendVoice`,
-            { method: 'POST', body: formData },
-        );
+        await this.delivery.sendWithReceipt('telegram', async () => {
+            const response = await fetch(
+                `https://api.telegram.org/bot${this.config.botToken}/sendVoice`,
+                { method: 'POST', body: formData },
+            );
 
-        if (!response.ok) {
-            const error = await response.text();
-            log.error('Failed to send Telegram voice', { error });
-        }
+            if (!response.ok) {
+                const error = await response.text();
+                log.error('Failed to send Telegram voice', { error });
+                throw new Error(`Telegram sendVoice failed: ${response.status}`);
+            }
+        });
 
         // Also send as text for accessibility
         await this.sendText(chatId, text, replyTo);


### PR DESCRIPTION
## Summary
- Adds `DeliveryTracker` service (`server/lib/delivery-tracker.ts`) that wraps outbound API calls with success/failure tracking and automatic retry (exponential backoff via existing `withRetry`)
- Integrates tracking into all three bridges: Discord (`sendEmbed`, `sendReplyEmbed`, `sendMessage`), Telegram (`sendText`, `sendVoice`), and Slack (`sendMessage`)
- Adds `GET /api/bridges/delivery` endpoint returning per-platform metrics (total, success, failure, success rate, recent failures)
- 14 new tests (DeliveryTracker unit tests + route tests), all existing 105 bridge tests continue to pass

## Context
This completes the final open checklist item on #631 (Bridge Hardening). All other items were already implemented:
- ✅ Telegram exponential backoff on poll failures
- ✅ Telegram dedup by `update_id` via `DedupService`
- ✅ Discord resume/reconnect on gateway disconnect
- ✅ Slack webhook signature verification
- ✅ Per-user rate limiting (all bridges)
- ✅ **Delivery receipt tracking** (this PR)

Closes #631

## Test plan
- [x] 14 new tests pass (delivery-tracker + route)
- [x] 105 existing bridge tests pass (discord, telegram, slack)
- [x] 5,798/5,798 full suite passes
- [x] 112/112 specs pass
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)