### PR TITLE
feat: integrate SandboxManager into ProcessManager (#382)

### DIFF
--- a/server/__tests__/sandbox-manager.test.ts
+++ b/server/__tests__/sandbox-manager.test.ts
@@ -4,11 +4,12 @@
  * - manager.ts: Pool management, assignment, release
  * - policy.ts: Per-agent resource limits
  */
-import { test, expect, describe, beforeEach } from 'bun:test';
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { runMigrations } from '../db/schema';
 import { getAgentPolicy, setAgentPolicy, removeAgentPolicy, listAgentPolicies } from '../sandbox/policy';
 import { DEFAULT_RESOURCE_LIMITS, DEFAULT_POOL_CONFIG } from '../sandbox/types';
+import { ProcessManager } from '../process/manager';
 
 // ─── DB Setup ───────────────────────────────────────────────────────────────
 
@@ -172,5 +173,70 @@ describe('SandboxManager', () => {
         const { SandboxManager } = require('../sandbox/manager');
         const manager = new SandboxManager(setupDb());
         expect(manager.getContainerForSession('session-1')).toBeNull();
+    });
+});
+
+// ─── ProcessManager Integration Tests ─────────────────────────────────────────
+
+describe('ProcessManager Sandbox Integration', () => {
+    let pmDb: Database;
+    let pm: ProcessManager;
+
+    beforeEach(() => {
+        pmDb = new Database(':memory:');
+        pmDb.exec('PRAGMA foreign_keys = ON');
+        runMigrations(pmDb);
+        pm = new ProcessManager(pmDb);
+    });
+
+    afterEach(() => {
+        pm.shutdown();
+        pmDb.close();
+    });
+
+    test('setSandboxManager accepts a SandboxManager instance', () => {
+        const { SandboxManager } = require('../sandbox/manager');
+        const sandbox = new SandboxManager(setupDb());
+        // Should not throw
+        pm.setSandboxManager(sandbox);
+    });
+
+    test('cleanupSessionState does not throw when sandbox is not set', () => {
+        // No sandbox manager set — should gracefully skip
+        pm.cleanupSessionState('session-1');
+        expect(pm.getMemoryStats().processes).toBe(0);
+    });
+
+    test('cleanupSessionState does not throw when sandbox is disabled', () => {
+        const { SandboxManager } = require('../sandbox/manager');
+        const sandbox = new SandboxManager(setupDb());
+        // Not initialized — isEnabled() returns false
+        pm.setSandboxManager(sandbox);
+        pm.cleanupSessionState('session-1');
+        expect(pm.getMemoryStats().processes).toBe(0);
+    });
+
+    test('cleanupSessionState calls releaseContainer when sandbox is enabled', async () => {
+        let releasedSessionId = '' as string;
+
+        // Create a mock sandbox manager that tracks calls
+        const mockSandbox = {
+            isEnabled: () => true,
+            assignContainer: async () => 'mock-container-id',
+            releaseContainer: async (sessionId: string) => {
+                releasedSessionId = sessionId;
+            },
+            getContainerForSession: () => null,
+            getPoolStats: () => ({ total: 0, warm: 0, assigned: 0, maxContainers: 10, enabled: true }),
+            shutdown: async () => {},
+            initialize: async () => true,
+        };
+
+        pm.setSandboxManager(mockSandbox as unknown as import('../sandbox/manager').SandboxManager);
+        pm.cleanupSessionState('session-abc');
+
+        // Wait for async release to complete
+        await new Promise(resolve => setTimeout(resolve, 50));
+        expect(releasedSessionId).toBe('session-abc');
     });
 });

--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -261,6 +261,9 @@ export async function bootstrapServices(db: Database, startTime: number): Promis
     const dailyReviewService = new DailyReviewService(db, memoryManager);
 
     // ── Cross-dependency wiring ──────────────────────────────────────────
+    if (sandboxManager) {
+        processManager.setSandboxManager(sandboxManager);
+    }
     schedulerService.setImprovementLoopService(improvementLoopService);
     schedulerService.setReputationServices(reputationScorer, reputationAttestation);
     schedulerService.setNotificationService(notificationService);

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -25,6 +25,7 @@ import { createLogger } from '../lib/logger';
 import { SessionEventBus } from './event-bus';
 import { SessionTimerManager } from './session-timer-manager';
 import { SessionResilienceManager, MAX_RESTARTS } from './session-resilience-manager';
+import type { SandboxManager } from '../sandbox/manager';
 
 // Re-export EventCallback from interfaces for backward compatibility —
 // callers importing { EventCallback } from './manager' continue to work.
@@ -67,6 +68,9 @@ export class ProcessManager {
 
     // MCP services — composed container set after AlgoChat init
     private readonly mcpServices = new McpServiceContainer();
+
+    // Sandbox — optional container isolation for agent sessions
+    private sandboxManager: SandboxManager | null = null;
 
     // Composed managers — delegated concerns
     private readonly timerManager: SessionTimerManager;
@@ -121,6 +125,11 @@ export class ProcessManager {
     /** Register MCP-related services so agent sessions get corvid_* tools. */
     setMcpServices(services: McpServices): void {
         this.mcpServices.setServices(services);
+    }
+
+    /** Set the sandbox manager so sessions can be assigned containers. */
+    setSandboxManager(manager: SandboxManager): void {
+        this.sandboxManager = manager;
     }
 
     /** Build an McpToolContext for a given agent, or null if MCP services aren't available. */
@@ -368,6 +377,19 @@ export class ProcessManager {
         this.timerManager.startStableTimer(session.id);
         this.timerManager.startSessionTimeout(session.id);
 
+        // Assign a sandbox container if enabled (async, best-effort)
+        if (this.sandboxManager?.isEnabled() && session.agentId) {
+            const workDir = (session as { workDir?: string }).workDir ?? null;
+            this.sandboxManager.assignContainer(session.agentId, session.id, workDir).then((containerId) => {
+                log.info(`Sandbox container assigned`, { sessionId: session.id, containerId: containerId.slice(0, 12) });
+            }).catch((err) => {
+                log.warn(`Failed to assign sandbox container`, {
+                    sessionId: session.id,
+                    error: err instanceof Error ? err.message : String(err),
+                });
+            });
+        }
+
         log.info(`Started process for session ${session.id}`, { pid: process.pid });
 
         this.eventBus.emit(session.id, {
@@ -582,6 +604,16 @@ export class ProcessManager {
         this.timerManager.cleanupSession(sessionId);
         this.approvalManager.cancelSession(sessionId);
         this.ownerQuestionManager.cancelSession(sessionId);
+
+        // Release sandbox container if one was assigned
+        if (this.sandboxManager?.isEnabled()) {
+            this.sandboxManager.releaseContainer(sessionId).catch((err) => {
+                log.warn(`Failed to release sandbox container`, {
+                    sessionId,
+                    error: err instanceof Error ? err.message : String(err),
+                });
+            });
+        }
     }
 
     /**

--- a/specs/sandbox/sandbox.spec.md
+++ b/specs/sandbox/sandbox.spec.md
@@ -113,6 +113,16 @@ Manages Docker container lifecycle for sandboxed agent execution, including a wa
 - **When** `createContainer` is called
 - **Then** an `AuthorizationError` is thrown before any Docker command runs
 
+### Scenario: ProcessManager assigns container on session start
+- **Given** `SANDBOX_ENABLED=true`, Docker is available, and `ProcessManager.setSandboxManager()` has been called
+- **When** a session starts via `startProcess()` or `resumeProcess()`
+- **Then** `assignContainer(agentId, sessionId, workDir)` is called asynchronously; failure logs a warning but does not prevent the session from running
+
+### Scenario: ProcessManager releases container on session cleanup
+- **Given** a sandbox container is assigned to a session
+- **When** the session is stopped or cleaned up via `cleanupSessionState()`
+- **Then** `releaseContainer(sessionId)` is called asynchronously; failure logs a warning
+
 ### Scenario: Agent policy lookup with no custom config
 - **Given** no row exists in `sandbox_configs` for `agent-1`
 - **When** `getAgentPolicy(db, 'agent-1')` is called
@@ -144,7 +154,8 @@ Manages Docker container lifecycle for sandboxed agent execution, including a wa
 
 | Module | What is used |
 |--------|-------------|
-| `server/index.ts` | `SandboxManager` class (initialization and lifecycle) |
+| `server/bootstrap.ts` | `SandboxManager` class (initialization, lifecycle, and wiring into `ProcessManager`) |
+| `server/process/manager.ts` | `SandboxManager` type for container assignment on session start and release on session cleanup |
 | `routes/sandbox` | `SandboxManager` type for pool stats; `getAgentPolicy`, `setAgentPolicy`, `removeAgentPolicy`, `listAgentPolicies` for policy CRUD |
 | `routes/index` | `SandboxManager` type for route handler context |
 | `db/sandbox` | `SandboxConfigRecord` type |
@@ -154,4 +165,5 @@ Manages Docker container lifecycle for sandboxed agent execution, including a wa
 
 | Date | Author | Change |
 |------|--------|--------|
+| 2026-03-08 | corvid-agent | Integrated SandboxManager into ProcessManager: container assignment on session start, release on cleanup |
 | 2026-03-04 | corvid-agent | Initial spec |


### PR DESCRIPTION
## Summary
- Wires `SandboxManager` into `ProcessManager` via `setSandboxManager()` setter
- On session start (`registerProcess`): assigns a container asynchronously when `SANDBOX_ENABLED=true`
- On session cleanup (`cleanupSessionState`): releases the container asynchronously
- Bootstrap wiring in `bootstrap.ts` connects the two when sandbox is enabled
- 4 new integration tests verify the wiring (mock sandbox manager, disabled/enabled paths)
- Spec updated with ProcessManager integration docs and behavioral examples

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` — passes
- [x] `bun test` — 5,802 pass, 0 fail
- [x] `bun run spec:check` — 112/112 pass
- [x] Sandbox manager tests: 18 pass (including 4 new integration tests)
- [x] Process manager cleanup tests: 15 pass (no regressions)

Closes #382 (partial — container lifecycle integration; full container execution is a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)