### PR TITLE
feat: governance v2 proposals with weighted voting and lifecycle (#633)

### DIFF
--- a/server/__tests__/governance-proposals.test.ts
+++ b/server/__tests__/governance-proposals.test.ts
@@ -1,0 +1,460 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import {
+    createProposal,
+    getProposal,
+    listProposals,
+    updateProposal,
+    updateProposalStatus,
+    deleteProposal,
+    castProposalVote,
+    getProposalVotes,
+} from '../db/proposals';
+import {
+    evaluateProposalQuorum,
+    resolveQuorumConfig,
+    isValidTransition,
+    type GovernanceTier,
+} from '../councils/governance';
+import { handleProposalRoutes } from '../routes/proposals';
+
+let db: Database;
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+});
+
+afterEach(() => {
+    db.close();
+});
+
+// ─── DB layer tests ─────────────────────────────────────────────────────────
+
+describe('governance proposals DB', () => {
+    test('creates and retrieves a proposal', () => {
+        const proposal = createProposal(db, {
+            title: 'Test Proposal',
+            description: 'A test governance proposal',
+            authorAgentId: 'agent-1',
+            governanceTier: 2,
+            affectedPaths: ['server/routes/test.ts'],
+        });
+
+        expect(proposal.id).toBeDefined();
+        expect(proposal.title).toBe('Test Proposal');
+        expect(proposal.description).toBe('A test governance proposal');
+        expect(proposal.authorAgentId).toBe('agent-1');
+        expect(proposal.governanceTier).toBe(2);
+        expect(proposal.affectedPaths).toEqual(['server/routes/test.ts']);
+        expect(proposal.status).toBe('draft');
+        expect(proposal.decision).toBeNull();
+        expect(proposal.quorumThreshold).toBeNull();
+        expect(proposal.minVoters).toBeNull();
+
+        const fetched = getProposal(db, proposal.id);
+        expect(fetched).not.toBeNull();
+        expect(fetched!.title).toBe('Test Proposal');
+    });
+
+    test('creates proposal with quorum overrides', () => {
+        const proposal = createProposal(db, {
+            title: 'Custom Quorum',
+            authorAgentId: 'agent-1',
+            quorumThreshold: 0.8,
+            minVoters: 3,
+        });
+
+        expect(proposal.quorumThreshold).toBe(0.8);
+        expect(proposal.minVoters).toBe(3);
+    });
+
+    test('lists proposals with filters', () => {
+        createProposal(db, { title: 'P1', authorAgentId: 'agent-1', councilId: 'c1' });
+        createProposal(db, { title: 'P2', authorAgentId: 'agent-2', councilId: 'c1' });
+        createProposal(db, { title: 'P3', authorAgentId: 'agent-1', councilId: 'c2' });
+
+        const all = listProposals(db);
+        expect(all.length).toBe(3);
+
+        const byCouncil = listProposals(db, { councilId: 'c1' });
+        expect(byCouncil.length).toBe(2);
+
+        const byAuthor = listProposals(db, { authorAgentId: 'agent-1' });
+        expect(byAuthor.length).toBe(2);
+
+        const byStatus = listProposals(db, { status: 'draft' });
+        expect(byStatus.length).toBe(3);
+    });
+
+    test('updates proposal in draft status', () => {
+        const proposal = createProposal(db, { title: 'Original', authorAgentId: 'agent-1' });
+        const updated = updateProposal(db, proposal.id, { title: 'Updated', quorumThreshold: 0.6 });
+
+        expect(updated).not.toBeNull();
+        expect(updated!.title).toBe('Updated');
+        expect(updated!.quorumThreshold).toBe(0.6);
+    });
+
+    test('refuses to update non-draft proposal', () => {
+        const proposal = createProposal(db, { title: 'Test', authorAgentId: 'agent-1' });
+        updateProposalStatus(db, proposal.id, 'open');
+
+        const result = updateProposal(db, proposal.id, { title: 'Changed' });
+        expect(result).toBeNull();
+    });
+
+    test('deletes draft proposal', () => {
+        const proposal = createProposal(db, { title: 'To Delete', authorAgentId: 'agent-1' });
+        expect(deleteProposal(db, proposal.id)).toBe(true);
+        expect(getProposal(db, proposal.id)).toBeNull();
+    });
+
+    test('refuses to delete non-draft proposal', () => {
+        const proposal = createProposal(db, { title: 'Open', authorAgentId: 'agent-1' });
+        updateProposalStatus(db, proposal.id, 'open');
+        expect(deleteProposal(db, proposal.id)).toBe(false);
+    });
+
+    test('transitions proposal status', () => {
+        const proposal = createProposal(db, { title: 'Lifecycle', authorAgentId: 'agent-1' });
+
+        updateProposalStatus(db, proposal.id, 'open');
+        expect(getProposal(db, proposal.id)!.status).toBe('open');
+
+        updateProposalStatus(db, proposal.id, 'voting', { voteStartAt: '2026-01-01T00:00:00Z' });
+        const voting = getProposal(db, proposal.id)!;
+        expect(voting.status).toBe('voting');
+        expect(voting.voteStartAt).toBe('2026-01-01T00:00:00Z');
+
+        updateProposalStatus(db, proposal.id, 'decided', {
+            decision: 'approved',
+            decidedAt: '2026-01-02T00:00:00Z',
+            voteEndAt: '2026-01-02T00:00:00Z',
+        });
+        const decided = getProposal(db, proposal.id)!;
+        expect(decided.status).toBe('decided');
+        expect(decided.decision).toBe('approved');
+        expect(decided.decidedAt).toBe('2026-01-02T00:00:00Z');
+
+        updateProposalStatus(db, proposal.id, 'enacted', { enactedAt: '2026-01-03T00:00:00Z' });
+        expect(getProposal(db, proposal.id)!.status).toBe('enacted');
+    });
+
+    test('casts and retrieves proposal votes', () => {
+        const proposal = createProposal(db, { title: 'Vote Test', authorAgentId: 'agent-1' });
+        updateProposalStatus(db, proposal.id, 'open');
+        updateProposalStatus(db, proposal.id, 'voting');
+
+        castProposalVote(db, { proposalId: proposal.id, agentId: 'agent-1', vote: 'approve', weight: 80 });
+        castProposalVote(db, { proposalId: proposal.id, agentId: 'agent-2', vote: 'reject', weight: 40 });
+        castProposalVote(db, { proposalId: proposal.id, agentId: 'agent-3', vote: 'abstain', weight: 60 });
+
+        const votes = getProposalVotes(db, proposal.id);
+        expect(votes.length).toBe(3);
+        expect(votes[0].agentId).toBe('agent-1');
+        expect(votes[0].vote).toBe('approve');
+        expect(votes[0].weight).toBe(80);
+    });
+
+    test('upserts proposal vote (update on conflict)', () => {
+        const proposal = createProposal(db, { title: 'Upsert', authorAgentId: 'agent-1' });
+
+        castProposalVote(db, { proposalId: proposal.id, agentId: 'agent-1', vote: 'approve', weight: 50 });
+        castProposalVote(db, { proposalId: proposal.id, agentId: 'agent-1', vote: 'reject', weight: 50 });
+
+        const votes = getProposalVotes(db, proposal.id);
+        expect(votes.length).toBe(1);
+        expect(votes[0].vote).toBe('reject');
+    });
+});
+
+// ─── Quorum evaluation tests ────────────────────────────────────────────────
+
+describe('evaluateProposalQuorum', () => {
+    test('Layer 0 always fails', () => {
+        const result = evaluateProposalQuorum(
+            0 as GovernanceTier,
+            [{ vote: 'approve', weight: 100 }],
+            { threshold: 0.5, minVoters: 1 },
+        );
+        expect(result.passed).toBe(false);
+        expect(result.reason).toContain('Layer 0');
+    });
+
+    test('fails with insufficient voters', () => {
+        const result = evaluateProposalQuorum(
+            2 as GovernanceTier,
+            [{ vote: 'approve', weight: 100 }],
+            { threshold: 0.5, minVoters: 3 },
+        );
+        expect(result.passed).toBe(false);
+        expect(result.voterCount).toBe(1);
+        expect(result.requiredMinVoters).toBe(3);
+        expect(result.reason).toContain('Insufficient voters');
+    });
+
+    test('passes with weighted majority at Layer 2', () => {
+        const result = evaluateProposalQuorum(
+            2 as GovernanceTier,
+            [
+                { vote: 'approve', weight: 80 },
+                { vote: 'approve', weight: 70 },
+                { vote: 'reject', weight: 30 },
+            ],
+            { threshold: 0.5, minVoters: 2 },
+        );
+        expect(result.passed).toBe(true);
+        expect(result.weightedApprovalRatio).toBeGreaterThan(0.5);
+    });
+
+    test('fails below threshold', () => {
+        const result = evaluateProposalQuorum(
+            2 as GovernanceTier,
+            [
+                { vote: 'approve', weight: 20 },
+                { vote: 'reject', weight: 80 },
+            ],
+            { threshold: 0.5, minVoters: 1 },
+        );
+        expect(result.passed).toBe(false);
+        expect(result.weightedApprovalRatio).toBeLessThan(0.5);
+    });
+
+    test('awaits human approval for Layer 1', () => {
+        const result = evaluateProposalQuorum(
+            1 as GovernanceTier,
+            [
+                { vote: 'approve', weight: 80 },
+                { vote: 'approve', weight: 90 },
+            ],
+            { threshold: 0.75, minVoters: 1 },
+            false,
+        );
+        expect(result.passed).toBe(false);
+        expect(result.awaitingHumanApproval).toBe(true);
+    });
+
+    test('passes Layer 1 with human approval', () => {
+        const result = evaluateProposalQuorum(
+            1 as GovernanceTier,
+            [
+                { vote: 'approve', weight: 80 },
+                { vote: 'approve', weight: 90 },
+            ],
+            { threshold: 0.75, minVoters: 1 },
+            true,
+        );
+        expect(result.passed).toBe(true);
+    });
+
+    test('abstentions excluded from voter count', () => {
+        const result = evaluateProposalQuorum(
+            2 as GovernanceTier,
+            [
+                { vote: 'approve', weight: 90 },
+                { vote: 'abstain', weight: 50 },
+                { vote: 'abstain', weight: 50 },
+            ],
+            { threshold: 0.5, minVoters: 2 },
+        );
+        expect(result.passed).toBe(false);
+        expect(result.voterCount).toBe(1);
+        expect(result.reason).toContain('Insufficient voters');
+    });
+
+    test('no votes returns failure', () => {
+        const result = evaluateProposalQuorum(
+            2 as GovernanceTier,
+            [],
+            { threshold: 0.5, minVoters: 1 },
+        );
+        expect(result.passed).toBe(false);
+    });
+});
+
+// ─── Quorum config resolution ───────────────────────────────────────────────
+
+describe('resolveQuorumConfig', () => {
+    test('uses proposal-level overrides first', () => {
+        const config = resolveQuorumConfig(2 as GovernanceTier, 0.8, 5, 0.6);
+        expect(config.threshold).toBe(0.8);
+        expect(config.minVoters).toBe(5);
+    });
+
+    test('falls back to council threshold', () => {
+        const config = resolveQuorumConfig(2 as GovernanceTier, null, null, 0.6);
+        expect(config.threshold).toBe(0.6);
+        expect(config.minVoters).toBe(1); // default
+    });
+
+    test('falls back to tier default', () => {
+        const config = resolveQuorumConfig(1 as GovernanceTier, null, null, null);
+        expect(config.threshold).toBe(0.75); // Layer 1 supermajority
+        expect(config.minVoters).toBe(1);
+    });
+});
+
+// ─── Lifecycle transition validation ────────────────────────────────────────
+
+describe('isValidTransition', () => {
+    test('allows valid transitions', () => {
+        expect(isValidTransition('draft', 'open')).toBe(true);
+        expect(isValidTransition('open', 'voting')).toBe(true);
+        expect(isValidTransition('open', 'draft')).toBe(true);
+        expect(isValidTransition('voting', 'decided')).toBe(true);
+        expect(isValidTransition('decided', 'enacted')).toBe(true);
+    });
+
+    test('rejects invalid transitions', () => {
+        expect(isValidTransition('draft', 'voting')).toBe(false);
+        expect(isValidTransition('draft', 'decided')).toBe(false);
+        expect(isValidTransition('voting', 'open')).toBe(false);
+        expect(isValidTransition('enacted', 'draft')).toBe(false);
+        expect(isValidTransition('decided', 'voting')).toBe(false);
+    });
+});
+
+// ─── Route handler tests ────────────────────────────────────────────────────
+
+describe('proposal route handler', () => {
+    test('returns null for non-matching paths', () => {
+        const req = new Request('http://localhost/api/agents', { method: 'GET' });
+        const url = new URL(req.url);
+        const result = handleProposalRoutes(req, url, db);
+        expect(result).toBeNull();
+    });
+
+    test('creates and lists proposals via routes', async () => {
+        // Create
+        const createReq = new Request('http://localhost/api/governance/proposals', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                title: 'Route Test',
+                authorAgentId: 'agent-1',
+                governanceTier: 2,
+            }),
+        });
+        const createRes = await handleProposalRoutes(createReq, new URL(createReq.url), db);
+        expect(createRes).not.toBeNull();
+        expect(createRes!.status).toBe(201);
+        const created = await createRes!.json();
+        expect(created.title).toBe('Route Test');
+
+        // List
+        const listReq = new Request('http://localhost/api/governance/proposals', { method: 'GET' });
+        const listRes = await Promise.resolve(handleProposalRoutes(listReq, new URL(listReq.url), db));
+        expect(listRes).not.toBeNull();
+        const list = await listRes!.json();
+        expect(list.length).toBe(1);
+    });
+
+    test('transitions proposal lifecycle via routes', async () => {
+        const proposal = createProposal(db, { title: 'Lifecycle', authorAgentId: 'agent-1' });
+
+        // draft → open
+        const openReq = new Request(`http://localhost/api/governance/proposals/${proposal.id}/transition`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ status: 'open' }),
+        });
+        const openRes = await handleProposalRoutes(openReq, new URL(openReq.url), db);
+        expect(openRes!.status).toBe(200);
+        const opened = await openRes!.json();
+        expect(opened.status).toBe('open');
+
+        // open → voting
+        const voteReq = new Request(`http://localhost/api/governance/proposals/${proposal.id}/transition`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ status: 'voting' }),
+        });
+        const voteRes = await handleProposalRoutes(voteReq, new URL(voteReq.url), db);
+        expect(voteRes!.status).toBe(200);
+
+        // Invalid: voting → open
+        const invalidReq = new Request(`http://localhost/api/governance/proposals/${proposal.id}/transition`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ status: 'open' }),
+        });
+        const invalidRes = await handleProposalRoutes(invalidReq, new URL(invalidReq.url), db);
+        expect(invalidRes!.status).toBe(400);
+    });
+
+    test('casts votes and evaluates quorum via routes', async () => {
+        const proposal = createProposal(db, {
+            title: 'Vote Test',
+            authorAgentId: 'agent-1',
+            minVoters: 2,
+        });
+        updateProposalStatus(db, proposal.id, 'open');
+        updateProposalStatus(db, proposal.id, 'voting');
+
+        // Cast vote
+        const voteReq = new Request(`http://localhost/api/governance/proposals/${proposal.id}/votes`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ agentId: 'agent-1', vote: 'approve' }),
+        });
+        const voteRes = await handleProposalRoutes(voteReq, new URL(voteReq.url), db);
+        expect(voteRes!.status).toBe(200);
+        const voteResult = await voteRes!.json();
+        expect(voteResult.ok).toBe(true);
+        expect(voteResult.weight).toBe(50); // Default weight (no reputation scorer)
+
+        // Get votes
+        const getReq = new Request(`http://localhost/api/governance/proposals/${proposal.id}/votes`, { method: 'GET' });
+        const getRes = await handleProposalRoutes(getReq, new URL(getReq.url), db);
+        const votesData = await getRes!.json();
+        expect(votesData.votes.length).toBe(1);
+        expect(votesData.evaluation).toBeDefined();
+    });
+
+    test('rejects vote on non-voting proposal', async () => {
+        const proposal = createProposal(db, { title: 'Draft', authorAgentId: 'agent-1' });
+
+        const voteReq = new Request(`http://localhost/api/governance/proposals/${proposal.id}/votes`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ agentId: 'agent-1', vote: 'approve' }),
+        });
+        const res = await handleProposalRoutes(voteReq, new URL(voteReq.url), db);
+        expect(res!.status).toBe(400);
+    });
+
+    test('requires decision when transitioning to decided', async () => {
+        const proposal = createProposal(db, { title: 'No Decision', authorAgentId: 'agent-1' });
+        updateProposalStatus(db, proposal.id, 'open');
+        updateProposalStatus(db, proposal.id, 'voting');
+
+        const req = new Request(`http://localhost/api/governance/proposals/${proposal.id}/transition`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ status: 'decided' }),
+        });
+        const res = await handleProposalRoutes(req, new URL(req.url), db);
+        expect(res!.status).toBe(400);
+        const body = await res!.json();
+        expect(body.error).toContain('Decision');
+    });
+
+    test('only approved proposals can be enacted', async () => {
+        const proposal = createProposal(db, { title: 'Rejected', authorAgentId: 'agent-1' });
+        updateProposalStatus(db, proposal.id, 'open');
+        updateProposalStatus(db, proposal.id, 'voting');
+        updateProposalStatus(db, proposal.id, 'decided', { decision: 'rejected', decidedAt: new Date().toISOString() });
+
+        const req = new Request(`http://localhost/api/governance/proposals/${proposal.id}/transition`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ status: 'enacted' }),
+        });
+        const res = await handleProposalRoutes(req, new URL(req.url), db);
+        expect(res!.status).toBe(400);
+        const body = await res!.json();
+        expect(body.error).toContain('approved');
+    });
+});

--- a/server/councils/governance.ts
+++ b/server/councils/governance.ts
@@ -424,6 +424,167 @@ export interface AutomationCheckResult {
     blockedPaths: string[];
 }
 
+// ─── Proposal quorum evaluation ───────────────────────────────────────────────
+
+export interface ProposalQuorumConfig {
+    /** Fraction of weighted approvals required (0.0–1.0). Falls back to governance tier default. */
+    threshold: number;
+    /** Minimum number of voters (non-abstaining) for a valid quorum. */
+    minVoters: number;
+}
+
+export interface ProposalQuorumCheck {
+    /** Whether the proposal vote passes. */
+    passed: boolean;
+    /** Weighted approval ratio (sum of approve weights / total weights). */
+    weightedApprovalRatio: number;
+    /** Required threshold. */
+    requiredThreshold: number;
+    /** Number of non-abstaining voters. */
+    voterCount: number;
+    /** Minimum voters required. */
+    requiredMinVoters: number;
+    /** Whether human approval is still needed. */
+    awaitingHumanApproval: boolean;
+    /** Reason for pass/fail. */
+    reason: string;
+}
+
+/**
+ * Evaluate whether a proposal vote meets quorum requirements.
+ *
+ * Combines weighted voting (reputation-based), configurable threshold,
+ * and minimum voter requirements.
+ */
+export function evaluateProposalQuorum(
+    tier: GovernanceTier,
+    votes: { vote: 'approve' | 'reject' | 'abstain'; weight: number }[],
+    config: ProposalQuorumConfig,
+    humanApproved: boolean = false,
+): ProposalQuorumCheck {
+    const tierInfo = GOVERNANCE_TIERS[tier];
+
+    // Layer 0 — NEVER passes via council vote
+    if (tier === 0) {
+        return {
+            passed: false,
+            weightedApprovalRatio: 0,
+            requiredThreshold: 1.0,
+            voterCount: 0,
+            requiredMinVoters: config.minVoters,
+            awaitingHumanApproval: false,
+            reason: 'Layer 0 (Constitutional) changes cannot be approved by proposal — human-only commits required',
+        };
+    }
+
+    const activeVotes = votes.filter((v) => v.vote !== 'abstain');
+    const voterCount = activeVotes.length;
+
+    // Check minimum voters
+    if (voterCount < config.minVoters) {
+        return {
+            passed: false,
+            weightedApprovalRatio: 0,
+            requiredThreshold: config.threshold,
+            voterCount,
+            requiredMinVoters: config.minVoters,
+            awaitingHumanApproval: false,
+            reason: `Insufficient voters: ${voterCount} of ${config.minVoters} required`,
+        };
+    }
+
+    if (activeVotes.length === 0) {
+        return {
+            passed: false,
+            weightedApprovalRatio: 0,
+            requiredThreshold: config.threshold,
+            voterCount: 0,
+            requiredMinVoters: config.minVoters,
+            awaitingHumanApproval: false,
+            reason: 'No votes cast yet',
+        };
+    }
+
+    // Weighted calculation
+    const totalWeight = votes.reduce((sum, v) => sum + v.weight, 0);
+    const approveWeight = votes.filter((v) => v.vote === 'approve').reduce((sum, v) => sum + v.weight, 0);
+    const weightedApprovalRatio = totalWeight > 0 ? approveWeight / totalWeight : 0;
+
+    const meetsThreshold = weightedApprovalRatio >= config.threshold;
+
+    if (!meetsThreshold) {
+        return {
+            passed: false,
+            weightedApprovalRatio,
+            requiredThreshold: config.threshold,
+            voterCount,
+            requiredMinVoters: config.minVoters,
+            awaitingHumanApproval: false,
+            reason: `Weighted approval ${(weightedApprovalRatio * 100).toFixed(0)}% below ${(config.threshold * 100).toFixed(0)}% threshold`,
+        };
+    }
+
+    // Threshold met — check if human approval is needed
+    if (tierInfo.requiresHumanApproval && !humanApproved) {
+        return {
+            passed: false,
+            weightedApprovalRatio,
+            requiredThreshold: config.threshold,
+            voterCount,
+            requiredMinVoters: config.minVoters,
+            awaitingHumanApproval: true,
+            reason: `Weighted vote passed (${(weightedApprovalRatio * 100).toFixed(0)}%) but awaiting human approval`,
+        };
+    }
+
+    return {
+        passed: true,
+        weightedApprovalRatio,
+        requiredThreshold: config.threshold,
+        voterCount,
+        requiredMinVoters: config.minVoters,
+        awaitingHumanApproval: false,
+        reason: `Approved: ${(weightedApprovalRatio * 100).toFixed(0)}% weighted approval meets ${tierInfo.label} tier threshold`,
+    };
+}
+
+/**
+ * Resolve the effective quorum config for a proposal.
+ *
+ * Priority: proposal-level overrides > council-level > governance tier defaults.
+ */
+export function resolveQuorumConfig(
+    tier: GovernanceTier,
+    proposalThreshold: number | null,
+    proposalMinVoters: number | null,
+    councilThreshold: number | null,
+): ProposalQuorumConfig {
+    const tierInfo = GOVERNANCE_TIERS[tier];
+    return {
+        threshold: proposalThreshold ?? councilThreshold ?? tierInfo.quorumThreshold,
+        minVoters: proposalMinVoters ?? 1,
+    };
+}
+
+// ─── Proposal lifecycle validation ────────────────────────────────────────────
+
+const VALID_TRANSITIONS: Record<string, string[]> = {
+    draft: ['open'],
+    open: ['voting', 'draft'],
+    voting: ['decided'],
+    decided: ['enacted'],
+    enacted: [],
+};
+
+/**
+ * Check if a proposal status transition is valid.
+ */
+export function isValidTransition(from: string, to: string): boolean {
+    return VALID_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+// ─── Automation enforcement ───────────────────────────────────────────────────
+
 /**
  * Check whether an automated workflow (scheduler, work task) may modify a set of paths.
  * Layer 0 and Layer 1 paths are blocked from automated modification.

--- a/server/db/migrations/072_governance_proposals.ts
+++ b/server/db/migrations/072_governance_proposals.ts
@@ -1,0 +1,63 @@
+/**
+ * Migration 072: Governance v2 proposals table.
+ *
+ * Adds governance_proposals table with lifecycle states:
+ *   draft → open → voting → decided → enacted
+ *
+ * Proposals formalize governance actions with configurable quorum rules,
+ * weighted voting based on reputation scores, and minimum voter requirements.
+ */
+
+import { Database } from 'bun:sqlite';
+
+export function up(db: Database): void {
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS governance_proposals (
+            id                TEXT PRIMARY KEY,
+            title             TEXT NOT NULL,
+            description       TEXT NOT NULL DEFAULT '',
+            author_agent_id   TEXT NOT NULL,
+            council_id        TEXT REFERENCES councils(id) ON DELETE SET NULL,
+            governance_tier   INTEGER NOT NULL DEFAULT 2,
+            affected_paths    TEXT NOT NULL DEFAULT '[]',
+            status            TEXT NOT NULL DEFAULT 'draft'
+                              CHECK(status IN ('draft', 'open', 'voting', 'decided', 'enacted')),
+            decision          TEXT DEFAULT NULL
+                              CHECK(decision IS NULL OR decision IN ('approved', 'rejected')),
+            quorum_threshold  REAL DEFAULT NULL,
+            min_voters        INTEGER DEFAULT NULL,
+            vote_start_at     TEXT DEFAULT NULL,
+            vote_end_at       TEXT DEFAULT NULL,
+            decided_at        TEXT DEFAULT NULL,
+            enacted_at        TEXT DEFAULT NULL,
+            launch_id         TEXT DEFAULT NULL REFERENCES council_launches(id) ON DELETE SET NULL,
+            tenant_id         TEXT NOT NULL DEFAULT 'default',
+            created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    `);
+    db.exec('CREATE INDEX IF NOT EXISTS idx_gov_proposals_status ON governance_proposals(status)');
+    db.exec('CREATE INDEX IF NOT EXISTS idx_gov_proposals_council ON governance_proposals(council_id)');
+    db.exec('CREATE INDEX IF NOT EXISTS idx_gov_proposals_author ON governance_proposals(author_agent_id)');
+    db.exec('CREATE INDEX IF NOT EXISTS idx_gov_proposals_tenant ON governance_proposals(tenant_id)');
+
+    // Proposal votes — individual agent votes on a proposal
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS governance_proposal_votes (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            proposal_id     TEXT NOT NULL REFERENCES governance_proposals(id) ON DELETE CASCADE,
+            agent_id        TEXT NOT NULL,
+            vote            TEXT NOT NULL CHECK(vote IN ('approve', 'reject', 'abstain')),
+            weight          REAL NOT NULL DEFAULT 50,
+            reason          TEXT NOT NULL DEFAULT '',
+            created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(proposal_id, agent_id)
+        )
+    `);
+    db.exec('CREATE INDEX IF NOT EXISTS idx_gov_proposal_votes_proposal ON governance_proposal_votes(proposal_id)');
+}
+
+export function down(db: Database): void {
+    db.exec('DROP TABLE IF EXISTS governance_proposal_votes');
+    db.exec('DROP TABLE IF EXISTS governance_proposals');
+}

--- a/server/db/proposals.ts
+++ b/server/db/proposals.ts
@@ -1,0 +1,288 @@
+import type { Database, SQLQueryBindings } from 'bun:sqlite';
+import type {
+    GovernanceProposal,
+    GovernanceProposalVote,
+    CreateProposalInput,
+    UpdateProposalInput,
+    ProposalStatus,
+    ProposalDecision,
+} from '../../shared/types';
+import { DEFAULT_TENANT_ID } from '../tenant/types';
+import { withTenantFilter } from '../tenant/db-filter';
+
+// ─── Row types ──────────────────────────────────────────────────────────────
+
+interface ProposalRow {
+    id: string;
+    title: string;
+    description: string;
+    author_agent_id: string;
+    council_id: string | null;
+    governance_tier: number;
+    affected_paths: string;
+    status: string;
+    decision: string | null;
+    quorum_threshold: number | null;
+    min_voters: number | null;
+    vote_start_at: string | null;
+    vote_end_at: string | null;
+    decided_at: string | null;
+    enacted_at: string | null;
+    launch_id: string | null;
+    tenant_id: string;
+    created_at: string;
+    updated_at: string;
+}
+
+interface ProposalVoteRow {
+    id: number;
+    proposal_id: string;
+    agent_id: string;
+    vote: string;
+    weight: number;
+    reason: string;
+    created_at: string;
+}
+
+// ─── Row converters ─────────────────────────────────────────────────────────
+
+function rowToProposal(row: ProposalRow): GovernanceProposal {
+    return {
+        id: row.id,
+        title: row.title,
+        description: row.description,
+        authorAgentId: row.author_agent_id,
+        councilId: row.council_id,
+        governanceTier: row.governance_tier,
+        affectedPaths: JSON.parse(row.affected_paths),
+        status: row.status as ProposalStatus,
+        decision: row.decision as ProposalDecision | null,
+        quorumThreshold: row.quorum_threshold,
+        minVoters: row.min_voters,
+        voteStartAt: row.vote_start_at,
+        voteEndAt: row.vote_end_at,
+        decidedAt: row.decided_at,
+        enactedAt: row.enacted_at,
+        launchId: row.launch_id,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+    };
+}
+
+function rowToVote(row: ProposalVoteRow): GovernanceProposalVote {
+    return {
+        id: row.id,
+        proposalId: row.proposal_id,
+        agentId: row.agent_id,
+        vote: row.vote as 'approve' | 'reject' | 'abstain',
+        weight: row.weight,
+        reason: row.reason,
+        createdAt: row.created_at,
+    };
+}
+
+// ─── Proposal CRUD ──────────────────────────────────────────────────────────
+
+export function createProposal(
+    db: Database,
+    input: CreateProposalInput,
+    tenantId: string = DEFAULT_TENANT_ID,
+): GovernanceProposal {
+    const id = crypto.randomUUID();
+    db.query(`
+        INSERT INTO governance_proposals
+            (id, title, description, author_agent_id, council_id, governance_tier,
+             affected_paths, quorum_threshold, min_voters, tenant_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+        id,
+        input.title,
+        input.description ?? '',
+        input.authorAgentId,
+        input.councilId ?? null,
+        input.governanceTier ?? 2,
+        JSON.stringify(input.affectedPaths ?? []),
+        input.quorumThreshold ?? null,
+        input.minVoters ?? null,
+        tenantId,
+    );
+
+    return getProposal(db, id)!;
+}
+
+export function getProposal(db: Database, id: string): GovernanceProposal | null {
+    const row = db.query('SELECT * FROM governance_proposals WHERE id = ?')
+        .get(id) as ProposalRow | null;
+    return row ? rowToProposal(row) : null;
+}
+
+export function listProposals(
+    db: Database,
+    opts?: { councilId?: string; status?: ProposalStatus; authorAgentId?: string },
+    tenantId: string = DEFAULT_TENANT_ID,
+): GovernanceProposal[] {
+    const conditions: string[] = [];
+    const values: unknown[] = [];
+
+    if (opts?.councilId) {
+        conditions.push('council_id = ?');
+        values.push(opts.councilId);
+    }
+    if (opts?.status) {
+        conditions.push('status = ?');
+        values.push(opts.status);
+    }
+    if (opts?.authorAgentId) {
+        conditions.push('author_agent_id = ?');
+        values.push(opts.authorAgentId);
+    }
+
+    let sql = 'SELECT * FROM governance_proposals';
+    if (conditions.length > 0) {
+        sql += ` WHERE ${conditions.join(' AND ')}`;
+    }
+
+    const { query, bindings } = withTenantFilter(sql + ' ORDER BY updated_at DESC', tenantId);
+    const rows = db.query(query).all(...(values as SQLQueryBindings[]), ...bindings) as ProposalRow[];
+    return rows.map(rowToProposal);
+}
+
+export function updateProposal(
+    db: Database,
+    id: string,
+    input: UpdateProposalInput,
+): GovernanceProposal | null {
+    const existing = getProposal(db, id);
+    if (!existing) return null;
+    if (existing.status !== 'draft') return null; // Only draft proposals can be edited
+
+    const fields: string[] = [];
+    const values: unknown[] = [];
+
+    if (input.title !== undefined) {
+        fields.push('title = ?');
+        values.push(input.title);
+    }
+    if (input.description !== undefined) {
+        fields.push('description = ?');
+        values.push(input.description);
+    }
+    if (input.governanceTier !== undefined) {
+        fields.push('governance_tier = ?');
+        values.push(input.governanceTier);
+    }
+    if (input.affectedPaths !== undefined) {
+        fields.push('affected_paths = ?');
+        values.push(JSON.stringify(input.affectedPaths));
+    }
+    if (input.quorumThreshold !== undefined) {
+        fields.push('quorum_threshold = ?');
+        values.push(input.quorumThreshold);
+    }
+    if (input.minVoters !== undefined) {
+        fields.push('min_voters = ?');
+        values.push(input.minVoters);
+    }
+
+    if (fields.length > 0) {
+        fields.push("updated_at = datetime('now')");
+        values.push(id);
+        db.query(`UPDATE governance_proposals SET ${fields.join(', ')} WHERE id = ?`)
+            .run(...(values as SQLQueryBindings[]));
+    }
+
+    return getProposal(db, id);
+}
+
+export function updateProposalStatus(
+    db: Database,
+    id: string,
+    status: ProposalStatus,
+    extras?: {
+        decision?: ProposalDecision;
+        decidedAt?: string;
+        enactedAt?: string;
+        voteStartAt?: string;
+        voteEndAt?: string;
+        launchId?: string;
+    },
+): void {
+    const fields: string[] = ['status = ?', "updated_at = datetime('now')"];
+    const values: unknown[] = [status];
+
+    if (extras?.decision !== undefined) {
+        fields.push('decision = ?');
+        values.push(extras.decision);
+    }
+    if (extras?.decidedAt !== undefined) {
+        fields.push('decided_at = ?');
+        values.push(extras.decidedAt);
+    }
+    if (extras?.enactedAt !== undefined) {
+        fields.push('enacted_at = ?');
+        values.push(extras.enactedAt);
+    }
+    if (extras?.voteStartAt !== undefined) {
+        fields.push('vote_start_at = ?');
+        values.push(extras.voteStartAt);
+    }
+    if (extras?.voteEndAt !== undefined) {
+        fields.push('vote_end_at = ?');
+        values.push(extras.voteEndAt);
+    }
+    if (extras?.launchId !== undefined) {
+        fields.push('launch_id = ?');
+        values.push(extras.launchId);
+    }
+
+    values.push(id);
+    db.query(`UPDATE governance_proposals SET ${fields.join(', ')} WHERE id = ?`)
+        .run(...(values as SQLQueryBindings[]));
+}
+
+export function deleteProposal(db: Database, id: string): boolean {
+    const existing = getProposal(db, id);
+    if (!existing) return false;
+    if (existing.status !== 'draft') return false; // Only draft proposals can be deleted
+    const result = db.query('DELETE FROM governance_proposals WHERE id = ?').run(id);
+    return result.changes > 0;
+}
+
+// ─── Proposal Votes ─────────────────────────────────────────────────────────
+
+export function castProposalVote(
+    db: Database,
+    params: {
+        proposalId: string;
+        agentId: string;
+        vote: 'approve' | 'reject' | 'abstain';
+        weight?: number;
+        reason?: string;
+    },
+): GovernanceProposalVote {
+    const result = db.query(`
+        INSERT INTO governance_proposal_votes (proposal_id, agent_id, vote, weight, reason)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(proposal_id, agent_id) DO UPDATE SET
+            vote = excluded.vote,
+            weight = excluded.weight,
+            reason = excluded.reason,
+            created_at = datetime('now')
+    `).run(
+        params.proposalId,
+        params.agentId,
+        params.vote,
+        params.weight ?? 50,
+        params.reason ?? '',
+    );
+
+    return db.query('SELECT * FROM governance_proposal_votes WHERE id = ?')
+        .get(result.lastInsertRowid) as GovernanceProposalVote;
+}
+
+export function getProposalVotes(db: Database, proposalId: string): GovernanceProposalVote[] {
+    const rows = db.query(
+        'SELECT * FROM governance_proposal_votes WHERE proposal_id = ? ORDER BY created_at ASC'
+    ).all(proposalId) as ProposalVoteRow[];
+    return rows.map(rowToVote);
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,6 +1,6 @@
 import { Database } from 'bun:sqlite';
 
-const SCHEMA_VERSION = 71;
+const SCHEMA_VERSION = 72;
 
 const MIGRATIONS: Record<number, string[]> = {
     1: [
@@ -1328,6 +1328,47 @@ const MIGRATIONS: Record<number, string[]> = {
         // Governance v2: quorum configuration on councils
         `ALTER TABLE councils ADD COLUMN quorum_type TEXT DEFAULT 'majority'`,
         `ALTER TABLE councils ADD COLUMN quorum_threshold REAL DEFAULT NULL`,
+    ],
+    72: [
+        // Governance v2: proposals table with lifecycle states
+        `CREATE TABLE IF NOT EXISTS governance_proposals (
+            id                TEXT PRIMARY KEY,
+            title             TEXT NOT NULL,
+            description       TEXT NOT NULL DEFAULT '',
+            author_agent_id   TEXT NOT NULL,
+            council_id        TEXT REFERENCES councils(id) ON DELETE SET NULL,
+            governance_tier   INTEGER NOT NULL DEFAULT 2,
+            affected_paths    TEXT NOT NULL DEFAULT '[]',
+            status            TEXT NOT NULL DEFAULT 'draft'
+                              CHECK(status IN ('draft', 'open', 'voting', 'decided', 'enacted')),
+            decision          TEXT DEFAULT NULL
+                              CHECK(decision IS NULL OR decision IN ('approved', 'rejected')),
+            quorum_threshold  REAL DEFAULT NULL,
+            min_voters        INTEGER DEFAULT NULL,
+            vote_start_at     TEXT DEFAULT NULL,
+            vote_end_at       TEXT DEFAULT NULL,
+            decided_at        TEXT DEFAULT NULL,
+            enacted_at        TEXT DEFAULT NULL,
+            launch_id         TEXT DEFAULT NULL REFERENCES council_launches(id) ON DELETE SET NULL,
+            tenant_id         TEXT NOT NULL DEFAULT 'default',
+            created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+        )`,
+        `CREATE INDEX IF NOT EXISTS idx_gov_proposals_status ON governance_proposals(status)`,
+        `CREATE INDEX IF NOT EXISTS idx_gov_proposals_council ON governance_proposals(council_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_gov_proposals_author ON governance_proposals(author_agent_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_gov_proposals_tenant ON governance_proposals(tenant_id)`,
+        `CREATE TABLE IF NOT EXISTS governance_proposal_votes (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            proposal_id     TEXT NOT NULL REFERENCES governance_proposals(id) ON DELETE CASCADE,
+            agent_id        TEXT NOT NULL,
+            vote            TEXT NOT NULL CHECK(vote IN ('approve', 'reject', 'abstain')),
+            weight          REAL NOT NULL DEFAULT 50,
+            reason          TEXT NOT NULL DEFAULT '',
+            created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(proposal_id, agent_id)
+        )`,
+        `CREATE INDEX IF NOT EXISTS idx_gov_proposal_votes_proposal ON governance_proposal_votes(proposal_id)`,
     ],
 };
 

--- a/server/lib/validation.ts
+++ b/server/lib/validation.ts
@@ -730,3 +730,36 @@ export const CreditGrantSchema = z.object({
     amount: z.number().positive().finite(),
     reference: z.string().optional(),
 });
+
+// ─── Governance Proposals ──────────────────────────────────────────────────
+
+export const CreateProposalSchema = z.object({
+    title: z.string().min(1),
+    description: z.string().optional(),
+    authorAgentId: z.string().min(1),
+    councilId: z.string().optional(),
+    governanceTier: z.number().int().min(0).max(2).optional(),
+    affectedPaths: z.array(z.string()).optional(),
+    quorumThreshold: z.number().min(0).max(1).nullable().optional(),
+    minVoters: z.number().int().min(1).nullable().optional(),
+});
+
+export const UpdateProposalSchema = z.object({
+    title: z.string().min(1).optional(),
+    description: z.string().optional(),
+    governanceTier: z.number().int().min(0).max(2).optional(),
+    affectedPaths: z.array(z.string()).optional(),
+    quorumThreshold: z.number().min(0).max(1).nullable().optional(),
+    minVoters: z.number().int().min(1).nullable().optional(),
+});
+
+export const ProposalTransitionSchema = z.object({
+    status: z.enum(['open', 'voting', 'decided', 'enacted', 'draft']),
+    decision: z.enum(['approved', 'rejected']).optional(),
+});
+
+export const ProposalVoteSchema = z.object({
+    agentId: z.string().min(1),
+    vote: z.enum(['approve', 'reject', 'abstain']),
+    reason: z.string().optional(),
+});

--- a/server/openapi/route-registry.ts
+++ b/server/openapi/route-registry.ts
@@ -27,6 +27,7 @@ import {
     CreateMcpServerConfigSchema, UpdateMcpServerConfigSchema,
     EscalationResolveSchema, OperationalModeSchema, SelfTestSchema, SwitchNetworkSchema,
     OllamaPullModelSchema, OllamaDeleteModelSchema,
+    CreateProposalSchema, UpdateProposalSchema, ProposalTransitionSchema, ProposalVoteSchema,
 } from '../lib/validation';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -454,6 +455,62 @@ export const routes: RouteEntry[] = [
         summary: 'Continue chat on completed council',
         tags: ['Councils'],
         auth: 'required',
+    },
+
+    // ── Governance Proposals ─────────────────────────────────────────────────
+    {
+        method: 'GET', path: '/api/governance/proposals',
+        summary: 'List governance proposals',
+        description: 'Filter by councilId, status, or authorAgentId query parameters.',
+        tags: ['Governance'],
+        auth: 'required',
+    },
+    {
+        method: 'POST', path: '/api/governance/proposals',
+        summary: 'Create governance proposal',
+        tags: ['Governance'],
+        auth: 'required',
+        requestBody: CreateProposalSchema,
+    },
+    {
+        method: 'GET', path: '/api/governance/proposals/{id}',
+        summary: 'Get governance proposal by ID',
+        tags: ['Governance'],
+        auth: 'required',
+    },
+    {
+        method: 'PUT', path: '/api/governance/proposals/{id}',
+        summary: 'Update governance proposal (draft only)',
+        tags: ['Governance'],
+        auth: 'required',
+        requestBody: UpdateProposalSchema,
+    },
+    {
+        method: 'DELETE', path: '/api/governance/proposals/{id}',
+        summary: 'Delete governance proposal (draft only)',
+        tags: ['Governance'],
+        auth: 'required',
+    },
+    {
+        method: 'POST', path: '/api/governance/proposals/{id}/transition',
+        summary: 'Transition proposal status',
+        description: 'Lifecycle: draft → open → voting → decided → enacted.',
+        tags: ['Governance'],
+        auth: 'required',
+        requestBody: ProposalTransitionSchema,
+    },
+    {
+        method: 'GET', path: '/api/governance/proposals/{id}/votes',
+        summary: 'Get proposal votes and quorum evaluation',
+        tags: ['Governance'],
+        auth: 'required',
+    },
+    {
+        method: 'POST', path: '/api/governance/proposals/{id}/votes',
+        summary: 'Cast vote on proposal (reputation-weighted)',
+        tags: ['Governance'],
+        auth: 'required',
+        requestBody: ProposalVoteSchema,
     },
 
     // ── Work Tasks ──────────────────────────────────────────────────────────

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -3,6 +3,7 @@ import { handleProjectRoutes, handleBrowseDirs } from './projects';
 import { handleAgentRoutes } from './agents';
 import { handleSessionRoutes } from './sessions';
 import { handleCouncilRoutes } from './councils';
+import { handleProposalRoutes } from './proposals';
 import { handleWorkTaskRoutes } from './work-tasks';
 import { handleMcpApiRoutes } from './mcp-api';
 import { handleAllowlistRoutes } from './allowlist';
@@ -347,6 +348,9 @@ async function handleRoutes(
 
     const councilResponse = handleCouncilRoutes(req, url, db, processManager, agentMessenger, context, reputationScorer);
     if (councilResponse) return councilResponse;
+
+    const proposalResponse = handleProposalRoutes(req, url, db, context, reputationScorer);
+    if (proposalResponse) return proposalResponse;
 
     if (workTaskService) {
         const workTaskResponse = handleWorkTaskRoutes(req, url, workTaskService, context);

--- a/server/routes/proposals.ts
+++ b/server/routes/proposals.ts
@@ -1,0 +1,284 @@
+import type { Database } from 'bun:sqlite';
+import type { ReputationScorer } from '../reputation/scorer';
+import type { RequestContext } from '../middleware/guards';
+import type { ProposalStatus } from '../../shared/types';
+import { tenantRoleGuard } from '../middleware/guards';
+import {
+    parseBodyOrThrow,
+    ValidationError,
+    CreateProposalSchema,
+    UpdateProposalSchema,
+    ProposalTransitionSchema,
+    ProposalVoteSchema,
+} from '../lib/validation';
+import { json, handleRouteError } from '../lib/response';
+import {
+    createProposal,
+    getProposal,
+    listProposals,
+    updateProposal,
+    updateProposalStatus,
+    deleteProposal,
+    castProposalVote,
+    getProposalVotes,
+} from '../db/proposals';
+import { getCouncil } from '../db/councils';
+import {
+    evaluateProposalQuorum,
+    resolveQuorumConfig,
+    isValidTransition,
+    type GovernanceTier,
+} from '../councils/governance';
+
+// ─── Route handler ────────────────────────────────────────────────────────────
+
+export function handleProposalRoutes(
+    req: Request,
+    url: URL,
+    db: Database,
+    context?: RequestContext,
+    reputationScorer?: ReputationScorer | null,
+): Response | Promise<Response> | null {
+    const path = url.pathname;
+    const method = req.method;
+    const tenantId = context?.tenantId ?? 'default';
+
+    // List proposals
+    if (path === '/api/governance/proposals' && method === 'GET') {
+        const councilId = url.searchParams.get('councilId') ?? undefined;
+        const status = url.searchParams.get('status') as ProposalStatus | undefined;
+        const authorAgentId = url.searchParams.get('authorAgentId') ?? undefined;
+        return json(listProposals(db, { councilId, status, authorAgentId }, tenantId));
+    }
+
+    // Create proposal
+    if (path === '/api/governance/proposals' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
+        return handleCreateProposal(req, db, tenantId);
+    }
+
+    // Single proposal routes
+    const proposalMatch = path.match(/^\/api\/governance\/proposals\/([^/]+)(\/(.+))?$/);
+    if (!proposalMatch) return null;
+
+    const proposalId = proposalMatch[1];
+    const action = proposalMatch[3];
+
+    // GET proposal
+    if (!action && method === 'GET') {
+        const proposal = getProposal(db, proposalId);
+        if (!proposal) return json({ error: 'Not found' }, 404);
+        const votes = getProposalVotes(db, proposalId);
+        return json({ ...proposal, votes });
+    }
+
+    // PUT update proposal (draft only)
+    if (!action && method === 'PUT') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
+        return handleUpdateProposal(req, db, proposalId);
+    }
+
+    // DELETE proposal (draft only)
+    if (!action && method === 'DELETE') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
+        const deleted = deleteProposal(db, proposalId);
+        return deleted ? json({ ok: true }) : json({ error: 'Not found or not in draft status' }, 400);
+    }
+
+    // POST transition status
+    if (action === 'transition' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
+        return handleTransition(req, db, proposalId);
+    }
+
+    // GET votes
+    if (action === 'votes' && method === 'GET') {
+        const proposal = getProposal(db, proposalId);
+        if (!proposal) return json({ error: 'Not found' }, 404);
+        const votes = getProposalVotes(db, proposalId);
+
+        // Also include quorum evaluation
+        const council = proposal.councilId ? getCouncil(db, proposal.councilId) : null;
+        const quorumConfig = resolveQuorumConfig(
+            proposal.governanceTier as GovernanceTier,
+            proposal.quorumThreshold,
+            proposal.minVoters,
+            council?.quorumThreshold ?? null,
+        );
+        const evaluation = evaluateProposalQuorum(
+            proposal.governanceTier as GovernanceTier,
+            votes.map((v) => ({ vote: v.vote, weight: v.weight })),
+            quorumConfig,
+        );
+
+        return json({ votes, evaluation, quorumConfig });
+    }
+
+    // POST cast vote
+    if (action === 'votes' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
+        return handleCastVote(req, db, proposalId, reputationScorer);
+    }
+
+    return null;
+}
+
+// ─── Handlers ─────────────────────────────────────────────────────────────────
+
+async function handleCreateProposal(
+    req: Request,
+    db: Database,
+    tenantId: string,
+): Promise<Response> {
+    try {
+        const data = await parseBodyOrThrow(req, CreateProposalSchema);
+        const proposal = createProposal(db, data, tenantId);
+        return json(proposal, 201);
+    } catch (err) {
+        if (err instanceof ValidationError) return json({ error: err.detail }, 400);
+        return handleRouteError(err);
+    }
+}
+
+async function handleUpdateProposal(
+    req: Request,
+    db: Database,
+    proposalId: string,
+): Promise<Response> {
+    try {
+        const data = await parseBodyOrThrow(req, UpdateProposalSchema);
+        const proposal = updateProposal(db, proposalId, data);
+        if (!proposal) return json({ error: 'Not found or not in draft status' }, 400);
+        return json(proposal);
+    } catch (err) {
+        if (err instanceof ValidationError) return json({ error: err.detail }, 400);
+        return handleRouteError(err);
+    }
+}
+
+async function handleTransition(
+    req: Request,
+    db: Database,
+    proposalId: string,
+): Promise<Response> {
+    try {
+        const body = await parseBodyOrThrow(req, ProposalTransitionSchema);
+        const proposal = getProposal(db, proposalId);
+        if (!proposal) return json({ error: 'Not found' }, 404);
+
+        if (!isValidTransition(proposal.status, body.status)) {
+            return json({
+                error: `Invalid transition from '${proposal.status}' to '${body.status}'`,
+            }, 400);
+        }
+
+        const now = new Date().toISOString();
+        const extras: Parameters<typeof updateProposalStatus>[3] = {};
+
+        if (body.status === 'voting') {
+            extras.voteStartAt = now;
+        }
+        if (body.status === 'decided') {
+            if (!body.decision) {
+                return json({ error: 'Decision (approved/rejected) is required when transitioning to decided' }, 400);
+            }
+            extras.decision = body.decision;
+            extras.decidedAt = now;
+            extras.voteEndAt = now;
+        }
+        if (body.status === 'enacted') {
+            if (proposal.decision !== 'approved') {
+                return json({ error: 'Only approved proposals can be enacted' }, 400);
+            }
+            extras.enactedAt = now;
+        }
+
+        updateProposalStatus(db, proposalId, body.status, extras);
+        const updated = getProposal(db, proposalId);
+        return json(updated);
+    } catch (err) {
+        if (err instanceof ValidationError) return json({ error: err.detail }, 400);
+        return handleRouteError(err);
+    }
+}
+
+async function handleCastVote(
+    req: Request,
+    db: Database,
+    proposalId: string,
+    reputationScorer?: ReputationScorer | null,
+): Promise<Response> {
+    try {
+        const body = await parseBodyOrThrow(req, ProposalVoteSchema);
+        const proposal = getProposal(db, proposalId);
+        if (!proposal) return json({ error: 'Not found' }, 404);
+
+        if (proposal.status !== 'voting') {
+            return json({ error: `Proposal is in '${proposal.status}' status, not accepting votes` }, 400);
+        }
+
+        // If council-bound, verify the agent is a member
+        if (proposal.councilId) {
+            const council = getCouncil(db, proposal.councilId);
+            if (council && !council.agentIds.includes(body.agentId)) {
+                return json({ error: 'Agent is not a member of the proposal council' }, 403);
+            }
+        }
+
+        // Resolve reputation weight
+        let weight = 50;
+        if (reputationScorer) {
+            const score = reputationScorer.getCachedScore(body.agentId);
+            if (score) weight = score.overallScore;
+        }
+
+        castProposalVote(db, {
+            proposalId,
+            agentId: body.agentId,
+            vote: body.vote,
+            weight,
+            reason: body.reason,
+        });
+
+        // Re-evaluate quorum
+        const votes = getProposalVotes(db, proposalId);
+        const council = proposal.councilId ? getCouncil(db, proposal.councilId) : null;
+        const quorumConfig = resolveQuorumConfig(
+            proposal.governanceTier as GovernanceTier,
+            proposal.quorumThreshold,
+            proposal.minVoters,
+            council?.quorumThreshold ?? null,
+        );
+        const evaluation = evaluateProposalQuorum(
+            proposal.governanceTier as GovernanceTier,
+            votes.map((v) => ({ vote: v.vote, weight: v.weight })),
+            quorumConfig,
+        );
+
+        return json({
+            ok: true,
+            vote: body.vote,
+            agentId: body.agentId,
+            weight,
+            evaluation,
+        });
+    } catch (err) {
+        if (err instanceof ValidationError) return json({ error: err.detail }, 400);
+        return handleRouteError(err);
+    }
+}

--- a/shared/types/councils.ts
+++ b/shared/types/councils.ts
@@ -140,3 +140,70 @@ export interface CouncilAgentError {
     sessionId?: string;
     round?: number;
 }
+
+// ─── Governance v2: Proposals ────────────────────────────────────────────────
+
+/** Lifecycle states for a governance proposal. */
+export type ProposalStatus = 'draft' | 'open' | 'voting' | 'decided' | 'enacted';
+
+/** Final decision on a proposal after voting completes. */
+export type ProposalDecision = 'approved' | 'rejected';
+
+export interface GovernanceProposal {
+    id: string;
+    title: string;
+    description: string;
+    authorAgentId: string;
+    councilId: string | null;
+    governanceTier: number;
+    affectedPaths: string[];
+    status: ProposalStatus;
+    decision: ProposalDecision | null;
+    /** Custom quorum threshold (0.0–1.0). Overrides tier default when set. */
+    quorumThreshold: number | null;
+    /** Minimum number of voters required for a valid quorum. */
+    minVoters: number | null;
+    voteStartAt: string | null;
+    voteEndAt: string | null;
+    decidedAt: string | null;
+    enactedAt: string | null;
+    launchId: string | null;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface GovernanceProposalVote {
+    id: number;
+    proposalId: string;
+    agentId: string;
+    vote: 'approve' | 'reject' | 'abstain';
+    weight: number;
+    reason: string;
+    createdAt: string;
+}
+
+export interface CreateProposalInput {
+    title: string;
+    description?: string;
+    authorAgentId: string;
+    councilId?: string;
+    governanceTier?: number;
+    affectedPaths?: string[];
+    quorumThreshold?: number | null;
+    minVoters?: number | null;
+}
+
+export interface UpdateProposalInput {
+    title?: string;
+    description?: string;
+    governanceTier?: number;
+    affectedPaths?: string[];
+    quorumThreshold?: number | null;
+    minVoters?: number | null;
+}
+
+export interface ProposalVoteInput {
+    agentId: string;
+    vote: 'approve' | 'reject' | 'abstain';
+    reason?: string;
+}


### PR DESCRIPTION
## Summary
- Implements governance v2 proposal system with full lifecycle: **draft → open → voting → decided → enacted**
- Adds **reputation-weighted voting** — each vote is weighted by the agent's reputation score (0–100)
- Adds **configurable quorum rules**: percentage threshold and minimum voter requirements
- Quorum config priority chain: proposal-level overrides → council-level → governance tier defaults (Layer 0/1/2)
- Layer 0 (Constitutional) proposals are always blocked; Layer 1 (Structural) requires human approval

## Changes
- **Migration 072**: `governance_proposals` and `governance_proposal_votes` tables
- **`server/db/proposals.ts`**: DB layer with CRUD, vote casting, and status transitions
- **`server/councils/governance.ts`**: `evaluateProposalQuorum()`, `resolveQuorumConfig()`, `isValidTransition()` 
- **`server/routes/proposals.ts`**: REST API at `/api/governance/proposals` (8 endpoints)
- **`server/lib/validation.ts`**: Zod schemas for proposal create/update/transition/vote
- **`server/openapi/route-registry.ts`**: OpenAPI metadata for all new endpoints
- **`shared/types/councils.ts`**: `GovernanceProposal`, `ProposalStatus`, `ProposalDecision` types
- **`server/db/schema.ts`**: Inline schema bumped to v72

## Test plan
- [x] 30 new tests in `governance-proposals.test.ts` covering:
  - DB CRUD (create, list, update, delete with draft-only constraints)
  - Lifecycle transitions (valid/invalid state machine)
  - Weighted quorum evaluation (Layer 0/1/2, min voters, threshold, abstentions)
  - Quorum config resolution (proposal → council → tier fallback)
  - Route handlers (create, list, transition, vote, error cases)
- [x] All 45 existing governance tests still pass
- [x] `tsc --noEmit --skipLibCheck` passes clean

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)