### PR TITLE
feat: add GH_TOKEN OAuth scope validation on server startup

### DIFF
--- a/server/__tests__/github-token-check.test.ts
+++ b/server/__tests__/github-token-check.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'bun:test';
+import { checkGitHubToken, validateGitHubTokenOnStartup } from '../lib/github-token-check';
+
+// --- Helpers ----------------------------------------------------------------
+
+function mockFetch(
+    status: number,
+    scopeHeader: string | null,
+): (url: string, init?: RequestInit) => Promise<Response> {
+    return async () =>
+        new Response('{}', {
+            status,
+            headers: scopeHeader !== null ? { 'x-oauth-scopes': scopeHeader } : {},
+        });
+}
+
+function mockFetchError(error: Error): (url: string, init?: RequestInit) => Promise<Response> {
+    return async () => {
+        throw error;
+    };
+}
+
+// --- checkGitHubToken -------------------------------------------------------
+
+describe('checkGitHubToken', () => {
+    it('returns not configured when no token provided', async () => {
+        const result = await checkGitHubToken('', mockFetch(200, 'repo'));
+        expect(result.configured).toBe(false);
+        expect(result.valid).toBe(false);
+        expect(result.missingScopes).toEqual(['repo', 'read:org']);
+    });
+
+    it('reports all scopes present', async () => {
+        const result = await checkGitHubToken(
+            'ghp_test123',
+            mockFetch(200, 'repo, read:org, user'),
+        );
+        expect(result.configured).toBe(true);
+        expect(result.valid).toBe(true);
+        expect(result.scopes).toEqual(['repo', 'read:org', 'user']);
+        expect(result.missingScopes).toEqual([]);
+        expect(result.fineGrained).toBe(false);
+    });
+
+    it('reports missing scopes', async () => {
+        const result = await checkGitHubToken(
+            'ghp_test123',
+            mockFetch(200, 'user'),
+        );
+        expect(result.configured).toBe(true);
+        expect(result.valid).toBe(true);
+        expect(result.missingScopes).toEqual(['repo', 'read:org']);
+    });
+
+    it('reports partially missing scopes', async () => {
+        const result = await checkGitHubToken(
+            'ghp_test123',
+            mockFetch(200, 'repo, user'),
+        );
+        expect(result.configured).toBe(true);
+        expect(result.valid).toBe(true);
+        expect(result.missingScopes).toEqual(['read:org']);
+    });
+
+    it('handles fine-grained tokens (no scope header)', async () => {
+        const result = await checkGitHubToken(
+            'github_pat_test123',
+            mockFetch(200, null),
+        );
+        expect(result.configured).toBe(true);
+        expect(result.valid).toBe(true);
+        expect(result.fineGrained).toBe(true);
+        expect(result.missingScopes).toEqual([]);
+    });
+
+    it('handles HTTP 401 (bad token)', async () => {
+        const result = await checkGitHubToken(
+            'ghp_bad',
+            mockFetch(401, null),
+        );
+        expect(result.configured).toBe(true);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('401');
+    });
+
+    it('handles HTTP 403 (forbidden)', async () => {
+        const result = await checkGitHubToken(
+            'ghp_forbidden',
+            mockFetch(403, null),
+        );
+        expect(result.configured).toBe(true);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('403');
+    });
+
+    it('handles network errors gracefully', async () => {
+        const result = await checkGitHubToken(
+            'ghp_test',
+            mockFetchError(new Error('ECONNREFUSED')),
+        );
+        expect(result.configured).toBe(true);
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('ECONNREFUSED');
+    });
+
+    it('handles empty scope header', async () => {
+        const result = await checkGitHubToken(
+            'ghp_test',
+            mockFetch(200, ''),
+        );
+        expect(result.configured).toBe(true);
+        expect(result.valid).toBe(true);
+        expect(result.scopes).toEqual([]);
+        expect(result.missingScopes).toEqual(['repo', 'read:org']);
+        expect(result.fineGrained).toBe(false);
+    });
+});
+
+// --- validateGitHubTokenOnStartup -------------------------------------------
+
+describe('validateGitHubTokenOnStartup', () => {
+    it('does not throw when token is not set', async () => {
+        const saved = process.env.GH_TOKEN;
+        delete process.env.GH_TOKEN;
+        try {
+            await validateGitHubTokenOnStartup(mockFetch(200, 'repo'));
+        } finally {
+            if (saved !== undefined) process.env.GH_TOKEN = saved;
+        }
+    });
+
+    it('does not throw when scopes are valid', async () => {
+        const saved = process.env.GH_TOKEN;
+        process.env.GH_TOKEN = 'ghp_validtoken';
+        try {
+            await validateGitHubTokenOnStartup(mockFetch(200, 'repo, read:org'));
+        } finally {
+            if (saved !== undefined) process.env.GH_TOKEN = saved;
+            else delete process.env.GH_TOKEN;
+        }
+    });
+
+    it('does not throw when scopes are missing', async () => {
+        const saved = process.env.GH_TOKEN;
+        process.env.GH_TOKEN = 'ghp_limited';
+        try {
+            await validateGitHubTokenOnStartup(mockFetch(200, 'user'));
+        } finally {
+            if (saved !== undefined) process.env.GH_TOKEN = saved;
+            else delete process.env.GH_TOKEN;
+        }
+    });
+
+    it('does not throw on network error', async () => {
+        const saved = process.env.GH_TOKEN;
+        process.env.GH_TOKEN = 'ghp_test';
+        try {
+            await validateGitHubTokenOnStartup(
+                mockFetchError(new Error('DNS resolution failed')),
+            );
+        } finally {
+            if (saved !== undefined) process.env.GH_TOKEN = saved;
+            else delete process.env.GH_TOKEN;
+        }
+    });
+
+    it('does not throw on fine-grained token', async () => {
+        const saved = process.env.GH_TOKEN;
+        process.env.GH_TOKEN = 'github_pat_fine_grained';
+        try {
+            await validateGitHubTokenOnStartup(mockFetch(200, null));
+        } finally {
+            if (saved !== undefined) process.env.GH_TOKEN = saved;
+            else delete process.env.GH_TOKEN;
+        }
+    });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,12 +29,16 @@ import type { HealthCheckDeps } from './health/service';
 import { bootstrapServices } from './bootstrap';
 import { wireEventBroadcasting, publishToTenant } from './events/broadcasting';
 import { initAlgoChat, switchNetwork as switchAlgoChatNetwork, wirePostInit, type AlgoChatInitDeps } from './algochat/init';
+import { validateGitHubTokenOnStartup } from './lib/github-token-check';
 
 const log = createLogger('Server');
 
 // Load auth configuration for WebSocket authentication
 const authConfig = loadAuthConfig();
 validateStartupSecurity(authConfig);
+
+// Validate GH_TOKEN scopes (async, never blocks startup)
+validateGitHubTokenOnStartup().catch(() => { /* swallowed — logged internally */ });
 
 const PORT = parseInt(process.env.PORT ?? '3000', 10);
 const BIND_HOST = process.env.BIND_HOST || '127.0.0.1';

--- a/server/lib/github-token-check.ts
+++ b/server/lib/github-token-check.ts
@@ -1,0 +1,150 @@
+/**
+ * GitHub Token OAuth Scope Validation
+ *
+ * Checks GH_TOKEN at startup and warns if required scopes (repo, read:org)
+ * are missing. Never blocks startup — informational only.
+ */
+
+import { createLogger } from './logger';
+
+const log = createLogger('GitHubTokenCheck');
+
+const REQUIRED_SCOPES = ['repo', 'read:org'];
+
+export interface GitHubTokenCheckResult {
+    configured: boolean;
+    valid: boolean;
+    scopes: string[];
+    missingScopes: string[];
+    fineGrained: boolean;
+    error?: string;
+}
+
+/**
+ * Validate GH_TOKEN OAuth scopes by calling the GitHub API root endpoint.
+ * Returns scope information without blocking or throwing.
+ */
+export async function checkGitHubToken(
+    token?: string,
+    fetchFn: (url: string, init?: RequestInit) => Promise<Response> = globalThis.fetch,
+): Promise<GitHubTokenCheckResult> {
+    const ghToken = token ?? process.env.GH_TOKEN;
+
+    if (!ghToken) {
+        return {
+            configured: false,
+            valid: false,
+            scopes: [],
+            missingScopes: REQUIRED_SCOPES,
+            fineGrained: false,
+            error: 'GH_TOKEN not set',
+        };
+    }
+
+    try {
+        const resp = await fetchFn('https://api.github.com/', {
+            headers: {
+                Authorization: `token ${ghToken}`,
+                Accept: 'application/json',
+                'User-Agent': 'CorvidAgent-StartupCheck',
+            },
+        });
+
+        if (!resp.ok) {
+            return {
+                configured: true,
+                valid: false,
+                scopes: [],
+                missingScopes: REQUIRED_SCOPES,
+                fineGrained: false,
+                error: `GitHub API returned HTTP ${resp.status}`,
+            };
+        }
+
+        const scopeHeader = resp.headers.get('x-oauth-scopes');
+
+        // Fine-grained personal access tokens do not return the X-OAuth-Scopes header
+        if (scopeHeader === null || scopeHeader === undefined) {
+            return {
+                configured: true,
+                valid: true,
+                scopes: [],
+                missingScopes: [],
+                fineGrained: true,
+            };
+        }
+
+        const scopes = scopeHeader
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean);
+
+        const missingScopes = REQUIRED_SCOPES.filter((req) => !scopes.includes(req));
+
+        return {
+            configured: true,
+            valid: true,
+            scopes,
+            missingScopes,
+            fineGrained: false,
+        };
+    } catch (err) {
+        return {
+            configured: true,
+            valid: false,
+            scopes: [],
+            missingScopes: REQUIRED_SCOPES,
+            fineGrained: false,
+            error: err instanceof Error ? err.message : String(err),
+        };
+    }
+}
+
+/**
+ * Run the GitHub token check and log results.
+ * Safe to call during startup — never throws or blocks.
+ */
+export async function validateGitHubTokenOnStartup(
+    fetchFn?: (url: string, init?: RequestInit) => Promise<Response>,
+): Promise<void> {
+    try {
+        const result = await checkGitHubToken(undefined, fetchFn);
+
+        if (!result.configured) {
+            log.warn('GH_TOKEN is not set — GitHub features (PRs, issues, stars) will be unavailable');
+            return;
+        }
+
+        if (!result.valid) {
+            log.warn('GH_TOKEN validation failed — GitHub features may not work', {
+                error: result.error,
+            });
+            return;
+        }
+
+        if (result.fineGrained) {
+            log.info(
+                'GH_TOKEN is a fine-grained token — scope validation skipped (scopes are managed via token permissions)',
+            );
+            return;
+        }
+
+        if (result.missingScopes.length > 0) {
+            log.warn(
+                `GH_TOKEN is missing required OAuth scopes: ${result.missingScopes.join(', ')}`,
+                { currentScopes: result.scopes, missingScopes: result.missingScopes },
+            );
+            log.warn(
+                'Some GitHub features may fail. Regenerate your token with "repo" and "read:org" scopes.',
+            );
+            return;
+        }
+
+        log.info('GH_TOKEN validated — all required scopes present', {
+            scopes: result.scopes,
+        });
+    } catch {
+        // Absolute safety net — never let this crash startup
+        log.warn('GH_TOKEN validation encountered an unexpected error — skipping');
+    }
+}


### PR DESCRIPTION
## Summary
- Creates `server/lib/github-token-check.ts` that validates GH_TOKEN OAuth scopes on startup by calling `GET https://api.github.com/` and inspecting the `X-OAuth-Scopes` response header
- Warns if `repo` or `read:org` scopes are missing
- Gracefully handles fine-grained tokens (no scope header), invalid tokens, and network errors
- Never blocks startup — informational logging only
- Called from `server/index.ts` during startup (async, fire-and-forget)
- 14 unit tests covering all code paths

Closes #729 (re-do of closed PR #733)

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` passes
- [x] `bun test server/__tests__/github-token-check.test.ts` — 14/14 pass
- [x] Manual: start server without GH_TOKEN → warns "not set"
- [x] Manual: start server with valid token → logs "all required scopes present"
- [x] Manual: start server with fine-grained PAT → logs "scope validation skipped"

🤖 Generated with [Claude Code](https://claude.com/claude-code)