### PR TITLE
feat: governance v2 proposals with weighted voting and quorum rules (#633)

### DIFF
--- a/server/councils/governance.ts
+++ b/server/councils/governance.ts
@@ -307,12 +307,20 @@ export interface WeightedGovernanceVoteCheck extends GovernanceVoteCheck {
  *
  * Falls back to unweighted evaluation if no weights are provided.
  */
+export interface QuorumConfig {
+    /** Custom quorum threshold (0.0–1.0). Overrides tier default. */
+    threshold?: number | null;
+    /** Minimum number of voters (non-abstaining) required for a valid vote. */
+    minimumVoters?: number | null;
+}
+
 export function evaluateWeightedVote(
     tier: GovernanceTier,
     totalMembers: number,
     votes: WeightedVoteRecord[],
     humanApproved: boolean = false,
     customThreshold?: number | null,
+    minimumVoters?: number | null,
 ): WeightedGovernanceVoteCheck {
     const tierInfo = GOVERNANCE_TIERS[tier];
     const threshold = customThreshold ?? tierInfo.quorumThreshold;
@@ -354,6 +362,19 @@ export function evaluateWeightedVote(
             requiredThreshold: threshold,
             awaitingHumanApproval: false,
             reason: 'No votes cast yet',
+            voteWeights,
+        };
+    }
+
+    // Check minimum voters requirement
+    if (minimumVoters != null && minimumVoters > 0 && activeVotes.length < minimumVoters) {
+        return {
+            passed: false,
+            approvalRatio: 0,
+            weightedApprovalRatio: 0,
+            requiredThreshold: threshold,
+            awaitingHumanApproval: false,
+            reason: `Only ${activeVotes.length} of required ${minimumVoters} minimum voters have voted`,
             voteWeights,
         };
     }
@@ -461,5 +482,57 @@ export function checkAutomationAllowed(filePaths: string[]): AutomationCheckResu
         tier: mostRestrictiveTier,
         reason: 'All paths are within automation-allowed tiers',
         blockedPaths: [],
+    };
+}
+
+// ─── Proposal evaluation ──────────────────────────────────────────────────────
+
+export interface ProposalEvaluationResult extends WeightedGovernanceVoteCheck {
+    /** Whether the minimum voter requirement is satisfied. */
+    minimumVotersMet: boolean;
+    /** The effective quorum threshold used for evaluation. */
+    effectiveThreshold: number;
+    /** The effective minimum voters requirement. */
+    effectiveMinimumVoters: number;
+}
+
+/**
+ * Evaluate a proposal's vote using its quorum configuration.
+ *
+ * Resolves the effective threshold from (in priority order):
+ *   1. Proposal-level quorumThreshold
+ *   2. Council-level quorumThreshold
+ *   3. Governance tier default
+ *
+ * Also enforces minimumVoters when set on the proposal.
+ */
+export function evaluateProposalVote(
+    tier: GovernanceTier,
+    totalMembers: number,
+    votes: WeightedVoteRecord[],
+    humanApproved: boolean,
+    quorum: QuorumConfig = {},
+): ProposalEvaluationResult {
+    const tierInfo = GOVERNANCE_TIERS[tier];
+    const effectiveThreshold = quorum.threshold ?? tierInfo.quorumThreshold;
+    const effectiveMinimumVoters = quorum.minimumVoters ?? 0;
+
+    const check = evaluateWeightedVote(
+        tier,
+        totalMembers,
+        votes,
+        humanApproved,
+        effectiveThreshold,
+        effectiveMinimumVoters > 0 ? effectiveMinimumVoters : null,
+    );
+
+    const activeVotes = votes.filter((v) => v.vote !== 'abstain');
+    const minimumVotersMet = effectiveMinimumVoters <= 0 || activeVotes.length >= effectiveMinimumVoters;
+
+    return {
+        ...check,
+        minimumVotersMet,
+        effectiveThreshold,
+        effectiveMinimumVoters,
     };
 }

--- a/server/db/migrations/072_governance_proposals.ts
+++ b/server/db/migrations/072_governance_proposals.ts
@@ -1,0 +1,43 @@
+/**
+ * Migration 072: Governance proposals table.
+ *
+ * Adds a proposals table for the governance v2 proposal lifecycle:
+ *   draft → open → voting → decided → enacted
+ *
+ * Includes configurable quorum rules (threshold + minimum voters)
+ * and ties into existing governance tiers and council votes.
+ */
+
+import { Database } from 'bun:sqlite';
+
+export function up(db: Database): void {
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS governance_proposals (
+            id TEXT PRIMARY KEY,
+            council_id TEXT NOT NULL REFERENCES councils(id) ON DELETE CASCADE,
+            title TEXT NOT NULL,
+            description TEXT NOT NULL DEFAULT '',
+            author_id TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'draft',
+            decision TEXT DEFAULT NULL,
+            governance_tier INTEGER NOT NULL DEFAULT 2,
+            affected_paths TEXT NOT NULL DEFAULT '[]',
+            quorum_threshold REAL DEFAULT NULL,
+            minimum_voters INTEGER DEFAULT NULL,
+            launch_id TEXT DEFAULT NULL,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            decided_at TEXT DEFAULT NULL,
+            enacted_at TEXT DEFAULT NULL
+        )
+    `);
+
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_governance_proposals_council ON governance_proposals(council_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_governance_proposals_status ON governance_proposals(status)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_governance_proposals_tenant ON governance_proposals(tenant_id)`);
+}
+
+export function down(db: Database): void {
+    db.exec('DROP TABLE IF EXISTS governance_proposals');
+}

--- a/server/db/proposals.ts
+++ b/server/db/proposals.ts
@@ -1,0 +1,241 @@
+/**
+ * Database functions for governance proposals.
+ *
+ * Proposals follow a lifecycle: draft → open → voting → decided → enacted.
+ * Each proposal belongs to a council and targets a governance tier with
+ * configurable quorum rules (percentage threshold + minimum voters).
+ */
+
+import type { Database, SQLQueryBindings } from 'bun:sqlite';
+import type {
+    GovernanceProposal,
+    ProposalStatus,
+    ProposalDecision,
+    CreateProposalInput,
+    UpdateProposalInput,
+} from '../../shared/types';
+import { DEFAULT_TENANT_ID } from '../tenant/types';
+import { withTenantFilter, validateTenantOwnership } from '../tenant/db-filter';
+
+// ─── Row type ────────────────────────────────────────────────────────────────
+
+interface ProposalRow {
+    id: string;
+    council_id: string;
+    title: string;
+    description: string;
+    author_id: string;
+    status: string;
+    decision: string | null;
+    governance_tier: number;
+    affected_paths: string;
+    quorum_threshold: number | null;
+    minimum_voters: number | null;
+    launch_id: string | null;
+    tenant_id: string;
+    created_at: string;
+    updated_at: string;
+    decided_at: string | null;
+    enacted_at: string | null;
+}
+
+function rowToProposal(row: ProposalRow): GovernanceProposal {
+    return {
+        id: row.id,
+        councilId: row.council_id,
+        title: row.title,
+        description: row.description,
+        authorId: row.author_id,
+        status: row.status as ProposalStatus,
+        decision: (row.decision as ProposalDecision) ?? null,
+        governanceTier: row.governance_tier,
+        affectedPaths: JSON.parse(row.affected_paths),
+        quorumThreshold: row.quorum_threshold,
+        minimumVoters: row.minimum_voters,
+        launchId: row.launch_id,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+        decidedAt: row.decided_at,
+        enactedAt: row.enacted_at,
+    };
+}
+
+// ─── CRUD ────────────────────────────────────────────────────────────────────
+
+export function createProposal(
+    db: Database,
+    input: CreateProposalInput,
+    tenantId: string = DEFAULT_TENANT_ID,
+): GovernanceProposal {
+    const id = crypto.randomUUID();
+
+    db.query(`
+        INSERT INTO governance_proposals
+            (id, council_id, title, description, author_id, governance_tier, affected_paths, quorum_threshold, minimum_voters, tenant_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+        id,
+        input.councilId,
+        input.title,
+        input.description ?? '',
+        input.authorId,
+        input.governanceTier ?? 2,
+        JSON.stringify(input.affectedPaths ?? []),
+        input.quorumThreshold ?? null,
+        input.minimumVoters ?? null,
+        tenantId,
+    );
+
+    return getProposal(db, id, tenantId)!;
+}
+
+export function getProposal(
+    db: Database,
+    id: string,
+    tenantId: string = DEFAULT_TENANT_ID,
+): GovernanceProposal | null {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'governance_proposals', id, tenantId)) {
+        return null;
+    }
+    const row = db.query('SELECT * FROM governance_proposals WHERE id = ?').get(id) as ProposalRow | null;
+    return row ? rowToProposal(row) : null;
+}
+
+export function listProposals(
+    db: Database,
+    opts?: { councilId?: string; status?: ProposalStatus },
+    tenantId: string = DEFAULT_TENANT_ID,
+): GovernanceProposal[] {
+    const conditions: string[] = [];
+    const bindings: SQLQueryBindings[] = [];
+
+    if (opts?.councilId) {
+        conditions.push('council_id = ?');
+        bindings.push(opts.councilId);
+    }
+    if (opts?.status) {
+        conditions.push('status = ?');
+        bindings.push(opts.status);
+    }
+
+    let sql = 'SELECT * FROM governance_proposals';
+    if (conditions.length > 0) {
+        sql += ' WHERE ' + conditions.join(' AND ');
+    }
+    sql += ' ORDER BY updated_at DESC';
+
+    const { query, bindings: tenantBindings } = withTenantFilter(sql, tenantId);
+    const rows = db.query(query).all(...bindings, ...tenantBindings) as ProposalRow[];
+    return rows.map(rowToProposal);
+}
+
+export function updateProposal(
+    db: Database,
+    id: string,
+    input: UpdateProposalInput,
+    tenantId: string = DEFAULT_TENANT_ID,
+): GovernanceProposal | null {
+    const existing = getProposal(db, id, tenantId);
+    if (!existing) return null;
+
+    const fields: string[] = [];
+    const values: unknown[] = [];
+
+    if (input.title !== undefined) {
+        fields.push('title = ?');
+        values.push(input.title);
+    }
+    if (input.description !== undefined) {
+        fields.push('description = ?');
+        values.push(input.description);
+    }
+    if (input.affectedPaths !== undefined) {
+        fields.push('affected_paths = ?');
+        values.push(JSON.stringify(input.affectedPaths));
+    }
+    if (input.quorumThreshold !== undefined) {
+        fields.push('quorum_threshold = ?');
+        values.push(input.quorumThreshold);
+    }
+    if (input.minimumVoters !== undefined) {
+        fields.push('minimum_voters = ?');
+        values.push(input.minimumVoters);
+    }
+
+    if (fields.length > 0) {
+        fields.push("updated_at = datetime('now')");
+        values.push(id);
+        db.query(`UPDATE governance_proposals SET ${fields.join(', ')} WHERE id = ?`).run(
+            ...(values as SQLQueryBindings[]),
+        );
+    }
+
+    return getProposal(db, id, tenantId);
+}
+
+export function deleteProposal(
+    db: Database,
+    id: string,
+    tenantId: string = DEFAULT_TENANT_ID,
+): boolean {
+    if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'governance_proposals', id, tenantId)) {
+        return false;
+    }
+    const result = db.query('DELETE FROM governance_proposals WHERE id = ?').run(id);
+    return result.changes > 0;
+}
+
+// ─── Lifecycle transitions ───────────────────────────────────────────────────
+
+const VALID_TRANSITIONS: Record<ProposalStatus, ProposalStatus[]> = {
+    draft: ['open'],
+    open: ['voting', 'draft'], // can go back to draft
+    voting: ['decided'],
+    decided: ['enacted'],
+    enacted: [],
+};
+
+export function transitionProposal(
+    db: Database,
+    id: string,
+    newStatus: ProposalStatus,
+    decision?: ProposalDecision,
+    tenantId: string = DEFAULT_TENANT_ID,
+): GovernanceProposal | null {
+    const existing = getProposal(db, id, tenantId);
+    if (!existing) return null;
+
+    const allowed = VALID_TRANSITIONS[existing.status];
+    if (!allowed.includes(newStatus)) {
+        throw new Error(`Invalid transition: ${existing.status} → ${newStatus}`);
+    }
+
+    const fields: string[] = ['status = ?'];
+    const values: SQLQueryBindings[] = [newStatus];
+
+    if (newStatus === 'decided' && decision) {
+        fields.push('decision = ?');
+        values.push(decision);
+        fields.push("decided_at = datetime('now')");
+    }
+    if (newStatus === 'enacted') {
+        fields.push("enacted_at = datetime('now')");
+    }
+
+    fields.push("updated_at = datetime('now')");
+    values.push(id);
+
+    db.query(`UPDATE governance_proposals SET ${fields.join(', ')} WHERE id = ?`).run(...values);
+    return getProposal(db, id, tenantId);
+}
+
+export function linkProposalToLaunch(
+    db: Database,
+    proposalId: string,
+    launchId: string,
+): void {
+    db.query("UPDATE governance_proposals SET launch_id = ?, updated_at = datetime('now') WHERE id = ?").run(
+        launchId,
+        proposalId,
+    );
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,6 +1,6 @@
 import { Database } from 'bun:sqlite';
 
-const SCHEMA_VERSION = 71;
+const SCHEMA_VERSION = 72;
 
 const MIGRATIONS: Record<number, string[]> = {
     1: [
@@ -1328,6 +1328,31 @@ const MIGRATIONS: Record<number, string[]> = {
         // Governance v2: quorum configuration on councils
         `ALTER TABLE councils ADD COLUMN quorum_type TEXT DEFAULT 'majority'`,
         `ALTER TABLE councils ADD COLUMN quorum_threshold REAL DEFAULT NULL`,
+    ],
+    72: [
+        // Governance v2: proposals lifecycle table
+        `CREATE TABLE IF NOT EXISTS governance_proposals (
+            id                TEXT PRIMARY KEY,
+            council_id        TEXT NOT NULL REFERENCES councils(id) ON DELETE CASCADE,
+            title             TEXT NOT NULL,
+            description       TEXT NOT NULL DEFAULT '',
+            author_id         TEXT NOT NULL,
+            status            TEXT NOT NULL DEFAULT 'draft',
+            decision          TEXT DEFAULT NULL,
+            governance_tier   INTEGER NOT NULL DEFAULT 2,
+            affected_paths    TEXT NOT NULL DEFAULT '[]',
+            quorum_threshold  REAL DEFAULT NULL,
+            minimum_voters    INTEGER DEFAULT NULL,
+            launch_id         TEXT DEFAULT NULL,
+            tenant_id         TEXT NOT NULL DEFAULT 'default',
+            created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at        TEXT NOT NULL DEFAULT (datetime('now')),
+            decided_at        TEXT DEFAULT NULL,
+            enacted_at        TEXT DEFAULT NULL
+        )`,
+        `CREATE INDEX IF NOT EXISTS idx_governance_proposals_council ON governance_proposals(council_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_governance_proposals_status ON governance_proposals(status)`,
+        `CREATE INDEX IF NOT EXISTS idx_governance_proposals_tenant ON governance_proposals(tenant_id)`,
     ],
 };
 

--- a/server/lib/validation.ts
+++ b/server/lib/validation.ts
@@ -229,6 +229,32 @@ export const CouncilChatSchema = z.object({
     message: z.string().min(1, 'message is required'),
 });
 
+// ─── Governance Proposals ──────────────────────────────────────────────────────
+
+export const CreateProposalSchema = z.object({
+    councilId: z.string().min(1, 'councilId is required'),
+    title: z.string().min(1, 'title is required'),
+    description: z.string().optional(),
+    authorId: z.string().min(1, 'authorId is required'),
+    governanceTier: z.number().int().min(0).max(2).optional(),
+    affectedPaths: z.array(z.string()).optional(),
+    quorumThreshold: z.number().min(0).max(1).nullable().optional(),
+    minimumVoters: z.number().int().min(0).nullable().optional(),
+});
+
+export const UpdateProposalSchema = z.object({
+    title: z.string().min(1).optional(),
+    description: z.string().optional(),
+    affectedPaths: z.array(z.string()).optional(),
+    quorumThreshold: z.number().min(0).max(1).nullable().optional(),
+    minimumVoters: z.number().int().min(0).nullable().optional(),
+});
+
+export const TransitionProposalSchema = z.object({
+    status: z.enum(['draft', 'open', 'voting', 'decided', 'enacted']),
+    decision: z.enum(['approved', 'rejected']).optional(),
+});
+
 // ─── Work Tasks ────────────────────────────────────────────────────────────────
 
 export const CreateWorkTaskSchema = z.object({

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -3,6 +3,7 @@ import { handleProjectRoutes, handleBrowseDirs } from './projects';
 import { handleAgentRoutes } from './agents';
 import { handleSessionRoutes } from './sessions';
 import { handleCouncilRoutes } from './councils';
+import { handleProposalRoutes } from './proposals';
 import { handleWorkTaskRoutes } from './work-tasks';
 import { handleMcpApiRoutes } from './mcp-api';
 import { handleAllowlistRoutes } from './allowlist';
@@ -347,6 +348,9 @@ async function handleRoutes(
 
     const councilResponse = handleCouncilRoutes(req, url, db, processManager, agentMessenger, context, reputationScorer);
     if (councilResponse) return councilResponse;
+
+    const proposalResponse = handleProposalRoutes(req, url, db, context, reputationScorer);
+    if (proposalResponse) return proposalResponse;
 
     if (workTaskService) {
         const workTaskResponse = handleWorkTaskRoutes(req, url, workTaskService, context);

--- a/server/routes/proposals.ts
+++ b/server/routes/proposals.ts
@@ -1,0 +1,239 @@
+/**
+ * Governance Proposal API routes.
+ *
+ * Endpoints:
+ *   GET    /api/proposals              — list proposals (filter by councilId, status)
+ *   POST   /api/proposals              — create a new proposal (starts as draft)
+ *   GET    /api/proposals/:id          — get proposal by ID
+ *   PUT    /api/proposals/:id          — update proposal (only in draft/open)
+ *   DELETE /api/proposals/:id          — delete proposal (only in draft)
+ *   POST   /api/proposals/:id/transition — advance proposal lifecycle
+ *   GET    /api/proposals/:id/evaluate — evaluate current vote status
+ */
+
+import type { Database } from 'bun:sqlite';
+import type { ProposalStatus } from '../../shared/types';
+import type { RequestContext } from '../middleware/guards';
+import type { ReputationScorer } from '../reputation/scorer';
+import { tenantRoleGuard } from '../middleware/guards';
+import {
+    parseBodyOrThrow,
+    ValidationError,
+    CreateProposalSchema,
+    UpdateProposalSchema,
+    TransitionProposalSchema,
+} from '../lib/validation';
+import { json, handleRouteError } from '../lib/response';
+import {
+    createProposal,
+    getProposal,
+    listProposals,
+    updateProposal,
+    deleteProposal,
+    transitionProposal,
+} from '../db/proposals';
+import { getCouncil } from '../db/councils';
+import { getGovernanceVote } from '../db/councils';
+import { getGovernanceMemberVotes } from '../db/councils';
+import {
+    evaluateProposalVote,
+    type GovernanceTier,
+    type WeightedVoteRecord,
+} from '../councils/governance';
+
+export function handleProposalRoutes(
+    req: Request,
+    url: URL,
+    db: Database,
+    context?: RequestContext,
+    reputationScorer?: ReputationScorer | null,
+): Response | Promise<Response> | null {
+    const path = url.pathname;
+    const method = req.method;
+    const tenantId = context?.tenantId ?? 'default';
+
+    // Collection endpoints
+    if (path === '/api/proposals' && method === 'GET') {
+        const councilId = url.searchParams.get('councilId') ?? undefined;
+        const status = (url.searchParams.get('status') as ProposalStatus) ?? undefined;
+        return json(listProposals(db, { councilId, status }, tenantId));
+    }
+
+    if (path === '/api/proposals' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
+        return handleCreate(req, db, tenantId);
+    }
+
+    // Single proposal routes
+    const match = path.match(/^\/api\/proposals\/([^/]+)(\/(.+))?$/);
+    if (!match) return null;
+
+    const id = match[1];
+    const action = match[3];
+
+    if (!action) {
+        if (method === 'GET') {
+            const proposal = getProposal(db, id, tenantId);
+            return proposal ? json(proposal) : json({ error: 'Not found' }, 404);
+        }
+        if (method === 'PUT') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
+            return handleUpdate(req, db, id, tenantId);
+        }
+        if (method === 'DELETE') {
+            if (context) {
+                const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+                if (denied) return denied;
+            }
+            return handleDelete(db, id, tenantId);
+        }
+    }
+
+    if (action === 'transition' && method === 'POST') {
+        if (context) {
+            const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
+            if (denied) return denied;
+        }
+        return handleTransition(req, db, id, tenantId);
+    }
+
+    if (action === 'evaluate' && method === 'GET') {
+        return handleEvaluate(db, id, tenantId, reputationScorer);
+    }
+
+    return null;
+}
+
+// ─── Handlers ────────────────────────────────────────────────────────────────
+
+async function handleCreate(req: Request, db: Database, tenantId: string): Promise<Response> {
+    try {
+        const data = await parseBodyOrThrow(req, CreateProposalSchema);
+
+        // Verify the council exists
+        const council = getCouncil(db, data.councilId, tenantId);
+        if (!council) return json({ error: 'Council not found' }, 404);
+
+        const proposal = createProposal(db, data, tenantId);
+        return json(proposal, 201);
+    } catch (err) {
+        if (err instanceof ValidationError) return json({ error: err.detail }, 400);
+        return handleRouteError(err);
+    }
+}
+
+async function handleUpdate(req: Request, db: Database, id: string, tenantId: string): Promise<Response> {
+    try {
+        const data = await parseBodyOrThrow(req, UpdateProposalSchema);
+
+        const existing = getProposal(db, id, tenantId);
+        if (!existing) return json({ error: 'Not found' }, 404);
+
+        // Can only update proposals in draft or open status
+        if (existing.status !== 'draft' && existing.status !== 'open') {
+            return json({ error: `Cannot update proposal in '${existing.status}' status` }, 400);
+        }
+
+        const proposal = updateProposal(db, id, data, tenantId);
+        return proposal ? json(proposal) : json({ error: 'Not found' }, 404);
+    } catch (err) {
+        if (err instanceof ValidationError) return json({ error: err.detail }, 400);
+        return handleRouteError(err);
+    }
+}
+
+function handleDelete(db: Database, id: string, tenantId: string): Response {
+    const existing = getProposal(db, id, tenantId);
+    if (!existing) return json({ error: 'Not found' }, 404);
+
+    if (existing.status !== 'draft') {
+        return json({ error: 'Can only delete proposals in draft status' }, 400);
+    }
+
+    const deleted = deleteProposal(db, id, tenantId);
+    return deleted ? json({ ok: true }) : json({ error: 'Not found' }, 404);
+}
+
+async function handleTransition(
+    req: Request,
+    db: Database,
+    id: string,
+    tenantId: string,
+): Promise<Response> {
+    try {
+        const data = await parseBodyOrThrow(req, TransitionProposalSchema);
+        const proposal = transitionProposal(db, id, data.status, data.decision ?? null, tenantId);
+        return proposal ? json(proposal) : json({ error: 'Not found' }, 404);
+    } catch (err) {
+        if (err instanceof ValidationError) return json({ error: err.detail }, 400);
+        if (err instanceof Error && err.message.startsWith('Invalid transition')) {
+            return json({ error: err.message }, 400);
+        }
+        return handleRouteError(err);
+    }
+}
+
+function handleEvaluate(
+    db: Database,
+    id: string,
+    tenantId: string,
+    reputationScorer?: ReputationScorer | null,
+): Response {
+    const proposal = getProposal(db, id, tenantId);
+    if (!proposal) return json({ error: 'Not found' }, 404);
+
+    const council = getCouncil(db, proposal.councilId, tenantId);
+    if (!council) return json({ error: 'Council not found' }, 404);
+
+    const totalMembers = council.agentIds.length;
+
+    // If proposal has a linked launch with governance votes, use those
+    let weightedVotes: WeightedVoteRecord[] = [];
+    if (proposal.launchId) {
+        const governanceVote = getGovernanceVote(db, proposal.launchId);
+        if (governanceVote) {
+            const memberVotes = getGovernanceMemberVotes(db, governanceVote.id);
+            weightedVotes = memberVotes.map((mv) => {
+                let weight = 50;
+                if (reputationScorer) {
+                    const score = reputationScorer.getCachedScore(mv.agent_id);
+                    if (score) weight = score.overallScore;
+                }
+                return {
+                    agentId: mv.agent_id,
+                    vote: mv.vote as 'approve' | 'reject' | 'abstain',
+                    reason: mv.reason,
+                    votedAt: mv.created_at,
+                    weight,
+                };
+            });
+        }
+    }
+
+    const evaluation = evaluateProposalVote(
+        proposal.governanceTier as GovernanceTier,
+        totalMembers,
+        weightedVotes,
+        false, // humanApproved — checked separately
+        {
+            threshold: proposal.quorumThreshold ?? council.quorumThreshold,
+            minimumVoters: proposal.minimumVoters,
+        },
+    );
+
+    return json({
+        proposalId: proposal.id,
+        status: proposal.status,
+        decision: proposal.decision,
+        governanceTier: proposal.governanceTier,
+        totalMembers,
+        votes: weightedVotes,
+        evaluation,
+    });
+}

--- a/shared/types/councils.ts
+++ b/shared/types/councils.ts
@@ -128,6 +128,68 @@ export interface CouncilDiscussionMessage {
     createdAt: string;
 }
 
+// ─── Governance Proposals ────────────────────────────────────────────────────
+
+/**
+ * Proposal lifecycle:
+ *   draft → open → voting → decided → enacted
+ *
+ * - draft: author is still editing, not yet visible to voters
+ * - open: visible for discussion but voting hasn't started
+ * - voting: votes are being collected
+ * - decided: vote concluded (approved/rejected), awaiting enactment
+ * - enacted: approved proposal has been applied
+ */
+export type ProposalStatus = 'draft' | 'open' | 'voting' | 'decided' | 'enacted';
+
+export type ProposalDecision = 'approved' | 'rejected' | null;
+
+export interface GovernanceProposal {
+    id: string;
+    councilId: string;
+    title: string;
+    description: string;
+    /** Who created the proposal (agent or human identifier). */
+    authorId: string;
+    /** Current lifecycle status. */
+    status: ProposalStatus;
+    /** Decision after voting concludes (null while voting or before). */
+    decision: ProposalDecision;
+    /** Governance tier this proposal targets (0, 1, or 2). */
+    governanceTier: number;
+    /** Paths affected by the proposed change. */
+    affectedPaths: string[];
+    /** Minimum percentage of weighted votes required to pass (0.0–1.0). Overrides council/tier default. */
+    quorumThreshold: number | null;
+    /** Minimum number of voters required for a valid vote (regardless of weight). */
+    minimumVoters: number | null;
+    /** Optional council launch ID if a council deliberation was started for this proposal. */
+    launchId: string | null;
+    createdAt: string;
+    updatedAt: string;
+    decidedAt: string | null;
+    enactedAt: string | null;
+}
+
+export interface CreateProposalInput {
+    councilId: string;
+    title: string;
+    description?: string;
+    authorId: string;
+    governanceTier?: number;
+    affectedPaths?: string[];
+    quorumThreshold?: number | null;
+    minimumVoters?: number | null;
+}
+
+export interface UpdateProposalInput {
+    title?: string;
+    description?: string;
+    affectedPaths?: string[];
+    quorumThreshold?: number | null;
+    minimumVoters?: number | null;
+}
+
 /** Structured error emitted when a council agent fails mid-session. */
 export interface CouncilAgentError {
     launchId: string;


### PR DESCRIPTION
## Summary
- Adds **proposal lifecycle** (`draft → open → voting → decided → enacted`) with validated state transitions
- Extends **weighted voting** with configurable `minimumVoters` quorum parameter — enforced alongside existing reputation-weighted threshold
- Adds **`evaluateProposalVote()`** which resolves effective quorum from proposal → council → governance tier defaults
- Full **REST API** for proposal CRUD: create, list, get, update, delete, transition, evaluate
- Migration 072 creates `governance_proposals` table with council FK, tier, quorum config, and lifecycle timestamps

## Changes
- `shared/types/councils.ts` — new `GovernanceProposal`, `ProposalStatus`, `CreateProposalInput`, `UpdateProposalInput` types
- `server/db/migrations/072_governance_proposals.ts` — proposals table + indexes
- `server/db/schema.ts` — inline migration 72, bump `SCHEMA_VERSION` to 72
- `server/db/proposals.ts` — CRUD, lifecycle transitions, launch linking
- `server/councils/governance.ts` — `QuorumConfig` interface, `minimumVoters` in `evaluateWeightedVote`, `evaluateProposalVote()`
- `server/lib/validation.ts` — `CreateProposalSchema`, `UpdateProposalSchema`, `TransitionProposalSchema`
- `server/routes/proposals.ts` — full route handler with auth guards
- `server/routes/index.ts` — register proposal routes

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` passes (0 errors)
- [x] `bun test` passes (5798 pass, 0 fail)
- [x] Manual: POST /api/proposals → creates draft proposal
- [x] Manual: POST /api/proposals/:id/transition → advances lifecycle
- [x] Manual: GET /api/proposals/:id/evaluate → returns weighted vote evaluation

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)