### PR TITLE
feat: automate stats collection and drift detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
       - name: Spec check
         run: bun run spec:check
 
+      - name: Stats check
+        if: matrix.os == 'ubuntu-latest'
+        run: bun run stats:check -- --skip-tests
+
       - name: Build client
         run: bun run build:client
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">
   <img src="https://img.shields.io/badge/Angular-21-dd0031?logo=angular" alt="Angular 21">
-  <img src="https://img.shields.io/badge/tests-5725%20unit%20%7C%20360%20E2E-brightgreen" alt="5725 Unit | 360 E2E Tests">
+  <img src="https://img.shields.io/badge/tests-5821%20unit%20%7C%20360%20E2E-brightgreen" alt="5725 Unit | 360 E2E Tests">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>
 </p>
 
@@ -20,12 +20,12 @@ See [VISION.md](VISION.md) for architecture, competitive positioning, and long-t
 
 | Metric | Count |
 |--------|-------|
-| Unit tests | **5,725** across 228 files (15,933 assertions) |
+| Unit tests | **5,821** across 236 files (16,195 assertions) |
 | E2E tests | **360** across 31 Playwright specs |
-| Module specs | **111** with automated validation |
+| Module specs | **113** with automated validation |
 | MCP tools | **38** corvid_* tool handlers |
 | API endpoints | **~200** across 38 route modules |
-| DB migrations | **21** (squashed baseline, 81 tables) |
+| DB migrations | **23** (squashed baseline, 82 tables) |
 | Test:code ratio | **1.14×** — more test code than production code |
 
 Cross-platform CI: Ubuntu, macOS, Windows.

--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -37,13 +37,13 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | TypeScript LOC | 182,301 |
 | Server modules | 47 |
 | API routes | 38 modules (~200 endpoints) |
-| Database tables | 81 |
-| Database migrations | 21 (squashed baseline) |
+| Database tables | 82 |
+| Database migrations | 23 (squashed baseline) |
 | MCP tools | 38 corvid_* handlers |
-| Unit tests | 5,725 across 228 files |
+| Unit tests | 5,821 across 236 files |
 | E2E tests | 360 across 31 Playwright specs |
 | Security tests | 232 dedicated |
-| Module specs | 111 .spec.md files |
+| Module specs | 113 .spec.md files |
 | Test:code ratio | 1.14x (more test than production) |
 | Dependencies | 17 direct |
 | Version | 0.20.0 |

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "openapi:validate": "bun scripts/openapi-validate.ts",
     "openapi:export": "bun scripts/openapi-validate.ts --export",
     "lint:sql": "bash scripts/check-sql-injection.sh",
-    "security:scan": "bun scripts/ci-security-scan.ts"
+    "security:scan": "bun scripts/ci-security-scan.ts",
+    "stats:check": "bun scripts/collect-stats.ts",
+    "stats:update": "bun scripts/collect-stats.ts --update"
   },
   "optionalDependencies": {
     "@corvidlabs/ts-algochat": "^0.3.0"

--- a/scripts/collect-stats.ts
+++ b/scripts/collect-stats.ts
@@ -1,0 +1,385 @@
+/**
+ * collect-stats.ts — Collect and verify codebase statistics
+ *
+ * Collects live stats from the codebase and compares them against values
+ * documented in README.md and docs/deep-dive.md. Exits non-zero when
+ * documented stats have drifted beyond allowed thresholds.
+ *
+ * Usage:
+ *   bun scripts/collect-stats.ts           # verify stats (CI mode)
+ *   bun scripts/collect-stats.ts --update   # update docs in-place
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { execSync } from 'node:child_process';
+
+const ROOT = resolve(import.meta.dir, '..');
+
+// ─── Stat Collectors ────────────────────────────────────────────────────
+
+function countFiles(dir: string, pattern: RegExp): number {
+    let count = 0;
+    function walk(d: string) {
+        for (const entry of readdirSync(d)) {
+            const full = join(d, entry);
+            if (entry === 'node_modules' || entry === '.git') continue;
+            const stat = statSync(full);
+            if (stat.isDirectory()) walk(full);
+            else if (pattern.test(entry)) count++;
+        }
+    }
+    walk(dir);
+    return count;
+}
+
+function countTestFiles(): number {
+    return countFiles(ROOT, /\.test\.ts$/);
+}
+
+function countSpecFiles(): number {
+    return countFiles(join(ROOT, 'specs'), /\.spec\.md$/);
+}
+
+function countMigrations(): number {
+    return readdirSync(join(ROOT, 'server/db/migrations'))
+        .filter(f => f.endsWith('.ts'))
+        .length;
+}
+
+function countRouteModules(): number {
+    return readdirSync(join(ROOT, 'server/routes'))
+        .filter(f => f.endsWith('.ts'))
+        .length;
+}
+
+function countApiEndpoints(): number {
+    const registry = readFileSync(join(ROOT, 'server/openapi/route-registry.ts'), 'utf-8');
+    return (registry.match(/method:/g) || []).length;
+}
+
+function countDbTables(): number {
+    const schema = readFileSync(join(ROOT, 'server/db/schema.ts'), 'utf-8');
+    return (schema.match(/CREATE TABLE/g) || []).length;
+}
+
+function countE2eSpecFiles(): number {
+    try {
+        return readdirSync(join(ROOT, 'e2e'))
+            .filter(f => f.endsWith('.spec.ts'))
+            .length;
+    } catch {
+        return 0;
+    }
+}
+
+function countMcpTools(): number {
+    // Count unique corvid_* tool names across direct-tools and sdk-tools
+    const tools = new Set<string>();
+    for (const file of ['server/mcp/direct-tools.ts', 'server/mcp/sdk-tools.ts']) {
+        try {
+            const content = readFileSync(join(ROOT, file), 'utf-8');
+            const matches = content.matchAll(/['"]corvid_(\w+)['"]/g);
+            for (const m of matches) tools.add(m[1]);
+        } catch { /* file may not exist */ }
+    }
+    return tools.size;
+}
+
+// ─── Run bun test to get counts ─────────────────────────────────────────
+
+interface TestResults {
+    pass: number;
+    files: number;
+    assertions: number;
+}
+
+function getTestResults(): TestResults {
+    try {
+        const output = execSync('bun test 2>&1', {
+            cwd: ROOT,
+            timeout: 300_000,
+            encoding: 'utf-8',
+        });
+        const passMatch = output.match(/(\d+)\s+pass/);
+        const filesMatch = output.match(/Ran\s+\d+\s+tests\s+across\s+(\d+)\s+files/);
+        const assertMatch = output.match(/([\d,]+)\s+expect\(\)\s+calls/);
+        return {
+            pass: passMatch ? parseInt(passMatch[1]) : 0,
+            files: filesMatch ? parseInt(filesMatch[1]) : 0,
+            assertions: assertMatch ? parseInt(assertMatch[1].replace(/,/g, '')) : 0,
+        };
+    } catch {
+        return { pass: 0, files: 0, assertions: 0 };
+    }
+}
+
+// ─── Stats Definition ───────────────────────────────────────────────────
+
+interface Stat {
+    name: string;
+    collect: () => number;
+    /** Maximum allowed drift percentage before flagging (default 0 = exact) */
+    driftPct?: number;
+}
+
+const STATS: Stat[] = [
+    { name: 'test_files', collect: countTestFiles },
+    { name: 'spec_files', collect: countSpecFiles },
+    { name: 'migration_files', collect: countMigrations },
+    { name: 'route_modules', collect: countRouteModules },
+    { name: 'api_endpoints', collect: countApiEndpoints },
+    { name: 'db_tables', collect: countDbTables },
+    { name: 'e2e_spec_files', collect: countE2eSpecFiles },
+    { name: 'mcp_tools', collect: countMcpTools },
+];
+
+// ─── Document Patterns ──────────────────────────────────────────────────
+
+interface DocStat {
+    file: string;
+    /** Regex with a capture group for the number */
+    pattern: RegExp;
+    statName: string;
+    format: (n: number) => string;
+}
+
+const fmtNum = (n: number) => n.toLocaleString('en-US');
+
+const DOC_STATS: DocStat[] = [
+    // README.md
+    {
+        file: 'README.md',
+        pattern: /Unit tests\s*\|\s*\*\*([0-9,]+)\*\*\s*across\s+(\d+)\s+files/,
+        statName: 'unit_tests_readme',
+        format: (n) => n.toString(),
+    },
+    {
+        file: 'README.md',
+        pattern: /Module specs\s*\|\s*\*\*(\d+)\*\*/,
+        statName: 'spec_files',
+        format: fmtNum,
+    },
+    {
+        file: 'README.md',
+        pattern: /MCP tools\s*\|\s*\*\*(\d+)\*\*/,
+        statName: 'mcp_tools',
+        format: fmtNum,
+    },
+    {
+        file: 'README.md',
+        pattern: /DB migrations\s*\|\s*\*\*(\d+)\*\*/,
+        statName: 'migration_files',
+        format: fmtNum,
+    },
+    {
+        file: 'README.md',
+        pattern: /tests-([\d]+)%20unit/,
+        statName: 'badge_unit_tests',
+        format: (n) => n.toString(),
+    },
+    // docs/deep-dive.md
+    {
+        file: 'docs/deep-dive.md',
+        pattern: /Unit tests\s*\|\s*([0-9,]+)\s+across\s+(\d+)\s+files/,
+        statName: 'unit_tests_deepdive',
+        format: fmtNum,
+    },
+    {
+        file: 'docs/deep-dive.md',
+        pattern: /Module specs\s*\|\s*(\d+)/,
+        statName: 'spec_files',
+        format: fmtNum,
+    },
+    {
+        file: 'docs/deep-dive.md',
+        pattern: /Database tables\s*\|\s*(\d+)/,
+        statName: 'db_tables',
+        format: fmtNum,
+    },
+    {
+        file: 'docs/deep-dive.md',
+        pattern: /Database migrations\s*\|\s*(\d+)/,
+        statName: 'migration_files',
+        format: fmtNum,
+    },
+    {
+        file: 'docs/deep-dive.md',
+        pattern: /MCP tools\s*\|\s*(\d+)/,
+        statName: 'mcp_tools',
+        format: fmtNum,
+    },
+];
+
+// ─── Main ───────────────────────────────────────────────────────────────
+
+const updateMode = process.argv.includes('--update');
+
+console.log('Collecting codebase stats...\n');
+
+// Collect filesystem stats
+const collected: Record<string, number> = {};
+for (const stat of STATS) {
+    const value = stat.collect();
+    collected[stat.name] = value;
+    console.log(`  ${stat.name}: ${value}`);
+}
+
+// Run tests if not in --update mode (tests are slow)
+const skipTests = process.argv.includes('--skip-tests');
+let testResults: TestResults | null = null;
+if (!skipTests) {
+    console.log('\nRunning tests to collect counts...');
+    testResults = getTestResults();
+    collected['unit_tests'] = testResults.pass;
+    collected['test_file_count'] = testResults.files;
+    collected['assertions'] = testResults.assertions;
+    console.log(`  unit_tests: ${testResults.pass}`);
+    console.log(`  test_files_from_runner: ${testResults.files}`);
+    console.log(`  assertions: ${testResults.assertions}`);
+}
+
+// Check documented values
+console.log('\nChecking documented stats...\n');
+let drifts: string[] = [];
+
+for (const doc of DOC_STATS) {
+    const filePath = join(ROOT, doc.file);
+    const content = readFileSync(filePath, 'utf-8');
+    const match = content.match(doc.pattern);
+
+    if (!match) {
+        console.log(`  ⚠ ${doc.file}: pattern not found for ${doc.statName}`);
+        continue;
+    }
+
+    const documented = parseInt(match[1].replace(/,/g, ''));
+    let actual: number | undefined;
+
+    // Map doc stat to collected values
+    if (doc.statName === 'unit_tests_readme' || doc.statName === 'unit_tests_deepdive') {
+        actual = collected['unit_tests'];
+    } else if (doc.statName === 'badge_unit_tests') {
+        actual = collected['unit_tests'];
+    } else {
+        actual = collected[doc.statName];
+    }
+
+    if (actual === undefined) {
+        if (skipTests && (doc.statName.includes('unit_tests') || doc.statName === 'badge_unit_tests')) {
+            console.log(`  ⏭ ${doc.file} ${doc.statName}: skipped (--skip-tests)`);
+            continue;
+        }
+        console.log(`  ⚠ ${doc.file} ${doc.statName}: no collected value`);
+        continue;
+    }
+
+    if (documented === actual) {
+        console.log(`  ✓ ${doc.file} ${doc.statName}: ${actual}`);
+    } else {
+        const drift = `${doc.file} ${doc.statName}: documented=${documented}, actual=${actual}`;
+        console.log(`  ✗ ${drift}`);
+        drifts.push(drift);
+    }
+}
+
+// Update mode
+if (updateMode && drifts.length > 0) {
+    console.log('\nUpdating documented stats...\n');
+
+    // Update README badge
+    if (collected['unit_tests']) {
+        updateFile('README.md', /tests-[\d]+%20unit/, `tests-${collected['unit_tests']}%20unit`);
+    }
+
+    // Update README table
+    if (collected['unit_tests'] && collected['test_file_count'] && collected['assertions']) {
+        updateFile(
+            'README.md',
+            /Unit tests\s*\|\s*\*\*[0-9,]+\*\*\s*across\s+\d+\s+files\s*\([0-9,]+\s+assertions\)/,
+            `Unit tests | **${fmtNum(collected['unit_tests'])}** across ${collected['test_file_count']} files (${fmtNum(collected['assertions'])} assertions)`,
+        );
+    }
+    if (collected['spec_files']) {
+        updateFile(
+            'README.md',
+            /Module specs\s*\|\s*\*\*\d+\*\*/,
+            `Module specs | **${collected['spec_files']}**`,
+        );
+    }
+    if (collected['mcp_tools']) {
+        updateFile(
+            'README.md',
+            /MCP tools\s*\|\s*\*\*\d+\*\*/,
+            `MCP tools | **${collected['mcp_tools']}**`,
+        );
+    }
+    if (collected['migration_files']) {
+        updateFile(
+            'README.md',
+            /DB migrations\s*\|\s*\*\*\d+\*\*/,
+            `DB migrations | **${collected['migration_files']}**`,
+        );
+    }
+    if (collected['db_tables']) {
+        updateFile(
+            'README.md',
+            /DB migrations\s*\|\s*\*\*\d+\*\*\s*\(squashed baseline,\s*\d+\s*tables\)/,
+            `DB migrations | **${collected['migration_files']}** (squashed baseline, ${collected['db_tables']} tables)`,
+        );
+    }
+
+    // Update deep-dive.md
+    if (collected['unit_tests'] && collected['test_file_count']) {
+        updateFile(
+            'docs/deep-dive.md',
+            /Unit tests\s*\|\s*[0-9,]+\s+across\s+\d+\s+files/,
+            `Unit tests | ${fmtNum(collected['unit_tests'])} across ${collected['test_file_count']} files`,
+        );
+    }
+    if (collected['spec_files']) {
+        updateFile(
+            'docs/deep-dive.md',
+            /Module specs\s*\|\s*\d+\s/,
+            `Module specs | ${collected['spec_files']} `,
+        );
+    }
+    if (collected['db_tables']) {
+        updateFile(
+            'docs/deep-dive.md',
+            /Database tables\s*\|\s*\d+/,
+            `Database tables | ${collected['db_tables']}`,
+        );
+    }
+    if (collected['migration_files']) {
+        updateFile(
+            'docs/deep-dive.md',
+            /Database migrations\s*\|\s*\d+/,
+            `Database migrations | ${collected['migration_files']}`,
+        );
+    }
+    if (collected['mcp_tools']) {
+        updateFile(
+            'docs/deep-dive.md',
+            /MCP tools\s*\|\s*\d+/,
+            `MCP tools | ${collected['mcp_tools']}`,
+        );
+    }
+
+    console.log('Done. Re-run without --update to verify.\n');
+} else if (drifts.length > 0) {
+    console.log(`\n✗ ${drifts.length} stat(s) have drifted. Run with --update to fix.\n`);
+    process.exit(1);
+} else {
+    console.log('\n✓ All documented stats are up to date.\n');
+}
+
+function updateFile(relPath: string, pattern: RegExp, replacement: string) {
+    const filePath = join(ROOT, relPath);
+    const content = readFileSync(filePath, 'utf-8');
+    const updated = content.replace(pattern, replacement);
+    if (updated !== content) {
+        writeFileSync(filePath, updated);
+        console.log(`  Updated ${relPath}`);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `scripts/collect-stats.ts` — collects live codebase stats and compares against documented values in README.md and docs/deep-dive.md
- `bun run stats:check` exits non-zero when docs drift from reality; `bun run stats:update` auto-fixes
- CI step added to ubuntu build matrix to catch drift before merge
- Fixes stale stats: specs 111→113, migrations 21→23, tables 81→82, unit tests 5725→5821

Closes #537

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — 5,821 pass, 0 fail
- [x] `bun run spec:check` — 112/112 passed, 0 warnings
- [x] `bun run stats:check --skip-tests` — all documented stats match
- [x] CI pipeline passes on all 3 OS targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
