### PR TITLE
fix: align Helm chart version to app version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Spec check
         run: bun run spec:check
 
+      - name: Version alignment check
+        run: bun run version:check
+
       - name: Stats check
         if: matrix.os == 'ubuntu-latest'
         run: bun run stats:check -- --skip-tests

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: corvid-agent
 description: Agent orchestration platform with MCP tools, AlgoChat messaging, and on-chain wallet integration
 type: application
-version: 0.13.0
-appVersion: "0.13.0"
+version: 0.20.0
+appVersion: "0.20.0"
 keywords:
   - ai
   - agent

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "lint:sql": "bash scripts/check-sql-injection.sh",
     "security:scan": "bun scripts/ci-security-scan.ts",
     "stats:check": "bun scripts/collect-stats.ts",
-    "stats:update": "bun scripts/collect-stats.ts --update"
+    "stats:update": "bun scripts/collect-stats.ts --update",
+    "version:check": "bun scripts/version-check.ts"
   },
   "optionalDependencies": {
     "@corvidlabs/ts-algochat": "^0.3.0"

--- a/scripts/version-check.ts
+++ b/scripts/version-check.ts
@@ -1,0 +1,56 @@
+/**
+ * version-check.ts — Ensures version strings stay aligned across the project.
+ *
+ * Checks that deploy/helm/Chart.yaml version + appVersion match package.json version.
+ *
+ * Usage: bun scripts/version-check.ts
+ * Exit code 0 = aligned, 1 = drift detected
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const ROOT = resolve(import.meta.dir, '..');
+
+// ─── Read package.json version (source of truth) ─────────────────────────
+
+const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8'));
+const appVersion: string = pkg.version;
+
+console.log(`package.json version: ${appVersion}`);
+
+// ─── Check Helm Chart.yaml ───────────────────────────────────────────────
+
+const chartPath = join(ROOT, 'deploy/helm/Chart.yaml');
+const chartContent = readFileSync(chartPath, 'utf-8');
+
+const versionMatch = chartContent.match(/^version:\s*(.+)$/m);
+const appVersionMatch = chartContent.match(/^appVersion:\s*"?([^"\n]+)"?$/m);
+
+const chartVersion = versionMatch?.[1]?.trim();
+const chartAppVersion = appVersionMatch?.[1]?.trim();
+
+let errors = 0;
+
+if (chartVersion !== appVersion) {
+    console.error(`FAIL: Chart.yaml version (${chartVersion}) != package.json (${appVersion})`);
+    errors++;
+} else {
+    console.log(`Chart.yaml version: ${chartVersion} ✓`);
+}
+
+if (chartAppVersion !== appVersion) {
+    console.error(`FAIL: Chart.yaml appVersion (${chartAppVersion}) != package.json (${appVersion})`);
+    errors++;
+} else {
+    console.log(`Chart.yaml appVersion: ${chartAppVersion} ✓`);
+}
+
+// ─── Summary ─────────────────────────────────────────────────────────────
+
+if (errors > 0) {
+    console.error(`\n${errors} version drift(s) detected. Update deploy/helm/Chart.yaml to match package.json.`);
+    process.exit(1);
+} else {
+    console.log('\nAll versions aligned.');
+}

--- a/server/openapi/generator.ts
+++ b/server/openapi/generator.ts
@@ -8,6 +8,8 @@
 import { z } from 'zod';
 import { routes, type HttpMethod } from './route-registry';
 
+const APP_VERSION: string = (require('../../package.json') as { version: string }).version;
+
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 interface OpenApiInfo {
@@ -264,7 +266,7 @@ export function generateOpenApiSpec(options: GeneratorOptions = {}): OpenApiSpec
         openapi: '3.0.3',
         info: {
             title: 'Corvid Agent API',
-            version: '0.13.0',
+            version: APP_VERSION,
             description: 'AI agent framework with on-chain identity and messaging via AlgoChat on Algorand. Provides multi-agent orchestration, GitHub automation, workflow pipelines, and an agent marketplace.',
             license: {
                 name: 'MIT',


### PR DESCRIPTION
## Summary
- Update `deploy/helm/Chart.yaml` version and appVersion from 0.13.0 → 0.20.0 to match `package.json`
- Make `server/openapi/generator.ts` read version from `package.json` instead of hardcoding it
- Add `scripts/version-check.ts` CI script that detects version drift between package.json and Chart.yaml
- Add `version:check` step to CI workflow so drift is caught on every PR

## Test plan
- [x] `bun run version:check` passes (all versions aligned)
- [x] `bun x tsc --noEmit --skipLibCheck` passes
- [x] CI pipeline runs version check on this PR

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)