### PR TITLE
docs: update README and CHANGELOG stats for v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,24 +6,25 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - **Work pipeline v2** — parallel execution, task dependencies, and retry policies for work tasks (#793, #632)
-- **Governance v2** — proposals with weighted voting and quorum rules (#789, #633)
+- **Governance v2** — proposals with weighted voting, quorum rules, and proposal lifecycle (#789, #633)
 - **Encryption at rest** — encrypt env_vars using AES-256-GCM (#791)
 - **Container sandboxing** — integrate SandboxManager into ProcessManager with resource limits and network isolation (#786, #382)
 - **KeyProvider abstraction** — wallet encryption via pluggable KeyProvider interface (#772, #383)
 - **Bridge delivery receipts** — message delivery receipt tracking for bridge hardening (#780, #631)
-- **Security Overview dashboard** — new dashboard page for security posture visibility (#779)
+- **Security Overview dashboard** — new dashboard page showing live security posture (#779)
 - **Stats automation** — automated stats collection and drift detection (#792, #537)
 - **GH_TOKEN scope validation** — OAuth scope validation on server startup (#787)
 - **Discord passive channel mode** — threads via `/session` only, no unsolicited replies (#761)
 - **Council Discord notifications** — post council synthesis to Discord on completion (#766)
-- **Real-time session status** — live session status updates with silent death prevention (#775)
+- **Real-time session status** — live thinking/tool_use status with silent death prevention (#775)
 - **Telegram bridge hardening** — poll backoff and message deduplication (#762)
 
 ### Security
 - **Error message sanitization** — sanitize error messages in WS and AlgoChat handlers to prevent info leakage (#763)
+- **Auto-merge hardened** — security scan now comments instead of closing PRs, preventing accidental PR destruction (#784)
 
 ### Fixed
-- Document 7 undocumented exports in security and infra specs (#790)
+- Document undocumented exports in security, infra, and marketplace specs (#790, #801)
 - Prevent duplicate Discord messages and normalize coding-tool paths (#788)
 - Relax protected files and stop auto-closing PRs (#784)
 - Remove duplicate properties in playwright config (#770)
@@ -38,11 +39,11 @@ All notable changes to this project will be documented in this file.
 - Wait-sessions, tenant middleware, and plugin permissions coverage (#773)
 
 ### Documentation
+- API reference for workflows, councils, marketplace, reputation, and billing routes (#798)
 - TaskQueue design doc — prerequisite for work pipeline (#771)
 - Document all 17 remaining undocumented exports (#768)
 - Sync stale stats across README and doc files (#767)
 - Discord passive channel mode spec (#760)
-- Update version references to 0.20.0 (#745)
 
 ### Cross-Repo
 - **corvid-agent-chat:** toast, chat-messages, search coverage (+69 tests, #58); split chat.ts view (#57); device-name and wallet lifecycle coverage (+51, #56); wallet idle lock (#55); icon sizing fixes (#49, #52, #54)
@@ -50,11 +51,11 @@ All notable changes to this project will be documented in this file.
 - **corvid-reputation:** standardize git author identity in generate workflow (#1)
 
 ### Stats
-- **5,802** unit tests across 235 files (16,167 assertions)
+- **5,838** unit tests across 237 files (16,222 assertions)
 - **360** E2E tests across 31 Playwright specs
-- **112** module specs with automated validation
-- **38** MCP tools, **~200** API endpoints, **81** tables
-- **42** PRs merged across 4 repositories this week
+- **113** module specs with automated validation
+- **38** MCP tools, **~200** API endpoints, **42** route modules, **82** tables
+- **29** commits, **13** PRs merged this release
 
 ## [0.20.0] - 2026-03-07
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.20.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.21.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">
   <img src="https://img.shields.io/badge/Angular-21-dd0031?logo=angular" alt="Angular 21">
-  <img src="https://img.shields.io/badge/tests-5821%20unit%20%7C%20360%20E2E-brightgreen" alt="5725 Unit | 360 E2E Tests">
+  <img src="https://img.shields.io/badge/tests-5838%20unit%20%7C%20360%20E2E-brightgreen" alt="5838 Unit | 360 E2E Tests">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>
 </p>
 
@@ -20,11 +20,11 @@ See [VISION.md](VISION.md) for architecture, competitive positioning, and long-t
 
 | Metric | Count |
 |--------|-------|
-| Unit tests | **5,821** across 236 files (16,195 assertions) |
+| Unit tests | **5,838** across 237 files (16,222 assertions) |
 | E2E tests | **360** across 31 Playwright specs |
 | Module specs | **113** with automated validation |
 | MCP tools | **38** corvid_* tool handlers |
-| API endpoints | **~200** across 38 route modules |
+| API endpoints | **~200** across 42 route modules |
 | DB migrations | **24** (squashed baseline, 82 tables) |
 | Test:code ratio | **1.14×** — more test code than production code |
 


### PR DESCRIPTION
## Summary
- Update version badge to 0.21.0
- Update test counts (5,838 unit tests, 237 files, 16,222 assertions)
- Update route modules count (42)
- Add post-changelog PRs (#797, #798, #801) to CHANGELOG
- Add auto-merge hardening to security section
- Correct stats section

## Test plan
- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)