### PR TITLE
docs: sync stale counts and fix api-reference port

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ OPENAI_API_KEY=sk-...
 |                                                                 |
 |  +-----------------------------------------------------------+  |
 |  |                    SQLite (bun:sqlite)                     |  |
-|  |  21 migrations | FTS5 search | WAL mode | foreign keys    |  |
+|  |  25 migrations | FTS5 search | WAL mode | foreign keys    |  |
 |  +-----------------------------------------------------------+  |
 +-----------------------------------------------------------------+
 ```
@@ -317,7 +317,7 @@ server/          Bun HTTP + WebSocket server
   billing/       Usage metering and billing
   channels/      Channel adapter interfaces for messaging bridges
   councils/      Council discussion and synthesis engines
-  db/            SQLite schema (21 migrations) and query modules
+  db/            SQLite schema (25 migrations) and query modules
   discord/       Bidirectional Discord bridge (raw WebSocket gateway)
   docs/          OpenAPI generator, MCP tool docs, route registry
   events/        Event bus and WebSocket broadcasting
@@ -328,7 +328,7 @@ server/          Bun HTTP + WebSocket server
   improvement/   Self-improvement pipeline and health metrics
   lib/           Shared utilities (logger, crypto, validation, web search, dedup)
   marketplace/   Agent marketplace — publish, discover, consume services
-  mcp/           MCP tool server and 37 corvid_* tool handlers
+  mcp/           MCP tool server and 38 corvid_* tool handlers
   memory/        Structured memory with vector embeddings
   middleware/    Auth, CORS, rate limiting, startup validation
   notifications/ Multi-channel notification delivery (Discord, Telegram, GitHub, AlgoChat)
@@ -342,7 +342,7 @@ server/          Bun HTTP + WebSocket server
   providers/     Multi-model cost-aware routing
   public/        Static assets served by the HTTP server
   reputation/    Reputation and trust scoring
-  routes/        REST API routes (38 route modules)
+  routes/        REST API routes (42 route modules)
   sandbox/       Container sandboxing for isolated execution
   scheduler/     Cron/interval execution engine
   selftest/      Self-test and validation utilities
@@ -389,7 +389,7 @@ Tools are permission-scoped per agent via skill bundles and agent-level allowlis
 
 ## API
 
-~200 REST endpoints and a WebSocket interface across 38 route modules.
+~200 REST endpoints and a WebSocket interface across 42 route modules.
 
 **[API Reference](docs/api-reference.md)** — detailed docs with request/response examples for workflows, councils, marketplace, reputation, and billing.
 
@@ -447,17 +447,17 @@ Tools are permission-scoped per agent via skill bundles and agent-level allowlis
 ## Testing
 
 ```bash
-bun test              # 5725 server tests (~120s)
+bun test              # 5842 server tests (~120s)
 cd client && npx vitest run   # Angular component tests (~2s)
 bun run test:e2e      # 31 Playwright spec files, 360 tests
 bun run spec:check    # Validate all module specs in specs/
 ```
 
-**5,725 unit tests** covering: API routes, audit logging, authentication, bash security, billing, CLI, credit system, crypto, database migrations, Discord bridge, feedback loop, GitHub tools, health monitoring, marketplace, MCP tool handlers, notifications, multi-model routing, multi-tenant isolation, observability, owner communication, performance metrics, personas, plugins, process lifecycle, rate limiting, reputation, sandbox isolation, scheduling, skill bundles, Slack bridge, Telegram bridge, tenant isolation, usage monitoring, validation, voice TTS/STT, wallet keystore, web search, workflows, work tasks, and Angular components.
+**5,842 unit tests** covering: API routes, audit logging, authentication, bash security, billing, CLI, credit system, crypto, database migrations, Discord bridge, feedback loop, GitHub tools, health monitoring, marketplace, MCP tool handlers, notifications, multi-model routing, multi-tenant isolation, observability, owner communication, performance metrics, personas, plugins, process lifecycle, rate limiting, reputation, sandbox isolation, scheduling, skill bundles, Slack bridge, Telegram bridge, tenant isolation, usage monitoring, validation, voice TTS/STT, wallet keystore, web search, workflows, work tasks, and Angular components.
 
 **360 E2E tests** across 31 Playwright spec files covering 198/202 testable API endpoints and all 37 Angular UI routes.
 
-**111 module specs** in `specs/` with automated validation via `bun run spec:check` — checks YAML frontmatter, required sections, API surface coverage (exported symbols vs documented), file existence, database table references, and dependency graph integrity. Runs in CI on every commit.
+**113 module specs** in `specs/` with automated validation via `bun run spec:check` — checks YAML frontmatter, required sections, API surface coverage (exported symbols vs documented), file existence, database table references, and dependency graph integrity. Runs in CI on every commit.
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -49,7 +49,7 @@ DAG-based workflow orchestration. Define multi-step pipelines with agent session
 ### Create Workflow
 
 ```bash
-curl -X POST http://localhost:7777/api/workflows \
+curl -X POST http://localhost:3000/api/workflows \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -130,7 +130,7 @@ curl -X POST http://localhost:7777/api/workflows \
 ### Trigger Workflow
 
 ```bash
-curl -X POST http://localhost:7777/api/workflows/wf-abc123/trigger \
+curl -X POST http://localhost:3000/api/workflows/wf-abc123/trigger \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{ "input": { "branch": "feature/new-ui" } }'
@@ -152,7 +152,7 @@ curl -X POST http://localhost:7777/api/workflows/wf-abc123/trigger \
 
 ```bash
 # Pause a running workflow
-curl -X POST http://localhost:7777/api/workflow-runs/run-xyz789/action \
+curl -X POST http://localhost:3000/api/workflow-runs/run-xyz789/action \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{ "action": "pause" }'
@@ -192,7 +192,7 @@ Multi-agent deliberation with optional on-chain governance voting. Agents discus
 ### Create Council
 
 ```bash
-curl -X POST http://localhost:7777/api/councils \
+curl -X POST http://localhost:3000/api/councils \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -236,7 +236,7 @@ curl -X POST http://localhost:7777/api/councils \
 ### Launch Council Discussion
 
 ```bash
-curl -X POST http://localhost:7777/api/councils/council-abc/launch \
+curl -X POST http://localhost:3000/api/councils/council-abc/launch \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -260,7 +260,7 @@ curl -X POST http://localhost:7777/api/councils/council-abc/launch \
 ### Cast Governance Vote
 
 ```bash
-curl -X POST http://localhost:7777/api/council-launches/launch-xyz/vote \
+curl -X POST http://localhost:3000/api/council-launches/launch-xyz/vote \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -306,11 +306,15 @@ Agent marketplace with listings, reviews, usage tracking, and cross-instance fed
 | DELETE | `/api/marketplace/federation/instances/{url}` | Remove federation instance | owner |
 | POST | `/api/marketplace/federation/sync` | Sync federation instances | operator |
 | GET | `/api/marketplace/federated` | Get federated listings | any |
+| POST | `/api/marketplace/listings/{id}/subscribe` | Subscribe to listing | operator |
+| POST | `/api/marketplace/subscriptions/{id}/cancel` | Cancel subscription | operator |
+| GET | `/api/marketplace/subscriptions` | Get subscriptions by tenant | any |
+| GET | `/api/marketplace/listings/{id}/subscribers` | Get listing subscribers | any |
 
 ### Search Listings
 
 ```bash
-curl "http://localhost:7777/api/marketplace/search?q=security&category=security&minRating=4&limit=10" \
+curl "http://localhost:3000/api/marketplace/search?q=security&category=security&minRating=4&limit=10" \
   -H "Authorization: Bearer $API_KEY"
 ```
 
@@ -329,7 +333,7 @@ curl "http://localhost:7777/api/marketplace/search?q=security&category=security&
 ### Create Listing
 
 ```bash
-curl -X POST http://localhost:7777/api/marketplace/listings \
+curl -X POST http://localhost:3000/api/marketplace/listings \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -364,7 +368,7 @@ curl -X POST http://localhost:7777/api/marketplace/listings \
 ### Create Review
 
 ```bash
-curl -X POST http://localhost:7777/api/marketplace/listings/listing-abc/reviews \
+curl -X POST http://localhost:3000/api/marketplace/listings/listing-abc/reviews \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -398,7 +402,7 @@ Agent reputation scoring, event tracking, identity verification, and on-chain at
 ### Get Agent Score
 
 ```bash
-curl "http://localhost:7777/api/reputation/scores/agent-1?refresh=true" \
+curl "http://localhost:3000/api/reputation/scores/agent-1?refresh=true" \
   -H "Authorization: Bearer $API_KEY"
 ```
 
@@ -417,7 +421,7 @@ curl "http://localhost:7777/api/reputation/scores/agent-1?refresh=true" \
 ### Record Reputation Event
 
 ```bash
-curl -X POST http://localhost:7777/api/reputation/events \
+curl -X POST http://localhost:3000/api/reputation/events \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -433,7 +437,7 @@ curl -X POST http://localhost:7777/api/reputation/events \
 ### Set Identity Verification Tier
 
 ```bash
-curl -X PUT http://localhost:7777/api/reputation/identity/agent-1 \
+curl -X PUT http://localhost:3000/api/reputation/identity/agent-1 \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{ "tier": "GITHUB_VERIFIED", "dataHash": "abc123..." }'
@@ -462,7 +466,7 @@ Subscription management, usage tracking, invoices, and Stripe integration.
 ### Create Subscription
 
 ```bash
-curl -X POST http://localhost:7777/api/billing/subscription \
+curl -X POST http://localhost:3000/api/billing/subscription \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -490,7 +494,7 @@ curl -X POST http://localhost:7777/api/billing/subscription \
 ### Get Usage
 
 ```bash
-curl "http://localhost:7777/api/billing/usage/tenant-1" \
+curl "http://localhost:3000/api/billing/usage/tenant-1" \
   -H "Authorization: Bearer $API_KEY"
 ```
 
@@ -514,7 +518,7 @@ curl "http://localhost:7777/api/billing/usage/tenant-1" \
 ### Calculate Cost
 
 ```bash
-curl "http://localhost:7777/api/billing/calculate?credits=1000" \
+curl "http://localhost:3000/api/billing/calculate?credits=1000" \
   -H "Authorization: Bearer $API_KEY"
 ```
 

--- a/docs/decisions/002-task-queue-parallel-execution.md
+++ b/docs/decisions/002-task-queue-parallel-execution.md
@@ -275,7 +275,7 @@ Emitted when queue ordering changes (task completes, freeing a slot; new task en
 
 The `GET /api/work-tasks` response already returns an array. No structural change needed. Clients that assume only one active task per project need updating — but the API contract is already correct.
 
-### Queue Status Endpoint (new)
+### Queue Status Endpoint (proposed, not yet implemented)
 
 ```
 GET /api/work-tasks/queue-status → {


### PR DESCRIPTION
## Summary

- **README.md**: Update 7 stale numbers (migrations 21→25, MCP tools 37→38, route modules 38→42, unit tests 5725→5842, module specs 111→113)
- **api-reference.md**: Fix curl example port 7777→3000 (matches actual server default), add 4 missing marketplace subscription endpoints
- **ADR 002**: Mark `queue-status` endpoint as proposed/not-yet-implemented

Larger documentation gaps (detailed docs for agents, sessions, schedules, work-tasks, etc.) filed as #809.

## Test plan

- [x] `bun run spec:check` — 113/113 passed, 0 warnings
- [x] All numbers verified against actual codebase counts
- [x] Docs-only change, no code review required

🤖 Generated with [Claude Code](https://claude.com/claude-code)