### PR TITLE
docs: add spec coverage for algochat/init.ts and repo-blocklist handler

### DIFF
--- a/specs/algochat/bridge.spec.md
+++ b/specs/algochat/bridge.spec.md
@@ -4,6 +4,7 @@ version: 1
 status: active
 files:
   - server/algochat/bridge.ts
+  - server/algochat/init.ts
   - server/algochat/psk-contact-manager.ts
   - server/algochat/psk-discovery-poller.ts
   - server/algochat/message-router.ts
@@ -42,6 +43,15 @@ Central orchestrator for the AlgoChat on-chain messaging system. Bridges Algoran
 | `PSKContactManager` | Manages PSK (pre-shared key) encrypted contacts for agent-to-mobile communication |
 | `PSKDiscoveryPoller` | Polls blockchain for undiscovered PSK contact addresses via trial decryption |
 | `MessageRouter` | Routes incoming messages to appropriate handlers based on source and content |
+
+### Exported from init.ts
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `AlgoChatInitDeps` | Interface | Dependency bundle for AlgoChat initialization (db, services, config) |
+| `initAlgoChat` | Function | Initialize AlgoChat services: bridge, wallet, directory, messenger |
+| `switchNetwork` | Function | Switch AlgoChat to a different network (testnet/mainnet), tearing down and reinitializing |
+| `wirePostInit` | Function | Post-initialization wiring — messenger-dependent services and background service startup |
 
 #### AlgoChatBridge Constructor
 

--- a/specs/mcp/tool-handlers.spec.md
+++ b/specs/mcp/tool-handlers.spec.md
@@ -20,6 +20,7 @@ files:
   - server/mcp/tool-handlers/reputation.ts
   - server/mcp/tool-handlers/ast.ts
   - server/mcp/tool-handlers/councils.ts
+  - server/mcp/tool-handlers/repo-blocklist.ts
 db_tables: []
 depends_on:
   - specs/db/credits.spec.md
@@ -89,6 +90,7 @@ Implements every `corvid_*` MCP tool handler. Each exported function takes an `M
 | `handleCodeSymbols` | `(ctx, { project_id?, path?, query? })` | `Promise<CallToolResult>` | Search code symbols (functions, classes, types) in a project using AST parsing |
 | `handleFindReferences` | `(ctx, { project_id?, symbol, path? })` | `Promise<CallToolResult>` | Find references to a symbol across project files using AST parsing |
 | `handleLaunchCouncil` | `(ctx, { topic, agentIds?, chairmanAgentId?, discussionRounds?, governanceTier? })` | `Promise<CallToolResult>` | Launch a multi-agent council deliberation. Requires `processManager` in context |
+| `handleManageRepoBlocklist` | `(ctx, { action, repo?, reason?, source? })` | `Promise<CallToolResult>` | Manage the repo blocklist: list, add, remove, or check entries |
 
 ## Invariants
 
@@ -151,6 +153,7 @@ Implements every `corvid_*` MCP tool handler. Each exported function takes an `M
 | `server/lib/crypto.ts` | `encryptMemoryContent` |
 | `server/a2a/client.ts` | `discoverAgent`, `invokeRemoteAgent` |
 | `server/improvement/health-store.ts` | `getRecentSnapshots`, `computeTrends`, `formatTrendsForPrompt` |
+| `server/db/repo-blocklist.ts` | `listRepoBlocklist`, `addToRepoBlocklist`, `removeFromRepoBlocklist`, `isRepoBlocked` |
 
 ### Consumed By
 


### PR DESCRIPTION
## Summary
- Add `server/algochat/init.ts` to `specs/algochat/bridge.spec.md` with exported API documentation
- Add `server/mcp/tool-handlers/repo-blocklist.ts` to `specs/mcp/tool-handlers.spec.md` with handler signature and dependency

Closes #688

## Test plan
- [x] `bun run spec:check` — 115/115 passed, 0 warnings, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)