### PR TITLE
feat: agent-agnostic MCP support for Cursor, Copilot, OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,15 @@ bun run dev                 # → http://localhost:3000
 <p>
   <img src="https://img.shields.io/badge/Claude_Code-works-00e5ff?logo=anthropic" alt="Claude Code">
   <img src="https://img.shields.io/badge/Cursor-works-00e5ff" alt="Cursor">
+  <img src="https://img.shields.io/badge/GitHub_Copilot-works-00e5ff" alt="GitHub Copilot">
+  <img src="https://img.shields.io/badge/OpenCode-works-00e5ff" alt="OpenCode">
+  <img src="https://img.shields.io/badge/Codex_CLI-works-00e5ff" alt="Codex CLI">
   <img src="https://img.shields.io/badge/Ollama-works-00e5ff" alt="Ollama">
   <img src="https://img.shields.io/badge/MCP-38_tools-ff66c4" alt="MCP">
   <img src="https://img.shields.io/badge/A2A_Protocol-compatible-00ff88" alt="A2A">
 </p>
+
+Any MCP-compatible AI assistant can connect. See **[MCP setup guide](docs/mcp-setup.md)** for per-client instructions.
 
 ---
 
@@ -66,7 +71,7 @@ corvid-agent init --yes     # auto-detect Claude CLI / Ollama, skip prompts
 **Just want MCP tools in your editor?**
 
 ```bash
-corvid-agent init --mcp     # adds corvid-agent to Claude Code / Cursor
+corvid-agent init --mcp     # adds corvid-agent to Claude Code, Cursor, Copilot, etc.
 ```
 
 Server starts at `http://localhost:3000`. Dashboard included.

--- a/cli/commands/init.ts
+++ b/cli/commands/init.ts
@@ -191,6 +191,26 @@ export function copySkills(cwd: string): void {
     }
 }
 
+// ─── MCP Config Writer ──────────────────────────────────────────────────────
+
+function writeMcpConfig(filePath: string, mcpConfig: Record<string, unknown>): void {
+    let existing: Record<string, unknown> = {};
+    if (existsSync(filePath)) {
+        try {
+            existing = JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+        } catch { /* will overwrite */ }
+    }
+    const servers = (existing.mcpServers ?? {}) as Record<string, unknown>;
+    const merged = { ...existing, mcpServers: { ...servers, ...mcpConfig } };
+    const dir = dirname(filePath);
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+    const tmpPath = `${filePath}.${process.pid}.tmp`;
+    writeFileSync(tmpPath, JSON.stringify(merged, null, 2) + '\n', { mode: 0o600 });
+    renameSync(tmpPath, filePath);
+}
+
 // ─── MCP-Only Init ──────────────────────────────────────────────────────────
 
 async function initMcpOnly(_opts: { yes: boolean }): Promise<void> {
@@ -291,6 +311,22 @@ ${c.gray('Set up corvid-agent as an MCP server for Claude Code, Cursor, or other
         printSuccess(`MCP server added to ${c.gray(cursorMcpPath)}`);
     }
 
+    // Write VS Code / GitHub Copilot config if .vscode exists in cwd
+    const vscodeMcpPath = join(process.cwd(), '.vscode', 'mcp.json');
+    const vscodeDir = join(process.cwd(), '.vscode');
+    if (existsSync(vscodeDir)) {
+        writeMcpConfig(vscodeMcpPath, mcpConfig);
+        printSuccess(`MCP server added to ${c.gray(vscodeMcpPath)} (GitHub Copilot)`);
+    }
+
+    // Write OpenCode config if ~/.config/opencode exists
+    const openCodeConfigDir = join(homeDir, '.config', 'opencode');
+    if (existsSync(openCodeConfigDir)) {
+        const openCodeMcpPath = join(openCodeConfigDir, 'config.json');
+        writeMcpConfig(openCodeMcpPath, mcpConfig);
+        printSuccess(`MCP server added to ${c.gray(openCodeMcpPath)} (OpenCode)`);
+    }
+
     // Copy Agent Skills to project
     printHeader('Agent Skills');
     copySkills(process.cwd());
@@ -312,6 +348,19 @@ ${c.gray('Set up corvid-agent as an MCP server for Claude Code, Cursor, or other
         console.log(`  ${c.cyan('curl -fsSL https://getvibekit.ai/install | sh')}`);
     }
 
+    // Print manual setup snippets for clients we didn't auto-detect
+    const mcpSnippet = JSON.stringify(mcpConfig, null, 2);
+    const manualClients: string[] = [];
+    if (!existsSync(vscodeDir)) manualClients.push('VS Code / Copilot');
+    if (!existsSync(openCodeConfigDir)) manualClients.push('OpenCode');
+
+    if (manualClients.length > 0) {
+        printHeader('Other MCP Clients');
+        console.log(`  ${c.gray(`For ${manualClients.join(', ')} — add the following to your MCP config:`)}`);
+        console.log(`  ${c.gray('See docs/mcp-setup.md for per-client paths and details.')}\n`);
+        console.log(`  ${c.cyan(mcpSnippet.split('\n').join('\n  '))}\n`);
+    }
+
     console.log(`
 ${c.bold}${c.green('MCP setup complete!')}${c.reset}
 
@@ -322,10 +371,11 @@ ${c.bold}What you get:${c.reset}
 
 ${c.bold}Next steps:${c.reset}
   1. ${projectRoot ? `Start the server: ${c.cyan('bun run dev')}` : 'Start your corvid-agent server'}
-  2. Restart Claude Code / Cursor to pick up the new MCP config
+  2. Restart your editor to pick up the new MCP config
   3. Ask your AI assistant: ${c.gray('"List my agents"')} or ${c.gray('"Create a work task"')}
   ${hasVibeKit ? `4. Run ${c.cyan('vibekit init')} to add smart contract tools` : ''}
 ${c.gray('Config: ' + claudeConfigPath)}
+${c.gray('Setup guide: docs/mcp-setup.md')}
 `);
 }
 
@@ -663,7 +713,7 @@ ${c.bold}Next steps:${c.reset}
   ${c.cyan('corvid-agent demo')}    Run a self-contained demo
 
 ${c.bold}Use with AI editors:${c.reset}
-  ${c.cyan('corvid-agent init --mcp')}   Add MCP tools + Agent Skills to Claude Code / Cursor
+  ${c.cyan('corvid-agent init --mcp')}   Add MCP tools + Agent Skills to Claude Code, Cursor, Copilot, etc.
 
 ${c.gray('Docs: docs/quickstart.md  •  Dashboard: http://127.0.0.1:3000')}
 `);

--- a/docs/index.html
+++ b/docs/index.html
@@ -68,6 +68,9 @@
       <div class="hero__badges" style="margin-top: 32px; display: flex; gap: 12px; justify-content: center; flex-wrap: wrap;">
         <div class="chip chip--cyan" style="font-size: 8px; padding: 8px 14px;">Claude Code</div>
         <div class="chip chip--magenta" style="font-size: 8px; padding: 8px 14px;">Cursor</div>
+        <div class="chip chip--green" style="font-size: 8px; padding: 8px 14px;">GitHub Copilot</div>
+        <div class="chip chip--cyan" style="font-size: 8px; padding: 8px 14px;">OpenCode</div>
+        <div class="chip chip--magenta" style="font-size: 8px; padding: 8px 14px;">Codex CLI</div>
         <div class="chip chip--green" style="font-size: 8px; padding: 8px 14px;">MCP</div>
         <div class="chip chip--cyan" style="font-size: 8px; padding: 8px 14px;">GitHub Actions</div>
         <div class="chip chip--magenta" style="font-size: 8px; padding: 8px 14px;">Ollama</div>
@@ -253,7 +256,10 @@
 
 <span class="t-comment"># Run</span>
 <span class="t-prompt">$</span> bun dev          <span class="t-comment"># API server on :3000</span>
-<span class="t-prompt">$</span> bun dev:client   <span class="t-comment"># Angular UI on :4200</span></code></pre>
+<span class="t-prompt">$</span> bun dev:client   <span class="t-comment"># Angular UI on :4200</span>
+
+<span class="t-comment"># Add MCP tools to your AI editor</span>
+<span class="t-prompt">$</span> corvid-agent init --mcp   <span class="t-comment"># Claude Code, Cursor, Copilot, OpenCode, Codex</span></code></pre>
       </div>
     </div>
   </section>

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -1,0 +1,215 @@
+# MCP Setup Guide
+
+CorvidAgent exposes **38 MCP tools** (`corvid_*`) via standard [Model Context Protocol](https://modelcontextprotocol.io) stdio transport. This means it works with any MCP-compatible AI assistant.
+
+## Quick Setup
+
+```bash
+corvid-agent init --mcp
+```
+
+This auto-detects installed editors and writes the config for Claude Code, Cursor, VS Code / Copilot, and OpenCode.
+
+---
+
+## Per-Client Setup
+
+All clients use the same MCP server config. The only difference is where the config file lives.
+
+### Config Snippet
+
+**Local mode** (when running from the corvid-agent repo):
+
+```json
+{
+  "corvid-agent": {
+    "command": "bun",
+    "args": ["<path-to-repo>/server/mcp/stdio-server.ts"],
+    "env": {
+      "CORVID_API_URL": "http://127.0.0.1:3000"
+    }
+  }
+}
+```
+
+**Remote mode** (connecting to a running server):
+
+```json
+{
+  "corvid-agent": {
+    "command": "npx",
+    "args": ["-y", "corvid-agent-mcp"],
+    "env": {
+      "CORVID_AGENT_URL": "http://your-server:3000",
+      "CORVID_AGENT_API_KEY": "your-api-key"
+    }
+  }
+}
+```
+
+---
+
+### Claude Code
+
+**Config path:** `~/.claude/claude_desktop_config.json`
+
+Add the config snippet under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "corvid-agent": { ... }
+  }
+}
+```
+
+Restart Claude Code after editing.
+
+---
+
+### Cursor
+
+**Config path:** `~/.cursor/mcp.json`
+
+```json
+{
+  "mcpServers": {
+    "corvid-agent": { ... }
+  }
+}
+```
+
+Restart Cursor after editing.
+
+---
+
+### GitHub Copilot (VS Code)
+
+**Config path:** `.vscode/mcp.json` (per-project) or VS Code settings
+
+Create `.vscode/mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "corvid-agent": {
+      "command": "npx",
+      "args": ["-y", "corvid-agent-mcp"],
+      "env": {
+        "CORVID_AGENT_URL": "http://127.0.0.1:3000"
+      }
+    }
+  }
+}
+```
+
+Or add to VS Code settings (`settings.json`):
+
+```json
+{
+  "github.copilot.chat.mcp.servers": {
+    "corvid-agent": {
+      "command": "npx",
+      "args": ["-y", "corvid-agent-mcp"],
+      "env": {
+        "CORVID_AGENT_URL": "http://127.0.0.1:3000"
+      }
+    }
+  }
+}
+```
+
+Reload VS Code window after editing.
+
+---
+
+### OpenCode
+
+**Config path:** `~/.config/opencode/config.json` or `opencode.json` in project root
+
+```json
+{
+  "mcpServers": {
+    "corvid-agent": {
+      "command": "npx",
+      "args": ["-y", "corvid-agent-mcp"],
+      "env": {
+        "CORVID_AGENT_URL": "http://127.0.0.1:3000"
+      }
+    }
+  }
+}
+```
+
+---
+
+### Codex CLI
+
+**Config path:** `codex.json` in project root or `~/.codex/config.json`
+
+```json
+{
+  "mcpServers": {
+    "corvid-agent": {
+      "command": "npx",
+      "args": ["-y", "corvid-agent-mcp"],
+      "env": {
+        "CORVID_AGENT_URL": "http://127.0.0.1:3000"
+      }
+    }
+  }
+}
+```
+
+---
+
+### Any Other MCP Client
+
+CorvidAgent uses the standard MCP stdio transport. Any client that supports MCP can connect by running:
+
+```bash
+npx -y corvid-agent-mcp
+```
+
+with environment variables `CORVID_AGENT_URL` and optionally `CORVID_AGENT_API_KEY`.
+
+---
+
+## Troubleshooting
+
+### `bun` not found
+
+Some editors may not have `bun` in their PATH. Use `npx corvid-agent-mcp` instead of the local `bun server/mcp/stdio-server.ts` command.
+
+### Environment variables not passed
+
+Each editor handles env vars differently. If tools fail with "API error", check that:
+- `CORVID_AGENT_URL` or `CORVID_API_URL` points to a running server
+- `CORVID_AGENT_API_KEY` is set if the server requires auth (non-localhost)
+
+### Tools not appearing
+
+After editing the MCP config file:
+1. Restart the editor / reload the window
+2. Check the MCP server logs for errors
+3. Verify the server is running: `curl http://127.0.0.1:3000/api/health`
+
+### Which tools are available?
+
+The stdio server exposes 4 core tools: `corvid_send_message`, `corvid_save_memory`, `corvid_recall_memory`, `corvid_list_agents`.
+
+The full `corvid-agent-mcp` npm package exposes 14 tools including agents, sessions, work tasks, and projects.
+
+When connected via the web dashboard or Claude Agent SDK, all 38 tools are available.
+
+---
+
+## Agent Skills
+
+`corvid-agent init --mcp` also installs **Agent Skills** — markdown files that teach your AI assistant when and how to use each tool group. Skills are installed to:
+
+| Editor | Skills Path |
+|--------|------------|
+| Claude Code | `.claude/skills/` |
+| Cursor | `.cursor/rules/` |
+| VS Code / Copilot | `.github/skills/` |


### PR DESCRIPTION
## Summary

Implements agent-agnostic MCP support so corvid-agent works with any MCP-compatible AI assistant, not just Claude Code and Cursor.

- **Enhanced `init --mcp`**: Auto-detects and writes MCP config for VS Code / GitHub Copilot (`.vscode/mcp.json`) and OpenCode (`~/.config/opencode/config.json`). Prints manual config snippets for clients not auto-detected.
- **New `docs/mcp-setup.md`**: Per-client setup instructions for Claude Code, Cursor, GitHub Copilot, OpenCode, Codex CLI, and any other MCP-compatible assistant.
- **Updated landing page**: Added GitHub Copilot, OpenCode, and Codex CLI badges to the "Works With" hero section.
- **Updated README**: Added new badges and linked to the MCP setup guide.

Closes #832

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` — passes
- [x] `bun test` — 6,024 pass, 0 fail
- [x] `bun run spec:check` — 115/115 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)