### PR TITLE
fix: check PR author for Dependabot lockfile sync

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   lockfile-sync:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98  # v4.3.1


### PR DESCRIPTION
## Summary
- The lockfile-sync workflow was using `github.actor` to detect Dependabot PRs, but `github.actor` is whoever **triggered** the run (e.g., a human merging main), not the PR author
- Changed to `github.event.pull_request.user.login` which correctly identifies Dependabot as the PR author regardless of who triggers re-runs

Fixes the skipped lockfile-sync jobs on #824, #825, #826, #827.

## Test plan
- [ ] Merge this PR, then re-trigger CI on Dependabot PRs
- [ ] Verify `lockfile-sync` job runs (not skipped) and `Dependency Vulnerability Audit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)