### PR TITLE
fix: use staged diff for Dependabot lockfile change detection

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -30,20 +30,9 @@ jobs:
       - name: Regenerate lockfile
         run: bun install --ignore-scripts
 
-      - name: Check for lockfile changes
-        id: diff
-        run: |
-          if git diff --quiet bun.lockb; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Commit updated lockfile
-        if: steps.diff.outputs.changed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add bun.lockb
-          git commit -m "deps: regenerate bun.lockb for Dependabot update"
-          git push
+          git diff --cached --quiet && echo "No lockfile changes" || (git commit -m "deps: regenerate bun.lockb for Dependabot update" && git push)


### PR DESCRIPTION
## Summary
- `git diff --quiet bun.lockb` fails in shallow clones (default `fetch-depth: 1`) with "ambiguous argument" for binary files
- Replaced with: stage first via `git add`, then `git diff --cached --quiet` which reliably detects binary file changes
- Simplified from separate check + conditional commit steps into a single step

Fixes lockfile-sync failures on #824, #825, #826, #827.

## Test plan
- [ ] Merge and re-trigger CI on Dependabot PRs
- [ ] Verify lockfile-sync job succeeds and pushes regenerated lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)