### PR TITLE
fix: use correct lockfile name in Dependabot sync workflow

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,5 +1,5 @@
-# Auto-regenerate bun.lockb for Dependabot PRs
-# Dependabot can't update Bun's binary lockfile, so CI fails on --frozen-lockfile.
+# Auto-regenerate bun.lock for Dependabot PRs
+# Dependabot can't update Bun's lockfile, so CI fails on --frozen-lockfile.
 # This workflow regenerates the lockfile and pushes it back to the PR branch.
 
 name: Dependabot Lockfile Sync
@@ -34,5 +34,5 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add bun.lockb
-          git diff --cached --quiet && echo "No lockfile changes" || (git commit -m "deps: regenerate bun.lockb for Dependabot update" && git push)
+          git add bun.lock
+          git diff --cached --quiet && echo "No lockfile changes" || (git commit -m "deps: regenerate bun.lock for Dependabot update" && git push)


### PR DESCRIPTION
## Summary
- The Dependabot lockfile sync workflow referenced `bun.lockb` (legacy binary format)
- This repo uses `bun.lock` (text format), so `git add bun.lockb` failed with "pathspec did not match any files"
- Updated all references from `bun.lockb` to `bun.lock`

Fixes lockfile-sync failures on #824, #825, #826, #827.

## Test plan
- [ ] Merge and re-trigger CI on Dependabot PRs
- [ ] Verify lockfile-sync pushes the updated `bun.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)