### PR TITLE
fix: skip frozen-lockfile for Dependabot PRs in security scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,8 +42,15 @@ jobs:
         with:
           bun-version: "1.3.8"
 
+      # Skip --frozen-lockfile for Dependabot PRs: the lockfile-sync workflow
+      # pushes an updated lockfile but GITHUB_TOKEN pushes don't re-trigger CI.
       - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
+        run: |
+          if [ "${{ github.event.pull_request.user.login }}" = "dependabot[bot]" ]; then
+            bun install --ignore-scripts
+          else
+            bun install --frozen-lockfile --ignore-scripts
+          fi
 
       - name: Run security scanners
         run: bun scripts/ci-security-scan.ts
@@ -59,7 +66,12 @@ jobs:
           bun-version: "1.3.8"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
+        run: |
+          if [ "${{ github.event.pull_request.user.login }}" = "dependabot[bot]" ]; then
+            bun install --ignore-scripts
+          else
+            bun install --frozen-lockfile --ignore-scripts
+          fi
 
       - name: Audit dependencies
         run: bun x npm-audit-ci --moderate


### PR DESCRIPTION
## Summary
- The lockfile-sync workflow pushes an updated lockfile via `GITHUB_TOKEN`, but GitHub doesn't trigger new workflow runs from `GITHUB_TOKEN` pushes (prevents infinite loops)
- Security scans run in parallel with lockfile-sync against the pre-lockfile commit and fail on `--frozen-lockfile`
- Skip `--frozen-lockfile` for Dependabot PRs in both `code-scan` and `dep-audit` jobs — the lockfile is regenerated at install time anyway

This is the final piece needed to make Dependabot PRs pass CI (#824, #825, #826, #827).

## Test plan
- [ ] Merge this PR, then re-run failed security scans on Dependabot PRs
- [ ] Verify both `Malicious Code & Fetch Scan` and `Dependency Vulnerability Audit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)