### PR TITLE
feat: Discord onboarding flow for new users

### DIFF
--- a/server/__tests__/discord-bridge.test.ts
+++ b/server/__tests__/discord-bridge.test.ts
@@ -490,9 +490,12 @@ describe('DiscordBridge work_intake mode', () => {
             expect(input.source).toBe('discord');
             expect(input.sourceId).toBe('200000000000000001');
 
-            // Should have sent an embed acknowledgment
+            // Should have sent an embed acknowledgment (may also include first-interaction tip)
             expect(fetchBodies.length).toBeGreaterThanOrEqual(1);
-            const embedBody = fetchBodies.find((b: unknown) => (b as { embeds?: unknown[] }).embeds) as { embeds: Array<{ title: string }> } | undefined;
+            const embedBody = fetchBodies.find((b: unknown) => {
+                const embeds = (b as { embeds?: Array<{ title?: string }> }).embeds;
+                return embeds?.some(e => e.title === 'Task Queued');
+            }) as { embeds: Array<{ title: string }> } | undefined;
             expect(embedBody).toBeDefined();
             expect(embedBody!.embeds[0].title).toBe('Task Queued');
         } finally {
@@ -731,6 +734,142 @@ describe('DiscordBridge work_intake mode', () => {
             const textBody = fetchBodies.find((b: unknown) => (b as { content?: string }).content) as { content: string } | undefined;
             expect(textBody).toBeDefined();
             expect(textBody!.content).toContain('WorkTaskService');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+});
+
+describe('DiscordBridge onboarding', () => {
+    test('/help responds with embed containing command fields', async () => {
+        const pm = createMockProcessManager();
+        createAgent(db, { name: 'TestAgent' });
+        const config: DiscordBridgeConfig = {
+            botToken: 'test-token',
+            channelId: '100000000000000001',
+            allowedUserIds: [],
+            appId: '800000000000000001',
+        };
+        const bridge = new DiscordBridge(db, pm, config);
+
+        const fetchBodies: unknown[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+            if (init?.body) fetchBodies.push(JSON.parse(String(init.body)));
+            return new Response(JSON.stringify({}), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            await (bridge as unknown as { handleInteraction: (i: unknown) => Promise<void> }).handleInteraction({
+                id: '300000000000000001',
+                token: 'test-interaction-token-abcdef123456',
+                type: 2, // APPLICATION_COMMAND
+                channel_id: '100000000000000001',
+                data: { name: 'help' },
+                member: { user: { id: 'user-1' }, roles: [] },
+            });
+
+            expect(fetchBodies.length).toBe(1);
+            const body = fetchBodies[0] as { data: { embeds: Array<{ title: string; fields: Array<{ name: string }> }> } };
+            expect(body.data.embeds).toBeDefined();
+            expect(body.data.embeds[0].title).toBe('CorvidAgent Commands');
+            const fieldNames = body.data.embeds[0].fields.map((f: { name: string }) => f.name);
+            expect(fieldNames).toContain('Conversations');
+            expect(fieldNames).toContain('Information');
+            expect(fieldNames).toContain('Advanced');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test('/quickstart responds with welcome embed listing agents', async () => {
+        const pm = createMockProcessManager();
+        createAgent(db, { name: 'AlphaAgent' });
+        createAgent(db, { name: 'BetaAgent' });
+        const config: DiscordBridgeConfig = {
+            botToken: 'test-token',
+            channelId: '100000000000000001',
+            allowedUserIds: [],
+            appId: '800000000000000001',
+        };
+        const bridge = new DiscordBridge(db, pm, config);
+
+        const fetchBodies: unknown[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+            if (init?.body) fetchBodies.push(JSON.parse(String(init.body)));
+            return new Response(JSON.stringify({}), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            await (bridge as unknown as { handleInteraction: (i: unknown) => Promise<void> }).handleInteraction({
+                id: '300000000000000002',
+                token: 'test-interaction-token-quickstart789',
+                type: 2,
+                channel_id: '100000000000000001',
+                data: { name: 'quickstart' },
+                member: { user: { id: 'user-1' }, roles: [] },
+            });
+
+            expect(fetchBodies.length).toBe(1);
+            const body = fetchBodies[0] as { data: { embeds: Array<{ title: string; description: string; fields: Array<{ value: string }> }> } };
+            expect(body.data.embeds[0].title).toBe('Welcome to CorvidAgent!');
+            expect(body.data.embeds[0].description).toContain('/session');
+            // Should list agents in the field
+            expect(body.data.embeds[0].fields[0].value).toContain('AlphaAgent');
+            expect(body.data.embeds[0].fields[0].value).toContain('BetaAgent');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test('first-interaction tip is sent once on @mention', async () => {
+        const pm = createMockProcessManager();
+        createAgent(db, { name: 'TestAgent' });
+        const config: DiscordBridgeConfig = {
+            botToken: 'test-token',
+            channelId: '100000000000000001',
+            allowedUserIds: [],
+        };
+        const bridge = new DiscordBridge(db, pm, config);
+        setBotUserId(bridge, '999000000000000001');
+
+        const fetchBodies: unknown[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+            if (init?.body) fetchBodies.push(JSON.parse(String(init.body)));
+            return new Response(JSON.stringify({}), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        try {
+            const msg = {
+                id: '200000000000000010',
+                channel_id: '100000000000000001',
+                author: { id: 'new-user-1', username: 'NewUser' },
+                content: '<@999000000000000001> Hello!',
+                timestamp: new Date().toISOString(),
+                mentions: [{ id: '999000000000000001', username: 'CorvidBot' }],
+            };
+
+            // First interaction — should send welcome tip
+            await (bridge as unknown as { handleMessage: (m: unknown) => Promise<void> }).handleMessage(msg);
+            const welcomeEmbed = fetchBodies.find((b: unknown) => {
+                const embeds = (b as { embeds?: Array<{ footer?: { text: string } }> }).embeds;
+                return embeds?.some(e => e.footer?.text === 'This tip only appears once');
+            });
+            expect(welcomeEmbed).toBeDefined();
+
+            // Second interaction — no welcome tip
+            fetchBodies.length = 0;
+            await (bridge as unknown as { handleMessage: (m: unknown) => Promise<void> }).handleMessage({
+                ...msg,
+                id: '200000000000000011',
+            });
+            const secondWelcome = fetchBodies.find((b: unknown) => {
+                const embeds = (b as { embeds?: Array<{ footer?: { text: string } }> }).embeds;
+                return embeds?.some(e => e.footer?.text === 'This tip only appears once');
+            });
+            expect(secondWelcome).toBeUndefined();
         } finally {
             globalThis.fetch = originalFetch;
         }

--- a/server/discord/bridge.ts
+++ b/server/discord/bridge.ts
@@ -89,6 +89,9 @@ export class DiscordBridge {
     /** Users muted from bot interactions (admin-managed). */
     private mutedUsers: Set<string> = new Set();
 
+    /** Users who have interacted at least once — used for first-interaction welcome tips. */
+    private interactedUsers: Set<string> = new Set();
+
     /** Debounce timer for updateSlashCommands — coalesces rapid agent changes. */
     private slashCommandDebounceTimer: ReturnType<typeof setTimeout> | null = null;
     private static readonly SLASH_COMMAND_DEBOUNCE_MS = 2_000;
@@ -281,6 +284,11 @@ export class DiscordBridge {
                     type: 3, // STRING
                     required: true,
                 }],
+            },
+            {
+                name: 'quickstart',
+                description: 'Guided walkthrough for new users',
+                type: 1,
             },
             {
                 name: 'help',
@@ -559,20 +567,79 @@ export class DiscordBridge {
                 break;
             }
 
-            case 'help': {
-                const helpText = [
-                    '**Commands:**',
-                    '`/session` — Start a new conversation thread (select agent + topic)',
-                    '`/agents` — List all available agents',
-                    '`/status` — Show bot status and active sessions',
-                    '`/council <topic>` — Launch a council deliberation',
-                    '`/mute <user>` — Mute a user from bot interactions (admin)',
-                    '`/unmute <user>` — Unmute a user (admin)',
-                    '`/help` — Show this help message',
+            case 'quickstart': {
+                const agents = listAgents(this.db);
+                const agentCount = agents.length;
+                const firstAgent = agents[0]?.name ?? 'your agent';
+
+                const steps = [
+                    '**1. Start a session**',
+                    `Use \`/session\` to pick an agent and topic. ${agentCount > 0 ? `Try \`/session ${firstAgent} Hello!\`` : 'Set up an agent first in the dashboard.'}`,
                     '',
-                    'You can also @mention the bot for a quick one-off reply.',
+                    '**2. Chat in the thread**',
+                    'A new thread is created for your conversation. Send messages and the agent will respond.',
+                    '',
+                    '**3. Quick one-off replies**',
+                    `@mention the bot in the channel for a fast reply without creating a thread.`,
+                    '',
+                    '**4. Explore commands**',
+                    'Use `/help` to see all available commands and what they do.',
                 ].join('\n');
-                await this.respondToInteraction(interaction, helpText);
+
+                await this.respondToInteractionEmbed(interaction, {
+                    title: 'Welcome to CorvidAgent!',
+                    description: steps,
+                    color: 0x5865f2, // Discord blurple
+                    fields: [
+                        {
+                            name: 'Available Agents',
+                            value: agentCount > 0
+                                ? agents.slice(0, 5).map(a => `\`${a.name}\` — ${a.model || 'unknown'}`).join('\n')
+                                    + (agentCount > 5 ? `\n_...and ${agentCount - 5} more (use \`/agents\`)_` : '')
+                                : '_No agents configured yet — check the dashboard._',
+                            inline: false,
+                        },
+                    ],
+                    footer: { text: 'Use /help to see all commands' },
+                });
+                break;
+            }
+
+            case 'help': {
+                await this.respondToInteractionEmbed(interaction, {
+                    title: 'CorvidAgent Commands',
+                    color: 0x5865f2, // Discord blurple
+                    fields: [
+                        {
+                            name: 'Conversations',
+                            value: [
+                                '`/session <agent> <topic>` — Start a threaded conversation',
+                                '`/quickstart` — Guided walkthrough for new users',
+                                '`@mention` — Quick one-off reply in channel',
+                            ].join('\n'),
+                            inline: false,
+                        },
+                        {
+                            name: 'Information',
+                            value: [
+                                '`/agents` — List all available agents and models',
+                                '`/status` — Show active sessions and bot status',
+                                '`/help` — Show this help message',
+                            ].join('\n'),
+                            inline: false,
+                        },
+                        {
+                            name: 'Advanced',
+                            value: [
+                                '`/council <topic>` — Launch a multi-agent council deliberation',
+                                '`/mute <user>` — Mute a user (admin)',
+                                '`/unmute <user>` — Unmute a user (admin)',
+                            ].join('\n'),
+                            inline: false,
+                        },
+                    ],
+                    footer: { text: 'New here? Try /quickstart for a guided walkthrough' },
+                });
                 break;
             }
 
@@ -718,6 +785,46 @@ export class DiscordBridge {
         if (!response.ok) {
             const error = await response.text();
             log.error('Failed to acknowledge button', { status: response.status, error: error.slice(0, 200) });
+        }
+    }
+
+    /**
+     * Respond to an interaction with a rich embed (optionally ephemeral).
+     */
+    private async respondToInteractionEmbed(
+        interaction: DiscordInteractionData,
+        embed: {
+            title?: string;
+            description?: string;
+            color?: number;
+            fields?: Array<{ name: string; value: string; inline?: boolean }>;
+            footer?: { text: string };
+        },
+        ephemeral = false,
+    ): Promise<void> {
+        assertSnowflake(interaction.id, 'interaction ID');
+        assertInteractionToken(interaction.token);
+        const response = await fetch(
+            `https://discord.com/api/v10/interactions/${interaction.id}/${interaction.token}/callback`,
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    type: InteractionCallbackType.CHANNEL_MESSAGE,
+                    data: {
+                        embeds: [embed],
+                        ...(ephemeral ? { flags: 64 } : {}),
+                    },
+                }),
+            },
+        );
+
+        if (!response.ok) {
+            const error = await response.text();
+            log.error('Failed to respond to Discord interaction with embed', {
+                status: response.status,
+                error: error.slice(0, 200),
+            });
         }
     }
 
@@ -871,6 +978,25 @@ export class DiscordBridge {
         log.info('User unmuted from Discord bot', { userId });
     }
 
+    /**
+     * Send a one-time welcome tip to a user on their first interaction.
+     * Fire-and-forget — does not block the message flow.
+     */
+    private sendFirstInteractionTip(userId: string, channelId: string): void {
+        if (this.interactedUsers.has(userId)) return;
+        this.interactedUsers.add(userId);
+        this.sendEmbed(channelId, {
+            description: [
+                `Hey <@${userId}>! Looks like your first time here.`,
+                '',
+                'Use `/quickstart` for a guided walkthrough, or `/help` to see all commands.',
+                'You can also @mention me for a quick reply!',
+            ].join('\n'),
+            color: 0x57f287, // green
+            footer: { text: 'This tip only appears once' },
+        }).catch(() => {});
+    }
+
     private async handleMessage(data: DiscordMessageData): Promise<void> {
         // Ignore bot messages
         if (data.author.bot) return;
@@ -933,6 +1059,7 @@ export class DiscordBridge {
 
         // If this message is in a thread we're tracking, route to that thread's session
         if (isOurThread) {
+            this.sendFirstInteractionTip(userId, channelId);
             // Acknowledge receipt with reaction and show typing
             this.addReaction(channelId, data.id, '%F0%9F%91%80').catch(() => {}); // 👀
             this.sendTypingIndicator(channelId).catch(() => {});
@@ -946,6 +1073,9 @@ export class DiscordBridge {
             : false;
 
         if (!isBotMentioned) return; // silently ignore regular channel messages
+
+        // First-interaction welcome tip for @mention users
+        this.sendFirstInteractionTip(userId, channelId);
 
         // Acknowledge with reaction and typing indicator
         this.addReaction(channelId, data.id, '%F0%9F%91%80').catch(() => {}); // 👀


### PR DESCRIPTION
## Summary
- Add `/quickstart` slash command with guided walkthrough (lists agents, step-by-step usage tips)
- Upgrade `/help` from plain text to rich embeds with categorized command groups (Conversations, Information, Advanced)
- Add first-interaction detection: sends a one-time welcome tip embed on a user's first @mention or thread message
- Add `respondToInteractionEmbed` method for sending embed responses to slash commands
- 3 new tests covering `/help` embed, `/quickstart` embed, and first-interaction tip behavior

Closes #890

## Test plan
- [x] All 6327 tests pass (0 fail)
- [x] TypeScript compiles with no errors
- [x] Spec check: 115/115 passed
- [x] Manual test: `/help` shows rich embed with 3 field categories
- [x] Manual test: `/quickstart` shows welcome embed with agent list
- [x] Manual test: First message in channel triggers welcome tip once only

🤖 Generated with [Claude Code](https://claude.com/claude-code)