### PR TITLE
fix: remove eyes reaction on Discord message receipt

### DIFF
--- a/server/discord/bridge.ts
+++ b/server/discord/bridge.ts
@@ -1060,8 +1060,7 @@ export class DiscordBridge {
         // If this message is in a thread we're tracking, route to that thread's session
         if (isOurThread) {
             this.sendFirstInteractionTip(userId, channelId);
-            // Acknowledge receipt with reaction and show typing
-            this.addReaction(channelId, data.id, '%F0%9F%91%80').catch(() => {}); // 👀
+            // Acknowledge receipt with typing indicator
             this.sendTypingIndicator(channelId).catch(() => {});
             await this.routeToThread(channelId, userId, text);
             return;
@@ -1077,8 +1076,7 @@ export class DiscordBridge {
         // First-interaction welcome tip for @mention users
         this.sendFirstInteractionTip(userId, channelId);
 
-        // Acknowledge with reaction and typing indicator
-        this.addReaction(channelId, data.id, '%F0%9F%91%80').catch(() => {}); // 👀
+        // Acknowledge with typing indicator
         this.sendTypingIndicator(channelId).catch(() => {});
 
         // Handle @mention as one-off reply or work intake

--- a/specs/discord/bridge.spec.md
+++ b/specs/discord/bridge.spec.md
@@ -151,7 +151,7 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 27. **Smart message splitting**: Messages are split at natural boundaries (paragraphs, then sentences, then words). Code blocks are never split mid-block — oversized code blocks get their own opening/closing fences per chunk. Embed descriptions use 4096-char limit, plain messages use 2000-char limit. Implemented in `message-formatter.ts`
 28. **Content extraction**: Assistant responses use `extractContentText()` to properly handle both string and `ContentBlock[]` formats
 29. **Typing indicators**: A typing indicator is sent when a message is received and periodically refreshed (every 8s) while the agent is responding, since Discord typing indicators expire after ~10 seconds
-30. **Message reactions**: The bot reacts with 👀 when a message is received (before processing). Thread titles are updated with a ✓ prefix when the session completes
+30. **Message reactions**: Thread titles are updated with a ✓ prefix when the session completes
 31. **Stale thread auto-archive**: Threads inactive for 2 hours are automatically archived with a closing message. The stale check runs every 10 minutes. Thread sessions and subscriptions are cleaned up on archive
 
 ### Commands


### PR DESCRIPTION
## Summary
- Remove the 👀 reaction that was added to every incoming Discord message before processing
- The typing indicator alone is sufficient acknowledgement — the reaction was noisy
- Updates bridge spec accordingly

## Test plan
- [x] Spec check passes (115/115)
- [x] TSC clean
- [ ] Verify in Discord that messages no longer get 👀 reaction
- [ ] Confirm typing indicator still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)