### PR TITLE
fix: persist Discord interacted users to DB across restarts

### DIFF
--- a/server/db/discord-config.ts
+++ b/server/db/discord-config.ts
@@ -33,6 +33,8 @@ export interface DiscordDynamicConfig {
     statusText: string;
     /** Activity type (0=Playing, 1=Streaming, 2=Listening, 3=Watching, 5=Competing) */
     activityType: number;
+    /** Discord user IDs who have interacted at least once (comma-separated in DB) */
+    interactedUsers: string[];
 }
 
 // ─── Config helpers ───────────────────────────────────────────────────────
@@ -48,6 +50,7 @@ const DEFAULTS: DiscordDynamicConfig = {
     rateLimitByLevel: {},
     statusText: 'corvid-agent',
     activityType: 3,
+    interactedUsers: [],
 };
 
 function parseCommaSeparated(value: string | undefined): string[] {
@@ -85,6 +88,7 @@ export function getDiscordConfig(db: Database): DiscordDynamicConfig {
         rateLimitByLevel: parseJsonOrDefault(map.get('rate_limit_by_level'), DEFAULTS.rateLimitByLevel),
         statusText: map.get('status_text') ?? DEFAULTS.statusText,
         activityType: parseInt(map.get('activity_type') ?? String(DEFAULTS.activityType), 10),
+        interactedUsers: parseCommaSeparated(map.get('interacted_users')),
     };
 }
 

--- a/server/discord/bridge.ts
+++ b/server/discord/bridge.ts
@@ -21,7 +21,7 @@ import { extractContentText } from '../process/types';
 import { recordAudit } from '../db/audit';
 import { getDeliveryTracker, type DeliveryTracker } from '../lib/delivery-tracker';
 import { splitMessage, splitEmbedDescription } from './message-formatter';
-import { getDiscordConfig } from '../db/discord-config';
+import { getDiscordConfig, updateDiscordConfig } from '../db/discord-config';
 
 const log = createLogger('DiscordBridge');
 
@@ -204,6 +204,13 @@ export class DiscordBridge {
 
             // Update bot presence if status/activity changed
             this.gateway.updatePresence(dbConfig.statusText, dbConfig.activityType);
+
+            // Load persisted interacted users (only merge in — never remove from memory)
+            if (dbConfig.interactedUsers.length > 0) {
+                for (const uid of dbConfig.interactedUsers) {
+                    this.interactedUsers.add(uid);
+                }
+            }
         } catch (err) {
             log.warn('Failed to reload Discord config from DB', {
                 error: err instanceof Error ? err.message : String(err),
@@ -985,6 +992,8 @@ export class DiscordBridge {
     private sendFirstInteractionTip(userId: string, channelId: string): void {
         if (this.interactedUsers.has(userId)) return;
         this.interactedUsers.add(userId);
+        // Persist to DB so the tip survives restarts
+        this.persistInteractedUsers();
         this.sendEmbed(channelId, {
             description: [
                 `Hey <@${userId}>! Looks like your first time here.`,
@@ -995,6 +1004,17 @@ export class DiscordBridge {
             color: 0x57f287, // green
             footer: { text: 'This tip only appears once' },
         }).catch(() => {});
+    }
+
+    /** Persist the interactedUsers set to the discord_config table. */
+    private persistInteractedUsers(): void {
+        try {
+            updateDiscordConfig(this.db, 'interacted_users', [...this.interactedUsers].join(','));
+        } catch (err) {
+            log.warn('Failed to persist interacted users', {
+                error: err instanceof Error ? err.message : String(err),
+            });
+        }
     }
 
     private async handleMessage(data: DiscordMessageData): Promise<void> {


### PR DESCRIPTION
## Summary
- Persist the Discord onboarding `interactedUsers` set to the `discord_config` DB table so the first-interaction tip is not re-shown after a server restart
- On config reload, merge persisted user IDs back into the in-memory set (additive only — never removes)
- Adds `interactedUsers` field to `DiscordDynamicConfig` interface with proper defaults

## Test plan
- [x] Verify first-interaction tip is sent on first message from a new user
- [x] Restart the server and confirm the tip is NOT re-sent to the same user
- [x] Check `discord_config` table for `interacted_users` key after a tip is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)