### PR TITLE
feat: Discord /admin commands + release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.24.0] - 2026-03-10
+
+### Added
+- **Discord `/admin` commands** — manage bot configuration directly from Discord using native mentions. Subcommands: `channels add/remove/list` (#channel mentions), `users add/remove/list` (@user mentions), `roles set/remove/list` (@role mentions with permission level dropdown), `mode` (chat/work_intake toggle), `public` (role-based access toggle), `show` (full config summary). All mutations audit-logged and persisted to `discord_config` table with 30s hot-reload
+- **Discord `/work` command** — fire-and-forget work task creation from Discord with rich embed confirmations, @mention notifications on completion/failure, and PR link delivery
+- **AlgoChat `/work` improvements** — `--project` flag for project targeting, clear status indicators, PR URL in completion messages
+- **Project discovery MCP tools** — `corvid_list_projects` and `corvid_current_project` tools for agent project awareness
+- **RC verification script** — `scripts/verify-rc.sh` for release candidate validation and mainnet config template
+
+### Changed
+- **Discord bridge spec v8** — `/admin` command fully documented with subcommand groups, recursive `DiscordInteractionOption` type
+- **AlgoChat commands spec v2** — `--project` flag, behavioral examples for project resolution
+
+### Tests
+- 20 new tests for `/admin` command handlers (channels, users, roles, mode, public, show)
+- Discord `/work` and AlgoChat `/work` spec coverage
+
+### Stats
+- **6,347** unit tests across 262 files (17,499 assertions)
+- **360** E2E tests across 31 Playwright specs
+- **115** module specs with automated validation (0 warnings)
+- **41** MCP tools, **~205** API endpoints, **44** route modules, **90** tables
+- **4** commits, **2** PRs merged this release
+
 ## [0.23.2] - 2026-03-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.23.2-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.24.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">
   <img src="https://img.shields.io/badge/Angular-21-dd0031?logo=angular" alt="Angular 21">
-  <img src="https://img.shields.io/badge/tests-6327%20unit%20%7C%20360%20E2E-brightgreen" alt="6215 Unit | 360 E2E Tests">
+  <img src="https://img.shields.io/badge/tests-6347%20unit%20%7C%20360%20E2E-brightgreen" alt="6215 Unit | 360 E2E Tests">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>
 </p>
 

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: corvid-agent
 description: Agent orchestration platform with MCP tools, AlgoChat messaging, and on-chain wallet integration
 type: application
-version: 0.23.2
-appVersion: "0.23.2"
+version: 0.24.0
+appVersion: "0.24.0"
 keywords:
   - ai
   - agent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",

--- a/server/__tests__/discord-admin-commands.test.ts
+++ b/server/__tests__/discord-admin-commands.test.ts
@@ -1,0 +1,452 @@
+import { test, expect, describe, mock, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import { DiscordBridge } from '../discord/bridge';
+import type { DiscordBridgeConfig } from '../discord/types';
+import { getDiscordConfigRaw } from '../db/discord-config';
+
+function createMockProcessManager() {
+    return {
+        getActiveSessionIds: () => [] as string[],
+        startProcess: mock(() => {}),
+        sendMessage: mock(() => true),
+        subscribe: mock(() => {}),
+        unsubscribe: mock(() => {}),
+        resumeProcess: mock(() => {}),
+    } as unknown as import('../process/manager').ProcessManager;
+}
+
+let db: Database;
+let originalFetch: typeof globalThis.fetch;
+let fetchBodies: unknown[];
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+
+    fetchBodies = [];
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+        if (init?.body) fetchBodies.push(JSON.parse(String(init.body)));
+        return new Response(JSON.stringify({}), { status: 200 });
+    }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+    db.close();
+});
+
+function createBridge(overrides?: Partial<DiscordBridgeConfig>) {
+    const pm = createMockProcessManager();
+    const config: DiscordBridgeConfig = {
+        botToken: 'test-token',
+        channelId: '100000000000000001',
+        allowedUserIds: ['200000000000000001'], // admin user
+        appId: '800000000000000001',
+        ...overrides,
+    };
+    return new DiscordBridge(db, pm, config);
+}
+
+function callInteraction(bridge: DiscordBridge, data: unknown) {
+    return (bridge as unknown as { handleInteraction: (i: unknown) => Promise<void> }).handleInteraction(data);
+}
+
+function makeInteraction(commandName: string, options: unknown[], userId = '200000000000000001') {
+    return {
+        id: '300000000000000001',
+        token: 'test-interaction-token-admin-abcdef',
+        type: 2, // APPLICATION_COMMAND
+        channel_id: '100000000000000001',
+        data: { name: commandName, options },
+        member: { user: { id: userId, username: 'Admin' }, roles: [] },
+    };
+}
+
+function getResponseText(): string {
+    if (fetchBodies.length === 0) return '';
+    const body = fetchBodies[0] as { data?: { content?: string; embeds?: Array<{ title?: string; description?: string }> } };
+    return body.data?.content ?? body.data?.embeds?.[0]?.description ?? body.data?.embeds?.[0]?.title ?? '';
+}
+
+function getResponseEmbed() {
+    if (fetchBodies.length === 0) return null;
+    const body = fetchBodies[0] as { data?: { embeds?: Array<Record<string, unknown>> } };
+    return body.data?.embeds?.[0] ?? null;
+}
+
+describe('/admin commands', () => {
+    test('rejects non-admin users', async () => {
+        const bridge = createBridge();
+
+        await callInteraction(bridge, makeInteraction('admin', [
+            { name: 'show', type: 1 },
+        ], '999000000000000001')); // non-admin user
+
+        expect(getResponseText()).toContain('permission');
+    });
+
+    // ── Channels ──────────────────────────────────────────────────────
+
+    describe('channels', () => {
+        test('add channel persists to DB', async () => {
+            const bridge = createBridge();
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                {
+                    name: 'channels', type: 2, options: [
+                        { name: 'add', type: 1, options: [{ name: 'channel', type: 7, value: '400000000000000001' }] },
+                    ],
+                },
+            ]));
+
+            const embed = getResponseEmbed();
+            expect(embed?.title).toBe('Channel Added');
+
+            const raw = getDiscordConfigRaw(db);
+            expect(raw['additional_channel_ids']).toBe('400000000000000001');
+        });
+
+        test('add duplicate channel shows already monitored', async () => {
+            const bridge = createBridge({ additionalChannelIds: ['400000000000000001'] });
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                {
+                    name: 'channels', type: 2, options: [
+                        { name: 'add', type: 1, options: [{ name: 'channel', type: 7, value: '400000000000000001' }] },
+                    ],
+                },
+            ]));
+
+            expect(getResponseText()).toContain('already monitored');
+        });
+
+        test('add primary channel rejects', async () => {
+            const bridge = createBridge();
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                {
+                    name: 'channels', type: 2, options: [
+                        { name: 'add', type: 1, options: [{ name: 'channel', type: 7, value: '100000000000000001' }] },
+                    ],
+                },
+            ]));
+
+            expect(getResponseText()).toContain('primary channel');
+        });
+
+        test('remove channel persists to DB', async () => {
+            const bridge = createBridge({ additionalChannelIds: ['400000000000000001', '400000000000000002'] });
+            // Seed the DB so we can verify the update
+            db.prepare('INSERT OR REPLACE INTO discord_config (key, value, updated_at) VALUES (?, ?, datetime(\'now\'))').run(
+                'additional_channel_ids', '400000000000000001,400000000000000002',
+            );
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                {
+                    name: 'channels', type: 2, options: [
+                        { name: 'remove', type: 1, options: [{ name: 'channel', type: 7, value: '400000000000000001' }] },
+                    ],
+                },
+            ]));
+
+            const embed = getResponseEmbed();
+            expect(embed?.title).toBe('Channel Removed');
+
+            const raw = getDiscordConfigRaw(db);
+            expect(raw['additional_channel_ids']).toBe('400000000000000002');
+        });
+
+        test('remove non-existent channel shows not in list', async () => {
+            const bridge = createBridge();
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                {
+                    name: 'channels', type: 2, options: [
+                        { name: 'remove', type: 1, options: [{ name: 'channel', type: 7, value: '400000000000000099' }] },
+                    ],
+                },
+            ]));
+
+            expect(getResponseText()).toContain('not in the monitored list');
+        });
+
+        test('list shows all channels', async () => {
+            const bridge = createBridge({ additionalChannelIds: ['400000000000000001'] });
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                {
+                    name: 'channels', type: 2, options: [
+                        { name: 'list', type: 1 },
+                    ],
+                },
+            ]));
+
+            const embed = getResponseEmbed();
+            expect(embed?.title).toBe('Monitored Channels');
+            expect(String(embed?.description)).toContain('primary');
+        });
+    });
+
+    // ── Users ─────────────────────────────────────────────────────────
+
+    describe('users', () => {
+        test('add user persists to DB', async () => {
+            const bridge = createBridge();
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                {
+                    name: 'users', type: 2, options: [
+                        { name: 'add', type: 1, options: [{ name: 'user', type: 6, value: '500000000000000001' }] },
+                    ],
+                },
+            ]));
+
+            const embed = getResponseEmbed();
+            expect(embed?.title).toBe('User Added');
+
+            const raw = getDiscordConfigRaw(db);
+            expect(raw['allowed_user_ids']).toContain('500000000000000001');
+        });
+
+        test('add duplicate user shows already on list', async () => {
+            const bridge = createBridge({ allowedUserIds: ['200000000000000001', '500000000000000001'] });
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                {
+                    name: 'users', type: 2, options: [
+                        { name: 'add', type: 1, options: [{ name: 'user', type: 6, value: '500000000000000001' }] },
+                    ],
+                },
+            ]));
+
+            expect(getResponseText()).toContain('already on the allow list');
+        });
+
+        test('remove user persists to DB', async () => {
+            const bridge = createBridge({ allowedUserIds: ['200000000000000001', '500000000000000001'] });
+            db.prepare('INSERT OR REPLACE INTO discord_config (key, value, updated_at) VALUES (?, ?, datetime(\'now\'))').run(
+                'allowed_user_ids', '200000000000000001,500000000000000001',
+            );
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                {
+                    name: 'users', type: 2, options: [
+                        { name: 'remove', type: 1, options: [{ name: 'user', type: 6, value: '500000000000000001' }] },
+                    ],
+                },
+            ]));
+
+            const embed = getResponseEmbed();
+            expect(embed?.title).toBe('User Removed');
+
+            const raw = getDiscordConfigRaw(db);
+            expect(raw['allowed_user_ids']).toBe('200000000000000001');
+        });
+
+        test('list users shows allow list and mode', async () => {
+            const bridge = createBridge({ allowedUserIds: ['200000000000000001'] });
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                {
+                    name: 'users', type: 2, options: [
+                        { name: 'list', type: 1 },
+                    ],
+                },
+            ]));
+
+            const embed = getResponseEmbed();
+            expect(embed?.title).toBe('Allowed Users');
+        });
+    });
+
+    // ── Roles ─────────────────────────────────────────────────────────
+
+    describe('roles', () => {
+        test('set role permission persists to DB', async () => {
+            const bridge = createBridge();
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                {
+                    name: 'roles', type: 2, options: [
+                        {
+                            name: 'set', type: 1, options: [
+                                { name: 'role', type: 8, value: '600000000000000001' },
+                                { name: 'level', type: 4, value: 2 },
+                            ],
+                        },
+                    ],
+                },
+            ]));
+
+            const embed = getResponseEmbed();
+            expect(embed?.title).toBe('Role Permission Set');
+            expect(String(embed?.description)).toContain('Standard');
+
+            const raw = getDiscordConfigRaw(db);
+            const rolePerms = JSON.parse(raw['role_permissions']);
+            expect(rolePerms['600000000000000001']).toBe(2);
+        });
+
+        test('remove role permission', async () => {
+            const bridge = createBridge({ rolePermissions: { '600000000000000001': 3 } });
+            db.prepare('INSERT OR REPLACE INTO discord_config (key, value, updated_at) VALUES (?, ?, datetime(\'now\'))').run(
+                'role_permissions', JSON.stringify({ '600000000000000001': 3 }),
+            );
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                {
+                    name: 'roles', type: 2, options: [
+                        {
+                            name: 'remove', type: 1, options: [
+                                { name: 'role', type: 8, value: '600000000000000001' },
+                            ],
+                        },
+                    ],
+                },
+            ]));
+
+            const embed = getResponseEmbed();
+            expect(embed?.title).toBe('Role Permission Removed');
+
+            const raw = getDiscordConfigRaw(db);
+            const rolePerms = JSON.parse(raw['role_permissions']);
+            expect(rolePerms['600000000000000001']).toBeUndefined();
+        });
+
+        test('remove non-existent role shows no override', async () => {
+            const bridge = createBridge();
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                {
+                    name: 'roles', type: 2, options: [
+                        {
+                            name: 'remove', type: 1, options: [
+                                { name: 'role', type: 8, value: '600000000000000099' },
+                            ],
+                        },
+                    ],
+                },
+            ]));
+
+            expect(getResponseText()).toContain('no permission override');
+        });
+
+        test('list roles shows mappings and defaults', async () => {
+            const bridge = createBridge({ rolePermissions: { '600000000000000001': 2, '600000000000000002': 3 } });
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                {
+                    name: 'roles', type: 2, options: [
+                        { name: 'list', type: 1 },
+                    ],
+                },
+            ]));
+
+            const embed = getResponseEmbed();
+            expect(embed?.title).toBe('Role Permissions');
+            const fields = embed?.fields as Array<{ name: string; value: string }>;
+            expect(fields.find(f => f.name === 'Default Level')).toBeDefined();
+        });
+    });
+
+    // ── Mode ──────────────────────────────────────────────────────────
+
+    describe('mode', () => {
+        test('set mode to work_intake', async () => {
+            const bridge = createBridge();
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                { name: 'mode', type: 1, options: [{ name: 'value', type: 3, value: 'work_intake' }] },
+            ]));
+
+            const embed = getResponseEmbed();
+            expect(embed?.title).toBe('Bridge Mode Updated');
+            expect(String(embed?.description)).toContain('Work Intake');
+
+            const raw = getDiscordConfigRaw(db);
+            expect(raw['mode']).toBe('work_intake');
+        });
+    });
+
+    // ── Public ────────────────────────────────────────────────────────
+
+    describe('public', () => {
+        test('enable public mode', async () => {
+            const bridge = createBridge();
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                { name: 'public', type: 1, options: [{ name: 'enabled', type: 5, value: true }] },
+            ]));
+
+            const embed = getResponseEmbed();
+            expect(embed?.title).toBe('Public Mode Updated');
+            expect(String(embed?.description)).toContain('enabled');
+
+            const raw = getDiscordConfigRaw(db);
+            expect(raw['public_mode']).toBe('true');
+        });
+
+        test('disable public mode', async () => {
+            // In public mode, use defaultPermissionLevel=3 so the test user gets ADMIN
+            const bridge = createBridge({ publicMode: true, defaultPermissionLevel: 3 });
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                { name: 'public', type: 1, options: [{ name: 'enabled', type: 5, value: false }] },
+            ]));
+
+            const embed = getResponseEmbed();
+            expect(String(embed?.description)).toContain('disabled');
+        });
+    });
+
+    // ── Show ──────────────────────────────────────────────────────────
+
+    describe('show', () => {
+        test('shows full config summary', async () => {
+            const bridge = createBridge({
+                allowedUserIds: ['200000000000000001'],
+                additionalChannelIds: ['400000000000000001'],
+                rolePermissions: { '600000000000000001': 2 },
+            });
+
+            await callInteraction(bridge, makeInteraction('admin', [
+                { name: 'show', type: 1 },
+            ]));
+
+            const embed = getResponseEmbed();
+            expect(embed?.title).toBe('Bot Configuration');
+            const fields = embed?.fields as Array<{ name: string; value: string }>;
+            expect(fields.find(f => f.name === 'Mode')).toBeDefined();
+            expect(fields.find(f => f.name === 'Public Mode')).toBeDefined();
+            expect(fields.find(f => f.name.startsWith('Channels'))).toBeDefined();
+            expect(fields.find(f => f.name === 'Allowed Users')).toBeDefined();
+            expect(fields.find(f => f.name === 'Role Permissions')).toBeDefined();
+        });
+    });
+
+    // ── Help includes admin section ───────────────────────────────────
+
+    test('/help includes admin configuration section', async () => {
+        const bridge = createBridge();
+
+        await callInteraction(bridge, makeInteraction('admin', [], '200000000000000001'));
+
+        // Reset and check /help
+        fetchBodies.length = 0;
+        await callInteraction(bridge, {
+            id: '300000000000000002',
+            token: 'test-interaction-token-help-abcdef',
+            type: 2,
+            channel_id: '100000000000000001',
+            data: { name: 'help' },
+            member: { user: { id: '200000000000000001', username: 'Admin' }, roles: [] },
+        });
+
+        const embed = getResponseEmbed();
+        const fields = embed?.fields as Array<{ name: string }>;
+        expect(fields.find(f => f.name === 'Admin Configuration')).toBeDefined();
+    });
+});

--- a/server/discord/bridge.ts
+++ b/server/discord/bridge.ts
@@ -6,6 +6,7 @@ import type {
     DiscordBridgeConfig,
     DiscordMessageData,
     DiscordInteractionData,
+    DiscordInteractionOption,
 } from './types';
 import { InteractionType, InteractionCallbackType, PermissionLevel, ComponentType, ButtonStyle } from './types';
 import type { DiscordActionRow } from './types';
@@ -364,6 +365,160 @@ export class DiscordBridge {
                     type: 6, // USER
                     required: true,
                 }],
+            },
+            {
+                name: 'admin',
+                description: 'Manage bot configuration (admin only)',
+                type: 1, // CHAT_INPUT
+                options: [
+                    {
+                        name: 'channels',
+                        description: 'Manage monitored channels',
+                        type: 2, // SUB_COMMAND_GROUP
+                        options: [
+                            {
+                                name: 'add',
+                                description: 'Add a channel to the monitored list',
+                                type: 1, // SUB_COMMAND
+                                options: [{
+                                    name: 'channel',
+                                    description: 'The channel to add',
+                                    type: 7, // CHANNEL
+                                    required: true,
+                                }],
+                            },
+                            {
+                                name: 'remove',
+                                description: 'Remove a channel from the monitored list',
+                                type: 1,
+                                options: [{
+                                    name: 'channel',
+                                    description: 'The channel to remove',
+                                    type: 7, // CHANNEL
+                                    required: true,
+                                }],
+                            },
+                            {
+                                name: 'list',
+                                description: 'Show all monitored channels',
+                                type: 1,
+                            },
+                        ],
+                    },
+                    {
+                        name: 'users',
+                        description: 'Manage allowed users',
+                        type: 2, // SUB_COMMAND_GROUP
+                        options: [
+                            {
+                                name: 'add',
+                                description: 'Add a user to the allow list',
+                                type: 1,
+                                options: [{
+                                    name: 'user',
+                                    description: 'The user to allow',
+                                    type: 6, // USER
+                                    required: true,
+                                }],
+                            },
+                            {
+                                name: 'remove',
+                                description: 'Remove a user from the allow list',
+                                type: 1,
+                                options: [{
+                                    name: 'user',
+                                    description: 'The user to remove',
+                                    type: 6, // USER
+                                    required: true,
+                                }],
+                            },
+                            {
+                                name: 'list',
+                                description: 'Show all allowed users',
+                                type: 1,
+                            },
+                        ],
+                    },
+                    {
+                        name: 'roles',
+                        description: 'Manage role permissions',
+                        type: 2, // SUB_COMMAND_GROUP
+                        options: [
+                            {
+                                name: 'set',
+                                description: 'Set permission level for a role',
+                                type: 1,
+                                options: [
+                                    {
+                                        name: 'role',
+                                        description: 'The role to configure',
+                                        type: 8, // ROLE
+                                        required: true,
+                                    },
+                                    {
+                                        name: 'level',
+                                        description: 'Permission level (0=blocked, 1=basic, 2=standard, 3=admin)',
+                                        type: 4, // INTEGER
+                                        required: true,
+                                        choices: [
+                                            { name: 'Blocked (0)', value: 0 },
+                                            { name: 'Basic (1) — chat, @mention', value: 1 },
+                                            { name: 'Standard (2) — slash commands', value: 2 },
+                                            { name: 'Admin (3) — full access', value: 3 },
+                                        ],
+                                    },
+                                ],
+                            },
+                            {
+                                name: 'remove',
+                                description: 'Remove permission override for a role',
+                                type: 1,
+                                options: [{
+                                    name: 'role',
+                                    description: 'The role to remove',
+                                    type: 8, // ROLE
+                                    required: true,
+                                }],
+                            },
+                            {
+                                name: 'list',
+                                description: 'Show all role permission mappings',
+                                type: 1,
+                            },
+                        ],
+                    },
+                    {
+                        name: 'mode',
+                        description: 'Set the bridge mode',
+                        type: 1, // SUB_COMMAND
+                        options: [{
+                            name: 'value',
+                            description: 'Bridge mode',
+                            type: 3, // STRING
+                            required: true,
+                            choices: [
+                                { name: 'Chat — interactive conversations', value: 'chat' },
+                                { name: 'Work Intake — fire-and-forget tasks', value: 'work_intake' },
+                            ],
+                        }],
+                    },
+                    {
+                        name: 'public',
+                        description: 'Toggle public mode (role-based access for all users)',
+                        type: 1,
+                        options: [{
+                            name: 'enabled',
+                            description: 'Enable or disable public mode',
+                            type: 5, // BOOLEAN
+                            required: true,
+                        }],
+                    },
+                    {
+                        name: 'show',
+                        description: 'Show current bot configuration',
+                        type: 1,
+                    },
+                ],
             },
         ];
 
@@ -806,15 +961,406 @@ export class DiscordBridge {
                             ].join('\n'),
                             inline: false,
                         },
+                        {
+                            name: 'Admin Configuration',
+                            value: [
+                                '`/admin channels add/remove/list` — Manage monitored channels',
+                                '`/admin users add/remove/list` — Manage allowed users',
+                                '`/admin roles set/remove/list` — Manage role permissions',
+                                '`/admin mode <chat|work_intake>` — Set bridge mode',
+                                '`/admin public <on|off>` — Toggle public mode',
+                                '`/admin show` — Show current configuration',
+                            ].join('\n'),
+                            inline: false,
+                        },
                     ],
                     footer: { text: 'New here? Try /quickstart for a guided walkthrough' },
                 });
                 break;
             }
 
+            case 'admin': {
+                if (permLevel < PermissionLevel.ADMIN) {
+                    await this.respondToInteraction(interaction, 'Only admins can use `/admin` commands.');
+                    break;
+                }
+                await this.handleAdminCommand(interaction, options);
+                break;
+            }
+
             default:
                 await this.respondToInteraction(interaction, `Unknown command: ${commandName}`);
         }
+    }
+
+    // ── Admin Command Handling ───────────────────────────────────────────
+
+    /**
+     * Handle `/admin` subcommands for managing channels, users, roles, mode, and config display.
+     * All changes persist to `discord_config` DB table and hot-reload within 30s.
+     */
+    private async handleAdminCommand(
+        interaction: DiscordInteractionData,
+        options: DiscordInteractionOption[],
+    ): Promise<void> {
+        // For subcommand groups: options[0] = group, options[0].options[0] = subcommand
+        // For direct subcommands: options[0] = subcommand
+        const group = options[0];
+        if (!group) {
+            await this.respondToInteraction(interaction, 'Missing subcommand.');
+            return;
+        }
+
+        const groupName = group.name;
+
+        // Direct subcommands (mode, public, show)
+        if (groupName === 'show') {
+            await this.handleAdminShow(interaction);
+            return;
+        }
+
+        if (groupName === 'mode') {
+            const sub = group.options?.[0];
+            const mode = sub?.value as string ?? group.value as string;
+            if (mode !== 'chat' && mode !== 'work_intake') {
+                await this.respondToInteraction(interaction, 'Invalid mode. Use `chat` or `work_intake`.');
+                return;
+            }
+            updateDiscordConfig(this.db, 'mode', mode);
+            this.config.mode = mode;
+            recordAudit(this.db, 'discord_config_update', interaction.member?.user?.id ?? 'unknown', 'discord_config', 'mode', JSON.stringify({ value: mode }));
+            await this.respondToInteractionEmbed(interaction, {
+                title: 'Bridge Mode Updated',
+                description: `Mode set to **${mode === 'chat' ? 'Chat' : 'Work Intake'}**`,
+                color: 0x57f287,
+                footer: { text: mode === 'chat' ? 'Messages route to agent sessions' : 'Messages create async work tasks' },
+            });
+            return;
+        }
+
+        if (groupName === 'public') {
+            const sub = group.options?.[0];
+            const enabled = (sub?.value ?? group.value) as boolean;
+            updateDiscordConfig(this.db, 'public_mode', String(enabled));
+            this.config.publicMode = enabled;
+            recordAudit(this.db, 'discord_config_update', interaction.member?.user?.id ?? 'unknown', 'discord_config', 'public_mode', JSON.stringify({ value: enabled }));
+            await this.respondToInteractionEmbed(interaction, {
+                title: 'Public Mode Updated',
+                description: enabled
+                    ? 'Public mode **enabled** — all users can interact (subject to role permissions)'
+                    : 'Public mode **disabled** — only allowed users can interact',
+                color: enabled ? 0x57f287 : 0xed4245,
+            });
+            return;
+        }
+
+        // Subcommand groups (channels, users, roles)
+        const subcommand = group.options?.[0];
+        if (!subcommand) {
+            await this.respondToInteraction(interaction, 'Missing subcommand.');
+            return;
+        }
+        const subName = subcommand.name;
+        const subOptions = subcommand.options ?? [];
+        const getSubOption = (name: string) => subOptions.find(o => o.name === name)?.value;
+
+        switch (groupName) {
+            case 'channels':
+                await this.handleAdminChannels(interaction, subName, getSubOption);
+                break;
+            case 'users':
+                await this.handleAdminUsers(interaction, subName, getSubOption);
+                break;
+            case 'roles':
+                await this.handleAdminRoles(interaction, subName, getSubOption);
+                break;
+            default:
+                await this.respondToInteraction(interaction, `Unknown admin subcommand: ${groupName}`);
+        }
+    }
+
+    private async handleAdminChannels(
+        interaction: DiscordInteractionData,
+        subName: string,
+        getSubOption: (name: string) => string | number | boolean | undefined,
+    ): Promise<void> {
+        const current = this.config.additionalChannelIds ?? [];
+
+        switch (subName) {
+            case 'add': {
+                const channelId = String(getSubOption('channel'));
+                if (!channelId || !DISCORD_SNOWFLAKE_RE.test(channelId)) {
+                    await this.respondToInteraction(interaction, 'Invalid channel.');
+                    return;
+                }
+                if (channelId === this.config.channelId) {
+                    await this.respondToInteraction(interaction, 'That is already the primary channel.');
+                    return;
+                }
+                if (current.includes(channelId)) {
+                    await this.respondToInteraction(interaction, `<#${channelId}> is already monitored.`);
+                    return;
+                }
+                const updated = [...current, channelId];
+                updateDiscordConfig(this.db, 'additional_channel_ids', updated.join(','));
+                this.config.additionalChannelIds = updated;
+                recordAudit(this.db, 'discord_config_update', interaction.member?.user?.id ?? 'unknown', 'discord_config', 'additional_channel_ids', JSON.stringify({ action: 'add', channelId }));
+                await this.respondToInteractionEmbed(interaction, {
+                    title: 'Channel Added',
+                    description: `<#${channelId}> is now being monitored.\n\nTotal monitored: **${updated.length + 1}** (including primary)`,
+                    color: 0x57f287,
+                });
+                break;
+            }
+            case 'remove': {
+                const channelId = String(getSubOption('channel'));
+                if (!channelId || !DISCORD_SNOWFLAKE_RE.test(channelId)) {
+                    await this.respondToInteraction(interaction, 'Invalid channel.');
+                    return;
+                }
+                if (channelId === this.config.channelId) {
+                    await this.respondToInteraction(interaction, 'Cannot remove the primary channel. Change `DISCORD_CHANNEL_ID` in your environment to change it.');
+                    return;
+                }
+                if (!current.includes(channelId)) {
+                    await this.respondToInteraction(interaction, `<#${channelId}> is not in the monitored list.`);
+                    return;
+                }
+                const updated = current.filter(id => id !== channelId);
+                updateDiscordConfig(this.db, 'additional_channel_ids', updated.join(','));
+                this.config.additionalChannelIds = updated;
+                recordAudit(this.db, 'discord_config_update', interaction.member?.user?.id ?? 'unknown', 'discord_config', 'additional_channel_ids', JSON.stringify({ action: 'remove', channelId }));
+                await this.respondToInteractionEmbed(interaction, {
+                    title: 'Channel Removed',
+                    description: `<#${channelId}> removed from monitoring.\n\nTotal monitored: **${updated.length + 1}** (including primary)`,
+                    color: 0xed4245,
+                });
+                break;
+            }
+            case 'list': {
+                const allChannels = [
+                    `<#${this.config.channelId}> *(primary)*`,
+                    ...current.map(id => `<#${id}>`),
+                ];
+                await this.respondToInteractionEmbed(interaction, {
+                    title: 'Monitored Channels',
+                    description: allChannels.join('\n') || 'No channels configured.',
+                    color: 0x5865f2,
+                    footer: { text: `${allChannels.length} channel${allChannels.length === 1 ? '' : 's'} total` },
+                });
+                break;
+            }
+        }
+    }
+
+    private async handleAdminUsers(
+        interaction: DiscordInteractionData,
+        subName: string,
+        getSubOption: (name: string) => string | number | boolean | undefined,
+    ): Promise<void> {
+        const current = [...this.config.allowedUserIds];
+
+        switch (subName) {
+            case 'add': {
+                const userId = String(getSubOption('user'));
+                if (!userId || !DISCORD_SNOWFLAKE_RE.test(userId)) {
+                    await this.respondToInteraction(interaction, 'Invalid user.');
+                    return;
+                }
+                if (current.includes(userId)) {
+                    await this.respondToInteraction(interaction, `<@${userId}> is already on the allow list.`);
+                    return;
+                }
+                const updated = [...current, userId];
+                updateDiscordConfig(this.db, 'allowed_user_ids', updated.join(','));
+                this.config.allowedUserIds = updated;
+                recordAudit(this.db, 'discord_config_update', interaction.member?.user?.id ?? 'unknown', 'discord_config', 'allowed_user_ids', JSON.stringify({ action: 'add', userId }));
+                await this.respondToInteractionEmbed(interaction, {
+                    title: 'User Added',
+                    description: `<@${userId}> added to the allow list.\n\nTotal allowed: **${updated.length}**`,
+                    color: 0x57f287,
+                });
+                break;
+            }
+            case 'remove': {
+                const userId = String(getSubOption('user'));
+                if (!userId || !DISCORD_SNOWFLAKE_RE.test(userId)) {
+                    await this.respondToInteraction(interaction, 'Invalid user.');
+                    return;
+                }
+                if (!current.includes(userId)) {
+                    await this.respondToInteraction(interaction, `<@${userId}> is not on the allow list.`);
+                    return;
+                }
+                const updated = current.filter(id => id !== userId);
+                updateDiscordConfig(this.db, 'allowed_user_ids', updated.join(','));
+                this.config.allowedUserIds = updated;
+                recordAudit(this.db, 'discord_config_update', interaction.member?.user?.id ?? 'unknown', 'discord_config', 'allowed_user_ids', JSON.stringify({ action: 'remove', userId }));
+                await this.respondToInteractionEmbed(interaction, {
+                    title: 'User Removed',
+                    description: `<@${userId}> removed from the allow list.\n\nTotal allowed: **${updated.length}**`,
+                    color: 0xed4245,
+                });
+                break;
+            }
+            case 'list': {
+                const userLines = current.length > 0
+                    ? current.map(id => `<@${id}>`).join('\n')
+                    : '_No users on allow list — all users have access (legacy mode with empty list)_';
+                await this.respondToInteractionEmbed(interaction, {
+                    title: 'Allowed Users',
+                    description: userLines,
+                    color: 0x5865f2,
+                    footer: { text: `${current.length} user${current.length === 1 ? '' : 's'} · ${this.config.publicMode ? 'Public mode (roles take precedence)' : 'Legacy mode (allow list enforced)'}` },
+                });
+                break;
+            }
+        }
+    }
+
+    private async handleAdminRoles(
+        interaction: DiscordInteractionData,
+        subName: string,
+        getSubOption: (name: string) => string | number | boolean | undefined,
+    ): Promise<void> {
+        const current = { ...(this.config.rolePermissions ?? {}) };
+        const levelName = (level: number) =>
+            level === 0 ? 'Blocked' : level === 1 ? 'Basic' : level === 2 ? 'Standard' : level === 3 ? 'Admin' : `Level ${level}`;
+
+        switch (subName) {
+            case 'set': {
+                const roleId = String(getSubOption('role'));
+                const level = Number(getSubOption('level'));
+                if (!roleId || !DISCORD_SNOWFLAKE_RE.test(roleId)) {
+                    await this.respondToInteraction(interaction, 'Invalid role.');
+                    return;
+                }
+                if (level < 0 || level > 3 || !Number.isInteger(level)) {
+                    await this.respondToInteraction(interaction, 'Permission level must be 0-3.');
+                    return;
+                }
+                current[roleId] = level;
+                const json = JSON.stringify(current);
+                updateDiscordConfig(this.db, 'role_permissions', json);
+                this.config.rolePermissions = current;
+                recordAudit(this.db, 'discord_config_update', interaction.member?.user?.id ?? 'unknown', 'discord_config', 'role_permissions', JSON.stringify({ action: 'set', roleId, level }));
+                await this.respondToInteractionEmbed(interaction, {
+                    title: 'Role Permission Set',
+                    description: `<@&${roleId}> → **${levelName(level)}** (${level})`,
+                    color: 0x57f287,
+                    footer: { text: `${Object.keys(current).length} role mapping${Object.keys(current).length === 1 ? '' : 's'} configured` },
+                });
+                break;
+            }
+            case 'remove': {
+                const roleId = String(getSubOption('role'));
+                if (!roleId || !DISCORD_SNOWFLAKE_RE.test(roleId)) {
+                    await this.respondToInteraction(interaction, 'Invalid role.');
+                    return;
+                }
+                if (!(roleId in current)) {
+                    await this.respondToInteraction(interaction, `<@&${roleId}> has no permission override.`);
+                    return;
+                }
+                delete current[roleId];
+                const json = JSON.stringify(current);
+                updateDiscordConfig(this.db, 'role_permissions', json);
+                this.config.rolePermissions = current;
+                recordAudit(this.db, 'discord_config_update', interaction.member?.user?.id ?? 'unknown', 'discord_config', 'role_permissions', JSON.stringify({ action: 'remove', roleId }));
+                await this.respondToInteractionEmbed(interaction, {
+                    title: 'Role Permission Removed',
+                    description: `<@&${roleId}> permission override removed.\nUsers with this role will get the default level (**${levelName(this.config.defaultPermissionLevel ?? 1)}**).`,
+                    color: 0xed4245,
+                });
+                break;
+            }
+            case 'list': {
+                const entries = Object.entries(current);
+                const roleLines = entries.length > 0
+                    ? entries.map(([rid, lvl]) => `<@&${rid}> → **${levelName(lvl)}** (${lvl})`).join('\n')
+                    : '_No role permissions configured_';
+                await this.respondToInteractionEmbed(interaction, {
+                    title: 'Role Permissions',
+                    description: roleLines,
+                    color: 0x5865f2,
+                    fields: [
+                        {
+                            name: 'Default Level',
+                            value: `**${levelName(this.config.defaultPermissionLevel ?? 1)}** (${this.config.defaultPermissionLevel ?? 1})`,
+                            inline: true,
+                        },
+                        {
+                            name: 'Public Mode',
+                            value: this.config.publicMode ? 'Enabled' : 'Disabled',
+                            inline: true,
+                        },
+                    ],
+                    footer: { text: entries.length > 0 ? `${entries.length} role mapping${entries.length === 1 ? '' : 's'}` : 'Use /admin roles set to add mappings' },
+                });
+                break;
+            }
+        }
+    }
+
+    private async handleAdminShow(interaction: DiscordInteractionData): Promise<void> {
+        const channels = [
+            `<#${this.config.channelId}> *(primary)*`,
+            ...(this.config.additionalChannelIds ?? []).map(id => `<#${id}>`),
+        ];
+        const users = this.config.allowedUserIds.length > 0
+            ? this.config.allowedUserIds.map(id => `<@${id}>`).join(', ')
+            : '_none_';
+        const roleEntries = Object.entries(this.config.rolePermissions ?? {});
+        const levelName = (level: number) =>
+            level === 0 ? 'Blocked' : level === 1 ? 'Basic' : level === 2 ? 'Standard' : level === 3 ? 'Admin' : `Level ${level}`;
+        const roles = roleEntries.length > 0
+            ? roleEntries.map(([rid, lvl]) => `<@&${rid}>=${levelName(lvl)}`).join(', ')
+            : '_none_';
+
+        await this.respondToInteractionEmbed(interaction, {
+            title: 'Bot Configuration',
+            color: 0x5865f2,
+            fields: [
+                {
+                    name: 'Mode',
+                    value: this.config.mode === 'work_intake' ? 'Work Intake' : 'Chat',
+                    inline: true,
+                },
+                {
+                    name: 'Public Mode',
+                    value: this.config.publicMode ? 'Enabled' : 'Disabled',
+                    inline: true,
+                },
+                {
+                    name: 'Default Permission',
+                    value: `${levelName(this.config.defaultPermissionLevel ?? 1)} (${this.config.defaultPermissionLevel ?? 1})`,
+                    inline: true,
+                },
+                {
+                    name: `Channels (${channels.length})`,
+                    value: channels.join('\n').slice(0, 1024),
+                    inline: false,
+                },
+                {
+                    name: 'Allowed Users',
+                    value: users.slice(0, 1024),
+                    inline: false,
+                },
+                {
+                    name: 'Role Permissions',
+                    value: roles.slice(0, 1024),
+                    inline: false,
+                },
+                {
+                    name: 'Muted Users',
+                    value: this.mutedUsers.size > 0
+                        ? [...this.mutedUsers].map(id => `<@${id}>`).join(', ').slice(0, 1024)
+                        : '_none_',
+                    inline: false,
+                },
+            ],
+            footer: { text: `Active sessions: ${this.threadSessions.size} · Config reloads every 30s` },
+        });
     }
 
     private async respondToInteraction(interaction: DiscordInteractionData, content: string): Promise<void> {

--- a/server/discord/types.ts
+++ b/server/discord/types.ts
@@ -37,6 +37,15 @@ export interface DiscordBridgeConfig {
     rateLimitByLevel?: Record<number, number>;
 }
 
+/** Recursive option type — supports subcommand groups and subcommands with nested options. */
+export interface DiscordInteractionOption {
+    name: string;
+    type: number;
+    value?: string | number | boolean;
+    /** Nested options — present for SUB_COMMAND (type 1) and SUB_COMMAND_GROUP (type 2) */
+    options?: DiscordInteractionOption[];
+}
+
 export interface DiscordInteractionData {
     id: string;
     type: number; // 1=PING, 2=APPLICATION_COMMAND, 3=MESSAGE_COMPONENT
@@ -46,7 +55,7 @@ export interface DiscordInteractionData {
     user?: DiscordAuthor;
     data?: {
         name: string;
-        options?: Array<{ name: string; type: number; value: string | number | boolean }>;
+        options?: DiscordInteractionOption[];
         /** For component interactions — the custom_id of the button clicked */
         custom_id?: string;
         /** For component interactions — the component type */

--- a/specs/discord/bridge.spec.md
+++ b/specs/discord/bridge.spec.md
@@ -1,6 +1,6 @@
 ---
 module: discord-bridge
-version: 8
+version: 9
 status: active
 files:
   - server/discord/bridge.ts
@@ -10,6 +10,7 @@ files:
 db_tables:
   - sessions
   - session_messages
+  - discord_config
 depends_on:
   - specs/process/process-manager.spec.md
   - specs/db/sessions.spec.md
@@ -93,6 +94,7 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | `DiscordReadyData` | `{ session_id: string; resume_gateway_url: string }` |
 | `DiscordMessageData` | `{ id, channel_id, author, content, timestamp, mentions?: DiscordAuthor[], member?: { roles: string[] } }` |
 | `DiscordAuthor` | `{ id: string; username: string; bot?: boolean }` |
+| `DiscordInteractionOption` | `{ name, type, value?, options?: DiscordInteractionOption[] }` — recursive option type for subcommands and subcommand groups |
 | `DiscordInteractionData` | Slash command interaction payload from gateway |
 | `GatewayOp` | Constants for gateway opcodes (DISPATCH=0, HEARTBEAT=1, IDENTIFY=2, PRESENCE_UPDATE=3, RESUME=6, RECONNECT=7, INVALID_SESSION=9, HELLO=10, HEARTBEAT_ACK=11) |
 | `GatewayIntent` | Bit flags: `GUILDS` (1<<0), `GUILD_MEMBERS` (1<<1), `GUILD_MESSAGES` (1<<9), `MESSAGE_CONTENT` (1<<15) |
@@ -140,7 +142,7 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 21. **Role-based access control**: Permission levels (BLOCKED=0, BASIC=1, STANDARD=2, ADMIN=3). In legacy mode, `allowedUserIds` grants ADMIN level. In `publicMode`, permissions are resolved from Discord roles via `rolePermissions` config. Highest matching role wins. Muted users are always BLOCKED
 22. **Tiered rate limiting**: Each user is limited per 60-second sliding window. Default is 10 messages. Can be customized per permission level via `rateLimitByLevel` config (e.g., BASIC=3, STANDARD=10, ADMIN=50)
 23. **Prompt injection scanning**: All incoming messages (channel @mentions and thread messages) are scanned via `scanForInjection()`. Blocked messages are audited and rejected
-24. **Permission-gated commands**: `/session` requires STANDARD or higher. `/council`, `/mute`, `/unmute` require ADMIN. `/agents`, `/status`, `/help` require BASIC
+24. **Permission-gated commands**: `/session` requires STANDARD or higher. `/council`, `/mute`, `/unmute`, `/admin` require ADMIN. `/agents`, `/status`, `/help` require BASIC
 25. **User muting**: Admins can mute/unmute users via `/mute` and `/unmute` slash commands. Muted users cannot interact with the bot regardless of their role permissions
 
 ### Response Formatting
@@ -156,7 +158,7 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 
 ### Commands
 
-32. **Slash commands**: If `appId` is configured, commands are registered as Discord Application Commands via `PUT /applications/{appId}/commands` (or guild-scoped if `guildId` is set). Interactions are handled via gateway `INTERACTION_CREATE` events. Commands: `/session`, `/work`, `/agents`, `/status`, `/council`, `/mute`, `/unmute`, `/help`
+32. **Slash commands**: If `appId` is configured, commands are registered as Discord Application Commands via `PUT /applications/{appId}/commands` (or guild-scoped if `guildId` is set). Interactions are handled via gateway `INTERACTION_CREATE` events. Commands: `/session`, `/work`, `/agents`, `/status`, `/council`, `/mute`, `/unmute`, `/help`, `/admin`
 33. **`/session` command** (interactive chat): Creates a new Discord thread with a live agent session. The user can go back and forth with the agent in real-time. Required options: `agent` (dropdown, capped at 25), `topic` (string, thread name). Optional: `project` (dropdown). The thread is created in the configured channel with the selected agent bound to it. Use `/session` when you want to **discuss, explore, or guide** the agent interactively
 34. **`/work` command** (autonomous task): Creates an async work task — the agent works autonomously (clones repo, makes changes, creates a PR) without further interaction. Required: `description` (what to do). Optional: `agent` (dropdown), `project` (dropdown). Responds with a rich confirmation embed showing task ID, agent, and status. Sends a completion notification with PR link (or error details) when done, mentioning the requester. Use `/work` when you want to **assign a task** and get notified with a PR
 35. **`/agents` command**: Lists all available agents with their models. Does not create a session
@@ -165,6 +167,7 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 38. **`/help` command**: Shows available commands and usage
 39. **Text commands deprecated**: Text commands (messages starting with `/`) are no longer parsed from regular channel messages. All commands use Discord's slash command system (requires `appId`)
 40. **Work intake mode**: When `mode='work_intake'`, @mentions and thread messages create async work tasks via `WorkTaskService` instead of chat sessions. Embeds are used for task status feedback
+41. **`/admin` command**: Admin-only configuration management with subcommand groups. All changes persist to `discord_config` DB table and hot-reload within 30s. Subcommands: `channels add/remove/list` (manage monitored channels via #channel mentions), `users add/remove/list` (manage allowed users via @user mentions), `roles set/remove/list` (manage role→permission mappings via @role mentions with level dropdown), `mode` (set bridge mode), `public` (toggle public mode), `show` (display full config summary). Every mutation is audit-logged. Responses use rich embeds with clear confirmation/status
 
 ## Behavioral Examples
 
@@ -347,4 +350,6 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | 2026-03-07 | corvid-agent | v4: Passive channel mode — bot no longer auto-responds to channel messages. Only responds to @mentions (one-off) and slash commands. Threads created exclusively via `/session` command with agent selection and topic. Removed `/switch` and `/new` commands (replaced by `/session`). Removed text command parsing (slash-only). Added `mentions` field to `DiscordMessageData` |
 | 2026-03-08 | corvid-agent | v5: Fix duplicate message bug — track active subscription per thread, unsubscribe previous callback before re-subscribing on each message. Added invariant #26 (subscription deduplication) |
 | 2026-03-10 | corvid-agent | v6: Public channel mode with role-based access control (BLOCKED/BASIC/STANDARD/ADMIN). Multi-channel support. Tiered rate limiting by permission level. Smart message splitting at natural boundaries with code block preservation. Typing indicators with periodic refresh. Message reactions for acknowledgment. Stale thread auto-archiving (2h). Thread title updates on session completion. `/mute` and `/unmute` admin commands. Added `message-formatter.ts`. Refs #891, #893 |
+| 2026-03-10 | corvid-agent | v7: DB-backed dynamic configuration with 30s hot-reload. Discord onboarding flow (`/quickstart`). First-interaction welcome tips. Persisted interacted users. `discord_config` table. Settings API endpoints |
 | 2026-03-10 | corvid-agent | v8: Added `/work` slash command for autonomous task creation (agent works independently, creates PR, notifies on completion). Added optional `project` dropdown to `/session`. Rich embed confirmations for `/work` with task status, agent, branch. Completion notifications @mention the requester. Added `sendMessageWithEmbed` for content+embed messages. AlgoChat `/work` now supports `--project <name>` flag. Clear documentation differentiating `/session` (interactive chat) vs `/work` (fire-and-forget task) |
+| 2026-03-10 | corvid-agent | v9: `/admin` slash command with subcommand groups for managing channels (add/remove/list), users (add/remove/list), roles (set/remove/list), bridge mode, and public mode — all from within Discord using native mentions. `DiscordInteractionOption` recursive type for nested subcommands. Audit logging on every config mutation. `/help` updated with Admin Configuration section. 20 new tests |


### PR DESCRIPTION
## Summary
- **Discord `/admin` commands** — manage channels, users, roles, bridge mode, and public mode directly from Discord using native mentions (@user, #channel, @role). All changes audit-logged and persist to `discord_config` DB table
- **Version bump to v0.24.0** — changelog covers this PR + PR #916 (project discovery tools, /work improvements, RC verification)

## New `/admin` Subcommands
| Command | Description |
|---------|-------------|
| `/admin channels add #channel` | Add channel to monitored list |
| `/admin channels remove #channel` | Remove channel from monitoring |
| `/admin channels list` | Show all monitored channels |
| `/admin users add @user` | Add user to allow list |
| `/admin users remove @user` | Remove user from allow list |
| `/admin users list` | Show allowed users |
| `/admin roles set @role <level>` | Set permission level for a role (0-3 dropdown) |
| `/admin roles remove @role` | Remove role permission override |
| `/admin roles list` | Show role permission mappings |
| `/admin mode <chat\|work_intake>` | Set bridge mode |
| `/admin public <on\|off>` | Toggle public mode |
| `/admin show` | Full config summary embed |

## Changes
- `server/discord/bridge.ts` — `/admin` command registration + handler methods (~350 lines)
- `server/discord/types.ts` — recursive `DiscordInteractionOption` type for nested subcommands
- `specs/discord/bridge.spec.md` — v8 with `/admin` documentation
- `server/__tests__/discord-admin-commands.test.ts` — 20 new tests
- Version bump: `package.json`, `Chart.yaml`, `README.md`, `CHANGELOG.md`

## Verification
- TSC: clean
- Tests: 6,347 pass / 0 fail across 262 files
- Specs: 115/115 pass, 0 warnings

## Test plan
- [ ] Verify `/admin show` displays correct config
- [ ] Test `/admin channels add #channel` adds and persists
- [ ] Test `/admin users add @user` adds to allow list
- [ ] Test `/admin roles set @role Standard` updates role permissions
- [ ] Test non-admin users cannot access `/admin` commands
- [ ] Verify audit log entries for config changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)