### PR TITLE
fix: resolve CodeQL unused import alerts

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,2 @@
+paths-ignore:
+  - "server/flock-directory/contract/*.generated.ts"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ jobs:
         uses: github/codeql-action/init@7aefa1c9aed02ae41531ec219164e64a0f087410  # v4
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql-config.yml
           queries: security-extended,security-and-quality
 
       - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461  # v2.1.3

--- a/bin/corvid-agent.mjs
+++ b/bin/corvid-agent.mjs
@@ -5,8 +5,7 @@
 // to bun if available. If only node is available, we provide helpful
 // instructions for commands that require bun.
 
-import { execFileSync, execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 


### PR DESCRIPTION
## Summary
- Remove unused `execSync` and `existsSync` imports from `bin/corvid-agent.mjs` (CodeQL alerts #293, #294)
- Add `.github/codeql-config.yml` to exclude `*.generated.ts` files from CodeQL analysis (alerts #297-302)
- Wire the config into the existing CodeQL workflow

## Test plan
- [ ] CI passes (CodeQL workflow picks up new config)
- [ ] `bin/corvid-agent.mjs` still works correctly without the removed imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)