### PR TITLE
fix: hide admin Discord commands from non-admin users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.24.2] - 2026-03-10
+
+### Fixed
+- Hide admin-only Discord commands (`/admin`, `/council`, `/mute`, `/unmute`) from non-admin users via `default_member_permissions` (#921)
+
 ## [0.24.1] - 2026-03-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.24.1-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.24.2-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: corvid-agent
 description: Agent orchestration platform with MCP tools, AlgoChat messaging, and on-chain wallet integration
 type: application
-version: 0.24.1
-appVersion: "0.24.1"
+version: 0.24.2
+appVersion: "0.24.2"
 keywords:
   - ai
   - agent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",

--- a/server/discord/bridge.ts
+++ b/server/discord/bridge.ts
@@ -327,6 +327,7 @@ export class DiscordBridge {
                 name: 'council',
                 description: 'Launch a council deliberation on a topic',
                 type: 1,
+                default_member_permissions: '8', // ADMINISTRATOR — hidden from non-admins
                 options: [{
                     name: 'topic',
                     description: 'The topic to deliberate on',
@@ -348,6 +349,7 @@ export class DiscordBridge {
                 name: 'mute',
                 description: 'Mute a user from bot interactions (admin only)',
                 type: 1,
+                default_member_permissions: '8', // ADMINISTRATOR — hidden from non-admins
                 options: [{
                     name: 'user',
                     description: 'The user to mute',
@@ -359,6 +361,7 @@ export class DiscordBridge {
                 name: 'unmute',
                 description: 'Unmute a user (admin only)',
                 type: 1,
+                default_member_permissions: '8', // ADMINISTRATOR — hidden from non-admins
                 options: [{
                     name: 'user',
                     description: 'The user to unmute',
@@ -370,6 +373,7 @@ export class DiscordBridge {
                 name: 'admin',
                 description: 'Manage bot configuration (admin only)',
                 type: 1, // CHAT_INPUT
+                default_member_permissions: '8', // ADMINISTRATOR — hidden from non-admins
                 options: [
                     {
                         name: 'channels',


### PR DESCRIPTION
## Summary
- Add `default_member_permissions: '8'` (ADMINISTRATOR) to `/admin`, `/council`, `/mute`, and `/unmute` slash commands
- Non-admin users will no longer see these commands in the Discord command picker
- Runtime permission checks remain as a safety net

## Changes
- `server/discord/bridge.ts` — add `default_member_permissions` to 4 command registrations
- `package.json` / `Chart.yaml` — bump to v0.24.2
- `README.md` — update version badge
- `CHANGELOG.md` — add v0.24.2 entry

## Test plan
- [x] `bun x tsc` passes
- [x] Discord slash command tests pass (4/4)
- [ ] Deploy and verify `/admin` is hidden from non-admin users in Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)