### PR TITLE
fix: serialize Ollama cloud model requests to prevent proxy timeouts

### DIFF
--- a/server/providers/ollama/provider.ts
+++ b/server/providers/ollama/provider.ts
@@ -436,6 +436,12 @@ export class OllamaProvider extends BaseLlmProvider {
 
     /** Resolve the concurrency weight for a model based on its parameter size. */
     private getModelWeight(modelName: string): number {
+        // Cloud models (e.g. "qwen3.5:cloud") are proxied through Ollama's cloud
+        // gateway which serializes requests. Assign maxWeight so only one cloud
+        // model inference runs at a time, preventing proxy bottleneck & timeouts.
+        if (modelName.includes('-cloud') || modelName.includes(':cloud')) {
+            return this.maxWeight;
+        }
         const tag = this.cachedTags.find(t => t.name === modelName);
         const paramSize = tag?.details?.parameter_size; // e.g. "14B", "3.4B", "8B"
         if (!paramSize) return 1; // unknown → assume small


### PR DESCRIPTION
## Summary
- Cloud Ollama models (e.g. `qwen3.5:cloud`) were getting weight=1 in the slot system because they're not in the local tags cache
- This allowed multiple cloud requests to run simultaneously through Ollama's proxy, causing bottlenecks and timeouts during council sessions
- Now cloud models get `maxWeight`, forcing serialization so only one cloud inference runs at a time

## Details
The Ollama provider uses a weight-based slot queue (`acquireSlot`/`releaseSlot`) to limit concurrent model inference. Local models get weight 1-3 based on parameter size. Cloud models were unrecognized (no local tag entry), so they defaulted to weight=1, allowing many to run in parallel. Since Ollama's cloud proxy serializes requests anyway, this caused timeouts.

The fix detects cloud models by name pattern (`-cloud` or `:cloud` suffix) and assigns `maxWeight` to force one-at-a-time execution through the slot system.

**No impact on**: local Ollama models, Claude, or OpenAI providers.

Closes #925

## Test plan
- [x] TSC compiles clean
- [x] 93/93 provider tests pass
- [ ] Run exams with cloud models to verify no timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)