### PR TITLE
release: v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.25.0] - 2026-03-11
+
+### Security
+- **KMS migration enforcement** — encrypted in-memory key cache, startup enforcement requiring KMS migration, key access audit logging with 18 new tests (#931)
+- **Hono CVE override** — update hono override to >=4.12.7 for CVE GHSA-v8w9-8mx6-g223 (#934)
+- **Admin role guard** — add admin role guard to repo-blocklist routes (#930)
+
+### Fixed
+- **Ollama cloud model serialization** — cloud models get `maxWeight` in the slot system to force serialization and prevent proxy timeouts (#937)
+- Hide admin Discord commands from non-admin users (#921)
+
+### Changed
+- **Discord bridge decomposition** — decompose `discord/bridge.ts` from 2,688 to 367 lines (#933)
+
+### Added
+- RC verification script and mainnet config template (#917)
+- Spec documentation for polling modules: auto-merge, auto-update, ci-retry (#936)
+
+### Chore
+- Align `@opentelemetry/exporter-prometheus` to 0.213.0 (#922)
+- Sync MCP tools, migration count, and directory structure in docs (#935)
+
 ## [0.24.2] - 2026-03-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.24.2-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.25.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: corvid-agent
 description: Agent orchestration platform with MCP tools, AlgoChat messaging, and on-chain wallet integration
 type: application
-version: 0.24.2
-appVersion: "0.24.2"
+version: 0.25.0
+appVersion: "0.25.0"
 keywords:
   - ai
   - agent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.24.2",
+  "version": "0.25.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version to 0.25.0 across package.json, README.md, Helm chart, and CHANGELOG.md
- Includes 10 commits since v0.24.1: KMS security enforcement, Ollama cloud fix, Discord bridge decomposition, admin role guard, Hono CVE override, RC verification script, polling specs, otel deps, docs sync

## Changelog highlights
- **Security:** KMS migration enforcement with encrypted key cache (#931), Hono CVE override (#934), admin role guard (#930)
- **Fixed:** Ollama cloud model serialization (#937), admin Discord command visibility (#921)
- **Changed:** Discord bridge.ts decomposed from 2,688 to 367 lines (#933)
- **Added:** RC verification script (#917), polling module specs (#936)

## Test plan
- [ ] CI passes (Build & Test on all 3 platforms)
- [ ] Version badge shows 0.25.0 in README
- [ ] Tag v0.25.0 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)