### PR TITLE
docs: update version references to v0.25.0

### DIFF
--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -46,7 +46,7 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Module specs | 119 .spec.md files |
 | Test:code ratio | 1.14x (more test than production) |
 | Dependencies | 17 direct |
-| Version | 0.22.0 |
+| Version | 0.25.0 |
 | Git commits | 558 |
 
 ### Tech Stack

--- a/server/__tests__/routes-health.test.ts
+++ b/server/__tests__/routes-health.test.ts
@@ -15,7 +15,7 @@ function createMockDeps(db: Database, overrides?: Partial<HealthCheckDeps>): Hea
     return {
         db,
         startTime: Date.now() - 60_000, // 1 minute ago
-        version: '0.22.0-test',
+        version: '0.25.0-test',
         getActiveSessions: mock(() => []),
         isAlgoChatConnected: mock(() => false),
         isShuttingDown: mock(() => false),
@@ -101,7 +101,7 @@ describe('routes/health', () => {
         const res = await handleHealthRoutes(req, url, deps, db);
         expect(res!.status).toBe(200);
         const data = await res!.json();
-        expect(data.version).toBe('0.22.0-test');
+        expect(data.version).toBe('0.25.0-test');
         expect(data.uptime).toBeGreaterThanOrEqual(0);
         expect(data.dependencies).toBeDefined();
         expect(data.dependencies.database.status).toBe('healthy');
@@ -113,7 +113,7 @@ describe('routes/health', () => {
         const res = await handleHealthRoutes(req, url, deps, db);
         expect(res!.status).toBe(200);
         const data = await res!.json();
-        expect(data.version).toBe('0.22.0-test');
+        expect(data.version).toBe('0.25.0-test');
     });
 
     it('returns 503 when shutting down', async () => {


### PR DESCRIPTION
## Summary
- Update version from 0.22.0 to 0.25.0 in `docs/deep-dive.md` and `server/__tests__/routes-health.test.ts`

## Test plan
- [x] Version string updated in docs
- [x] Health route test expectations updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)