### PR TITLE
fix: bypass allowlist for assignment-type GitHub mentions

### DIFF
--- a/server/__tests__/github-searcher.test.ts
+++ b/server/__tests__/github-searcher.test.ts
@@ -748,11 +748,15 @@ describe('GitHubSearcher', () => {
             const isAllowed = (sender: string) => sender === 'allowed-user';
 
             const result = await searcher.fetchMentions(config, isAllowed);
-            // Assigned search runs without mention filter, so it will include items
-            // but the global isAllowed filter should block 'blocked-user'
-            for (const m of result) {
+            // Non-assignment mentions from blocked users are filtered out.
+            // Assignment-type mentions bypass the allowlist (assignment = authorization).
+            const nonAssignment = result.filter(m => m.type !== 'assignment');
+            for (const m of nonAssignment) {
                 expect(m.sender).toBe('allowed-user');
             }
+            // Assignment mentions from blocked-user should still be included
+            const assignments = result.filter(m => m.type === 'assignment');
+            expect(assignments.length).toBeGreaterThan(0);
         });
 
         test('applies per-config allowed users filter', async () => {
@@ -780,9 +784,14 @@ describe('GitHubSearcher', () => {
             });
 
             const result = await searcher.fetchMentions(config, () => true);
-            for (const m of result) {
+            // Non-assignment mentions should only be from alice
+            const nonAssignment = result.filter(m => m.type !== 'assignment');
+            for (const m of nonAssignment) {
                 expect(m.sender.toLowerCase()).toBe('alice');
             }
+            // Assignment mentions bypass per-config filter too
+            const assignments = result.filter(m => m.type === 'assignment');
+            expect(assignments.length).toBeGreaterThan(0);
         });
 
         test('sorts mentions by createdAt descending', async () => {

--- a/server/polling/github-searcher.ts
+++ b/server/polling/github-searcher.ts
@@ -124,13 +124,28 @@ export class GitHubSearcher {
         // Sort by creation time descending (newest first)
         mentions.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
-        // Global allowlist filter (empty = open mode)
-        const globalFiltered = mentions.filter(m => isAllowed(m.sender));
+        // Global allowlist filter (empty = open mode).
+        // Assignment-type mentions bypass the allowlist — the assignment itself
+        // is authorization (someone with repo write access explicitly assigned us).
+        const globalFiltered = mentions.filter(m => {
+            if (m.type === 'assignment') return true;
+            const allowed = isAllowed(m.sender);
+            if (!allowed) {
+                log.debug('Filtered mention — sender not in allowlist', {
+                    sender: m.sender, type: m.type, number: m.number, id: m.id,
+                });
+            }
+            return allowed;
+        });
 
-        // Per-config allowed users filter (further restricts global list)
+        // Per-config allowed users filter (further restricts global list).
+        // Assignments still bypass this filter.
         if (config.allowedUsers.length > 0) {
             const allowed = new Set(config.allowedUsers.map(u => u.toLowerCase()));
-            return globalFiltered.filter(m => allowed.has(m.sender.toLowerCase()));
+            return globalFiltered.filter(m => {
+                if (m.type === 'assignment') return true;
+                return allowed.has(m.sender.toLowerCase());
+            });
         }
 
         return globalFiltered;


### PR DESCRIPTION
## Summary
- Assignment-type GitHub mentions now bypass both the global allowlist and per-config `allowedUsers` filters
- The assignment itself is the authorization signal — only users with repo write access can assign, making the allowlist check redundant
- Added debug logging when non-assignment mentions are filtered by allowlist

Fixes #944

## Context
`0xLeif` was in the allowlist, but the issue author's username was being checked against the allowlist for assignment mentions. The `sender` for assignment mentions is the issue **author**, not the assigner. This caused assignments to be silently dropped when the author wasn't allowlisted.

## Test plan
- [x] Updated existing tests to verify assignment bypass behavior
- [x] All 73 github-searcher tests pass
- [x] No new TSC errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)