### PR TITLE
release: v0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.25.2] - 2026-03-11
+
+### Fixed
+- **Discord typing indicator** — add safety timeout to prevent typing indicator interval leaks (#947)
+- **GitHub mention allowlist** — bypass allowlist for assignment-type GitHub mentions (#946)
+- **Process exit errors** — pass error details through process exit to session messages (#945)
+- **Discord mentions** — resolve Discord mentions to @username in message text (#942)
+
+### Chore
+- **Test coverage** — coverage expansion for response, builtin middleware, key rotation (#943)
+
 ## [0.25.1] - 2026-03-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.25.1-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.25.2-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: corvid-agent
 description: Agent orchestration platform with MCP tools, AlgoChat messaging, and on-chain wallet integration
 type: application
-version: 0.25.1
-appVersion: "0.25.1"
+version: 0.25.2
+appVersion: "0.25.2"
 keywords:
   - ai
   - agent

--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -46,7 +46,7 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Module specs | 119 .spec.md files |
 | Test:code ratio | 1.14x (more test than production) |
 | Dependencies | 17 direct |
-| Version | 0.25.1 |
+| Version | 0.25.2 |
 | Git commits | 558 |
 
 ### Tech Stack

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",

--- a/server/__tests__/routes-health.test.ts
+++ b/server/__tests__/routes-health.test.ts
@@ -15,7 +15,7 @@ function createMockDeps(db: Database, overrides?: Partial<HealthCheckDeps>): Hea
     return {
         db,
         startTime: Date.now() - 60_000, // 1 minute ago
-        version: '0.25.1-test',
+        version: '0.25.2-test',
         getActiveSessions: mock(() => []),
         isAlgoChatConnected: mock(() => false),
         isShuttingDown: mock(() => false),
@@ -101,7 +101,7 @@ describe('routes/health', () => {
         const res = await handleHealthRoutes(req, url, deps, db);
         expect(res!.status).toBe(200);
         const data = await res!.json();
-        expect(data.version).toBe('0.25.1-test');
+        expect(data.version).toBe('0.25.2-test');
         expect(data.uptime).toBeGreaterThanOrEqual(0);
         expect(data.dependencies).toBeDefined();
         expect(data.dependencies.database.status).toBe('healthy');
@@ -113,7 +113,7 @@ describe('routes/health', () => {
         const res = await handleHealthRoutes(req, url, deps, db);
         expect(res!.status).toBe(200);
         const data = await res!.json();
-        expect(data.version).toBe('0.25.1-test');
+        expect(data.version).toBe('0.25.2-test');
     });
 
     it('returns 503 when shutting down', async () => {


### PR DESCRIPTION
## Summary
- Bump version to 0.25.2 across all 6 version files
- Includes fixes from PRs #942, #943, #945, #946, #947 since v0.25.1

## Changes since v0.25.1
- fix: add safety timeout to Discord typing indicator intervals (#947)
- fix: bypass allowlist for assignment-type GitHub mentions (#946)
- fix: pass error details through process exit to session messages (#945)
- test: coverage expansion for response, builtin middleware, key rotation (#943)
- fix: resolve Discord mentions to @username in message text (#942)

## Test plan
- [x] CI passes (build, tests, coverage, security scans)
- [x] Version updated in package.json, README.md, Chart.yaml, deep-dive.md, CHANGELOG.md, routes-health.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)