### PR TITLE
release: v0.25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.25.3] - 2026-03-11
+
+### Fixed
+- **Install script** — read user input from /dev/tty so prompts work when piped via curl (#944, #949)
+
 ## [0.25.2] - 2026-03-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.25.2-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.25.3-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: corvid-agent
 description: Agent orchestration platform with MCP tools, AlgoChat messaging, and on-chain wallet integration
 type: application
-version: 0.25.2
-appVersion: "0.25.2"
+version: 0.25.3
+appVersion: "0.25.3"
 keywords:
   - ai
   - agent

--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -46,7 +46,7 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Module specs | 119 .spec.md files |
 | Test:code ratio | 1.14x (more test than production) |
 | Dependencies | 17 direct |
-| Version | 0.25.2 |
+| Version | 0.25.3 |
 | Git commits | 558 |
 
 ### Tech Stack

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",

--- a/server/__tests__/routes-health.test.ts
+++ b/server/__tests__/routes-health.test.ts
@@ -15,7 +15,7 @@ function createMockDeps(db: Database, overrides?: Partial<HealthCheckDeps>): Hea
     return {
         db,
         startTime: Date.now() - 60_000, // 1 minute ago
-        version: '0.25.2-test',
+        version: '0.25.3-test',
         getActiveSessions: mock(() => []),
         isAlgoChatConnected: mock(() => false),
         isShuttingDown: mock(() => false),
@@ -101,7 +101,7 @@ describe('routes/health', () => {
         const res = await handleHealthRoutes(req, url, deps, db);
         expect(res!.status).toBe(200);
         const data = await res!.json();
-        expect(data.version).toBe('0.25.2-test');
+        expect(data.version).toBe('0.25.3-test');
         expect(data.uptime).toBeGreaterThanOrEqual(0);
         expect(data.dependencies).toBeDefined();
         expect(data.dependencies.database.status).toBe('healthy');
@@ -113,7 +113,7 @@ describe('routes/health', () => {
         const res = await handleHealthRoutes(req, url, deps, db);
         expect(res!.status).toBe(200);
         const data = await res!.json();
-        expect(data.version).toBe('0.25.2-test');
+        expect(data.version).toBe('0.25.3-test');
     });
 
     it('returns 503 when shutting down', async () => {


### PR DESCRIPTION
## Summary
- Bump version to 0.25.3 across package.json, README, Helm chart, deep-dive docs, health tests, and CHANGELOG
- Includes fix for install script reading user input from /dev/tty when piped via curl (#944, #949)

## Changes
- `package.json` → 0.25.3
- `README.md` version badge → 0.25.3
- `deploy/helm/Chart.yaml` → 0.25.3
- `docs/deep-dive.md` version row → 0.25.3
- `server/__tests__/routes-health.test.ts` → 0.25.3-test
- `CHANGELOG.md` — new 0.25.3 section

## Test plan
- [ ] CI passes
- [ ] Health endpoint returns 0.25.3
- [ ] Helm chart lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)