### PR TITLE
fix: convert remaining DEFERRED transactions to BEGIN IMMEDIATE

### DIFF
--- a/server/__tests__/db-pool.test.ts
+++ b/server/__tests__/db-pool.test.ts
@@ -245,6 +245,157 @@ describe('DbPool', () => {
     });
 });
 
+// ── Concurrent write regression (SQLITE_BUSY prevention) ─────────────────
+
+describe('concurrent write contention regression', () => {
+    let tmpDir: string;
+    let dbPath: string;
+
+    beforeEach(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), 'dbcontention-test-'));
+        dbPath = join(tmpDir, 'test.db');
+        const setup = new Database(dbPath, { create: true });
+        setup.exec('PRAGMA journal_mode = WAL');
+        setup.exec('PRAGMA foreign_keys = ON');
+        setup.exec('CREATE TABLE counters (name TEXT PRIMARY KEY, value INTEGER NOT NULL DEFAULT 0)');
+        setup.exec("INSERT INTO counters (name, value) VALUES ('c', 0)");
+        setup.close();
+    });
+
+    afterEach(() => {
+        for (const suffix of ['', '-wal', '-shm']) {
+            const f = dbPath + suffix;
+            if (existsSync(f)) {
+                try { unlinkSync(f); } catch { /* ignore */ }
+            }
+        }
+    });
+
+    test('interleaved writes from two connections do not produce SQLITE_BUSY', () => {
+        // Simulates two parallel work task processes sharing the same DB file.
+        // In WAL mode + busy_timeout each connection waits rather than failing immediately.
+        const conn1 = new Database(dbPath);
+        conn1.exec('PRAGMA journal_mode = WAL');
+        conn1.exec('PRAGMA busy_timeout = 5000');
+
+        const conn2 = new Database(dbPath);
+        conn2.exec('PRAGMA journal_mode = WAL');
+        conn2.exec('PRAGMA busy_timeout = 5000');
+
+        const iterations = 20;
+        for (let i = 0; i < iterations; i++) {
+            writeTransaction(conn1, (db) => {
+                db.query('UPDATE counters SET value = value + 1 WHERE name = ?').run('c');
+            });
+            writeTransaction(conn2, (db) => {
+                db.query('UPDATE counters SET value = value + 1 WHERE name = ?').run('c');
+            });
+        }
+
+        const row = conn1.query('SELECT value FROM counters WHERE name = ?').get('c') as { value: number };
+        expect(row.value).toBe(iterations * 2);
+
+        conn1.close();
+        conn2.close();
+    });
+
+    test('WAL mode allows reads during writes from a second connection', () => {
+        const writer = new Database(dbPath);
+        writer.exec('PRAGMA journal_mode = WAL');
+        writer.exec('PRAGMA busy_timeout = 5000');
+
+        const reader = new Database(dbPath, { readonly: true });
+        reader.exec('PRAGMA journal_mode = WAL');
+        reader.exec('PRAGMA busy_timeout = 5000');
+
+        // Perform a write and immediately verify the reader sees consistent data
+        writeTransaction(writer, (db) => {
+            db.query('UPDATE counters SET value = 42 WHERE name = ?').run('c');
+        });
+
+        // WAL readers should see the committed value
+        const row = reader.query('SELECT value FROM counters WHERE name = ?').get('c') as { value: number };
+        expect(row.value).toBe(42);
+
+        writer.close();
+        reader.close();
+    });
+
+    test('writeTransaction retries and succeeds when a held lock releases', () => {
+        // Open two connections to the same file
+        const conn1 = new Database(dbPath);
+        conn1.exec('PRAGMA journal_mode = WAL');
+        conn1.exec('PRAGMA busy_timeout = 0'); // fail immediately — we rely on app-level retry
+
+        const conn2 = new Database(dbPath);
+        conn2.exec('PRAGMA journal_mode = WAL');
+        conn2.exec('PRAGMA busy_timeout = 0');
+
+        // conn1 manually acquires the write lock
+        conn1.exec('BEGIN IMMEDIATE');
+
+        let retried = false;
+        let attempts = 0;
+
+        // conn2 attempts a write: first try will get SQLITE_BUSY (conn1 holds lock),
+        // then we release conn1's lock during the retry delay, and conn2 succeeds.
+        // We simulate this by overriding the retry options with a callback hook.
+        //
+        // Since Bun is single-threaded and sleepSync blocks, we instead test the
+        // detection path: verify isSqliteBusy correctly classifies the error, and
+        // that writeTransaction propagates after maxRetries exhausted.
+        try {
+            writeTransaction(conn2, (db) => {
+                attempts++;
+                db.query('UPDATE counters SET value = 99 WHERE name = ?').run('c');
+            }, { maxRetries: 1, baseDelayMs: 1 });
+        } catch (err) {
+            retried = true;
+            expect(isSqliteBusy(err)).toBe(true);
+        }
+
+        // conn1 still held the lock — conn2 should have retried and then thrown SQLITE_BUSY
+        expect(retried).toBe(true);
+
+        conn1.exec('ROLLBACK');
+        conn1.close();
+        conn2.close();
+    });
+
+    test('no SQLITE_BUSY when writes from two connections are wrapped in writeTransaction with busy_timeout', () => {
+        // Both connections use busy_timeout=500 so SQLite waits before throwing
+        const conn1 = new Database(dbPath);
+        conn1.exec('PRAGMA journal_mode = WAL');
+        conn1.exec('PRAGMA busy_timeout = 500');
+
+        const conn2 = new Database(dbPath);
+        conn2.exec('PRAGMA journal_mode = WAL');
+        conn2.exec('PRAGMA busy_timeout = 500');
+
+        let errors = 0;
+
+        for (let i = 0; i < 10; i++) {
+            try {
+                writeTransaction(conn1, (db) => {
+                    db.query('UPDATE counters SET value = value + 1 WHERE name = ?').run('c');
+                });
+                writeTransaction(conn2, (db) => {
+                    db.query('UPDATE counters SET value = value + 1 WHERE name = ?').run('c');
+                });
+            } catch {
+                errors++;
+            }
+        }
+
+        expect(errors).toBe(0);
+        const row = conn1.query('SELECT value FROM counters WHERE name = ?').get('c') as { value: number };
+        expect(row.value).toBe(20);
+
+        conn1.close();
+        conn2.close();
+    });
+});
+
 // ── Integration: writeTransaction with existing DB functions ─────────────
 
 describe('writeTransaction integration', () => {

--- a/server/db/agents.ts
+++ b/server/db/agents.ts
@@ -1,4 +1,5 @@
 import { Database, type SQLQueryBindings } from 'bun:sqlite';
+import { writeTransaction } from './pool';
 import type { Agent, CreateAgentInput, UpdateAgentInput } from '../../shared/types';
 import { NotFoundError } from '../lib/errors';
 import { DEFAULT_TENANT_ID } from '../tenant/types';
@@ -180,7 +181,7 @@ export function deleteAgent(db: Database, id: string, tenantId: string = DEFAULT
     const existing = getAgent(db, id, tenantId);
     if (!existing) return false;
 
-    db.transaction(() => {
+    writeTransaction(db, (db) => {
         // Delete dependent records that reference this agent
         // Order matters: delete children before parents
 
@@ -234,7 +235,7 @@ export function deleteAgent(db: Database, id: string, tenantId: string = DEFAULT
 
         // Finally delete the agent
         db.query('DELETE FROM agents WHERE id = ?').run(id);
-    })();
+    });
 
     return true;
 }

--- a/server/db/councils.ts
+++ b/server/db/councils.ts
@@ -1,4 +1,5 @@
 import { Database, type SQLQueryBindings } from 'bun:sqlite';
+import { writeTransaction } from './pool';
 import type {
     Council,
     CouncilDiscussionMessage,
@@ -109,7 +110,7 @@ export function getCouncil(db: Database, id: string, tenantId: string = DEFAULT_
 export function createCouncil(db: Database, input: CreateCouncilInput, tenantId: string = DEFAULT_TENANT_ID): Council {
     const id = crypto.randomUUID();
 
-    db.transaction(() => {
+    writeTransaction(db, (db) => {
         db.query(
             `INSERT INTO councils (id, name, description, chairman_agent_id, discussion_rounds, on_chain_mode, quorum_type, quorum_threshold, tenant_id)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
@@ -120,7 +121,7 @@ export function createCouncil(db: Database, input: CreateCouncilInput, tenantId:
                 'INSERT INTO council_members (council_id, agent_id, sort_order) VALUES (?, ?, ?)'
             ).run(id, input.agentIds[i], i);
         }
-    })();
+    });
 
     return getCouncil(db, id) as Council;
 }
@@ -129,7 +130,7 @@ export function updateCouncil(db: Database, id: string, input: UpdateCouncilInpu
     const existing = getCouncil(db, id, tenantId);
     if (!existing) return null;
 
-    db.transaction(() => {
+    writeTransaction(db, (db) => {
         const fields: string[] = [];
         const values: unknown[] = [];
 
@@ -176,14 +177,14 @@ export function updateCouncil(db: Database, id: string, input: UpdateCouncilInpu
                 ).run(id, input.agentIds[i], i);
             }
         }
-    })();
+    });
 
     return getCouncil(db, id, tenantId);
 }
 
 export function deleteCouncil(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): boolean {
     if (tenantId !== DEFAULT_TENANT_ID && !validateTenantOwnership(db, 'councils', id, tenantId)) return false;
-    const result = db.transaction(() => {
+    const result = writeTransaction(db, (db) => {
         // council_launch_logs and council_discussion_messages cascade from council_launches
         // Sessions may reference council_launches via council_launch_id
         db.query(`UPDATE sessions SET council_launch_id = NULL WHERE council_launch_id IN
@@ -191,7 +192,7 @@ export function deleteCouncil(db: Database, id: string, tenantId: string = DEFAU
         db.query('DELETE FROM council_launches WHERE council_id = ?').run(id);
         // council_members has ON DELETE CASCADE, handled automatically
         return db.query('DELETE FROM councils WHERE id = ?').run(id);
-    })();
+    });
     return result.changes > 0;
 }
 

--- a/server/db/discord-config.ts
+++ b/server/db/discord-config.ts
@@ -6,6 +6,7 @@
  * Dynamic settings (channels, users, roles, permissions) live here.
  */
 import type { Database } from 'bun:sqlite';
+import { writeTransaction } from './pool';
 import { createLogger } from '../lib/logger';
 
 const log = createLogger('DiscordConfig');
@@ -118,12 +119,12 @@ export function updateDiscordConfigBatch(db: Database, updates: Record<string, s
         `INSERT OR REPLACE INTO discord_config (key, value, updated_at) VALUES (?, ?, datetime('now'))`,
     );
     let count = 0;
-    db.transaction(() => {
+    writeTransaction(db, (_db) => {
         for (const [key, value] of Object.entries(updates)) {
             stmt.run(key, value);
             count++;
         }
-    })();
+    });
     log.info('Discord config batch updated', { count });
     return count;
 }
@@ -170,7 +171,7 @@ export function initDiscordConfigFromEnv(db: Database): void {
     );
 
     let seeded = 0;
-    db.transaction(() => {
+    writeTransaction(db, (_db) => {
         for (const [envKey, dbKey] of envMappings) {
             const value = process.env[envKey];
             if (value !== undefined && value !== '') {
@@ -178,7 +179,7 @@ export function initDiscordConfigFromEnv(db: Database): void {
                 if (result.changes > 0) seeded++;
             }
         }
-    })();
+    });
 
     if (seeded > 0) {
         log.info('Discord config seeded from environment', { count: seeded });

--- a/server/db/projects.ts
+++ b/server/db/projects.ts
@@ -1,4 +1,5 @@
 import { Database, type SQLQueryBindings } from 'bun:sqlite';
+import { writeTransaction } from './pool';
 import type { Project, CreateProjectInput, UpdateProjectInput } from '../../shared/types';
 import { DEFAULT_TENANT_ID } from '../tenant/types';
 import { withTenantFilter, validateTenantOwnership, tenantQuery } from '../tenant/db-filter';
@@ -103,7 +104,7 @@ export function deleteProject(db: Database, id: string, tenantId: string = DEFAU
     const existing = getProject(db, id, tenantId);
     if (!existing) return false;
 
-    db.transaction(() => {
+    writeTransaction(db, (db) => {
         // Delete dependent records that reference this project
         // Order matters: delete children before parents
 
@@ -122,7 +123,7 @@ export function deleteProject(db: Database, id: string, tenantId: string = DEFAU
 
         // Finally delete the project itself
         db.query('DELETE FROM projects WHERE id = ?').run(id);
-    })();
+    });
 
     return true;
 }

--- a/server/db/sessions.ts
+++ b/server/db/sessions.ts
@@ -1,4 +1,5 @@
 import { Database, type SQLQueryBindings } from 'bun:sqlite';
+import { writeTransaction } from './pool';
 import type {
     Session,
     SessionMessage,
@@ -200,12 +201,12 @@ export function updateSessionAlgoSpent(db: Database, id: string, microAlgos: num
 
 export function deleteSession(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): boolean {
     if (!validateTenantOwnership(db, 'sessions', id, tenantId)) return false;
-    const result = db.transaction(() => {
+    const result = writeTransaction(db, (db) => {
         // Clean up dependent records
         db.query('DELETE FROM session_messages WHERE session_id = ?').run(id);
         db.query('UPDATE algochat_conversations SET session_id = NULL WHERE session_id = ?').run(id);
         return db.query('DELETE FROM sessions WHERE id = ?').run(id);
-    })();
+    });
     return result.changes > 0;
 }
 


### PR DESCRIPTION
## Summary

With TaskQueueService (#951) enabling parallel work task dispatch, SQLite write contention is a live reliability concern. The existing infrastructure (WAL mode, `busy_timeout=5000`, `DbPool` with `BEGIN IMMEDIATE` + exponential backoff) was already in place, but several multi-statement write paths in `server/db/` still used `db.transaction()` — which defaults to `BEGIN DEFERRED`.

**The problem with DEFERRED:** SQLite acquires the write lock lazily (at the first write statement). If two connections are mid-transaction and both attempt their first write simultaneously, one gets `SQLITE_BUSY` with no clean retry point.

**The fix — `BEGIN IMMEDIATE`:** Acquires the write lock at `BEGIN` time. Contention surfaces immediately, before any mutations, enabling clean retry via exponential backoff.

### Files converted

| File | Function(s) |
|------|-------------|
| `server/db/agents.ts` | `deleteAgent` (13 DELETE/UPDATE statements) |
| `server/db/councils.ts` | `createCouncil`, `updateCouncil`, `deleteCouncil` |
| `server/db/discord-config.ts` | `updateDiscordConfigBatch`, `initDiscordConfigFromEnv` |
| `server/db/projects.ts` | `deleteProject` |
| `server/db/sessions.ts` | `deleteSession` |

All now use `writeTransaction()` from `server/db/pool.ts`, which wraps `BEGIN IMMEDIATE` with retry (up to 3 attempts, exponential backoff with jitter).

## Tests

Added 4 regression tests to `server/__tests__/db-pool.test.ts`:

- **Interleaved two-connection writes** — 20 pairs of writes from two separate `Database` connections to the same file succeed without error
- **WAL reader isolation** — reader connection sees committed data after writer commits
- **Retry + SQLITE_BUSY propagation** — `writeTransaction` retries on busy, then re-throws `isSqliteBusy` error after exhaustion
- **No SQLITE_BUSY with busy_timeout** — sequential writes from two connections with `busy_timeout=500` produce zero errors

## Validation

- `bun x tsc --noEmit --skipLibCheck` → clean
- `bun test` → 6451 pass, 0 fail (267 files)
- `bun run spec:check` → 120/120

Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)