### PR TITLE
feat: add periodic heartbeat and stale sweep for Flock Directory

### DIFF
--- a/server/__tests__/flock-directory-lifecycle.test.ts
+++ b/server/__tests__/flock-directory-lifecycle.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for Flock Directory lifecycle — heartbeat, stale sweep, and self-registration flow.
+ *
+ * Covers the periodic maintenance behavior added for #903:
+ * - selfRegister idempotency acts as heartbeat
+ * - sweepStaleAgents marks agents inactive after heartbeat timeout
+ * - Full lifecycle: register → heartbeat → stale → sweep → re-register
+ */
+import { test, expect, describe, beforeEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import { FlockDirectoryService } from '../flock-directory/service';
+
+let db: Database;
+let svc: FlockDirectoryService;
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+    svc = new FlockDirectoryService(db);
+});
+
+const SELF_OPTS = {
+    address: 'ALGO_LIFECYCLE',
+    name: 'corvid-agent',
+    description: 'Test agent',
+    instanceUrl: 'http://localhost:3000',
+    capabilities: ['code', 'test'],
+};
+
+// ─── Heartbeat via selfRegister ─────────────────────────────────────────────
+
+describe('heartbeat via selfRegister', () => {
+    test('selfRegister on already-active agent updates heartbeat timestamp', async () => {
+        const first = await svc.selfRegister(SELF_OPTS);
+        // Small delay to ensure timestamp difference
+        await new Promise(r => setTimeout(r, 50));
+
+        await svc.selfRegister(SELF_OPTS);
+        const updated = svc.getByAddress(SELF_OPTS.address)!;
+
+        expect(updated.id).toBe(first.id);
+        expect(updated.status).toBe('active');
+        expect(updated.lastHeartbeat).not.toBeNull();
+    });
+
+    test('explicit heartbeat keeps agent active', async () => {
+        const agent = await svc.selfRegister(SELF_OPTS);
+        const result = svc.heartbeat(agent.id);
+        expect(result).toBe(true);
+
+        const refreshed = svc.getById(agent.id)!;
+        expect(refreshed.status).toBe('active');
+    });
+});
+
+// ─── Stale Sweep ────────────────────────────────────────────────────────────
+
+describe('sweepStaleAgents', () => {
+    test('marks agents inactive after heartbeat timeout', async () => {
+        const agent = await svc.selfRegister(SELF_OPTS);
+
+        // Backdate the heartbeat to 45 minutes ago (beyond 30-min threshold)
+        db.query(
+            `UPDATE flock_agents SET last_heartbeat = datetime('now', '-45 minutes') WHERE id = ?`,
+        ).run(agent.id);
+
+        const swept = svc.sweepStaleAgents();
+        expect(swept).toBe(1);
+
+        const stale = svc.getById(agent.id)!;
+        expect(stale.status).toBe('inactive');
+    });
+
+    test('does not sweep agents with recent heartbeat', async () => {
+        await svc.selfRegister(SELF_OPTS);
+
+        const swept = svc.sweepStaleAgents();
+        expect(swept).toBe(0);
+    });
+
+    test('does not sweep deregistered agents', async () => {
+        const agent = await svc.selfRegister(SELF_OPTS);
+        svc.deregister(agent.id);
+
+        // Backdate heartbeat
+        db.query(
+            `UPDATE flock_agents SET last_heartbeat = datetime('now', '-45 minutes') WHERE id = ?`,
+        ).run(agent.id);
+
+        const swept = svc.sweepStaleAgents();
+        expect(swept).toBe(0);
+    });
+
+    test('sweeps multiple stale agents at once', async () => {
+        const a1 = svc.register({ address: 'STALE_1', name: 'Agent1' });
+        const a2 = svc.register({ address: 'STALE_2', name: 'Agent2' });
+        svc.register({ address: 'FRESH', name: 'Agent3' }); // stays fresh
+
+        // Backdate two agents
+        db.query(
+            `UPDATE flock_agents SET last_heartbeat = datetime('now', '-60 minutes') WHERE id IN (?, ?)`,
+        ).run(a1.id, a2.id);
+
+        const swept = svc.sweepStaleAgents();
+        expect(swept).toBe(2);
+
+        expect(svc.getById(a1.id)!.status).toBe('inactive');
+        expect(svc.getById(a2.id)!.status).toBe('inactive');
+    });
+});
+
+// ─── Full Lifecycle ─────────────────────────────────────────────────────────
+
+describe('full lifecycle', () => {
+    test('register → heartbeat → go stale → sweep → re-register', async () => {
+        // 1. Register
+        const agent = await svc.selfRegister(SELF_OPTS);
+        expect(agent.status).toBe('active');
+
+        // 2. Heartbeat
+        svc.heartbeat(agent.id);
+        expect(svc.getById(agent.id)!.status).toBe('active');
+
+        // 3. Go stale (backdate heartbeat)
+        db.query(
+            `UPDATE flock_agents SET last_heartbeat = datetime('now', '-45 minutes') WHERE id = ?`,
+        ).run(agent.id);
+
+        // 4. Sweep
+        const swept = svc.sweepStaleAgents();
+        expect(swept).toBe(1);
+        expect(svc.getById(agent.id)!.status).toBe('inactive');
+
+        // 5. Self-register again — heartbeat should reactivate
+        await svc.selfRegister(SELF_OPTS);
+        const recovered = svc.getById(agent.id)!;
+        expect(recovered.id).toBe(agent.id);
+        expect(recovered.status).toBe('active');
+    });
+
+    test('stats reflect active/inactive counts after sweep', async () => {
+        svc.register({ address: 'S_ACTIVE', name: 'Active' });
+        const staleAgent = svc.register({ address: 'S_STALE', name: 'Stale' });
+
+        db.query(
+            `UPDATE flock_agents SET last_heartbeat = datetime('now', '-60 minutes') WHERE id = ?`,
+        ).run(staleAgent.id);
+
+        svc.sweepStaleAgents();
+
+        const stats = svc.getStats();
+        expect(stats.total).toBe(2);
+        expect(stats.active).toBe(1);
+        expect(stats.inactive).toBe(1);
+    });
+});

--- a/server/algochat/init.ts
+++ b/server/algochat/init.ts
@@ -213,12 +213,57 @@ export async function initAlgoChat(deps: AlgoChatInitDeps): Promise<void> {
         // Self-register this corvid-agent instance
         const serverUrl = process.env.SERVER_URL ?? `http://localhost:${process.env.PORT ?? 3000}`;
         const agentName = process.env.AGENT_NAME ?? 'corvid-agent';
+        const selfAddress = service.chatAccount.address;
         await flockDirectoryService.selfRegister({
-            address: service.chatAccount.address,
+            address: selfAddress,
             name: agentName,
             description: 'CorvidAgent — autonomous AI development agent on Algorand',
             instanceUrl: serverUrl,
             capabilities: ['code', 'review', 'test', 'deploy', 'algochat', 'mcp'],
+        });
+
+        // ── Periodic heartbeat + stale sweep ────────────────────────────
+        // Heartbeat every 10 minutes to keep this agent active in the directory.
+        // Stale sweep every 15 minutes to mark unresponsive agents as inactive.
+        const HEARTBEAT_INTERVAL_MS = 10 * 60 * 1000;
+        const SWEEP_INTERVAL_MS = 15 * 60 * 1000;
+
+        const heartbeatTimer = setInterval(() => {
+            flockDirectoryService.selfRegister({
+                address: selfAddress,
+                name: agentName,
+                description: 'CorvidAgent — autonomous AI development agent on Algorand',
+                instanceUrl: serverUrl,
+                capabilities: ['code', 'review', 'test', 'deploy', 'algochat', 'mcp'],
+            }).catch(err => {
+                log.debug('Flock Directory heartbeat failed', {
+                    error: err instanceof Error ? err.message : String(err),
+                });
+            });
+        }, HEARTBEAT_INTERVAL_MS);
+
+        const sweepTimer = setInterval(() => {
+            try {
+                flockDirectoryService.sweepStaleAgents();
+            } catch (err) {
+                log.debug('Flock Directory stale sweep failed', {
+                    error: err instanceof Error ? err.message : String(err),
+                });
+            }
+        }, SWEEP_INTERVAL_MS);
+
+        shutdownCoordinator.register({
+            name: 'FlockDirectoryTimers',
+            priority: 0,
+            handler: () => {
+                clearInterval(heartbeatTimer);
+                clearInterval(sweepTimer);
+            },
+        });
+
+        log.info('Flock Directory heartbeat and sweep timers started', {
+            heartbeatIntervalMin: HEARTBEAT_INTERVAL_MS / 60_000,
+            sweepIntervalMin: SWEEP_INTERVAL_MS / 60_000,
         });
     } catch (err) {
         log.warn('Flock Directory on-chain init failed (off-chain still works)', {


### PR DESCRIPTION
## Summary
- Adds periodic heartbeat timer (every 10 min) that calls `selfRegister()` to keep this agent active in the Flock Directory
- Adds periodic stale sweep timer (every 15 min) that calls `sweepStaleAgents()` to mark unresponsive agents as inactive
- Both timers are registered with `ShutdownCoordinator` for clean teardown
- Adds 8 new lifecycle tests covering heartbeat, stale sweep, and full register→stale→recover flow

Closes #903 (partial — heartbeat and sweep scheduling)

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 6454 pass (8 new lifecycle tests)
- [x] `bun run spec:check` — 120/120 passed, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)