### PR TITLE
security: add admin role guard for /api/permissions routes

### DIFF
--- a/server/__tests__/guards.test.ts
+++ b/server/__tests__/guards.test.ts
@@ -562,6 +562,34 @@ describe('requiresAdminRole api-key paths', () => {
     });
 });
 
+// --- requiresAdminRole includes permission broker paths ----------------------
+
+describe('requiresAdminRole permission paths', () => {
+    it('returns true for /api/permissions/grant', () => {
+        expect(requiresAdminRole('/api/permissions/grant')).toBe(true);
+    });
+
+    it('returns true for /api/permissions/revoke', () => {
+        expect(requiresAdminRole('/api/permissions/revoke')).toBe(true);
+    });
+
+    it('returns true for /api/permissions/emergency-revoke', () => {
+        expect(requiresAdminRole('/api/permissions/emergency-revoke')).toBe(true);
+    });
+
+    it('returns true for /api/permissions/check', () => {
+        expect(requiresAdminRole('/api/permissions/check')).toBe(true);
+    });
+
+    it('returns true for /api/permissions/:agentId', () => {
+        expect(requiresAdminRole('/api/permissions/agent-123')).toBe(true);
+    });
+
+    it('returns true for /api/permissions/actions', () => {
+        expect(requiresAdminRole('/api/permissions/actions')).toBe(true);
+    });
+});
+
 // --- createRequestContext ---------------------------------------------------
 
 describe('createRequestContext', () => {

--- a/server/middleware/guards.ts
+++ b/server/middleware/guards.ts
@@ -303,5 +303,7 @@ export function requiresAdminRole(pathname: string): boolean {
     if (pathname.startsWith('/api/performance')) return true;
     // Network switch can activate mainnet — admin-only to prevent accidental ALGO expenditure
     if (pathname === '/api/algochat/network') return true;
+    // Permission broker controls capability grants — admin-only to prevent privilege escalation
+    if (pathname.startsWith('/api/permissions')) return true;
     return false;
 }


### PR DESCRIPTION
## Summary
- **Privilege escalation fix**: `/api/permissions` routes (grant, revoke, emergency-revoke, check, list) were not included in `requiresAdminRole()`, allowing any authenticated user to grant/revoke agent capabilities without admin role validation.
- Adds `/api/permissions` prefix check to `requiresAdminRole()` in `server/middleware/guards.ts`
- Adds 6 test cases covering all permission endpoints

## Impact
Any authenticated user could previously call `POST /api/permissions/grant` to give themselves (or any agent) arbitrary capabilities, or `POST /api/permissions/emergency-revoke` to revoke all grants for any agent.

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test server/__tests__/guards.test.ts` — 55/55 pass (6 new)
- [x] `bun test server/__tests__/routes-permissions.test.ts` — 18/18 pass
- [x] `bun run spec:check` — 120/120 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)