### PR TITLE
chore: add debug logging to silent catch handlers

### DIFF
--- a/server/discord/commands.ts
+++ b/server/discord/commands.ts
@@ -406,7 +406,7 @@ export async function handleInteraction(
                 buildActionRow(
                     { label: 'Stop', customId: 'stop_session', style: ButtonStyle.DANGER, emoji: '⏹' },
                 ),
-            ]).catch(() => {});
+            ]).catch((err) => log.debug('Failed to send welcome embed', { error: err instanceof Error ? err.message : String(err) }));
 
             await respondToInteraction(interaction,
                 `Session started in <#${threadId}> with **${agent.name}**.\nTopic: ${topic}`);

--- a/server/discord/message-handler.ts
+++ b/server/discord/message-handler.ts
@@ -131,7 +131,7 @@ export async function handleMessage(ctx: MessageHandlerContext, data: DiscordMes
     // If this message is in a thread we're tracking, route to that thread's session
     if (isOurThread) {
         sendFirstInteractionTip(ctx, userId, channelId);
-        sendTypingIndicator(ctx.config.botToken, channelId).catch(() => {});
+        sendTypingIndicator(ctx.config.botToken, channelId).catch((err) => log.debug('Typing indicator failed', { error: err instanceof Error ? err.message : String(err) }));
         await routeToThread(ctx, channelId, userId, text);
         return;
     }
@@ -156,7 +156,7 @@ export async function handleMessage(ctx: MessageHandlerContext, data: DiscordMes
     }
 
     sendFirstInteractionTip(ctx, userId, channelId);
-    sendTypingIndicator(ctx.config.botToken, channelId).catch(() => {});
+    sendTypingIndicator(ctx.config.botToken, channelId).catch((err) => log.debug('Typing indicator failed', { error: err instanceof Error ? err.message : String(err) }));
 
     const mode = ctx.config.mode ?? 'chat';
     if (mode === 'work_intake') {
@@ -186,7 +186,7 @@ function sendFirstInteractionTip(ctx: MessageHandlerContext, userId: string, cha
         ].join('\n'),
         color: 0x57f287,
         footer: { text: 'This tip only appears once' },
-    }).catch(() => {});
+    }).catch((err) => log.debug('First-interaction tip failed', { error: err instanceof Error ? err.message : String(err) }));
 }
 
 async function handleWorkIntake(

--- a/server/routes/slack.ts
+++ b/server/routes/slack.ts
@@ -251,7 +251,7 @@ async function handleSlackEvents(
                             message: 'Answer received!',
                             level: 'success',
                             timestamp: new Date().toISOString(),
-                        }, event.thread_ts).catch(() => {});
+                        }, event.thread_ts).catch((err) => log.debug('Slack answer notification failed', { error: err instanceof Error ? err.message : String(err) }));
                     }
                 }
             }

--- a/server/scheduler/execution.ts
+++ b/server/scheduler/execution.ts
@@ -163,7 +163,8 @@ function broadcastScheduleResult(
     if (!agentMessenger) return;
     if (!BROADCAST_ACTION_TYPES.includes(actionType)) return;
     const msg = `[SCHEDULE:${actionType}] ${summary.slice(0, 200)}`;
-    agentMessenger.sendOnChainToSelf(agentId, msg).catch(() => {});
+    agentMessenger.sendOnChainToSelf(agentId, msg)
+        .catch((err) => log.debug('AlgoChat schedule notification failed', { error: err instanceof Error ? err.message : String(err) }));
 }
 
 function notifyScheduleEvent(

--- a/server/scheduler/service.ts
+++ b/server/scheduler/service.ts
@@ -150,7 +150,7 @@ export class SchedulerService {
 
     async stop(): Promise<void> {
         if (this.pollTimer) { clearInterval(this.pollTimer); this.pollTimer = null; }
-        if (this.tickPromise) { await this.tickPromise.catch(() => {}); this.tickPromise = null; }
+        if (this.tickPromise) { await this.tickPromise.catch((err) => log.debug('Pending tick error during shutdown', { error: err instanceof Error ? err.message : String(err) })); this.tickPromise = null; }
         log.info('Scheduler stopped');
     }
 

--- a/server/work/service.ts
+++ b/server/work/service.ts
@@ -510,7 +510,8 @@ export class WorkTaskService {
         if (this.agentMessenger) {
             const snippet = input.description.slice(0, 100);
             const priorityLabel = ['P0', 'P1', 'P2', 'P3'][task.priority];
-            this.agentMessenger.sendOnChainToSelf(input.agentId, `[WORK_TASK:created:${priorityLabel}] ${snippet}`).catch(() => {});
+            this.agentMessenger.sendOnChainToSelf(input.agentId, `[WORK_TASK:created:${priorityLabel}] ${snippet}`)
+                .catch((err) => log.debug('AlgoChat task-created notification failed', { error: err instanceof Error ? err.message : String(err) }));
         }
 
         recordAudit(
@@ -920,7 +921,8 @@ export class WorkTaskService {
                 const msg = task.status === 'completed'
                     ? `[WORK_TASK:completed] ${task.prUrl ? `PR: ${task.prUrl}` : task.description.slice(0, 100)}`
                     : `[WORK_TASK:failed] ${(task.error ?? task.description).slice(0, 100)}`;
-                this.agentMessenger.sendOnChainToSelf(task.agentId, msg).catch(() => {});
+                this.agentMessenger.sendOnChainToSelf(task.agentId, msg)
+                    .catch((err) => log.debug('AlgoChat task-completion notification failed', { error: err instanceof Error ? err.message : String(err) }));
             }
 
             const callbacks = this.completionCallbacks.get(taskId);


### PR DESCRIPTION
## Summary
- Replace 9 empty `.catch(() => {})` handlers with `log.debug()` calls across 6 files
- Covers fire-and-forget patterns in work task notifications, scheduler broadcasts, Discord typing/embeds, and Slack answer notifications
- No behavior change — failures are now observable at debug log level instead of silently swallowed

## Files changed
- `server/work/service.ts` — task created/completed AlgoChat notifications
- `server/scheduler/execution.ts` — schedule action AlgoChat broadcasts
- `server/scheduler/service.ts` — pending tick error during shutdown
- `server/discord/commands.ts` — welcome embed send
- `server/discord/message-handler.ts` — typing indicators, first-interaction tip
- `server/routes/slack.ts` — answer notification

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 6521 pass, 0 fail
- [x] `bun run spec:check` — 121/121 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)