### PR TITLE
Potential fix for code scanning alert no. 307: Insecure temporary file

### DIFF
--- a/server/__tests__/project-dir.test.ts
+++ b/server/__tests__/project-dir.test.ts
@@ -1,11 +1,11 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { resolveProjectDir, cleanupEphemeralDir, type ResolvedDir } from '../lib/project-dir';
 import type { Project } from '../../shared/types';
 
-const TEST_BASE = resolve(tmpdir(), `corvid-test-project-dir-${Date.now()}`);
+const TEST_BASE = mkdtempSync(resolve(tmpdir(), 'corvid-test-project-dir-'));
 const FAKE_REPO = resolve(TEST_BASE, 'fake-repo');
 
 function makeTestProject(overrides: Partial<Project> = {}): Project {


### PR DESCRIPTION
Potential fix for [https://github.com/CorvidLabs/corvid-agent/security/code-scanning/307](https://github.com/CorvidLabs/corvid-agent/security/code-scanning/307)

General approach: Avoid manually building paths under `os.tmpdir()` and then creating files there. Instead, use secure mechanisms that (a) ensure the path is unique and does not already exist, and (b) are created with appropriate permissions. In Node, `fs.mkdtempSync` can be used to create a unique, secure temp directory, and our test can then create files inside that securely-created directory. Another option is a library like `tmp`, but here we can rely on the standard library.

Best fix for this file: Change `TEST_BASE` so it is created with `mkdtempSync` instead of directly using `resolve(tmpdir(), ...)`. That way the base directory itself is securely created with a unique name and correct permissions. The rest of the test logic (creating subdirectories and files under `TEST_BASE`, including the `test.txt` file on line 137) can remain unchanged and will now be operating under a securely-created temp directory. This keeps existing behavior (tests still write where they expect, with similar names) while eliminating the insecure temp directory pattern that taints `tempDir` and thus the `resolve(tempDir, 'test.txt')` sink.

Concretely:

- In `server/__tests__/project-dir.test.ts`:
  - Extend the `fs` import to include `mkdtempSync`.
  - Change the definition of `TEST_BASE` from `resolve(tmpdir(), \`corvid-test-project-dir-${Date.now()}\`)` to `mkdtempSync(resolve(tmpdir(), 'corvid-test-project-dir-'))`.
- No other code needs to change; `FAKE_REPO`, `beforeEach`, and the tests remain the same but now work under a securely-created, unique directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
