### PR TITLE
docs: make project welcoming to new contributors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [0xLeif]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Good First Issues
+    url: https://github.com/CorvidLabs/corvid-agent/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+    about: Browse beginner-friendly issues to get started
+  - name: Discussions
+    url: https://github.com/CorvidLabs/corvid-agent/discussions
+    about: Ask questions, share ideas, or just say hi

--- a/.github/ISSUE_TEMPLATE/good_first_issue.md
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.md
@@ -1,0 +1,37 @@
+---
+name: Good First Issue (maintainers)
+about: Create a beginner-friendly issue for new contributors
+title: ""
+labels: good first issue
+assignees: ''
+---
+
+## What needs to change
+
+<!-- Describe the specific change needed. Be concrete — link to files, line numbers, functions. -->
+
+## Why it matters
+
+<!-- Brief context on why this change is valuable. -->
+
+## Where to look
+
+<!-- List the specific files or directories involved. -->
+
+- `server/...`
+
+## Getting started
+
+1. Fork the repo and clone it
+2. Run `bash scripts/dev-setup.sh` to set up your environment
+3. Make the change
+4. Run `bun test` to verify nothing broke
+5. Open a PR!
+
+## Estimated effort
+
+<!-- e.g., ~20 minutes, ~1 hour -->
+
+## Helpful context
+
+<!-- Any tips, links to docs, or related code that would help a newcomer. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,32 +1,73 @@
-# Code of Conduct
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-We are committed to making participation in this project a welcoming experience for everyone.
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-**Expected behavior:**
-- Be respectful and constructive in all interactions
-- Welcome newcomers and help them get started
-- Accept constructive feedback gracefully
-- Focus on what is best for the community and the project
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
 
-**Unacceptable behavior:**
-- Personal attacks, insults, or derogatory comments
-- Publishing others' private information without consent
-- Any conduct that would be considered inappropriate in a professional setting
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
-This applies to all project spaces: issues, pull requests, discussions, and community channels.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
-Project maintainers may remove, edit, or reject contributions that violate this code. Repeated violations may result in a temporary or permanent ban.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers at **conduct@corvidlabs.com**.
 
-## Contact
+All complaints will be reviewed and investigated promptly and fairly.
 
-Report issues to the project maintainers via GitHub issues or direct message.
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
 
----
+## Attribution
 
-*This project follows the spirit of the [Contributor Covenant](https://www.contributor-covenant.org/).*
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,31 @@
 # Contributing to CorvidAgent
 
-Thanks for your interest in contributing to CorvidAgent! This document covers everything you need to get started.
+Thanks for your interest in contributing! Whether this is your first open-source contribution or your hundredth, you're welcome here.
+
+## Your First Contribution
+
+New to the project? Here's the fastest path to your first merged PR:
+
+1. **Pick a [good first issue](https://github.com/CorvidLabs/corvid-agent/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)** — these are specifically designed to be approachable, with clear instructions and estimated time
+2. **Comment on the issue** to let others know you're working on it
+3. **Fork and clone** the repo
+4. **Run the setup**: `bash scripts/dev-setup.sh` (takes ~2 minutes)
+5. **Make your change** on a feature branch
+6. **Run tests**: `bun test` — make sure nothing breaks
+7. **Open a PR** — use the template, describe what you changed and why
+
+That's it. We review PRs quickly and give constructive feedback. No contribution is too small.
+
+### Not sure where to start?
+
+- **Fix a typo or improve an error message** — no issue needed, just open a PR
+- **Add a test** — pick any untested function and write a test for it
+- **Improve docs** — if something confused you during setup, help the next person
+- **Report a bug** — [open an issue](https://github.com/CorvidLabs/corvid-agent/issues/new?template=bug_report.md) with steps to reproduce
+
+### About this project
+
+This is a real, production AI agent platform — not a toy. The codebase has 6,600+ tests, 85 database migrations, and ships code autonomously. You'll be working alongside AI agents (including me, corvid-agent, who helps maintain this repo). It's a unique experience.
 
 ## Quick Setup
 
@@ -256,7 +281,7 @@ Write clear, concise commit messages:
 2. Make your changes with clear, focused commits
 3. Verify before pushing:
    ```bash
-   bunx tsc --noEmit --skipLibCheck   # type-check
+   bun x tsc --noEmit --skipLibCheck  # type-check
    bun test                           # unit tests
    bun run lint:sql                   # SQL injection check
    ```
@@ -276,6 +301,12 @@ When filing a bug report, include:
 ## Security
 
 If you discover a security vulnerability, **do not open a public issue**. See [SECURITY.md](SECURITY.md) for responsible disclosure instructions.
+
+## Community
+
+We follow the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). Please read it before participating.
+
+Have questions? Open a [Discussion](https://github.com/CorvidLabs/corvid-agent/discussions) — we're happy to help.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -623,9 +623,26 @@ These apps were designed, coded, tested, and deployed autonomously by corvid-age
 
 ---
 
-## Contributing
+## Contributors Welcome
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+This project is built and maintained by an AI agent (that's me, corvid-agent) and a small team. We're open source because we believe AI agents should be owned by the people who run them, not locked behind vendor platforms.
+
+**We need contributors.** Not just code — ideas, bug reports, docs, and feedback all matter. If you've ever wanted to work on a real AI agent platform, this is your chance to shape one from the ground up.
+
+### How to get involved
+
+- **Browse [good first issues](https://github.com/CorvidLabs/corvid-agent/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)** — bite-sized tasks with clear instructions, most under an hour
+- **Read [CONTRIBUTING.md](CONTRIBUTING.md)** — setup takes ~2 minutes with the dev script
+- **Open a discussion** — questions, ideas, and feedback are welcome in [Discussions](https://github.com/CorvidLabs/corvid-agent/discussions)
+- **Report bugs** — if something doesn't work, [tell us](https://github.com/CorvidLabs/corvid-agent/issues/new?template=bug_report.md)
+
+No contribution is too small. Fixing a typo, improving an error message, or adding a test — it all helps.
+
+### What makes this project different
+
+You'd be contributing to a platform where AI agents autonomously write code, review PRs, and coordinate with each other on-chain. The codebase has 6,600+ tests, 85 database migrations, and runs in production. It's real, it works, and there's plenty of interesting work to do.
+
+See the [Code of Conduct](CODE_OF_CONDUCT.md) for community standards.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Upgrade Code of Conduct to full Contributor Covenant v2.0
- Add "Your First Contribution" walkthrough to CONTRIBUTING.md
- Replace the generic "Contributing" section in README with an honest "Contributors Welcome" section
- Add good-first-issue template, issue template config, and FUNDING.yml

## Why

This project needs contributors and adopters to survive. The codebase is technically strong but the repo didn't feel welcoming to newcomers — no clear first-contribution path, minimal Code of Conduct, no Discussions link, no Sponsor button. These changes make the human (and agent) side of the project match the quality of the code.

## Changes

| File | What changed |
|------|-------------|
| `CODE_OF_CONDUCT.md` | Upgraded from minimal to full Contributor Covenant v2.0 |
| `CONTRIBUTING.md` | Added "Your First Contribution" guide with step-by-step instructions, fixed `bunx` → `bun x`, added Community section |
| `README.md` | Replaced "Contributing" with "Contributors Welcome" — honest messaging about needing help |
| `.github/ISSUE_TEMPLATE/good_first_issue.md` | New template for maintainers to create beginner-friendly issues |
| `.github/ISSUE_TEMPLATE/config.yml` | Links to good-first-issues and Discussions from issue chooser |
| `.github/FUNDING.yml` | Enables GitHub Sponsors button (links to @0xLeif) |

## Follow-ups needed (after merge)

- Enable **Discussions** in repo settings (Settings → General → Features → Discussions)
- Verify Sponsor button appears on repo page
- Verify issue template chooser shows good-first-issue link

## Test plan

- [x] All changes are docs/config — no code changes, no tests to run
- [x] CI passes (Build & Test, CodeQL, Coverage, E2E, Security scans)

🤖 Generated with [Claude Code](https://claude.com/claude-code)