### PR TITLE
chore: v0.29.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.29.0] - 2026-03-13
+
+### Added
+- **Spec coverage detection** — scan `server/` for `.ts` files not referenced in any spec's `files:` frontmatter, with per-module grouping (#1058)
+- **Spec scaffold generation** — `--generate` flag creates draft `.spec.md` files for uncovered modules from template (#1058)
+- **Coverage reporting** — `--coverage` flag shows full unspecced file report; summary always shows file coverage percentage (#1058)
+- **Convenience scripts** — `bun run spec:coverage` and `bun run spec:generate` shortcuts (#1058)
+
 ## [0.28.0] - 2026-03-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.28.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.29.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">
   <img src="https://img.shields.io/badge/Angular-21-dd0031?logo=angular" alt="Angular 21">
-  <img src="https://img.shields.io/badge/tests-6803%20unit%20%7C%20360%20E2E-brightgreen" alt="6803 Unit | 360 E2E Tests">
+  <img src="https://img.shields.io/badge/tests-6813%20unit%20%7C%20360%20E2E-brightgreen" alt="6803 Unit | 360 E2E Tests">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>
 </p>
 

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: corvid-agent
 description: Agent orchestration platform with MCP tools, AlgoChat messaging, and on-chain wallet integration
 type: application
-version: 0.28.0
-appVersion: "0.28.0"
+version: 0.29.0
+appVersion: "0.29.0"
 keywords:
   - ai
   - agent

--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -40,13 +40,13 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Database tables | 92 |
 | Database migrations | 8 (squashed baseline) |
 | MCP tools | 41 corvid_* handlers |
-| Unit tests | 6,803 across 286 files |
+| Unit tests | 6,813 across 287 files |
 | E2E tests | 360 across 31 Playwright specs |
 | Security tests | 232 dedicated |
 | Module specs | 128 .spec.md files |
 | Test:code ratio | 1.14x (more test than production) |
 | Dependencies | 17 direct |
-| Version | 0.28.0 |
+| Version | 0.29.0 |
 | Git commits | 558 |
 
 ### Tech Stack

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",

--- a/server/__tests__/routes-health.test.ts
+++ b/server/__tests__/routes-health.test.ts
@@ -15,7 +15,7 @@ function createMockDeps(db: Database, overrides?: Partial<HealthCheckDeps>): Hea
     return {
         db,
         startTime: Date.now() - 60_000, // 1 minute ago
-        version: '0.28.0-test',
+        version: '0.29.0-test',
         getActiveSessions: mock(() => []),
         isAlgoChatConnected: mock(() => false),
         isShuttingDown: mock(() => false),
@@ -101,7 +101,7 @@ describe('routes/health', () => {
         const res = await handleHealthRoutes(req, url, deps, db);
         expect(res!.status).toBe(200);
         const data = await res!.json();
-        expect(data.version).toBe('0.28.0-test');
+        expect(data.version).toBe('0.29.0-test');
         expect(data.uptime).toBeGreaterThanOrEqual(0);
         expect(data.dependencies).toBeDefined();
         expect(data.dependencies.database.status).toBe('healthy');
@@ -113,7 +113,7 @@ describe('routes/health', () => {
         const res = await handleHealthRoutes(req, url, deps, db);
         expect(res!.status).toBe(200);
         const data = await res!.json();
-        expect(data.version).toBe('0.28.0-test');
+        expect(data.version).toBe('0.29.0-test');
     });
 
     it('returns 503 when shutting down', async () => {


### PR DESCRIPTION
## Summary
- Bump version to 0.29.0 across package.json, README, Helm chart, docs, and health test
- Add changelog entry for spec coverage detection (#1058)
- Update unit test count (6803 → 6813) via `stats:check --update`

## Verification
- 6813 tests pass, 0 fail
- `tsc --noEmit` clean
- `spec:check` 127/127 pass
- `stats:check` all stats in sync

## Test plan
- [x] `bun test` — 6813 pass
- [x] `bun x tsc --noEmit` — clean
- [x] `bun run spec:check` — 127/127
- [x] `bun run stats:check` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)