### PR TITLE
fix: CLI client crashes on empty response body

### DIFF
--- a/cli/client.ts
+++ b/cli/client.ts
@@ -85,6 +85,7 @@ export class CorvidClient {
             const err: ApiError = { status: res.status, message };
             throw err;
         }
+        if (!text) return undefined as T;
         return JSON.parse(text) as T;
     }
 

--- a/server/__tests__/cli-client.test.ts
+++ b/server/__tests__/cli-client.test.ts
@@ -131,6 +131,21 @@ describe('CorvidClient', () => {
         }
     });
 
+    test('handles empty response body without crashing', async () => {
+        const mockResponse = new Response('', { status: 200 });
+
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mockFetch(() => Promise.resolve(mockResponse));
+
+        try {
+            const client = new CorvidClient(makeConfig());
+            const result = await client.delete('/api/sessions/123');
+            expect(result).toBeUndefined();
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
     test('put method sends body with PUT method', async () => {
         const mockResponse = new Response(JSON.stringify({ ok: true }), { status: 200 });
 


### PR DESCRIPTION
## Summary
- Fixes #1039 — `JSON.parse("")` throws when the server returns 200 with an empty body (e.g. DELETE/POST with no response payload)
- Returns `undefined` for empty responses instead of crashing
- Adds test coverage for the empty response case

## Test plan
- [x] New test: `handles empty response body without crashing`
- [x] All 9 CLI client tests pass
- [x] TypeScript compiles clean (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)