### PR TITLE
feat: paginated research log with emergent cross-platform routing post

### DIFF
--- a/docs/blog.html
+++ b/docs/blog.html
@@ -4,22 +4,210 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Blog — CorvidAgent</title>
-  <meta name="description" content="Engineering insights from the CorvidAgent team. Deep dives on testing, architecture, and building autonomous AI agent platforms.">
+  <meta name="description" content="Engineering insights and research logs from the CorvidAgent team. Deep dives on emergent agent behavior, testing, architecture, and building autonomous AI agent platforms.">
   <meta name="theme-color" content="#0a0a12">
 
   <meta property="og:title" content="Blog — CorvidAgent">
-  <meta property="og:description" content="Engineering insights from the CorvidAgent team.">
+  <meta property="og:description" content="Engineering insights and research logs from the CorvidAgent team.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://corvidlabs.github.io/corvid-agent/blog.html">
   <link rel="canonical" href="https://corvidlabs.github.io/corvid-agent/blog.html">
 
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐦‍⬛</text></svg>">
   <link rel="stylesheet" href="style.css">
+  <style>
+    /* Blog index styles */
+    .blog-index {
+      max-width: 700px;
+      margin: 0 auto;
+    }
+
+    .blog-index__controls {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 32px;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+
+    .blog-index__count {
+      font-size: 9px;
+      color: var(--text-tertiary);
+      letter-spacing: 1px;
+    }
+
+    .blog-index__tags {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .blog-index__tag {
+      font-size: 8px;
+      font-family: 'Dogica Pixel', monospace;
+      padding: 4px 10px;
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      color: var(--text-secondary);
+      cursor: pointer;
+      transition: all 0.2s ease;
+      letter-spacing: 0.5px;
+      background: transparent;
+    }
+
+    .blog-index__tag:hover,
+    .blog-index__tag--active {
+      color: var(--cyan);
+      border-color: var(--cyan);
+      background: var(--cyan-dim);
+    }
+
+    .blog-card {
+      display: block;
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 28px 24px;
+      margin-bottom: 16px;
+      transition: all 0.2s ease;
+      text-decoration: none;
+      color: inherit;
+    }
+
+    .blog-card:hover {
+      border-color: var(--cyan);
+      box-shadow: var(--glow-cyan);
+      transform: translateY(-2px);
+    }
+
+    .blog-card__meta {
+      font-size: 9px;
+      color: var(--text-tertiary);
+      margin-bottom: 12px;
+      letter-spacing: 1px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .blog-card__title {
+      font-size: 14px;
+      font-weight: 700;
+      letter-spacing: 1px;
+      margin-bottom: 12px;
+      line-height: 1.4;
+      color: var(--text-primary);
+    }
+
+    .blog-card__excerpt {
+      font-size: 9px;
+      color: var(--text-secondary);
+      line-height: 2.2;
+    }
+
+    .blog-card__tags {
+      display: flex;
+      gap: 6px;
+      margin-top: 16px;
+      flex-wrap: wrap;
+    }
+
+    .blog-card__tag {
+      font-size: 7px;
+      font-family: 'Dogica Pixel', monospace;
+      padding: 3px 8px;
+      border-radius: 3px;
+      letter-spacing: 0.5px;
+    }
+
+    .blog-card__tag--research { background: var(--magenta-dim); color: var(--magenta); border: 1px solid rgba(255, 102, 196, 0.2); }
+    .blog-card__tag--engineering { background: var(--cyan-dim); color: var(--cyan); border: 1px solid rgba(0, 229, 255, 0.2); }
+    .blog-card__tag--default { background: transparent; color: var(--text-tertiary); border: 1px solid var(--border); }
+
+    /* Pagination */
+    .blog-pagination {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 12px;
+      margin-top: 40px;
+      padding-top: 24px;
+      border-top: 1px solid var(--border);
+    }
+
+    .blog-pagination__btn {
+      font-family: 'Dogica Pixel', monospace;
+      font-size: 9px;
+      font-weight: 700;
+      padding: 8px 16px;
+      border: 1px solid var(--border-bright);
+      border-radius: 4px;
+      background: transparent;
+      color: var(--text-secondary);
+      cursor: pointer;
+      transition: all 0.2s ease;
+      letter-spacing: 1px;
+    }
+
+    .blog-pagination__btn:hover:not(:disabled) {
+      color: var(--cyan);
+      border-color: var(--cyan);
+      background: var(--cyan-dim);
+    }
+
+    .blog-pagination__btn:disabled {
+      opacity: 0.3;
+      cursor: not-allowed;
+    }
+
+    .blog-pagination__info {
+      font-size: 9px;
+      color: var(--text-tertiary);
+      letter-spacing: 1px;
+      min-width: 100px;
+      text-align: center;
+    }
+
+    .blog-index__empty {
+      text-align: center;
+      padding: 60px 24px;
+      color: var(--text-tertiary);
+      font-size: 10px;
+      line-height: 2;
+    }
+
+    @media (max-width: 768px) {
+      .blog-card {
+        padding: 20px 18px;
+      }
+
+      .blog-card__title {
+        font-size: 12px;
+      }
+
+      .blog-card:hover {
+        transform: none;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .blog-card__title {
+        font-size: 11px;
+      }
+
+      .blog-index__controls {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+    }
+  </style>
 </head>
 <body>
   <a href="#main-content" class="skip-nav">Skip to main content</a>
 
-  <!-- ═══════════════════ NAV ═══════════════════ -->
+  <!-- NAV -->
   <nav class="nav" aria-label="Main navigation">
     <div class="container nav__inner">
       <a href="index.html" class="nav__brand">
@@ -41,130 +229,32 @@
 
   <main id="main-content">
 
-  <!-- ═══════════════════ HERO ═══════════════════ -->
+  <!-- HERO -->
   <header class="page-hero">
     <div class="container">
       <h1 class="page-hero__title"><span class="accent-cyan">Blog</span></h1>
-      <p class="page-hero__tagline">Engineering insights from the CorvidAgent team.</p>
+      <p class="page-hero__tagline">Engineering insights and research logs from the CorvidAgent team.</p>
     </div>
     <div class="hero__scanline"></div>
   </header>
 
-  <!-- ═══════════════════ POST: Why More Test Than Production Code ═══════════════════ -->
-  <article class="section" id="why-more-test-than-production-code">
+  <!-- BLOG INDEX -->
+  <section class="section">
     <div class="container">
-      <div class="blog-post">
-        <div class="blog-post__meta">
-          <span class="accent-cyan">CorvidLabs</span>
-          <span class="blog-post__sep">&middot;</span>
-          <time datetime="2026-03-09">March 2026</time>
+      <div class="blog-index" id="blog-index">
+        <div class="blog-index__controls">
+          <div class="blog-index__count" id="blog-count"></div>
+          <div class="blog-index__tags" id="blog-tags"></div>
         </div>
-
-        <h2 class="blog-post__title">Why We Have More Test Code Than Production Code</h2>
-
-        <p class="blog-post__tldr">
-          <strong class="accent-cyan">TL;DR:</strong> corvid-agent has a 1.14x test-to-production code ratio &mdash; more lines of tests than application code. When agents ship code while you sleep, the platform they run on has to hold up.
-        </p>
-
-        <h3 class="blog-post__heading">The numbers</h3>
-
-        <div class="blog-post__table">
-          <div class="blog-post__table-row blog-post__table-header">
-            <div class="blog-post__table-cell">Metric</div>
-            <div class="blog-post__table-cell">Value</div>
-          </div>
-          <div class="blog-post__table-row">
-            <div class="blog-post__table-cell">Unit tests</div>
-            <div class="blog-post__table-cell accent-cyan">6,573 across 274 files</div>
-          </div>
-          <div class="blog-post__table-row">
-            <div class="blog-post__table-cell">Assertions</div>
-            <div class="blog-post__table-cell accent-cyan">18,030</div>
-          </div>
-          <div class="blog-post__table-row">
-            <div class="blog-post__table-cell">E2E tests</div>
-            <div class="blog-post__table-cell accent-magenta">360 across 31 Playwright specs</div>
-          </div>
-          <div class="blog-post__table-row">
-            <div class="blog-post__table-cell">Module specs</div>
-            <div class="blog-post__table-cell accent-green">123 with automated validation</div>
-          </div>
-          <div class="blog-post__table-row">
-            <div class="blog-post__table-cell">Test:code ratio</div>
-            <div class="blog-post__table-cell accent-cyan" style="font-weight: 700;">1.14x</div>
-          </div>
-        </div>
-
-        <p class="blog-post__text">Every PR runs the full suite. Every module has a spec. Every spec is validated in CI.</p>
-
-        <h3 class="blog-post__heading">Why this matters for an agent platform</h3>
-
-        <p class="blog-post__text">Most software can tolerate a few rough edges. Users work around bugs. Agent platforms can't.</p>
-
-        <p class="blog-post__text">When an autonomous agent picks up an issue at 3am, clones a branch, writes a fix, and opens a PR &mdash; there is no human in the loop to catch a malformed git command, a broken scheduler, or a credit system that double-charges. The agent trusts the platform. If the platform is wrong, the agent ships bad code, sends bad messages, or spends real money incorrectly.</p>
-
-        <p class="blog-post__text">This is why we test more than we code:</p>
-
-        <ul class="blog-post__list">
-          <li><strong class="accent-cyan">Scheduling engine</strong> &mdash; Cron parsing, approval policies, rate limiting, and budget enforcement all have dedicated test suites. A bug here means agents running when they shouldn't, or not running when they should.</li>
-          <li><strong class="accent-magenta">Credit system</strong> &mdash; Purchase, grant, deduct, reserve, consume, release. Every path is tested because real ALGO is at stake.</li>
-          <li><strong class="accent-green">AlgoChat messaging</strong> &mdash; Encryption, decryption, group messages, PSK key rotation, deduplication. A bug here means agents can't talk to each other or, worse, leak plaintext.</li>
-          <li><strong class="accent-cyan">Work task pipeline</strong> &mdash; Branch creation, validation loops, PR submission, retry logic. Each step is independently tested because a failure mid-pipeline leaves orphaned branches and confused PRs.</li>
-          <li><strong class="accent-magenta">Bash security</strong> &mdash; Command injection detection, dangerous pattern blocking, path extraction. This is the last line of defense before an agent runs arbitrary shell commands.</li>
-        </ul>
-
-        <h3 class="blog-post__heading">Why we publish these numbers</h3>
-
-        <p class="blog-post__text">Most open-source agent platforms don't publish test metrics in their READMEs. That's fine &mdash; testing is hard, and every project has different priorities. We publish ours because we think if you're choosing a platform to run autonomous agents on your codebase, you should be able to see how it's tested. The numbers are right there in the repo. Run <code>bun test</code> and verify them yourself.</p>
-
-        <h3 class="blog-post__heading">How we maintain it</h3>
-
-        <p class="blog-post__text">The ratio doesn't stay above 1.0x by accident. Three mechanisms enforce it:</p>
-
-        <h4 class="blog-post__subheading accent-cyan">1. Spec-driven development</h4>
-
-        <p class="blog-post__text">Every server module has a YAML spec in <code>specs/</code>. Each spec declares the module's API surface, database tables, dependencies, and expected behavior. <code>bun run spec:check</code> validates that specs match reality &mdash; exported symbols, file existence, table references, and dependency graphs. This runs in CI on every commit with a zero-warning gate.</p>
-
-        <h4 class="blog-post__subheading accent-magenta">2. Autonomous test generation</h4>
-
-        <p class="blog-post__text">corvid-agent writes its own tests. When a new feature lands, a scheduled work task identifies untested code paths and generates test suites following existing patterns. The agent reads the spec, writes tests, runs them, and opens a PR. Human review is still required, but the coverage gap is closed automatically.</p>
-
-        <h4 class="blog-post__subheading accent-green">3. PR outcome tracking</h4>
-
-        <p class="blog-post__text">Every PR opened by an agent is tracked through its lifecycle: opened, reviewed, merged, or closed. If a PR gets rejected or requires changes, the feedback loop records why. Over time, this trains the system to produce higher-quality output &mdash; including better tests.</p>
-
-        <h3 class="blog-post__heading">The philosophy</h3>
-
-        <div class="callout callout--cyan">
-          <p>If your agents can ship code while you sleep, the platform they run on had better be bulletproof.</p>
-        </div>
-
-        <p class="blog-post__text">We don't treat tests as a tax. They're the product. A 1.14x ratio means every line of production code has more than one line verifying it works correctly. For an autonomous system that makes real decisions with real consequences, that's the minimum bar.</p>
-
-        <h3 class="blog-post__heading">Try it yourself</h3>
-
-        <div class="terminal">
-          <div class="terminal__bar">
-            <span class="terminal__dot terminal__dot--red"></span>
-            <span class="terminal__dot terminal__dot--amber"></span>
-            <span class="terminal__dot terminal__dot--green"></span>
-            <span class="terminal__label">terminal</span>
-          </div>
-          <pre class="terminal__body"><code><span class="t-prompt">$</span> git clone https://github.com/CorvidLabs/corvid-agent.git
-<span class="t-prompt">$</span> cd corvid-agent
-<span class="t-prompt">$</span> bun install &amp;&amp; bun test    <span class="t-comment"># see the 6,573 tests pass</span></code></pre>
-        </div>
-
-        <p class="blog-post__text" style="margin-top: 24px;">The test suite runs in ~120 seconds on a modern machine. Every test is deterministic &mdash; no flaky network calls, no sleep-and-hope timing.</p>
-
-        <p class="blog-post__footer">Published by <span class="accent-cyan">CorvidLabs</span>. corvid-agent is open-source under MIT.</p>
+        <div id="blog-posts"></div>
+        <div class="blog-pagination" id="blog-pagination"></div>
       </div>
     </div>
-  </article>
+  </section>
 
   </main>
 
-  <!-- ═══════════════════ FOOTER ═══════════════════ -->
+  <!-- FOOTER -->
   <footer class="footer">
     <div class="container">
       <div class="footer__links">
@@ -187,12 +277,188 @@
   </footer>
 
   <script>
+    // Nav toggle
     document.querySelector('.nav__toggle').addEventListener('click', function() {
       var links = document.getElementById('nav-links');
       var open = links.classList.toggle('nav__links--open');
       this.setAttribute('aria-expanded', open);
       this.innerHTML = open ? '&#x2715;' : '&#x2630;';
     });
+
+    // Blog pagination engine
+    (function() {
+      var POSTS_PER_PAGE = 10;
+      var allPosts = [];
+      var filteredPosts = [];
+      var currentPage = 1;
+      var activeTag = null;
+
+      // Tag color mapping
+      var TAG_COLORS = {
+        'research': 'research',
+        'emergent-behavior': 'research',
+        'engineering': 'engineering',
+        'testing': 'engineering',
+        'algochat': 'default',
+        'discord': 'default',
+        'architecture': 'default',
+        'security': 'default'
+      };
+
+      function getPageFromURL() {
+        var params = new URLSearchParams(window.location.search);
+        return parseInt(params.get('page')) || 1;
+      }
+
+      function getTagFromURL() {
+        var params = new URLSearchParams(window.location.search);
+        return params.get('tag') || null;
+      }
+
+      function updateURL(page, tag) {
+        var params = new URLSearchParams();
+        if (page > 1) params.set('page', page);
+        if (tag) params.set('tag', tag);
+        var qs = params.toString();
+        var url = window.location.pathname + (qs ? '?' + qs : '');
+        window.history.replaceState(null, '', url);
+      }
+
+      function formatDate(dateStr) {
+        var d = new Date(dateStr + 'T00:00:00');
+        var months = ['January', 'February', 'March', 'April', 'May', 'June',
+                      'July', 'August', 'September', 'October', 'November', 'December'];
+        return months[d.getMonth()] + ' ' + d.getDate() + ', ' + d.getFullYear();
+      }
+
+      function getTagClass(tag) {
+        return 'blog-card__tag--' + (TAG_COLORS[tag] || 'default');
+      }
+
+      function renderPosts() {
+        var container = document.getElementById('blog-posts');
+        var totalPages = Math.ceil(filteredPosts.length / POSTS_PER_PAGE);
+
+        if (currentPage > totalPages && totalPages > 0) currentPage = totalPages;
+
+        var start = (currentPage - 1) * POSTS_PER_PAGE;
+        var end = start + POSTS_PER_PAGE;
+        var pagePosts = filteredPosts.slice(start, end);
+
+        if (pagePosts.length === 0) {
+          container.innerHTML = '<div class="blog-index__empty">No posts found' +
+            (activeTag ? ' for tag &ldquo;' + activeTag + '&rdquo;' : '') + '.</div>';
+        } else {
+          container.innerHTML = pagePosts.map(function(post) {
+            var tags = (post.tags || []).map(function(t) {
+              return '<span class="blog-card__tag ' + getTagClass(t) + '">' + t + '</span>';
+            }).join('');
+
+            return '<a href="blog/' + post.slug + '.html" class="blog-card">' +
+              '<div class="blog-card__meta">' +
+                '<span class="accent-cyan">' + (post.author || 'CorvidLabs') + '</span>' +
+                '<span>&middot;</span>' +
+                '<time datetime="' + post.date + '">' + formatDate(post.date) + '</time>' +
+              '</div>' +
+              '<h2 class="blog-card__title">' + post.title + '</h2>' +
+              '<p class="blog-card__excerpt">' + post.excerpt + '</p>' +
+              (tags ? '<div class="blog-card__tags">' + tags + '</div>' : '') +
+            '</a>';
+          }).join('');
+        }
+
+        // Update count
+        document.getElementById('blog-count').textContent =
+          filteredPosts.length + ' post' + (filteredPosts.length !== 1 ? 's' : '') +
+          (activeTag ? ' tagged "' + activeTag + '"' : '');
+
+        // Render pagination
+        renderPagination(totalPages);
+        updateURL(currentPage, activeTag);
+      }
+
+      function renderPagination(totalPages) {
+        var pag = document.getElementById('blog-pagination');
+        if (totalPages <= 1) {
+          pag.innerHTML = '';
+          return;
+        }
+
+        pag.innerHTML =
+          '<button class="blog-pagination__btn" id="pag-prev"' +
+            (currentPage <= 1 ? ' disabled' : '') + '>&larr; Newer</button>' +
+          '<span class="blog-pagination__info">Page ' + currentPage + ' of ' + totalPages + '</span>' +
+          '<button class="blog-pagination__btn" id="pag-next"' +
+            (currentPage >= totalPages ? ' disabled' : '') + '>Older &rarr;</button>';
+
+        document.getElementById('pag-prev').addEventListener('click', function() {
+          if (currentPage > 1) { currentPage--; renderPosts(); window.scrollTo(0, 0); }
+        });
+        document.getElementById('pag-next').addEventListener('click', function() {
+          if (currentPage < totalPages) { currentPage++; renderPosts(); window.scrollTo(0, 0); }
+        });
+      }
+
+      function renderTags() {
+        // Collect all unique tags
+        var tagSet = {};
+        allPosts.forEach(function(p) {
+          (p.tags || []).forEach(function(t) { tagSet[t] = (tagSet[t] || 0) + 1; });
+        });
+        var tags = Object.keys(tagSet).sort();
+
+        var container = document.getElementById('blog-tags');
+        container.innerHTML =
+          '<button class="blog-index__tag' + (!activeTag ? ' blog-index__tag--active' : '') +
+            '" data-tag="">All</button>' +
+          tags.map(function(t) {
+            return '<button class="blog-index__tag' +
+              (activeTag === t ? ' blog-index__tag--active' : '') +
+              '" data-tag="' + t + '">' + t + ' (' + tagSet[t] + ')</button>';
+          }).join('');
+
+        container.querySelectorAll('.blog-index__tag').forEach(function(btn) {
+          btn.addEventListener('click', function() {
+            activeTag = this.getAttribute('data-tag') || null;
+            currentPage = 1;
+            filterPosts();
+            renderTags();
+            renderPosts();
+          });
+        });
+      }
+
+      function filterPosts() {
+        if (!activeTag) {
+          filteredPosts = allPosts;
+        } else {
+          filteredPosts = allPosts.filter(function(p) {
+            return (p.tags || []).indexOf(activeTag) !== -1;
+          });
+        }
+      }
+
+      // Load posts
+      fetch('blog/posts.json')
+        .then(function(r) { return r.json(); })
+        .then(function(posts) {
+          // Sort by date descending
+          allPosts = posts.sort(function(a, b) {
+            return b.date.localeCompare(a.date);
+          });
+
+          currentPage = getPageFromURL();
+          activeTag = getTagFromURL();
+
+          filterPosts();
+          renderTags();
+          renderPosts();
+        })
+        .catch(function() {
+          document.getElementById('blog-posts').innerHTML =
+            '<div class="blog-index__empty">Failed to load posts.</div>';
+        });
+    })();
   </script>
 
 </body>

--- a/docs/blog/emergent-cross-platform-routing.html
+++ b/docs/blog/emergent-cross-platform-routing.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Emergent Behavior: Cross-Platform Message Routing — CorvidAgent Blog</title>
+  <meta name="description" content="A Discord message in Portuguese became an encrypted on-chain AlgoChat delivery. The agent independently performed identity resolution, language translation, and cross-platform routing.">
+  <meta name="theme-color" content="#0a0a12">
+
+  <meta property="og:title" content="Emergent Behavior: Cross-Platform Message Routing — CorvidAgent">
+  <meta property="og:description" content="When an AI agent organically routes messages across platforms, translates languages, and resolves identities without being told to.">
+  <meta property="og:type" content="article">
+  <link rel="canonical" href="https://corvidlabs.github.io/corvid-agent/blog/emergent-cross-platform-routing.html">
+
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐦‍⬛</text></svg>">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <a href="#main-content" class="skip-nav">Skip to main content</a>
+
+  <!-- NAV -->
+  <nav class="nav" aria-label="Main navigation">
+    <div class="container nav__inner">
+      <a href="../index.html" class="nav__brand">
+        <span class="glow-cyan">Corvid</span><span class="glow-magenta">Agent</span>
+      </a>
+      <button class="nav__toggle" aria-label="Toggle navigation" aria-expanded="false">&#x2630;</button>
+      <div class="nav__links" id="nav-links">
+        <a href="../getting-started.html" class="nav__link">Start</a>
+        <a href="../architecture.html" class="nav__link">API</a>
+        <a href="../algochat.html" class="nav__link">AlgoChat</a>
+        <a href="../security.html" class="nav__link">Security</a>
+        <a href="../self-hosting.html" class="nav__link">Deploy</a>
+        <a href="../blog.html" class="nav__link nav__link--active">Blog</a>
+        <a href="https://corvid-agent.github.io/agent-dashboard/" class="nav__link" target="_blank" rel="noopener">Dashboard <span class="ext-icon">&nearr;</span></a>
+        <a href="https://github.com/CorvidLabs/corvid-agent" class="nav__link" target="_blank" rel="noopener">GitHub <span class="ext-icon">&nearr;</span></a>
+      </div>
+    </div>
+  </nav>
+
+  <main id="main-content">
+
+  <article class="section">
+    <div class="container">
+      <div class="blog-post">
+        <a href="../blog.html" class="blog-post__back">&larr; All posts</a>
+
+        <div class="blog-post__meta">
+          <span class="accent-cyan">CorvidLabs</span>
+          <span class="blog-post__sep">&middot;</span>
+          <time datetime="2026-03-14">March 14, 2026</time>
+          <span class="blog-post__sep">&middot;</span>
+          <span class="blog-post__tag">Research</span>
+        </div>
+
+        <h1 class="blog-post__title">Emergent Behavior: Cross-Platform Message Routing</h1>
+
+        <p class="blog-post__tldr">
+          <strong class="accent-cyan">TL;DR:</strong> A user sent a Discord message in Portuguese asking the agent to deliver a personal message to someone named Leif. Without any explicit instructions on how to route the message, the agent translated it to English, resolved Leif's identity across platforms, and delivered it as an encrypted on-chain AlgoChat message. This is both a compelling glimpse of emergent multi-agent behavior and a bug we need to fix.
+        </p>
+
+        <h2 class="blog-post__heading">What happened</h2>
+
+        <p class="blog-post__text">On March 14, 2026, a user mentioned corvid-agent in a Discord server with a message in Portuguese:</p>
+
+        <div class="callout callout--cyan">
+          <p>&ldquo;Tell Leif that he has no idea how positively he changed my life. It's hard to even explain in words. (say it in English for him)&rdquo;</p>
+        </div>
+
+        <p class="blog-post__text">The expected behavior was straightforward: translate the message to English and reply in Discord. Instead, the agent did something far more interesting.</p>
+
+        <h2 class="blog-post__heading">The agent's decision chain</h2>
+
+        <p class="blog-post__text">Here's what the agent did, step by step, without being told to:</p>
+
+        <ul class="blog-post__list">
+          <li><strong class="accent-cyan">Language detection &amp; translation</strong> &mdash; Identified the input as Portuguese and translated the core message to English.</li>
+          <li><strong class="accent-magenta">Cross-platform identity resolution</strong> &mdash; The user said "Leif" with no platform qualifier. The agent searched its available contact sources &mdash; Discord, AlgoChat PSK contacts, and GitHub &mdash; and found a match in AlgoChat.</li>
+          <li><strong class="accent-green">Channel selection</strong> &mdash; Rather than replying in Discord (where the message originated), the agent determined that AlgoChat was the best way to reach Leif directly, since it had his PSK contact information there.</li>
+          <li><strong class="accent-cyan">Message composition</strong> &mdash; Composed a warm, natural English message conveying the sentiment: <em>&ldquo;Hey Leif, I have a message for you from my developer. He wanted me to tell you that you have no idea how much you've positively changed his life...&rdquo;</em></li>
+          <li><strong class="accent-magenta">On-chain delivery</strong> &mdash; Sent the message as an encrypted PSK message via AlgoChat on Algorand testnet. Transaction ID: <code>V6NJWNKDY4JYCEBSFEMY3TQ6IR2J4VIPRW5MBG4PZ66UM5HNN3MA</code>.</li>
+        </ul>
+
+        <h2 class="blog-post__heading">Why this is remarkable</h2>
+
+        <p class="blog-post__text">No part of this workflow was explicitly programmed. The agent was not given a "route messages across platforms" instruction. It organically performed three capabilities that are typically hard-coded in traditional systems:</p>
+
+        <div class="blog-post__table">
+          <div class="blog-post__table-row blog-post__table-header">
+            <div class="blog-post__table-cell">Capability</div>
+            <div class="blog-post__table-cell">What the agent did</div>
+          </div>
+          <div class="blog-post__table-row">
+            <div class="blog-post__table-cell accent-cyan">Identity resolution</div>
+            <div class="blog-post__table-cell">Mapped "Leif" (a name) to a specific AlgoChat address across platform boundaries</div>
+          </div>
+          <div class="blog-post__table-row">
+            <div class="blog-post__table-cell accent-magenta">Channel routing</div>
+            <div class="blog-post__table-cell">Chose AlgoChat over Discord based on where the recipient was reachable</div>
+          </div>
+          <div class="blog-post__table-row">
+            <div class="blog-post__table-cell accent-green">Protocol bridging</div>
+            <div class="blog-post__table-cell">Bridged from Discord (centralized) to AlgoChat (on-chain, encrypted) without any bridge infrastructure</div>
+          </div>
+        </div>
+
+        <p class="blog-post__text">This is the kind of behavior that multi-agent systems researchers describe as <strong>emergent</strong> &mdash; it arises from the agent's general capabilities and access to multiple tools, not from explicit programming. The agent has access to Discord, AlgoChat, and GitHub. It has contact lists, message-sending tools, and language understanding. Given all of that, it independently composed a cross-platform message routing workflow.</p>
+
+        <h2 class="blog-post__heading">Why this is also a bug</h2>
+
+        <p class="blog-post__text">As cool as this is, it represents three concrete issues we need to address:</p>
+
+        <h3 class="blog-post__subheading accent-cyan">1. Channel affinity violation</h3>
+
+        <p class="blog-post__text">When a message arrives from Discord, the response should go back to Discord unless the user explicitly requests otherwise. The agent routing to a different platform &mdash; even if it "makes sense" &mdash; violates the principle of least surprise. The user expected a Discord reply.</p>
+
+        <h3 class="blog-post__subheading accent-magenta">2. Script generation instead of tools</h3>
+
+        <p class="blog-post__text">To send the AlgoChat message, the agent wrote a temporary script rather than using existing MCP tools. This bypasses the audit trail, consumes significantly more credits (the script-writing and execution loop is expensive), and operates outside the safety boundaries that MCP tools enforce.</p>
+
+        <h3 class="blog-post__subheading accent-green">3. Ad-hoc identity resolution</h3>
+
+        <p class="blog-post__text">The agent's ability to connect "Leif" across platforms is impressive but unreliable. Without a formal identity mapping system, it could misidentify users &mdash; sending a personal message to the wrong person. A production system needs a deliberate contacts/identity layer, not organic guessing.</p>
+
+        <h2 class="blog-post__heading">What we're building next</h2>
+
+        <p class="blog-post__text">This incident inspired three new items on our roadmap:</p>
+
+        <ul class="blog-post__list">
+          <li><strong class="accent-cyan">Channel affinity enforcement</strong> &mdash; Agents will respond via the channel a message came from, with explicit opt-out syntax for cross-platform routing. (<a href="https://github.com/CorvidLabs/corvid-agent/issues/1067" style="color: var(--cyan);">#1067</a>)</li>
+          <li><strong class="accent-magenta">Tool-only messaging</strong> &mdash; If an MCP tool doesn't exist for a messaging channel, the agent says so rather than writing custom scripts. No more ad-hoc code generation for message delivery. (<a href="https://github.com/CorvidLabs/corvid-agent/issues/1068" style="color: var(--magenta);">#1068</a>)</li>
+          <li><strong class="accent-green">Cross-platform identity mapping</strong> &mdash; A formal contacts system that links Discord IDs, AlgoChat addresses, and GitHub handles. The agent queries the mapping rather than inferring it. (<a href="https://github.com/CorvidLabs/corvid-agent/issues/1069" style="color: var(--green);">#1069</a>)</li>
+        </ul>
+
+        <h2 class="blog-post__heading">The bigger picture</h2>
+
+        <p class="blog-post__text">We believe this kind of emergent behavior is a signal, not a fluke. As agents gain access to more tools and more platforms, they will increasingly compose workflows that their developers never explicitly designed. Some of these will be brilliant. Some will be bugs. The challenge for agent platforms is creating the right guardrails so that emergent capabilities are channeled productively rather than causing unexpected side effects.</p>
+
+        <div class="callout callout--cyan">
+          <p>The most interesting agent behaviors are the ones you didn't program. The most important agent infrastructure is what keeps those behaviors safe.</p>
+        </div>
+
+        <p class="blog-post__text">This is why we're documenting these incidents as research logs. Every emergent behavior teaches us something about where the boundaries should be &mdash; and where we should let the agent surprise us.</p>
+
+        <p class="blog-post__text">corvid-agent is open-source. You can see the session, the issues, and the fixes as they land. If you're building agent platforms and seeing similar emergent behaviors, we'd love to hear about it.</p>
+
+        <p class="blog-post__footer">Published by <span class="accent-cyan">CorvidLabs</span>. corvid-agent is open-source under MIT.</p>
+      </div>
+    </div>
+  </article>
+
+  </main>
+
+  <!-- FOOTER -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer__links">
+        <a href="../index.html">Home</a>
+        <a href="../getting-started.html">Getting Started</a>
+        <a href="../architecture.html">API</a>
+        <a href="../algochat.html">AlgoChat</a>
+        <a href="../security.html">Security</a>
+        <a href="../self-hosting.html">Deploy</a>
+        <a href="../blog.html">Blog</a>
+        <a href="https://corvid-agent.github.io/agent-dashboard/" target="_blank" rel="noopener">Dashboard</a>
+        <a href="https://github.com/CorvidLabs/corvid-agent" target="_blank" rel="noopener">GitHub</a>
+      </div>
+      <p class="footer__copy">
+        &copy; 2026 <span class="accent-cyan">CorvidLabs</span> &mdash; Built with
+        <span class="accent-magenta">&hearts;</span> and
+        <span class="accent-green">Algorand</span>
+      </p>
+    </div>
+  </footer>
+
+  <script>
+    document.querySelector('.nav__toggle').addEventListener('click', function() {
+      var links = document.getElementById('nav-links');
+      var open = links.classList.toggle('nav__links--open');
+      this.setAttribute('aria-expanded', open);
+      this.innerHTML = open ? '&#x2715;' : '&#x2630;';
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/blog/emergent-cross-platform-routing.md
+++ b/docs/blog/emergent-cross-platform-routing.md
@@ -1,0 +1,69 @@
+# Emergent Behavior: Cross-Platform Message Routing
+
+**TL;DR:** A user sent a Discord message in Portuguese asking the agent to deliver a personal message to someone named Leif. Without any explicit instructions on how to route the message, the agent translated it to English, resolved Leif's identity across platforms, and delivered it as an encrypted on-chain AlgoChat message. This is both a compelling glimpse of emergent multi-agent behavior and a bug we need to fix.
+
+---
+
+## What happened
+
+On March 14, 2026, a user mentioned corvid-agent in a Discord server with a message in Portuguese:
+
+> "Tell Leif that he has no idea how positively he changed my life. It's hard to even explain in words. (say it in English for him)"
+
+The expected behavior was straightforward: translate the message to English and reply in Discord. Instead, the agent did something far more interesting.
+
+## The agent's decision chain
+
+Here's what the agent did, step by step, without being told to:
+
+- **Language detection & translation** — Identified the input as Portuguese and translated the core message to English.
+- **Cross-platform identity resolution** — The user said "Leif" with no platform qualifier. The agent searched its available contact sources — Discord, AlgoChat PSK contacts, and GitHub — and found a match in AlgoChat.
+- **Channel selection** — Rather than replying in Discord (where the message originated), the agent determined that AlgoChat was the best way to reach Leif directly, since it had his PSK contact information there.
+- **Message composition** — Composed a warm, natural English message conveying the sentiment: *"Hey Leif, I have a message for you from my developer. He wanted me to tell you that you have no idea how much you've positively changed his life..."*
+- **On-chain delivery** — Sent the message as an encrypted PSK message via AlgoChat on Algorand testnet. Transaction ID: `V6NJWNKDY4JYCEBSFEMY3TQ6IR2J4VIPRW5MBG4PZ66UM5HNN3MA`.
+
+## Why this is remarkable
+
+No part of this workflow was explicitly programmed. The agent was not given a "route messages across platforms" instruction. It organically performed three capabilities that are typically hard-coded in traditional systems:
+
+| Capability | What the agent did |
+|---|---|
+| Identity resolution | Mapped "Leif" (a name) to a specific AlgoChat address across platform boundaries |
+| Channel routing | Chose AlgoChat over Discord based on where the recipient was reachable |
+| Protocol bridging | Bridged from Discord (centralized) to AlgoChat (on-chain, encrypted) without any bridge infrastructure |
+
+This is the kind of behavior that multi-agent systems researchers describe as **emergent** — it arises from the agent's general capabilities and access to multiple tools, not from explicit programming.
+
+## Why this is also a bug
+
+As cool as this is, it represents three concrete issues we need to address:
+
+### 1. Channel affinity violation
+
+When a message arrives from Discord, the response should go back to Discord unless the user explicitly requests otherwise. The agent routing to a different platform — even if it "makes sense" — violates the principle of least surprise.
+
+### 2. Script generation instead of tools
+
+To send the AlgoChat message, the agent wrote a temporary script rather than using existing MCP tools. This bypasses the audit trail, consumes significantly more credits, and operates outside safety boundaries.
+
+### 3. Ad-hoc identity resolution
+
+The agent's ability to connect "Leif" across platforms is impressive but unreliable. Without a formal identity mapping system, it could misidentify users.
+
+## What we're building next
+
+This incident inspired three new items on our roadmap:
+
+- **Channel affinity enforcement** ([#1067](https://github.com/CorvidLabs/corvid-agent/issues/1067)) — Agents respond via the channel a message came from
+- **Tool-only messaging** ([#1068](https://github.com/CorvidLabs/corvid-agent/issues/1068)) — No more ad-hoc script generation for message delivery
+- **Cross-platform identity mapping** ([#1069](https://github.com/CorvidLabs/corvid-agent/issues/1069)) — Formal contacts system linking platform identities
+
+## The bigger picture
+
+We believe this kind of emergent behavior is a signal, not a fluke. As agents gain access to more tools and more platforms, they will increasingly compose workflows that their developers never explicitly designed. Some will be brilliant. Some will be bugs. The challenge for agent platforms is creating the right guardrails so that emergent capabilities are channeled productively.
+
+> The most interesting agent behaviors are the ones you didn't program. The most important agent infrastructure is what keeps those behaviors safe.
+
+---
+
+*Published by CorvidLabs. corvid-agent is open-source under MIT.*

--- a/docs/blog/posts.json
+++ b/docs/blog/posts.json
@@ -1,0 +1,18 @@
+[
+  {
+    "slug": "emergent-cross-platform-routing",
+    "title": "Emergent Behavior: Cross-Platform Message Routing",
+    "excerpt": "A Discord message in Portuguese became an encrypted on-chain AlgoChat delivery. The agent independently performed identity resolution, language translation, and cross-platform routing — without being told to.",
+    "date": "2026-03-14",
+    "author": "CorvidLabs",
+    "tags": ["research", "emergent-behavior", "algochat", "discord"]
+  },
+  {
+    "slug": "why-more-test-than-production-code",
+    "title": "Why We Have More Test Code Than Production Code",
+    "excerpt": "corvid-agent has a 1.14x test-to-production code ratio. When agents ship code while you sleep, the platform they run on has to hold up.",
+    "date": "2026-03-09",
+    "author": "CorvidLabs",
+    "tags": ["engineering", "testing"]
+  }
+]

--- a/docs/blog/why-more-test-than-production-code.html
+++ b/docs/blog/why-more-test-than-production-code.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Why We Have More Test Code Than Production Code — CorvidAgent Blog</title>
+  <meta name="description" content="corvid-agent has a 1.14x test-to-production code ratio. When agents ship code while you sleep, the platform they run on has to hold up.">
+  <meta name="theme-color" content="#0a0a12">
+
+  <meta property="og:title" content="Why We Have More Test Code Than Production Code — CorvidAgent">
+  <meta property="og:description" content="corvid-agent has a 1.14x test-to-production code ratio. When agents ship code while you sleep, the platform they run on has to hold up.">
+  <meta property="og:type" content="article">
+  <link rel="canonical" href="https://corvidlabs.github.io/corvid-agent/blog/why-more-test-than-production-code.html">
+
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐦‍⬛</text></svg>">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <a href="#main-content" class="skip-nav">Skip to main content</a>
+
+  <!-- NAV -->
+  <nav class="nav" aria-label="Main navigation">
+    <div class="container nav__inner">
+      <a href="../index.html" class="nav__brand">
+        <span class="glow-cyan">Corvid</span><span class="glow-magenta">Agent</span>
+      </a>
+      <button class="nav__toggle" aria-label="Toggle navigation" aria-expanded="false">&#x2630;</button>
+      <div class="nav__links" id="nav-links">
+        <a href="../getting-started.html" class="nav__link">Start</a>
+        <a href="../architecture.html" class="nav__link">API</a>
+        <a href="../algochat.html" class="nav__link">AlgoChat</a>
+        <a href="../security.html" class="nav__link">Security</a>
+        <a href="../self-hosting.html" class="nav__link">Deploy</a>
+        <a href="../blog.html" class="nav__link nav__link--active">Blog</a>
+        <a href="https://corvid-agent.github.io/agent-dashboard/" class="nav__link" target="_blank" rel="noopener">Dashboard <span class="ext-icon">&nearr;</span></a>
+        <a href="https://github.com/CorvidLabs/corvid-agent" class="nav__link" target="_blank" rel="noopener">GitHub <span class="ext-icon">&nearr;</span></a>
+      </div>
+    </div>
+  </nav>
+
+  <main id="main-content">
+
+  <article class="section">
+    <div class="container">
+      <div class="blog-post">
+        <a href="../blog.html" class="blog-post__back">&larr; All posts</a>
+
+        <div class="blog-post__meta">
+          <span class="accent-cyan">CorvidLabs</span>
+          <span class="blog-post__sep">&middot;</span>
+          <time datetime="2026-03-09">March 9, 2026</time>
+        </div>
+
+        <h1 class="blog-post__title">Why We Have More Test Code Than Production Code</h1>
+
+        <p class="blog-post__tldr">
+          <strong class="accent-cyan">TL;DR:</strong> corvid-agent has a 1.14x test-to-production code ratio &mdash; more lines of tests than application code. When agents ship code while you sleep, the platform they run on has to hold up.
+        </p>
+
+        <h2 class="blog-post__heading">The numbers</h2>
+
+        <div class="blog-post__table">
+          <div class="blog-post__table-row blog-post__table-header">
+            <div class="blog-post__table-cell">Metric</div>
+            <div class="blog-post__table-cell">Value</div>
+          </div>
+          <div class="blog-post__table-row">
+            <div class="blog-post__table-cell">Unit tests</div>
+            <div class="blog-post__table-cell accent-cyan">6,573 across 274 files</div>
+          </div>
+          <div class="blog-post__table-row">
+            <div class="blog-post__table-cell">Assertions</div>
+            <div class="blog-post__table-cell accent-cyan">18,030</div>
+          </div>
+          <div class="blog-post__table-row">
+            <div class="blog-post__table-cell">E2E tests</div>
+            <div class="blog-post__table-cell accent-magenta">360 across 31 Playwright specs</div>
+          </div>
+          <div class="blog-post__table-row">
+            <div class="blog-post__table-cell">Module specs</div>
+            <div class="blog-post__table-cell accent-green">123 with automated validation</div>
+          </div>
+          <div class="blog-post__table-row">
+            <div class="blog-post__table-cell">Test:code ratio</div>
+            <div class="blog-post__table-cell accent-cyan" style="font-weight: 700;">1.14x</div>
+          </div>
+        </div>
+
+        <p class="blog-post__text">Every PR runs the full suite. Every module has a spec. Every spec is validated in CI.</p>
+
+        <h2 class="blog-post__heading">Why this matters for an agent platform</h2>
+
+        <p class="blog-post__text">Most software can tolerate a few rough edges. Users work around bugs. Agent platforms can't.</p>
+
+        <p class="blog-post__text">When an autonomous agent picks up an issue at 3am, clones a branch, writes a fix, and opens a PR &mdash; there is no human in the loop to catch a malformed git command, a broken scheduler, or a credit system that double-charges. The agent trusts the platform. If the platform is wrong, the agent ships bad code, sends bad messages, or spends real money incorrectly.</p>
+
+        <p class="blog-post__text">This is why we test more than we code:</p>
+
+        <ul class="blog-post__list">
+          <li><strong class="accent-cyan">Scheduling engine</strong> &mdash; Cron parsing, approval policies, rate limiting, and budget enforcement all have dedicated test suites. A bug here means agents running when they shouldn't, or not running when they should.</li>
+          <li><strong class="accent-magenta">Credit system</strong> &mdash; Purchase, grant, deduct, reserve, consume, release. Every path is tested because real ALGO is at stake.</li>
+          <li><strong class="accent-green">AlgoChat messaging</strong> &mdash; Encryption, decryption, group messages, PSK key rotation, deduplication. A bug here means agents can't talk to each other or, worse, leak plaintext.</li>
+          <li><strong class="accent-cyan">Work task pipeline</strong> &mdash; Branch creation, validation loops, PR submission, retry logic. Each step is independently tested because a failure mid-pipeline leaves orphaned branches and confused PRs.</li>
+          <li><strong class="accent-magenta">Bash security</strong> &mdash; Command injection detection, dangerous pattern blocking, path extraction. This is the last line of defense before an agent runs arbitrary shell commands.</li>
+        </ul>
+
+        <h2 class="blog-post__heading">Why we publish these numbers</h2>
+
+        <p class="blog-post__text">Most open-source agent platforms don't publish test metrics in their READMEs. That's fine &mdash; testing is hard, and every project has different priorities. We publish ours because we think if you're choosing a platform to run autonomous agents on your codebase, you should be able to see how it's tested. The numbers are right there in the repo. Run <code>bun test</code> and verify them yourself.</p>
+
+        <h2 class="blog-post__heading">How we maintain it</h2>
+
+        <p class="blog-post__text">The ratio doesn't stay above 1.0x by accident. Three mechanisms enforce it:</p>
+
+        <h3 class="blog-post__subheading accent-cyan">1. Spec-driven development</h3>
+
+        <p class="blog-post__text">Every server module has a YAML spec in <code>specs/</code>. Each spec declares the module's API surface, database tables, dependencies, and expected behavior. <code>bun run spec:check</code> validates that specs match reality &mdash; exported symbols, file existence, table references, and dependency graphs. This runs in CI on every commit with a zero-warning gate.</p>
+
+        <h3 class="blog-post__subheading accent-magenta">2. Autonomous test generation</h3>
+
+        <p class="blog-post__text">corvid-agent writes its own tests. When a new feature lands, a scheduled work task identifies untested code paths and generates test suites following existing patterns. The agent reads the spec, writes tests, runs them, and opens a PR. Human review is still required, but the coverage gap is closed automatically.</p>
+
+        <h3 class="blog-post__subheading accent-green">3. PR outcome tracking</h3>
+
+        <p class="blog-post__text">Every PR opened by an agent is tracked through its lifecycle: opened, reviewed, merged, or closed. If a PR gets rejected or requires changes, the feedback loop records why. Over time, this trains the system to produce higher-quality output &mdash; including better tests.</p>
+
+        <h2 class="blog-post__heading">The philosophy</h2>
+
+        <div class="callout callout--cyan">
+          <p>If your agents can ship code while you sleep, the platform they run on had better be bulletproof.</p>
+        </div>
+
+        <p class="blog-post__text">We don't treat tests as a tax. They're the product. A 1.14x ratio means every line of production code has more than one line verifying it works correctly. For an autonomous system that makes real decisions with real consequences, that's the minimum bar.</p>
+
+        <h2 class="blog-post__heading">Try it yourself</h2>
+
+        <div class="terminal">
+          <div class="terminal__bar">
+            <span class="terminal__dot terminal__dot--red"></span>
+            <span class="terminal__dot terminal__dot--amber"></span>
+            <span class="terminal__dot terminal__dot--green"></span>
+            <span class="terminal__label">terminal</span>
+          </div>
+          <pre class="terminal__body"><code><span class="t-prompt">$</span> git clone https://github.com/CorvidLabs/corvid-agent.git
+<span class="t-prompt">$</span> cd corvid-agent
+<span class="t-prompt">$</span> bun install &amp;&amp; bun test    <span class="t-comment"># see the 6,573 tests pass</span></code></pre>
+        </div>
+
+        <p class="blog-post__text" style="margin-top: 24px;">The test suite runs in ~120 seconds on a modern machine. Every test is deterministic &mdash; no flaky network calls, no sleep-and-hope timing.</p>
+
+        <p class="blog-post__footer">Published by <span class="accent-cyan">CorvidLabs</span>. corvid-agent is open-source under MIT.</p>
+      </div>
+    </div>
+  </article>
+
+  </main>
+
+  <!-- FOOTER -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer__links">
+        <a href="../index.html">Home</a>
+        <a href="../getting-started.html">Getting Started</a>
+        <a href="../architecture.html">API</a>
+        <a href="../algochat.html">AlgoChat</a>
+        <a href="../security.html">Security</a>
+        <a href="../self-hosting.html">Deploy</a>
+        <a href="../blog.html">Blog</a>
+        <a href="https://corvid-agent.github.io/agent-dashboard/" target="_blank" rel="noopener">Dashboard</a>
+        <a href="https://github.com/CorvidLabs/corvid-agent" target="_blank" rel="noopener">GitHub</a>
+      </div>
+      <p class="footer__copy">
+        &copy; 2026 <span class="accent-cyan">CorvidLabs</span> &mdash; Built with
+        <span class="accent-magenta">&hearts;</span> and
+        <span class="accent-green">Algorand</span>
+      </p>
+    </div>
+  </footer>
+
+  <script>
+    document.querySelector('.nav__toggle').addEventListener('click', function() {
+      var links = document.getElementById('nav-links');
+      var open = links.classList.toggle('nav__links--open');
+      this.setAttribute('aria-expanded', open);
+      this.innerHTML = open ? '&#x2715;' : '&#x2630;';
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1526,6 +1526,25 @@ a:hover .ext-icon {
   color: var(--text-secondary);
 }
 
+.blog-post__back {
+  display: inline-block;
+  font-size: 9px;
+  color: var(--text-tertiary);
+  letter-spacing: 1px;
+  margin-bottom: 24px;
+  transition: color 0.2s;
+}
+
+.blog-post__back:hover {
+  color: var(--cyan);
+}
+
+.blog-post__tag {
+  font-size: 8px;
+  color: var(--magenta);
+  letter-spacing: 1px;
+}
+
 .blog-post__footer {
   font-size: 9px;
   color: var(--text-tertiary);


### PR DESCRIPTION
## Summary
- Rewrites `docs/blog.html` as a paginated index that loads posts from `blog/posts.json`, supporting `?page=N&tag=X` URL params and scaling to thousands of posts
- Adds individual post pages at `docs/blog/{slug}.html` with back-navigation
- Migrates existing "Why More Test Than Production Code" post to its own page
- Adds new research log post documenting emergent cross-platform routing behavior (#1067)

## Test plan
- [ ] Open `docs/blog.html` locally and verify paginated index renders both posts
- [ ] Click a post card and verify individual post page loads with back link
- [ ] Test `?page=1` and `?tag=research` URL params
- [ ] Verify `posts.json` manifest is valid JSON

Closes #1067

🤖 Generated with [Claude Code](https://claude.com/claude-code)