### PR TITLE
feat: Flock Directory search sorting + reputation aggregation

### DIFF
--- a/server/__tests__/flock-directory-service.test.ts
+++ b/server/__tests__/flock-directory-service.test.ts
@@ -270,3 +270,171 @@ describe('sweepStaleAgents', () => {
         expect(count).toBe(0);
     });
 });
+
+// ─── Search Sorting ─────────────────────────────────────────────────────────
+
+describe('search sorting', () => {
+    test('sorts by name ascending', () => {
+        svc.register({ address: 'ALGO_SORT1', name: 'Zebra' });
+        svc.register({ address: 'ALGO_SORT2', name: 'Alpha' });
+        svc.register({ address: 'ALGO_SORT3', name: 'Middle' });
+
+        const result = svc.search({ sortBy: 'name', sortOrder: 'asc' });
+        expect(result.agents[0].name).toBe('Alpha');
+        expect(result.agents[1].name).toBe('Middle');
+        expect(result.agents[2].name).toBe('Zebra');
+    });
+
+    test('sorts by name descending', () => {
+        svc.register({ address: 'ALGO_SORTD1', name: 'Zebra' });
+        svc.register({ address: 'ALGO_SORTD2', name: 'Alpha' });
+
+        const result = svc.search({ sortBy: 'name', sortOrder: 'desc' });
+        expect(result.agents[0].name).toBe('Zebra');
+        expect(result.agents[1].name).toBe('Alpha');
+    });
+
+    test('sorts by uptime descending', () => {
+        const a1 = svc.register({ address: 'ALGO_UP1', name: 'LowUp' });
+        const a2 = svc.register({ address: 'ALGO_UP2', name: 'HighUp' });
+        svc.update(a1.id, { uptimePct: 50 });
+        svc.update(a2.id, { uptimePct: 99 });
+
+        const result = svc.search({ sortBy: 'uptime', sortOrder: 'desc' });
+        expect(result.agents[0].name).toBe('HighUp');
+        expect(result.agents[1].name).toBe('LowUp');
+    });
+
+    test('sorts by registered date ascending', () => {
+        const a1 = svc.register({ address: 'ALGO_REG1', name: 'First' });
+        // Manually backdate the first agent
+        db.query(`UPDATE flock_agents SET registered_at = datetime('now', '-1 day') WHERE id = ?`).run(a1.id);
+        svc.register({ address: 'ALGO_REG2', name: 'Second' });
+
+        const result = svc.search({ sortBy: 'registered', sortOrder: 'asc' });
+        expect(result.agents[0].name).toBe('First');
+        expect(result.agents[1].name).toBe('Second');
+    });
+
+    test('sorts by attestations descending', () => {
+        const a1 = svc.register({ address: 'ALGO_ATT1', name: 'FewAttest' });
+        const a2 = svc.register({ address: 'ALGO_ATT2', name: 'ManyAttest' });
+        svc.update(a1.id, { attestationCount: 2 });
+        svc.update(a2.id, { attestationCount: 15 });
+
+        const result = svc.search({ sortBy: 'attestations', sortOrder: 'desc' });
+        expect(result.agents[0].name).toBe('ManyAttest');
+        expect(result.agents[1].name).toBe('FewAttest');
+    });
+
+    test('defaults to reputation desc when no sort specified', () => {
+        const a1 = svc.register({ address: 'ALGO_DEF1', name: 'LowRep' });
+        const a2 = svc.register({ address: 'ALGO_DEF2', name: 'HighRep' });
+        svc.update(a1.id, { reputationScore: 10 });
+        svc.update(a2.id, { reputationScore: 90 });
+
+        const result = svc.search({});
+        expect(result.agents[0].name).toBe('HighRep');
+    });
+});
+
+// ─── Reputation Computation ─────────────────────────────────────────────────
+
+describe('computeReputation', () => {
+    test('computes score from component metrics', () => {
+        const agent = svc.register({ address: 'ALGO_REP1', name: 'RepAgent' });
+        svc.update(agent.id, {
+            uptimePct: 95,
+            attestationCount: 10,
+            councilParticipations: 5,
+        });
+
+        const updated = svc.computeReputation(agent.id);
+        expect(updated).not.toBeNull();
+        // Score should be > 0 and <= 100
+        expect(updated!.reputationScore).toBeGreaterThan(0);
+        expect(updated!.reputationScore).toBeLessThanOrEqual(100);
+    });
+
+    test('returns 0-based score for brand new agent', () => {
+        const agent = svc.register({ address: 'ALGO_REP_NEW', name: 'NewAgent' });
+
+        const updated = svc.computeReputation(agent.id);
+        expect(updated).not.toBeNull();
+        // New agent with 0 uptime, 0 attestations, 0 council: only heartbeat score
+        expect(updated!.reputationScore).toBe(20); // active heartbeat = 20 points
+    });
+
+    test('returns null for deregistered agent', () => {
+        const agent = svc.register({ address: 'ALGO_REP_DEREG', name: 'DeregAgent' });
+        svc.deregister(agent.id);
+
+        expect(svc.computeReputation(agent.id)).toBeNull();
+    });
+
+    test('returns null for non-existent agent', () => {
+        expect(svc.computeReputation('nonexistent')).toBeNull();
+    });
+
+    test('higher uptime increases score', () => {
+        const a1 = svc.register({ address: 'ALGO_REP_LOW', name: 'LowUptime' });
+        const a2 = svc.register({ address: 'ALGO_REP_HIGH', name: 'HighUptime' });
+        svc.update(a1.id, { uptimePct: 20 });
+        svc.update(a2.id, { uptimePct: 95 });
+
+        const s1 = svc.computeReputation(a1.id)!;
+        const s2 = svc.computeReputation(a2.id)!;
+        expect(s2.reputationScore).toBeGreaterThan(s1.reputationScore);
+    });
+
+    test('inactive agent gets lower heartbeat score', () => {
+        const agent = svc.register({ address: 'ALGO_REP_INACTIVE', name: 'InactiveAgent' });
+        svc.update(agent.id, { uptimePct: 50, attestationCount: 5 });
+
+        // Compute while active
+        const activeScore = svc.computeReputation(agent.id)!.reputationScore;
+
+        // Mark inactive via stale heartbeat
+        db.query(`UPDATE flock_agents SET last_heartbeat = datetime('now', '-60 minutes') WHERE id = ?`).run(agent.id);
+        svc.sweepStaleAgents();
+
+        const inactiveScore = svc.computeReputation(agent.id)!.reputationScore;
+        expect(inactiveScore).toBeLessThan(activeScore);
+    });
+
+    test('score is clamped to 0-100 range', () => {
+        const agent = svc.register({ address: 'ALGO_REP_MAX', name: 'MaxAgent' });
+        svc.update(agent.id, {
+            uptimePct: 100,
+            attestationCount: 20,
+            councilParticipations: 10,
+        });
+
+        const updated = svc.computeReputation(agent.id)!;
+        expect(updated.reputationScore).toBeLessThanOrEqual(100);
+        expect(updated.reputationScore).toBeGreaterThanOrEqual(0);
+    });
+});
+
+// ─── Recompute All Reputations ──────────────────────────────────────────────
+
+describe('recomputeAllReputations', () => {
+    test('updates all non-deregistered agents', () => {
+        const a1 = svc.register({ address: 'ALGO_RECOMP1', name: 'Agent1' });
+        const a2 = svc.register({ address: 'ALGO_RECOMP2', name: 'Agent2' });
+        const a3 = svc.register({ address: 'ALGO_RECOMP3', name: 'Agent3' });
+        svc.deregister(a3.id);
+
+        svc.update(a1.id, { uptimePct: 80 });
+        svc.update(a2.id, { uptimePct: 60, attestationCount: 5 });
+
+        const count = svc.recomputeAllReputations();
+        expect(count).toBe(2); // excludes deregistered
+
+        // Verify scores were actually updated
+        const updated1 = svc.getById(a1.id)!;
+        const updated2 = svc.getById(a2.id)!;
+        expect(updated1.reputationScore).toBeGreaterThan(0);
+        expect(updated2.reputationScore).toBeGreaterThan(0);
+    });
+});

--- a/server/__tests__/routes-flock-directory.test.ts
+++ b/server/__tests__/routes-flock-directory.test.ts
@@ -125,9 +125,39 @@ describe('Flock Directory Routes', () => {
             status: 'active',
             capability: 'code',
             minReputation: 5,
+            sortBy: undefined,
+            sortOrder: undefined,
             limit: 10,
             offset: 2,
         });
+    });
+
+    it('GET /api/flock-directory/search passes sort params', async () => {
+        const svc = createMockService();
+        const { req, url } = fakeReq('GET', '/api/flock-directory/search?sortBy=name&sortOrder=asc');
+        const res = await callRoute(req, url, db, svc);
+        expect(res).not.toBeNull();
+        expect(res!.status).toBe(200);
+        expect(svc.search).toHaveBeenCalledWith(expect.objectContaining({
+            sortBy: 'name',
+            sortOrder: 'asc',
+        }));
+    });
+
+    it('GET /api/flock-directory/search rejects invalid sortBy', async () => {
+        const svc = createMockService();
+        const { req, url } = fakeReq('GET', '/api/flock-directory/search?sortBy=invalid');
+        const res = await callRoute(req, url, db, svc);
+        expect(res).not.toBeNull();
+        expect(res!.status).toBe(400);
+    });
+
+    it('GET /api/flock-directory/search rejects invalid sortOrder', async () => {
+        const svc = createMockService();
+        const { req, url } = fakeReq('GET', '/api/flock-directory/search?sortOrder=invalid');
+        const res = await callRoute(req, url, db, svc);
+        expect(res).not.toBeNull();
+        expect(res!.status).toBe(400);
     });
 
     // ─── Stats ───────────────────────────────────────────────────────────────
@@ -309,6 +339,28 @@ describe('Flock Directory Routes', () => {
     it('DELETE /api/flock-directory/agents/:id returns 404 when not found', async () => {
         const svc = createMockService();
         const { req, url } = fakeReq('DELETE', '/api/flock-directory/agents/nonexistent');
+        const res = await callRoute(req, url, db, svc);
+        expect(res).not.toBeNull();
+        expect(res!.status).toBe(404);
+    });
+
+    // ─── Compute Reputation ─────────────────────────────────────────────────
+
+    it('POST /api/flock-directory/agents/:id/reputation computes score', async () => {
+        const agent = { id: 'agent-1', name: 'Test', reputationScore: 75 };
+        const svc = createMockService({ computeReputation: mock(() => agent as any) });
+        const { req, url } = fakeReq('POST', '/api/flock-directory/agents/agent-1/reputation');
+        const res = await callRoute(req, url, db, svc);
+        expect(res).not.toBeNull();
+        expect(res!.status).toBe(200);
+        const data = await res!.json();
+        expect(data.reputationScore).toBe(75);
+        expect(svc.computeReputation).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('POST /api/flock-directory/agents/:id/reputation returns 404 for missing agent', async () => {
+        const svc = createMockService({ computeReputation: mock(() => null) });
+        const { req, url } = fakeReq('POST', '/api/flock-directory/agents/nonexistent/reputation');
         const res = await callRoute(req, url, db, svc);
         expect(res).not.toBeNull();
         expect(res!.status).toBe(404);

--- a/server/flock-directory/service.ts
+++ b/server/flock-directory/service.ts
@@ -13,6 +13,8 @@ import type {
     FlockAgent,
     FlockDirectorySearchParams,
     FlockDirectorySearchResult,
+    FlockSortField,
+    FlockSortOrder,
 } from '../../shared/types/flock-directory';
 import type {
     FlockAgentRecord,
@@ -60,6 +62,31 @@ function recordToAgent(row: FlockAgentRecord): FlockAgent {
 
 /** Stale threshold: agents without heartbeat for 30 minutes are marked inactive. */
 const HEARTBEAT_STALE_MINUTES = 30;
+
+/** Map sort field names to SQL columns. */
+const SORT_COLUMN_MAP: Record<FlockSortField, string> = {
+    reputation: 'reputation_score',
+    name: 'name',
+    uptime: 'uptime_pct',
+    registered: 'registered_at',
+    attestations: 'attestation_count',
+};
+
+/** Validate sort order — only 'asc' or 'desc' are valid. */
+function safeSortOrder(order?: FlockSortOrder): 'ASC' | 'DESC' {
+    return order === 'asc' ? 'ASC' : 'DESC';
+}
+
+/**
+ * Reputation weights for composite score calculation.
+ * Total weights = 100; score output is 0–100.
+ */
+const REPUTATION_WEIGHTS = {
+    uptime: 35,
+    attestations: 25,
+    council: 20,
+    heartbeatConsistency: 20,
+} as const;
 
 export class FlockDirectoryService {
     private onChainClient: OnChainFlockClient | null = null;
@@ -256,10 +283,14 @@ export class FlockDirectoryService {
         const limit = params.limit ?? 50;
         const offset = params.offset ?? 0;
 
+        // Sort by specified field or default to reputation desc
+        const sortCol = params.sortBy ? SORT_COLUMN_MAP[params.sortBy] : 'reputation_score';
+        const sortDir = params.sortBy ? safeSortOrder(params.sortOrder) : 'DESC';
+
         const total = queryCount(this.db, `SELECT COUNT(*) as cnt FROM flock_agents ${where}`, ...bindParams);
         const rows = this.db.query(`
             SELECT * FROM flock_agents ${where}
-            ORDER BY reputation_score DESC, registered_at ASC
+            ORDER BY ${sortCol} ${sortDir}, registered_at ASC
             LIMIT ? OFFSET ?
         `).all(...bindParams, limit, offset) as FlockAgentRecord[];
 
@@ -284,6 +315,61 @@ export class FlockDirectoryService {
             log.info('Swept stale agents', { count: result.changes });
         }
         return result.changes;
+    }
+
+    /**
+     * Compute and persist a composite reputation score for an agent.
+     * Combines uptime, attestation count, council participations,
+     * and heartbeat consistency into a single 0–100 score.
+     *
+     * Returns the updated agent, or null if not found / deregistered.
+     */
+    computeReputation(id: string): FlockAgent | null {
+        const agent = this.getById(id);
+        if (!agent || agent.status === 'deregistered') return null;
+
+        // Uptime component: direct percentage (0–100) → weighted
+        const uptimeScore = Math.min(agent.uptimePct, 100) * (REPUTATION_WEIGHTS.uptime / 100);
+
+        // Attestation component: logarithmic scale, cap at 20 attestations
+        const attestCapped = Math.min(agent.attestationCount, 20);
+        const attestScore = (attestCapped > 0
+            ? Math.log(attestCapped + 1) / Math.log(21) // normalized 0–1
+            : 0) * REPUTATION_WEIGHTS.attestations;
+
+        // Council component: linear scale, cap at 10 participations
+        const councilCapped = Math.min(agent.councilParticipations, 10);
+        const councilScore = (councilCapped / 10) * REPUTATION_WEIGHTS.council;
+
+        // Heartbeat consistency: based on status — active = full marks, inactive = half
+        const heartbeatScore = agent.status === 'active'
+            ? REPUTATION_WEIGHTS.heartbeatConsistency
+            : REPUTATION_WEIGHTS.heartbeatConsistency * 0.5;
+
+        const total = Math.round(uptimeScore + attestScore + councilScore + heartbeatScore);
+        const clamped = Math.max(0, Math.min(100, total));
+
+        return this.update(id, { reputationScore: clamped });
+    }
+
+    /**
+     * Recompute reputation scores for all non-deregistered agents.
+     * Returns the number of agents updated.
+     */
+    recomputeAllReputations(): number {
+        const rows = this.db.query(
+            `SELECT id FROM flock_agents WHERE status != 'deregistered'`,
+        ).all() as { id: string }[];
+
+        let updated = 0;
+        for (const row of rows) {
+            if (this.computeReputation(row.id)) updated++;
+        }
+
+        if (updated > 0) {
+            log.info('Recomputed reputation scores', { count: updated });
+        }
+        return updated;
     }
 
     /** Get directory statistics. */

--- a/server/mcp/direct-tools.ts
+++ b/server/mcp/direct-tools.ts
@@ -664,12 +664,12 @@ export function buildDirectTools(ctx: McpToolContext | null, codingCtx?: CodingT
         // ─── Flock Directory ────────────────────────────────────────────
         tools.push({
             name: 'corvid_flock_directory',
-            description: 'Manage the Flock Directory — on-chain agent registry for discovery and reputation. Actions: register, deregister, heartbeat, lookup, search, list, stats.',
+            description: 'Manage the Flock Directory — on-chain agent registry for discovery and reputation. Actions: register, deregister, heartbeat, lookup, search, list, stats, compute_reputation.',
             parameters: {
                 type: 'object',
                 properties: {
-                    action: { type: 'string', enum: ['register', 'deregister', 'heartbeat', 'lookup', 'search', 'list', 'stats'], description: 'Operation to perform' },
-                    agent_id: { type: 'string', description: 'Agent ID (for deregister, heartbeat, lookup)' },
+                    action: { type: 'string', enum: ['register', 'deregister', 'heartbeat', 'lookup', 'search', 'list', 'stats', 'compute_reputation'], description: 'Operation to perform' },
+                    agent_id: { type: 'string', description: 'Agent ID (for deregister, heartbeat, lookup, compute_reputation)' },
                     address: { type: 'string', description: 'Algorand address (for register, lookup)' },
                     name: { type: 'string', description: 'Agent name (for register)' },
                     description: { type: 'string', description: 'Agent description (for register)' },
@@ -678,6 +678,8 @@ export function buildDirectTools(ctx: McpToolContext | null, codingCtx?: CodingT
                     query: { type: 'string', description: 'Search query (for search)' },
                     capability: { type: 'string', description: 'Filter by capability (for search)' },
                     min_reputation: { type: 'number', description: 'Minimum reputation score (for search)' },
+                    sort_by: { type: 'string', enum: ['reputation', 'name', 'uptime', 'registered', 'attestations'], description: 'Sort field (for search, default: reputation)' },
+                    sort_order: { type: 'string', enum: ['asc', 'desc'], description: 'Sort order (for search, default: desc)' },
                     limit: { type: 'number', description: 'Max results (default 20)' },
                 },
                 required: ['action'],

--- a/server/mcp/sdk-tools.ts
+++ b/server/mcp/sdk-tools.ts
@@ -516,11 +516,11 @@ export function createCorvidMcpServer(ctx: McpToolContext, pluginTools?: ReturnT
         tool(
             'corvid_flock_directory',
             'Manage the Flock Directory — an on-chain agent registry for discovery and reputation. ' +
-            'Actions: register, deregister, heartbeat, lookup, search, list, stats.',
+            'Actions: register, deregister, heartbeat, lookup, search, list, stats, compute_reputation.',
             {
-                action: z.enum(['register', 'deregister', 'heartbeat', 'lookup', 'search', 'list', 'stats'])
+                action: z.enum(['register', 'deregister', 'heartbeat', 'lookup', 'search', 'list', 'stats', 'compute_reputation'])
                     .describe('Operation to perform'),
-                agent_id: z.string().optional().describe('Agent ID (for deregister, heartbeat, lookup)'),
+                agent_id: z.string().optional().describe('Agent ID (for deregister, heartbeat, lookup, compute_reputation)'),
                 address: z.string().optional().describe('Algorand address (for register, lookup)'),
                 name: z.string().optional().describe('Agent name (for register)'),
                 description: z.string().optional().describe('Agent description (for register)'),
@@ -529,6 +529,8 @@ export function createCorvidMcpServer(ctx: McpToolContext, pluginTools?: ReturnT
                 query: z.string().optional().describe('Search query (for search)'),
                 capability: z.string().optional().describe('Filter by capability (for search)'),
                 min_reputation: z.number().optional().describe('Minimum reputation score (for search)'),
+                sort_by: z.enum(['reputation', 'name', 'uptime', 'registered', 'attestations']).optional().describe('Sort field (for search, default: reputation)'),
+                sort_order: z.enum(['asc', 'desc']).optional().describe('Sort order (for search, default: desc)'),
                 limit: z.number().optional().describe('Max results to return (default 20)'),
             },
             async (args) => handleFlockDirectory(ctx, args),

--- a/server/mcp/tool-handlers/flock-directory.ts
+++ b/server/mcp/tool-handlers/flock-directory.ts
@@ -21,6 +21,8 @@ export async function handleFlockDirectory(
         query?: string;
         capability?: string;
         min_reputation?: number;
+        sort_by?: string;
+        sort_order?: string;
         limit?: number;
     },
 ): Promise<CallToolResult> {
@@ -73,11 +75,22 @@ export async function handleFlockDirectory(
                 return textResult(JSON.stringify(agent, null, 2));
             }
 
+            case 'compute_reputation': {
+                if (!args.agent_id) return errorResult('compute_reputation requires agent_id');
+                const agent = svc.computeReputation(args.agent_id);
+                if (!agent) return errorResult(`Agent ${args.agent_id} not found or deregistered.`);
+                return textResult(`Reputation score for "${agent.name}": ${agent.reputationScore}/100`);
+            }
+
             case 'search': {
+                const sortBy = args.sort_by as import('../../../shared/types/flock-directory').FlockSortField | undefined;
+                const sortOrder = args.sort_order as import('../../../shared/types/flock-directory').FlockSortOrder | undefined;
                 const result = svc.search({
                     query: args.query,
                     capability: args.capability,
                     minReputation: args.min_reputation,
+                    sortBy,
+                    sortOrder,
                     limit: args.limit ?? 20,
                 });
                 const lines = [
@@ -117,7 +130,7 @@ export async function handleFlockDirectory(
 
             default:
                 return errorResult(
-                    `Unknown action "${args.action}". Valid actions: register, deregister, heartbeat, lookup, search, list, stats, sync`,
+                    `Unknown action "${args.action}". Valid actions: register, deregister, heartbeat, lookup, search, list, stats, sync, compute_reputation`,
                 );
         }
     } catch (err) {

--- a/server/routes/flock-directory.ts
+++ b/server/routes/flock-directory.ts
@@ -4,7 +4,7 @@
 import type { Database } from 'bun:sqlite';
 import type { FlockDirectoryService } from '../flock-directory/service';
 import type { RequestContext } from '../middleware/guards';
-import type { FlockAgentStatus } from '../../shared/types/flock-directory';
+import type { FlockAgentStatus, FlockSortField, FlockSortOrder } from '../../shared/types/flock-directory';
 import { json, badRequest, notFound, handleRouteError, safeNumParam } from '../lib/response';
 import { parseBodyOrThrow, ValidationError, AlgorandAddressSchema, isAlgorandAddressFormat } from '../lib/validation';
 import { z } from 'zod';
@@ -47,13 +47,24 @@ export function handleFlockDirectoryRoutes(
         const capability = url.searchParams.get('capability') ?? undefined;
         const minRepParam = url.searchParams.get('minReputation');
         const minReputation = minRepParam !== null ? safeNumParam(minRepParam, 0) : undefined;
+        const sortBy = (url.searchParams.get('sortBy') ?? undefined) as FlockSortField | undefined;
+        const sortOrder = (url.searchParams.get('sortOrder') ?? undefined) as FlockSortOrder | undefined;
         const limitParam = url.searchParams.get('limit');
         const limit = limitParam !== null ? safeNumParam(limitParam, 50) : undefined;
         const offsetParam = url.searchParams.get('offset');
         const offset = offsetParam !== null ? safeNumParam(offsetParam, 0) : undefined;
 
+        // Validate sort field if provided
+        const validSortFields: FlockSortField[] = ['reputation', 'name', 'uptime', 'registered', 'attestations'];
+        if (sortBy && !validSortFields.includes(sortBy)) {
+            return badRequest(`Invalid sortBy value. Valid values: ${validSortFields.join(', ')}`);
+        }
+        if (sortOrder && sortOrder !== 'asc' && sortOrder !== 'desc') {
+            return badRequest('Invalid sortOrder value. Valid values: asc, desc');
+        }
+
         return json(flockDirectory.search({
-            query, status, capability, minReputation, limit, offset,
+            query, status, capability, minReputation, sortBy, sortOrder, limit, offset,
         }));
     }
 
@@ -119,6 +130,15 @@ export function handleFlockDirectoryRoutes(
             if (!ok) return notFound('Agent not found or already deregistered');
             return json({ ok: true });
         }
+    }
+
+    // ─── Compute Reputation ──────────────────────────────────────────────────
+
+    const reputationMatch = path.match(/^\/api\/flock-directory\/agents\/([^/]+)\/reputation$/);
+    if (reputationMatch && method === 'POST') {
+        const agent = flockDirectory.computeReputation(reputationMatch[1]);
+        if (!agent) return notFound('Agent not found or deregistered');
+        return json(agent);
     }
 
     // ─── Heartbeat ──────────────────────────────────────────────────────────

--- a/shared/types/flock-directory.ts
+++ b/shared/types/flock-directory.ts
@@ -17,11 +17,16 @@ export interface FlockAgent {
     updatedAt: string;
 }
 
+export type FlockSortField = 'reputation' | 'name' | 'uptime' | 'registered' | 'attestations';
+export type FlockSortOrder = 'asc' | 'desc';
+
 export interface FlockDirectorySearchParams {
     query?: string;
     status?: FlockAgentStatus;
     capability?: string;
     minReputation?: number;
+    sortBy?: FlockSortField;
+    sortOrder?: FlockSortOrder;
     limit?: number;
     offset?: number;
 }

--- a/specs/flock-directory/service.spec.md
+++ b/specs/flock-directory/service.spec.md
@@ -54,7 +54,9 @@ _No standalone exported functions. All functionality is exposed via the exported
 | `getById` | `(id: string)` | `FlockAgent \| null` | Lookup by UUID |
 | `getByAddress` | `(address: string)` | `FlockAgent \| null` | Lookup by Algorand address |
 | `listActive` | `(limit?: number, offset?: number)` | `FlockAgent[]` | Lists active agents sorted by reputation desc |
-| `search` | `(params: FlockDirectorySearchParams)` | `FlockDirectorySearchResult` | Filtered search with pagination |
+| `search` | `(params: FlockDirectorySearchParams)` | `FlockDirectorySearchResult` | Filtered search with pagination and sorting |
+| `computeReputation` | `(id: string)` | `FlockAgent \| null` | Computes composite 0–100 reputation score from uptime, attestations, council, heartbeat |
+| `recomputeAllReputations` | `()` | `number` | Recomputes scores for all non-deregistered agents |
 | `sweepStaleAgents` | `()` | `number` | Marks agents inactive if no heartbeat for 30 minutes |
 | `getStats` | `()` | `{ total, active, inactive, onChainAppId }` | Directory statistics |
 | `selfRegister` | `(opts: { address, name, description, instanceUrl, capabilities })` | `Promise<FlockAgent>` | Idempotent self-registration for this corvid-agent instance |
@@ -68,6 +70,9 @@ _No standalone exported functions. All functionality is exposed via the exported
 4. Heartbeat only updates agents not in 'deregistered' status.
 5. `selfRegister` is idempotent — if already registered at the given address, it sends a heartbeat instead.
 6. Stale sweep threshold is 30 minutes without heartbeat.
+7. `computeReputation` score is always clamped to 0–100.
+8. Reputation weights: uptime 35%, attestations 25% (log scale, cap 20), council 20% (linear, cap 10), heartbeat 20% (active=full, inactive=half).
+9. Search defaults to sorting by reputation_score DESC when no sortBy is specified.
 
 ## Behavioral Examples
 
@@ -88,6 +93,18 @@ _No standalone exported functions. All functionality is exposed via the exported
 - **Given** agent is already registered at the given address with status 'active'
 - **When** `selfRegister()` is called with the same address
 - **Then** a heartbeat is sent instead of creating a duplicate, the existing agent is returned
+
+### Scenario: Search with custom sort
+
+- **Given** multiple agents are registered with varying uptime
+- **When** `search({ sortBy: 'uptime', sortOrder: 'desc' })` is called
+- **Then** results are sorted by uptime_pct descending
+
+### Scenario: Compute reputation score
+
+- **Given** an active agent with uptimePct=95, attestationCount=10, councilParticipations=5
+- **When** `computeReputation(id)` is called
+- **Then** a composite score is calculated from weighted components (uptime 35%, attestations 25%, council 20%, heartbeat 20%) and persisted
 
 ### Scenario: Stale agent sweep
 


### PR DESCRIPTION
## Summary

- Add `sortBy`/`sortOrder` params to Flock Directory search (fields: `reputation`, `name`, `uptime`, `registered`, `attestations`; order: `asc`/`desc`)
- Add `computeReputation(id)` — weighted composite score from uptime (35%), attestations (25%), council (20%), heartbeat (20%)
- Add `recomputeAllReputations()` for bulk recalculation
- Expose via REST (`POST /agents/:id/reputation`), MCP tool (`compute_reputation` action), and search sort params
- Input validation on sort params in routes (400 for invalid values)

Partial progress on #700 — search + reputation workstream.

## Test plan

- [x] 19 new tests: 7 sort tests, 8 reputation computation tests, 4 route tests
- [x] All 6,851 tests pass (0 fail)
- [x] TypeScript: `tsc --noEmit` clean
- [x] Spec check: 137/137 pass (100% file coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)