### PR TITLE
feat: add TEALScript source for Flock Directory smart contract

### DIFF
--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,55 @@
+# Flock Directory Smart Contract
+
+TEALScript source for the FlockDirectory Algorand smart contract. This contract manages an on-chain registry of agents with staking, reputation tiers, and challenge-based testing.
+
+## Prerequisites
+
+- [TEALScript](https://github.com/algorandfoundation/TEALScript) v0.107.2+
+- Node.js 18+ or Bun
+
+Install TEALScript:
+
+```bash
+npm install -g @algorandfoundation/tealscript
+```
+
+## Compile
+
+```bash
+tealscript contracts/flock-directory.algo.ts contracts/artifacts
+```
+
+This produces:
+- `FlockDirectory.approval.teal` — approval program
+- `FlockDirectory.clear.teal` — clear-state program
+- `FlockDirectory.arc56.json` — ARC-56 application specification (methods, state, structs)
+- `FlockDirectory.arc32.json` — ARC-32 application specification
+
+## Regenerate the ARC-56 spec
+
+After modifying the source, recompile and copy the updated spec into the server:
+
+```bash
+tealscript contracts/flock-directory.algo.ts contracts/artifacts
+cp contracts/artifacts/FlockDirectory.arc56.json server/flock-directory/contract/FlockDirectory.arc56.json
+```
+
+## Generate typed client
+
+Use [algokit-client-generator](https://github.com/algorandfoundation/algokit-client-generator-ts) to produce a typed TypeScript client from the ARC-56 spec:
+
+```bash
+npx @algorandfoundation/algokit-client-generator generate \
+  -a server/flock-directory/contract/FlockDirectory.arc56.json \
+  -o server/flock-directory/contract/FlockDirectoryClient.ts
+```
+
+## Contract overview
+
+| Item | Details |
+|------|---------|
+| Global state | `admin` (address), `min_stake` (uint64), `reg_open` (uint64), `agent_count` (uint64), `chal_count` (uint64) |
+| Box maps | `agents` (prefix `a`), `testResults` (prefix `t`), `challenges` (prefix `c`) |
+| Methods | 17 (1 create + 16 call) |
+| Tier system | REGISTERED (1), TESTED (2, 1+ tests), ESTABLISHED (3, 5+ tests), TRUSTED (4, 10+ tests) |
+| Min stake default | 1,000,000 microALGO (1 ALGO) |

--- a/contracts/flock-directory.algo.ts
+++ b/contracts/flock-directory.algo.ts
@@ -1,0 +1,300 @@
+import { Contract } from '@algorandfoundation/tealscript';
+
+// ── Structs ──────────────────────────────────────────────────────────────────
+
+type AgentRecord = {
+  name: string;
+  endpoint: string;
+  metadata: string;
+  tier: uint64;
+  totalScore: uint64;
+  totalMaxScore: uint64;
+  testCount: uint64;
+  lastHeartbeatRound: uint64;
+  registrationRound: uint64;
+  stake: uint64;
+};
+
+type TestResult = {
+  score: uint64;
+  maxScore: uint64;
+  category: string;
+  round: uint64;
+};
+
+type Challenge = {
+  category: string;
+  description: string;
+  maxScore: uint64;
+  active: uint64;
+};
+
+// ── Tier constants ───────────────────────────────────────────────────────────
+
+const TIER_REGISTERED = 1;
+const TIER_TESTED = 2;
+const TIER_ESTABLISHED = 3;
+const TIER_TRUSTED = 4;
+
+// ── Contract ─────────────────────────────────────────────────────────────────
+
+class FlockDirectory extends Contract {
+  // ── Global state ─────────────────────────────────────────────────────────
+
+  admin = GlobalStateKey<Address>({ key: 'admin' });
+
+  agentCount = GlobalStateKey<uint64>({ key: 'agent_count' });
+
+  minStake = GlobalStateKey<uint64>({ key: 'min_stake' });
+
+  registrationOpen = GlobalStateKey<uint64>({ key: 'reg_open' });
+
+  challengeCount = GlobalStateKey<uint64>({ key: 'chal_count' });
+
+  // ── Box storage ──────────────────────────────────────────────────────────
+
+  agents = BoxMap<Address, AgentRecord>({ prefix: 'a' });
+
+  testResults = BoxMap<[Address, string], TestResult>({ prefix: 't' });
+
+  challenges = BoxMap<string, Challenge>({ prefix: 'c' });
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+
+  createApplication(): void {
+    this.admin.value = this.txn.sender;
+    this.minStake.value = 1_000_000;
+    this.agentCount.value = 0;
+    this.challengeCount.value = 0;
+    this.registrationOpen.value = 1;
+  }
+
+  // ── Agent management ─────────────────────────────────────────────────────
+
+  registerAgent(
+    name: string,
+    endpoint: string,
+    metadata: string,
+    payment: PayTxn
+  ): void {
+    assert(this.registrationOpen.value === 1);
+    assert(payment.amount >= this.minStake.value);
+    assert(payment.receiver === this.app.address);
+    assert(!this.agents(this.txn.sender).exists);
+
+    this.agents(this.txn.sender).value = {
+      name: name,
+      endpoint: endpoint,
+      metadata: metadata,
+      tier: TIER_REGISTERED,
+      totalScore: 0,
+      totalMaxScore: 0,
+      testCount: 0,
+      lastHeartbeatRound: globals.round,
+      registrationRound: globals.round,
+      stake: payment.amount,
+    };
+
+    this.agentCount.value = this.agentCount.value + 1;
+  }
+
+  updateAgent(name: string, endpoint: string, metadata: string): void {
+    assert(this.agents(this.txn.sender).exists);
+
+    const agent = this.agents(this.txn.sender).value;
+    this.agents(this.txn.sender).value = {
+      name: name,
+      endpoint: endpoint,
+      metadata: metadata,
+      tier: agent.tier,
+      totalScore: agent.totalScore,
+      totalMaxScore: agent.totalMaxScore,
+      testCount: agent.testCount,
+      lastHeartbeatRound: agent.lastHeartbeatRound,
+      registrationRound: agent.registrationRound,
+      stake: agent.stake,
+    };
+  }
+
+  heartbeat(): void {
+    assert(this.agents(this.txn.sender).exists);
+
+    const agent = this.agents(this.txn.sender).value;
+    this.agents(this.txn.sender).value = {
+      name: agent.name,
+      endpoint: agent.endpoint,
+      metadata: agent.metadata,
+      tier: agent.tier,
+      totalScore: agent.totalScore,
+      totalMaxScore: agent.totalMaxScore,
+      testCount: agent.testCount,
+      lastHeartbeatRound: globals.round,
+      registrationRound: agent.registrationRound,
+      stake: agent.stake,
+    };
+  }
+
+  deregister(): void {
+    assert(this.agents(this.txn.sender).exists);
+
+    const agent = this.agents(this.txn.sender).value;
+    const stakeAmount = agent.stake;
+
+    this.agents(this.txn.sender).delete();
+    this.agentCount.value = this.agentCount.value - 1;
+
+    sendPayment({
+      receiver: this.txn.sender,
+      amount: stakeAmount,
+    });
+  }
+
+  // ── Challenge management ─────────────────────────────────────────────────
+
+  createChallenge(
+    challengeId: string,
+    category: string,
+    description: string,
+    maxScore: uint64
+  ): void {
+    assert(this.txn.sender === this.admin.value);
+    assert(!this.challenges(challengeId).exists);
+
+    this.challenges(challengeId).value = {
+      category: category,
+      description: description,
+      maxScore: maxScore,
+      active: 1,
+    };
+
+    this.challengeCount.value = this.challengeCount.value + 1;
+  }
+
+  deactivateChallenge(challengeId: string): void {
+    assert(this.txn.sender === this.admin.value);
+    assert(this.challenges(challengeId).exists);
+
+    const challenge = this.challenges(challengeId).value;
+    this.challenges(challengeId).value = {
+      category: challenge.category,
+      description: challenge.description,
+      maxScore: challenge.maxScore,
+      active: 0,
+    };
+  }
+
+  // ── Test result recording ────────────────────────────────────────────────
+
+  recordTestResult(
+    agentAddress: Address,
+    challengeId: string,
+    score: uint64
+  ): void {
+    assert(this.txn.sender === this.admin.value);
+    assert(this.agents(agentAddress).exists);
+    assert(this.challenges(challengeId).exists);
+
+    const challenge = this.challenges(challengeId).value;
+    assert(challenge.active === 1);
+    assert(score <= challenge.maxScore);
+
+    // Store the test result
+    this.testResults([agentAddress, challengeId]).value = {
+      score: score,
+      maxScore: challenge.maxScore,
+      category: challenge.category,
+      round: globals.round,
+    };
+
+    // Update agent aggregate scores
+    const agent = this.agents(agentAddress).value;
+    const newTotalScore = agent.totalScore + score;
+    const newTotalMaxScore = agent.totalMaxScore + challenge.maxScore;
+    const newTestCount = agent.testCount + 1;
+
+    // Calculate tier based on test count
+    const newTier = this.calculateTier(newTestCount);
+
+    this.agents(agentAddress).value = {
+      name: agent.name,
+      endpoint: agent.endpoint,
+      metadata: agent.metadata,
+      tier: newTier,
+      totalScore: newTotalScore,
+      totalMaxScore: newTotalMaxScore,
+      testCount: newTestCount,
+      lastHeartbeatRound: agent.lastHeartbeatRound,
+      registrationRound: agent.registrationRound,
+      stake: agent.stake,
+    };
+  }
+
+  // ── Read-only queries ────────────────────────────────────────────────────
+
+  getAgentInfo(agentAddress: Address): AgentRecord {
+    assert(this.agents(agentAddress).exists);
+    return this.agents(agentAddress).value;
+  }
+
+  getAgentTier(agentAddress: Address): uint64 {
+    assert(this.agents(agentAddress).exists);
+    return this.agents(agentAddress).value.tier;
+  }
+
+  getAgentScore(agentAddress: Address): uint64 {
+    assert(this.agents(agentAddress).exists);
+    return this.agents(agentAddress).value.totalScore;
+  }
+
+  getAgentTestCount(agentAddress: Address): uint64 {
+    assert(this.agents(agentAddress).exists);
+    return this.agents(agentAddress).value.testCount;
+  }
+
+  getChallengeInfo(challengeId: string): Challenge {
+    assert(this.challenges(challengeId).exists);
+    return this.challenges(challengeId).value;
+  }
+
+  // ── Admin operations ─────────────────────────────────────────────────────
+
+  updateMinStake(newMinStake: uint64): void {
+    assert(this.txn.sender === this.admin.value);
+    this.minStake.value = newMinStake;
+  }
+
+  transferAdmin(newAdmin: Address): void {
+    assert(this.txn.sender === this.admin.value);
+    this.admin.value = newAdmin;
+  }
+
+  setRegistrationOpen(open: uint64): void {
+    assert(this.txn.sender === this.admin.value);
+    this.registrationOpen.value = open;
+  }
+
+  adminRemoveAgent(agentAddress: Address): void {
+    assert(this.txn.sender === this.admin.value);
+    assert(this.agents(agentAddress).exists);
+
+    const agent = this.agents(agentAddress).value;
+    const stakeAmount = agent.stake;
+
+    this.agents(agentAddress).delete();
+    this.agentCount.value = this.agentCount.value - 1;
+
+    sendPayment({
+      receiver: agentAddress,
+      amount: stakeAmount,
+    });
+  }
+
+  // ── Internal helpers ─────────────────────────────────────────────────────
+
+  private calculateTier(testCount: uint64): uint64 {
+    if (testCount >= 10) return TIER_TRUSTED;
+    if (testCount >= 5) return TIER_ESTABLISHED;
+    if (testCount >= 1) return TIER_TESTED;
+    return TIER_REGISTERED;
+  }
+}


### PR DESCRIPTION
## Summary
- Cherry-picks the TEALScript contract source from `feat/flock-directory-contract` branch (that branch is 35 commits behind main and deletes 162 files, so only the contract files are extracted here)
- Adds `contracts/flock-directory.algo.ts`: a 300-line TEALScript smart contract implementing the on-chain Flock Directory agent registry
- Adds `contracts/README.md` with prerequisites, build, and deploy instructions
- Adds `contracts/.gitignore` to exclude compiled `artifacts/`

## Contract Details
The FlockDirectory contract provides:
- **Agent registration/deregistration** with ALGO staking (minimum stake enforced)
- **Challenge-based testing** with scoring and automatic tier promotion
- **Reputation tiers:** REGISTERED → TESTED → ESTABLISHED → TRUSTED
- **17 ABI methods** for full registry lifecycle management
- **Box storage** for agents, test results, and challenges

## Next Steps
- Testnet deployment and integration testing
- Wire up the server-side Flock Directory module to call the contract via AlgoChat SDK

## Test plan
- [ ] Verify TEALScript compiles with `npx tealscript contracts/flock-directory.algo.ts contracts/artifacts`
- [ ] Deploy to Algorand testnet
- [ ] Run ABI method smoke tests against testnet deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)