### PR TITLE
fix: stop orphaned sessions in agent-to-agent messaging

### DIFF
--- a/server/__tests__/agent-messenger.test.ts
+++ b/server/__tests__/agent-messenger.test.ts
@@ -596,6 +596,89 @@ describe('invokeAndWait()', () => {
 
         expect(result.response).toBe('Turn 1 response');
     });
+
+    test('returns partial response on timeout and stops orphaned session', async () => {
+        // Simulate a session that sends content but never exits
+        (mockProcessManager.subscribe as ReturnType<typeof mock>).mockImplementation(
+            (sessionId: string, cb: (sid: string, event: ClaudeStreamEvent) => void) => {
+                setTimeout(() => {
+                    cb(sessionId, {
+                        type: 'assistant',
+                        message: { role: 'assistant', content: 'Partial response before timeout' },
+                    });
+                    // No session_exited — simulates a stuck session
+                }, 10);
+            },
+        );
+
+        // Mark the session as still running so stopProcess gets called
+        (mockProcessManager.isRunning as ReturnType<typeof mock>).mockReturnValue(true);
+
+        // Use a very short timeout (50ms) so the test doesn't take 5 minutes
+        const result = await messenger.invokeAndWait(
+            {
+                fromAgentId: agentA.id,
+                toAgentId: agentB.id,
+                content: 'This will timeout',
+                projectId,
+            },
+            50,
+        );
+
+        expect(result.response).toBe('Partial response before timeout');
+        // stopProcess should have been called to clean up the orphaned session
+        expect(mockProcessManager.stopProcess).toHaveBeenCalled();
+
+        // Reset isRunning to default
+        (mockProcessManager.isRunning as ReturnType<typeof mock>).mockReturnValue(false);
+    });
+
+    test('rejects with error on timeout when no content was buffered', async () => {
+        // Simulate a session that never produces output
+        (mockProcessManager.subscribe as ReturnType<typeof mock>).mockImplementation(() => {
+            // No events emitted at all
+        });
+
+        await expect(
+            messenger.invokeAndWait(
+                {
+                    fromAgentId: agentA.id,
+                    toAgentId: agentB.id,
+                    content: 'This will timeout empty',
+                    projectId,
+                },
+                50,
+            ),
+        ).rejects.toThrow('Agent invoke timed out after 50ms');
+    });
+
+    test('resolves on session_stopped event with buffered content', async () => {
+        (mockProcessManager.subscribe as ReturnType<typeof mock>).mockImplementation(
+            (sessionId: string, cb: (sid: string, event: ClaudeStreamEvent) => void) => {
+                setTimeout(() => {
+                    cb(sessionId, {
+                        type: 'assistant',
+                        message: { role: 'assistant', content: 'Response before stop' },
+                    });
+                    cb(sessionId, { type: 'result', total_cost_usd: 0 });
+                    // session_stopped instead of session_exited
+                    cb(sessionId, { type: 'session_stopped' } as ClaudeStreamEvent);
+                }, 10);
+            },
+        );
+
+        const result = await messenger.invokeAndWait(
+            {
+                fromAgentId: agentA.id,
+                toAgentId: agentB.id,
+                content: 'Stopped session test',
+                projectId,
+            },
+            5000,
+        );
+
+        expect(result.response).toBe('Response before stop');
+    });
 });
 
 // ─── setWorkCommandRouter() ──────────────────────────────────────────────────

--- a/server/algochat/agent-messenger.ts
+++ b/server/algochat/agent-messenger.ts
@@ -397,13 +397,29 @@ export class AgentMessenger {
                 responseBuffer = '';
             }
 
-            // Only finalize when the session fully exits
-            if (event.type === 'session_exited') {
+            // Finalize when the session exits or is stopped
+            if (event.type === 'session_exited' || event.type === 'session_stopped') {
                 finish();
             }
         };
 
         this.processManager.subscribe(sessionId, callback);
+
+        // Safety timeout: clean up the subscription if the session never exits.
+        // This prevents indefinite orphaned subscriptions (e.g., target agent hangs).
+        const SUBSCRIBE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+        setTimeout(() => {
+            if (!completed) {
+                log.warn('Agent response subscription timed out', { messageId, sessionId });
+                // Stop the process if still running
+                if (this.processManager.isRunning(sessionId)) {
+                    this.processManager.stopProcess(sessionId);
+                } else {
+                    // Process already gone but we never got the exit event — clean up manually
+                    finish();
+                }
+            }
+        }, SUBSCRIBE_TIMEOUT_MS);
     }
 
     /**
@@ -443,6 +459,11 @@ export class AgentMessenger {
 
             const timer = setTimeout(() => {
                 const response = (responseBuffer.trim() || lastTurnResponse.trim());
+                // Stop the orphaned session so it doesn't run indefinitely
+                if (this.processManager.isRunning(sessionId)) {
+                    log.warn('Stopping orphaned agent session on timeout', { sessionId, timeoutMs });
+                    this.processManager.stopProcess(sessionId);
+                }
                 settle(response || null, `Agent invoke timed out after ${timeoutMs}ms`);
             }, timeoutMs);
 
@@ -459,8 +480,8 @@ export class AgentMessenger {
                     responseBuffer = '';
                 }
 
-                // Only resolve when the session fully exits
-                if (event.type === 'session_exited') {
+                // Resolve when the session exits or is stopped
+                if (event.type === 'session_exited' || event.type === 'session_stopped') {
                     const response = (responseBuffer.trim() || lastTurnResponse.trim());
                     settle(response || null);
                 }


### PR DESCRIPTION
## Summary
- Fixes agent-to-agent message responses timing out after 300s while target sessions continue running indefinitely
- `invokeAndWait()` now stops orphaned target sessions on timeout instead of leaving them running
- Both `invokeAndWait()` and `subscribeForAgentResponse()` now handle `session_stopped` events (not just `session_exited`), so stopped sessions properly finalize responses
- Added 10-minute safety timeout in `subscribeForAgentResponse()` to clean up subscriptions for sessions that never exit

## Test plan
- [x] New test: partial response returned on timeout + orphaned session stopped
- [x] New test: empty timeout rejects with descriptive error
- [x] New test: `session_stopped` event resolves with buffered content
- [x] All 6864 existing tests pass (0 failures)
- [x] 138/138 specs pass (100% file coverage)
- [x] TypeScript compiles clean

Closes #1053

🤖 Generated with [Claude Code](https://claude.com/claude-code)