### PR TITLE
chore: update web-tree-sitter to 0.26.x and add /session worktree isolation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "algosdk": "^3.5.2",
         "croner": "^10.0.1",
         "tree-sitter-wasms": "^0.1.13",
-        "web-tree-sitter": "^0.25.10",
+        "web-tree-sitter": "^0.26.6",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -603,7 +603,7 @@
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
-    "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
+    "web-tree-sitter": ["web-tree-sitter@0.26.7", "", {}, "sha512-KiZhelTvBA/ziUHEO7Emb75cGVAq8iGZNabYaZm53Zpy50NsXyOW+xSHlwHt5CVg/TRPZBfeVLTTobF0LjFJ1w=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/docs/dependency-audit.md
+++ b/docs/dependency-audit.md
@@ -18,7 +18,7 @@
 | algosdk | 3.5.2 | None | Algorand SDK |
 | croner | 10.0.1 | None | Cron scheduler |
 | zod | 4.3.5 | None | Schema validation |
-| web-tree-sitter | 0.25.10 | None | WASM-based parser |
+| web-tree-sitter | 0.26.7 | None | WASM-based parser |
 | tree-sitter-wasms | 0.1.13 | None | WASM grammars |
 | @opentelemetry/* | 1.9.0-2.6.0 | None | Observability SDK |
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "algosdk": "^3.5.2",
     "croner": "^10.0.1",
     "tree-sitter-wasms": "^0.1.13",
-    "web-tree-sitter": "^0.25.10",
+    "web-tree-sitter": "^0.26.6",
     "zod": "^4.3.6"
   },
   "patchedDependencies": {

--- a/server/ast/parser.ts
+++ b/server/ast/parser.ts
@@ -22,7 +22,7 @@ const LANGUAGE_WASM_FILES: Record<AstLanguage, string> = {
 export async function initParser(): Promise<void> {
     if (initialized) return;
     const wasmPath = join(
-        import.meta.dir, '..', '..', 'node_modules', 'web-tree-sitter', 'tree-sitter.wasm',
+        import.meta.dir, '..', '..', 'node_modules', 'web-tree-sitter', 'web-tree-sitter.wasm',
     );
     await Parser.init({
         locateFile: () => wasmPath,

--- a/server/discord/commands.ts
+++ b/server/discord/commands.ts
@@ -389,12 +389,30 @@ export async function handleInteraction(
                 break;
             }
 
+            // Create an isolated git worktree so /session doesn't run in the main working tree
+            const { createWorktree, generateChatBranchName } = await import('../lib/worktree');
+            let workDir: string | undefined;
+            if (project.workingDir) {
+                const sessionUuid = crypto.randomUUID();
+                const branchName = generateChatBranchName(agent.name, sessionUuid);
+                const wtResult = await createWorktree({
+                    projectWorkingDir: project.workingDir,
+                    branchName,
+                    worktreeId: `chat-${sessionUuid.slice(0, 12)}`,
+                });
+                if (wtResult.success) {
+                    workDir = wtResult.worktreeDir;
+                }
+                // If worktree creation fails, fall through to the main working dir (non-fatal).
+            }
+
             const session = createSession(ctx.db, {
                 projectId: project.id,
                 agentId: agent.id,
                 name: `Discord thread:${threadId}`,
                 initialPrompt: topic,
                 source: 'discord' as SessionSource,
+                workDir,
             });
 
             ctx.threadSessions.set(threadId, {

--- a/specs/discord/bridge.spec.md
+++ b/specs/discord/bridge.spec.md
@@ -238,7 +238,7 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 ### Commands
 
 32. **Slash commands**: If `appId` is configured, commands are registered as Discord Application Commands via `PUT /applications/{appId}/commands` (or guild-scoped if `guildId` is set). Interactions are handled via gateway `INTERACTION_CREATE` events. Commands: `/session`, `/work`, `/agents`, `/status`, `/tasks`, `/schedule`, `/config`, `/council`, `/mute`, `/unmute`, `/help`, `/admin`
-33. **`/session` command** (interactive chat): Creates a new Discord thread with a live agent session. The user can go back and forth with the agent in real-time. Required options: `agent` (dropdown, capped at 25), `topic` (string, thread name). Optional: `project` (dropdown). The thread is created in the configured channel with the selected agent bound to it. Use `/session` when you want to **discuss, explore, or guide** the agent interactively
+33. **`/session` command** (interactive chat): Creates a new Discord thread with a live agent session. The user can go back and forth with the agent in real-time. Required options: `agent` (dropdown, capped at 25), `topic` (string, thread name). Optional: `project` (dropdown). The thread is created in the configured channel with the selected agent bound to it. A git worktree is created so the session runs in isolation from the main working tree (graceful fallback if worktree creation fails). Use `/session` when you want to **discuss, explore, or guide** the agent interactively
 34. **`/work` command** (autonomous task): Creates an async work task — the agent works autonomously (clones repo, makes changes, creates a PR) without further interaction. Required: `description` (what to do). Optional: `agent` (dropdown), `project` (dropdown). Responds with a rich confirmation embed showing task ID, agent, and status. Sends a completion notification with PR link (or error details) when done, mentioning the requester. Use `/work` when you want to **assign a task** and get notified with a PR
 35. **`/agents` command**: Lists all available agents with their models. Does not create a session
 36. **`/status` command**: Shows the bot's current status and active sessions
@@ -289,7 +289,8 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 - **Given** a running Discord bridge with agents "CorvidAgent" and "ResearchBot"
 - **When** a user invokes `/session` and selects agent "ResearchBot" with topic "Algorand governance"
 - **Then** a Discord thread is created named `ResearchBot — Algorand governance`
-- **And** a new session is created with source `discord`, bound to "ResearchBot"
+- **And** a git worktree is created for the session (so the main working tree is not modified)
+- **And** a new session is created with source `discord`, bound to "ResearchBot", with `workDir` set to the worktree path
 - **And** the bot posts an initial embed in the thread confirming the session is active
 - **And** subsequent messages in the thread are handled by "ResearchBot" automatically (no @mention needed)
 


### PR DESCRIPTION
## Summary
- **Update web-tree-sitter** from 0.25.x to 0.26.x and align `package.json` + `bun.lock`
- **Fix duplicate Discord messages** — clear orphaned typing-interval timers when subscriptions are replaced in `thread-manager.ts`
- **Add worktree isolation to `/session`** — the Discord `/session` command now creates a git worktree so the agent operates in an isolated copy, matching the inline-mention handler pattern
- **Add `injection_bypassed` audit action** for admin bypass of injection scanner

## Test plan
- [x] TSC clean (0 errors)
- [x] Discord tests: 19 pass, 0 fail
- [x] Spec check: 138/138 passed, 369/369 file coverage (100%)
- [ ] Manual: run `/session` in Discord and verify worktree directory is created
- [ ] Manual: verify no duplicate "ended unexpectedly" messages on process crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>