### PR TITLE
fix: resolve session view race condition on conversation load

### DIFF
--- a/client/src/app/features/sessions/session-view.component.ts
+++ b/client/src/app/features/sessions/session-view.component.ts
@@ -169,22 +169,9 @@ export class SessionViewComponent implements OnInit, OnDestroy {
         this.sessionId = this.route.snapshot.paramMap.get('id');
         if (!this.sessionId) return;
 
-        const session = await this.sessionService.getSession(this.sessionId);
-        this.session.set(session);
-
-        const messages = await this.sessionService.getMessages(this.sessionId);
-        this.messages.set(messages);
-
-        if (session.agentId) {
-            this.agentService.getAgent(session.agentId).then((agent) => {
-                this.agentName.set(agent.name);
-            }).catch(() => {});
-        }
-
-        this.sessionService.subscribeToSession(this.sessionId);
-
-        // Listen for approval requests, questions, notifications, and status updates
+        // Subscribe to WebSocket FIRST so no events are missed during HTTP fetch
         const sid = this.sessionId;
+        this.sessionService.subscribeToSession(sid);
         this.approvalCleanup = this.wsService.onMessage((msg) => {
             if (msg.type === 'approval_request' && msg.request.sessionId === sid) {
                 this.pendingApproval.set(msg.request);
@@ -210,6 +197,20 @@ export class SessionViewComponent implements OnInit, OnDestroy {
                 }, msg.question.timeoutMs);
             }
         });
+
+        // Fetch session and messages in parallel
+        const [session, messages] = await Promise.all([
+            this.sessionService.getSession(sid),
+            this.sessionService.getMessages(sid),
+        ]);
+        this.session.set(session);
+        this.messages.set(messages);
+
+        if (session.agentId) {
+            this.agentService.getAgent(session.agentId).then((agent) => {
+                this.agentName.set(agent.name);
+            }).catch(() => {});
+        }
     }
 
     ngOnDestroy(): void {


### PR DESCRIPTION
## Summary
- Reorder `ngOnInit` in `SessionViewComponent` to subscribe to WebSocket **before** fetching session/messages via HTTP, preventing events from being silently dropped during the fetch window
- Parallelize the two independent HTTP calls (`getSession` + `getMessages`) with `Promise.all` for faster initial load

## Problem
When navigating to a conversation, the component would:
1. Fetch session via HTTP (await)
2. Fetch messages via HTTP (await)
3. **Then** subscribe to WebSocket

Events arriving on the server between step 2 completing and step 3's subscribe being received were lost. This caused inconsistent conversation loading where a page refresh would "fix" missing events.

## Test plan
- [x] Navigate to a running session — verify events stream immediately without needing a refresh
- [x] Navigate between sessions quickly — verify no event bleed between sessions
- [x] Verify approval requests and agent questions still appear correctly
- [x] `bun x tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)