### PR TITLE
fix: filter disabled agents from listAgents by default

### DIFF
--- a/server/__tests__/agents.test.ts
+++ b/server/__tests__/agents.test.ts
@@ -125,6 +125,23 @@ describe('getAgent and listAgents', () => {
         expect(agents).toHaveLength(2);
     });
 
+    test('listAgents excludes disabled agents by default', () => {
+        makeAgent({ name: 'Enabled' });
+        const disabled = makeAgent({ name: 'Disabled' });
+        updateAgent(db, disabled.id, { disabled: true });
+        const agents = listAgents(db);
+        expect(agents).toHaveLength(1);
+        expect(agents[0].name).toBe('Enabled');
+    });
+
+    test('listAgents includes disabled agents when includeDisabled is true', () => {
+        makeAgent({ name: 'Enabled' });
+        const disabled = makeAgent({ name: 'Disabled' });
+        updateAgent(db, disabled.id, { disabled: true });
+        const agents = listAgents(db, undefined, { includeDisabled: true });
+        expect(agents).toHaveLength(2);
+    });
+
     test('getAgent maps display fields from row (rowToAgent)', () => {
         const agent = makeAgent({
             displayColor: '#123456',

--- a/server/db/agents.ts
+++ b/server/db/agents.ts
@@ -66,8 +66,15 @@ function rowToAgent(row: AgentRow): Agent {
     };
 }
 
-export function listAgents(db: Database, tenantId: string = DEFAULT_TENANT_ID): Agent[] {
-    const { query, bindings } = withTenantFilter('SELECT * FROM agents ORDER BY updated_at DESC', tenantId);
+export function listAgents(
+    db: Database,
+    tenantId: string = DEFAULT_TENANT_ID,
+    options?: { includeDisabled?: boolean },
+): Agent[] {
+    const baseQuery = options?.includeDisabled
+        ? 'SELECT * FROM agents ORDER BY updated_at DESC'
+        : 'SELECT * FROM agents WHERE disabled = 0 ORDER BY updated_at DESC';
+    const { query, bindings } = withTenantFilter(baseQuery, tenantId);
     const rows = db.query(query).all(...bindings) as AgentRow[];
     return rows.map(rowToAgent);
 }
@@ -293,7 +300,7 @@ export function addAgentFunding(db: Database, agentId: string, algoAmount: numbe
 
 export function getAlgochatEnabledAgents(db: Database): Agent[] {
     const rows = db.query(
-        'SELECT * FROM agents WHERE algochat_enabled = 1 ORDER BY updated_at DESC'
+        'SELECT * FROM agents WHERE algochat_enabled = 1 AND disabled = 0 ORDER BY updated_at DESC'
     ).all() as AgentRow[];
     return rows.map(rowToAgent);
 }

--- a/server/routes/agents.ts
+++ b/server/routes/agents.ts
@@ -29,7 +29,7 @@ export function handleAgentRoutes(
     const method = req.method;
 
     if (path === '/api/agents' && method === 'GET') {
-        return json(listAgents(db, context.tenantId));
+        return json(listAgents(db, context.tenantId, { includeDisabled: true }));
     }
 
     if (path === '/api/agents' && method === 'POST') {


### PR DESCRIPTION
## Summary
- `listAgents()` now excludes disabled agents by default (`WHERE disabled = 0`)
- Added optional `{ includeDisabled: true }` parameter for callers that need all agents (e.g., admin dashboard)
- `getAlgochatEnabledAgents()` also filters out disabled agents
- Admin REST API (`GET /api/agents`) passes `includeDisabled: true` so the dashboard can still manage disabled agents

## Test plan
- [x] 2 new unit tests covering default filtering and `includeDisabled` override
- [x] All 28 existing agent tests pass
- [x] TypeScript typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)