### PR TITLE
fix: persist session metrics on error and abort terminations

### DIFF
--- a/server/__tests__/direct-process-metrics.test.ts
+++ b/server/__tests__/direct-process-metrics.test.ts
@@ -68,11 +68,59 @@ describe('buildSessionMetrics', () => {
     test('stallDetected=false for abort', () => {
         const m = buildSessionMetrics(makeState({ terminationReason: 'abort' }));
         expect(m.stallDetected).toBe(false);
+        expect(m.terminationReason).toBe('abort');
     });
 
     test('stallDetected=false for error', () => {
         const m = buildSessionMetrics(makeState({ terminationReason: 'error' }));
         expect(m.stallDetected).toBe(false);
+        expect(m.terminationReason).toBe('error');
+    });
+
+    test('error termination preserves all metric fields', () => {
+        const m = buildSessionMetrics(makeState({
+            terminationReason: 'error',
+            iteration: 3,
+            toolCallCount: 7,
+            maxChainDepth: 2,
+            nudgeCount: 1,
+            midChainNudgeCount: 0,
+            totalExplorationDrifts: 1,
+            loopDurationMs: 5000,
+            needsSummary: false,
+        }));
+        expect(m.terminationReason).toBe('error');
+        expect(m.stallDetected).toBe(false);
+        expect(m.stallType).toBeNull();
+        expect(m.totalIterations).toBe(3);
+        expect(m.toolCallCount).toBe(7);
+        expect(m.maxChainDepth).toBe(2);
+        expect(m.nudgeCount).toBe(1);
+        expect(m.explorationDriftCount).toBe(1);
+        expect(m.durationMs).toBe(5000);
+        expect(m.needsSummary).toBe(false);
+    });
+
+    test('abort termination preserves all metric fields', () => {
+        const m = buildSessionMetrics(makeState({
+            terminationReason: 'abort',
+            iteration: 10,
+            toolCallCount: 20,
+            maxChainDepth: 6,
+            nudgeCount: 0,
+            midChainNudgeCount: 0,
+            totalExplorationDrifts: 2,
+            loopDurationMs: 30000,
+            needsSummary: false,
+        }));
+        expect(m.terminationReason).toBe('abort');
+        expect(m.stallDetected).toBe(false);
+        expect(m.stallType).toBeNull();
+        expect(m.totalIterations).toBe(10);
+        expect(m.toolCallCount).toBe(20);
+        expect(m.maxChainDepth).toBe(6);
+        expect(m.explorationDriftCount).toBe(2);
+        expect(m.durationMs).toBe(30000);
     });
 
     test('maps iteration to totalIterations', () => {

--- a/server/process/direct-process.ts
+++ b/server/process/direct-process.ts
@@ -741,12 +741,65 @@ export function startDirectProcess(options: DirectProcessOptions): SdkProcess {
             }
         }
 
+        } catch (err) {
+            terminationReason = 'error';
+            const loopDurationMs = Date.now() - loopStartTime;
+            const sessionMetrics = buildSessionMetrics({
+                model,
+                tier: tierConfig.tier,
+                iteration,
+                toolCallCount,
+                maxChainDepth,
+                nudgeCount,
+                midChainNudgeCount,
+                totalExplorationDrifts,
+                stallType,
+                terminationReason,
+                loopDurationMs,
+                needsSummary,
+            });
+            onEvent({
+                type: 'result',
+                subtype: 'error',
+                total_cost_usd: 0,
+                duration_ms: loopDurationMs,
+                num_turns: iteration,
+                session_id: session.id,
+                metrics: sessionMetrics,
+            } as ClaudeStreamEvent);
+            throw err;
         } finally {
             // Release the slot so the next agent can run
             if (slotAcquired) provider.releaseSlot?.(model);
         }
 
-        if (aborted) return;
+        if (aborted) {
+            const loopDurationMs = Date.now() - loopStartTime;
+            const sessionMetrics = buildSessionMetrics({
+                model,
+                tier: tierConfig.tier,
+                iteration,
+                toolCallCount,
+                maxChainDepth,
+                nudgeCount,
+                midChainNudgeCount,
+                totalExplorationDrifts,
+                stallType,
+                terminationReason: 'abort',
+                loopDurationMs,
+                needsSummary,
+            });
+            onEvent({
+                type: 'result',
+                subtype: 'abort',
+                total_cost_usd: 0,
+                duration_ms: loopDurationMs,
+                num_turns: iteration,
+                session_id: session.id,
+                metrics: sessionMetrics,
+            } as ClaudeStreamEvent);
+            return;
+        }
 
         // Signal that the agent is done thinking
         onEvent({ type: 'thinking', thinking: false } as ClaudeStreamEvent);


### PR DESCRIPTION
## Summary
- **Error path**: Added catch block in `direct-process.ts` tool loop that builds and emits session metrics with `terminationReason: 'error'` before re-throwing, so ProcessManager can persist them
- **Abort path**: Changed the abort early-return to build and emit metrics with `terminationReason: 'abort'` instead of silently returning
- Previously, the `'error'` and `'abort'` termination reasons were defined in the `DirectProcessMetrics` interface but never actually recorded — all failed sessions were invisible in analytics

Closes #1022

## Test plan
- [x] `bun x tsc --noEmit` — clean
- [x] `bun test server/__tests__/direct-process-metrics.test.ts` — 14/14 pass (added 2 new comprehensive tests for error/abort field preservation)
- [x] `bun run spec:check` — 144/144 pass
- [x] Full suite: 7129 pass, 2 fail (pre-existing tree-sitter wasm issue #21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)