### PR TITLE
feat: AlgoChat worktree isolation and smart branch cleanup

### DIFF
--- a/server/algochat/message-router.ts
+++ b/server/algochat/message-router.ts
@@ -45,6 +45,8 @@ import { DedupService } from '../lib/dedup';
 import { createEventContext, runWithEventContext } from '../observability/event-context';
 import { scanForInjection } from '../lib/prompt-injection';
 import { recordAudit } from '../db/audit';
+import { getProject } from '../db/projects';
+import { createWorktree, generateChatBranchName } from '../lib/worktree';
 
 const log = createLogger('MessageRouter');
 
@@ -363,15 +365,17 @@ export class MessageRouter {
             this.subscriptionManager.cleanupLocalSession(existingSessionId);
         }
 
-        // Create a new session
+        // Create a new session with worktree isolation
         const resolvedProjectId = projectId ?? agent.defaultProjectId ?? this.discoveryService.getDefaultProjectId();
-        log.debug(`Creating new session`, { projectId: resolvedProjectId, agentId });
+        const workDir = await this.createSessionWorktree(resolvedProjectId);
+        log.debug(`Creating new session`, { projectId: resolvedProjectId, agentId, workDir });
         const session = createSession(this.db, {
             projectId: resolvedProjectId,
             agentId,
             name: `Chat: ${agent.name}`,
             initialPrompt: content,
             source: 'web',
+            workDir,
         });
 
         log.debug(`Session created: ${session.id}, starting process`);
@@ -588,12 +592,15 @@ export class MessageRouter {
             const agent = getAgent(this.db, agentId);
             if (!agent) return;
 
+            const projectId = agent.defaultProjectId ?? this.discoveryService.getDefaultProjectId();
+            const workDir = await this.createSessionWorktree(projectId);
             const session = createSession(this.db, {
-                projectId: agent.defaultProjectId ?? this.discoveryService.getDefaultProjectId(),
+                projectId,
                 agentId,
                 name: `AlgoChat: ${participant.slice(0, 8)}...`,
                 initialPrompt: agentContent,
                 source: 'algochat',
+                workDir,
             });
 
             conversation = createConversation(this.db, participant, agentId, session.id);
@@ -632,12 +639,15 @@ export class MessageRouter {
                     const agent = getAgent(this.db, agentId);
                     if (agent) {
                         const { updateConversationSession } = await import('../db/sessions');
+                        const projectId = agent.defaultProjectId ?? this.discoveryService.getDefaultProjectId();
+                        const workDir = await this.createSessionWorktree(projectId);
                         const session = createSession(this.db, {
-                            projectId: agent.defaultProjectId ?? this.discoveryService.getDefaultProjectId(),
+                            projectId,
                             agentId,
                             name: `AlgoChat: ${participant.slice(0, 8)}...`,
                             initialPrompt: agentContent,
                             source: 'algochat',
+                            workDir,
                         });
                         updateConversationSession(this.db, conversation.id, session.id);
                         conversation.sessionId = session.id;
@@ -697,6 +707,25 @@ export class MessageRouter {
                 this.pendingGroupChunks.delete(k);
             }
         }
+    }
+
+    /**
+     * Create a worktree for a chat session (same pattern as Discord's handleMentionReply).
+     * Non-fatal — returns undefined if worktree creation fails.
+     */
+    private async createSessionWorktree(projectId: string | null): Promise<string | undefined> {
+        if (!projectId) return undefined;
+        const project = getProject(this.db, projectId);
+        if (!project?.workingDir) return undefined;
+
+        const sessionId = crypto.randomUUID();
+        const branchName = generateChatBranchName('algochat', sessionId);
+        const result = await createWorktree({
+            projectWorkingDir: project.workingDir,
+            branchName,
+            worktreeId: `chat-${sessionId.slice(0, 12)}`,
+        });
+        return result.success ? result.worktreeDir : undefined;
     }
 }
 

--- a/server/lib/worktree.ts
+++ b/server/lib/worktree.ts
@@ -68,11 +68,31 @@ export async function createWorktree(options: CreateWorktreeOptions): Promise<Cr
     }
 }
 
+export interface RemoveWorktreeOptions {
+    /**
+     * If true, delete the branch after removing the worktree when it has
+     * zero commits ahead of main (i.e. the chat session produced no work).
+     * Branches with actual commits are kept for PRs/review.
+     */
+    cleanBranch?: boolean;
+}
+
 /**
- * Remove a git worktree. The branch is kept (needed for PRs and review).
+ * Remove a git worktree. By default the branch is kept (needed for PRs and review).
+ * Pass `{ cleanBranch: true }` to auto-delete branches with no commits ahead of main.
  * Idempotent — safe to call if the worktree was already removed.
  */
-export async function removeWorktree(projectWorkingDir: string, worktreeDir: string): Promise<void> {
+export async function removeWorktree(
+    projectWorkingDir: string,
+    worktreeDir: string,
+    options?: RemoveWorktreeOptions,
+): Promise<void> {
+    // Detect the branch name before removing the worktree (needed for cleanBranch)
+    let branchName: string | undefined;
+    if (options?.cleanBranch) {
+        branchName = await detectWorktreeBranch(projectWorkingDir, worktreeDir);
+    }
+
     try {
         const proc = Bun.spawn(
             ['git', 'worktree', 'remove', '--force', worktreeDir],
@@ -93,6 +113,74 @@ export async function removeWorktree(projectWorkingDir: string, worktreeDir: str
     } catch (err) {
         log.warn('Error removing worktree', {
             worktreeDir,
+            error: err instanceof Error ? err.message : String(err),
+        });
+    }
+
+    // Clean up empty branches after worktree removal
+    if (branchName) {
+        await cleanupEmptyBranch(projectWorkingDir, branchName);
+    }
+}
+
+/**
+ * Detect which branch a worktree is on by parsing `git worktree list --porcelain`.
+ */
+async function detectWorktreeBranch(projectWorkingDir: string, worktreeDir: string): Promise<string | undefined> {
+    try {
+        const proc = Bun.spawn(
+            ['git', 'worktree', 'list', '--porcelain'],
+            { cwd: projectWorkingDir, stdout: 'pipe', stderr: 'pipe' },
+        );
+        const stdout = await new Response(proc.stdout).text();
+        await proc.exited;
+
+        // Porcelain output: blocks separated by blank lines.
+        // Each block: "worktree <path>\nHEAD <sha>\nbranch refs/heads/<name>\n"
+        const blocks = stdout.split('\n\n');
+        for (const block of blocks) {
+            if (block.includes(`worktree ${worktreeDir}`)) {
+                const branchLine = block.split('\n').find(l => l.startsWith('branch '));
+                if (branchLine) {
+                    return branchLine.replace('branch refs/heads/', '');
+                }
+            }
+        }
+    } catch {
+        // Non-fatal — we just won't clean the branch
+    }
+    return undefined;
+}
+
+/**
+ * Delete a branch if it has zero commits ahead of main.
+ * Branches with actual work are preserved for PRs/review.
+ */
+async function cleanupEmptyBranch(projectWorkingDir: string, branchName: string): Promise<void> {
+    try {
+        // Check if the branch has any commits not on main
+        const logProc = Bun.spawn(
+            ['git', 'log', 'main..' + branchName, '--oneline'],
+            { cwd: projectWorkingDir, stdout: 'pipe', stderr: 'pipe' },
+        );
+        const logOutput = (await new Response(logProc.stdout).text()).trim();
+        await logProc.exited;
+
+        if (logOutput.length > 0) {
+            log.info('Keeping branch with commits', { branchName, commits: logOutput.split('\n').length });
+            return;
+        }
+
+        // No commits ahead — safe to delete
+        const delProc = Bun.spawn(
+            ['git', 'branch', '-D', branchName],
+            { cwd: projectWorkingDir, stdout: 'pipe', stderr: 'pipe' },
+        );
+        await delProc.exited;
+        log.info('Deleted empty branch', { branchName });
+    } catch (err) {
+        log.warn('Failed to clean up branch', {
+            branchName,
             error: err instanceof Error ? err.message : String(err),
         });
     }

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -1009,7 +1009,7 @@ export class ProcessManager {
         const project = session.projectId ? getProject(this.db, session.projectId) : null;
         if (!project?.workingDir) return;
 
-        removeWorktree(project.workingDir, session.workDir).catch((err) => {
+        removeWorktree(project.workingDir, session.workDir, { cleanBranch: true }).catch((err) => {
             log.warn('Failed to clean up chat worktree', {
                 sessionId,
                 workDir: session.workDir,

--- a/specs/lib/worktree.spec.md
+++ b/specs/lib/worktree.spec.md
@@ -22,7 +22,7 @@ Shared git worktree management extracted from `WorkTaskService`. Provides creati
 |----------|-----------|---------|-------------|
 | `getWorktreeBaseDir` | `(projectWorkingDir: string)` | `string` | Resolves the base directory for worktrees. Uses `WORKTREE_BASE_DIR` env var or defaults to `.corvid-worktrees` sibling directory |
 | `createWorktree` | `(options: CreateWorktreeOptions)` | `Promise<CreateWorktreeResult>` | Creates an isolated git worktree with a new branch |
-| `removeWorktree` | `(projectWorkingDir: string, worktreeDir: string)` | `Promise<void>` | Removes a git worktree (keeps the branch). Idempotent |
+| `removeWorktree` | `(projectWorkingDir: string, worktreeDir: string, options?: RemoveWorktreeOptions)` | `Promise<void>` | Removes a git worktree. With `cleanBranch: true`, auto-deletes branches with zero commits ahead of main. Idempotent |
 | `generateChatBranchName` | `(agentName: string, sessionId: string)` | `string` | Generates a branch name for chat session worktrees: `chat/{agentSlug}/{sessionIdPrefix}` |
 
 ### Exported Types
@@ -31,13 +31,14 @@ Shared git worktree management extracted from `WorkTaskService`. Provides creati
 |------|-------------|
 | `CreateWorktreeOptions` | Options for worktree creation: `projectWorkingDir`, `branchName`, `worktreeId` |
 | `CreateWorktreeResult` | Result of worktree creation: `success`, `worktreeDir`, optional `error` |
+| `RemoveWorktreeOptions` | Options for worktree removal: `cleanBranch` (auto-delete empty branches) |
 
 ## Invariants
 
 1. **Deterministic base dir**: `getWorktreeBaseDir` always returns a path that is a sibling of the project directory (or the override from `WORKTREE_BASE_DIR`)
 2. **Worktree isolation**: Each worktree directory is at `{baseDir}/{worktreeId}`, ensuring unique paths per session/task
 3. **Branch naming**: Chat branches follow `chat/{agentSlug}/{sessionPrefix}` pattern; work task branches follow `agent/{agentSlug}/{taskSlug}-{timestamp}-{suffix}` (handled by WorkTaskService)
-4. **Non-destructive removal**: `removeWorktree` only removes the worktree directory, never the branch (branches are needed for PRs/review)
+4. **Smart branch cleanup**: `removeWorktree` with `cleanBranch: true` deletes branches with zero commits ahead of main; branches with actual commits are preserved for PRs/review. Without the option, branches are always kept
 5. **Idempotent removal**: Calling `removeWorktree` on an already-removed worktree logs a warning but does not throw
 6. **Graceful failure**: `createWorktree` returns `{ success: false, error }` on failure rather than throwing
 
@@ -57,12 +58,26 @@ Shared git worktree management extracted from `WorkTaskService`. Provides creati
 - **Then** `{ success: false, error: '...' }` is returned
 - **And** no exception is thrown
 
-### Scenario: Removing a worktree
+### Scenario: Removing a worktree (default — keep branch)
 
 - **Given** a worktree exists at `/tmp/.corvid-worktrees/chat-abc123`
 - **When** `removeWorktree('/app/corvid-agent', '/tmp/.corvid-worktrees/chat-abc123')` is called
 - **Then** the worktree directory is removed via `git worktree remove --force`
 - **And** the branch is preserved
+
+### Scenario: Removing a worktree with cleanBranch (no commits)
+
+- **Given** a worktree exists with branch `chat/corvid/abc123` that has zero commits ahead of main
+- **When** `removeWorktree(projectDir, worktreeDir, { cleanBranch: true })` is called
+- **Then** the worktree directory is removed
+- **And** the branch is deleted via `git branch -D`
+
+### Scenario: Removing a worktree with cleanBranch (has commits)
+
+- **Given** a worktree exists with branch `chat/corvid/abc123` that has 3 commits ahead of main
+- **When** `removeWorktree(projectDir, worktreeDir, { cleanBranch: true })` is called
+- **Then** the worktree directory is removed
+- **And** the branch is preserved (needed for PRs/review)
 
 ### Scenario: Branch name generation
 
@@ -93,7 +108,9 @@ Shared git worktree management extracted from `WorkTaskService`. Provides creati
 |--------|-------------|
 | `server/work/service.ts` | `getWorktreeBaseDir`, `createWorktree`, `removeWorktree` for work task isolation |
 | `server/discord/message-handler.ts` | `createWorktree`, `generateChatBranchName` for chat session isolation |
-| `server/process/manager.ts` | `removeWorktree` for chat worktree cleanup on session exit |
+| `server/discord/commands.ts` | `createWorktree`, `generateChatBranchName` for slash-command chat session isolation |
+| `server/algochat/message-router.ts` | `createWorktree`, `generateChatBranchName` for AlgoChat session isolation |
+| `server/process/manager.ts` | `removeWorktree` (with `cleanBranch: true`) for chat worktree cleanup on session exit |
 
 ## Configuration
 
@@ -105,4 +122,5 @@ Shared git worktree management extracted from `WorkTaskService`. Provides creati
 
 | Date | Author | Change |
 |------|--------|--------|
+| 2026-03-15 | corvid-agent | Added `RemoveWorktreeOptions` / `cleanBranch` for smart branch cleanup; AlgoChat consumer |
 | 2026-03-12 | corvid-agent | Initial spec — extracted from WorkTaskService |


### PR DESCRIPTION
## Summary
- **AlgoChat worktree isolation**: All 3 session creation paths (new conversation, existing conversation without session, local chat) now create isolated git worktrees, matching the existing Discord pattern. Non-fatal — sessions fall back to the main working dir if worktree creation fails.
- **Smart branch cleanup**: `removeWorktree()` accepts a new `{ cleanBranch: true }` option that auto-deletes branches with zero commits ahead of main on session end. Branches with actual commits are preserved for PRs/review.
- **Stale branch prevention**: `cleanupChatWorktree()` in ProcessManager now passes `cleanBranch: true`, preventing accumulation of empty chat branches.

## Changes
| File | What |
|------|------|
| `server/lib/worktree.ts` | `RemoveWorktreeOptions` interface, `detectWorktreeBranch()` and `cleanupEmptyBranch()` helpers |
| `server/algochat/message-router.ts` | `createSessionWorktree()` private helper, worktree creation in all 3 paths |
| `server/process/manager.ts` | Pass `{ cleanBranch: true }` to `removeWorktree()` |
| `specs/lib/worktree.spec.md` | Updated spec with new type, scenarios, and consumers |

## Test plan
- [x] `bun x tsc --noEmit` — zero errors in changed files
- [x] `bun run spec:check` — 144/144 specs pass, 0 warnings, 100% file coverage
- [x] Manual: verify AlgoChat session creates a worktree (check `git worktree list`)
- [x] Manual: verify empty chat branches are deleted on session end
- [x] Manual: verify branches with commits are preserved on session end

🤖 Generated with [Claude Code](https://claude.com/claude-code)