### PR TITLE
feat: context_exhausted errors, better Discord messages, archive buttons

### DIFF
--- a/server/discord/commands.ts
+++ b/server/discord/commands.ts
@@ -37,6 +37,7 @@ import {
 import { resolvePermissionLevel } from './permissions';
 import { handleAdminCommand } from './admin-commands';
 import type { ThreadSessionInfo, ThreadCallbackInfo } from './thread-manager';
+import { archiveThread } from './thread-manager';
 
 const log = createLogger('DiscordCommands');
 
@@ -966,6 +967,29 @@ async function handleComponentInteraction(
                 return;
             }
             await respondToInteraction(interaction, 'Use `/session` to start a new conversation with an agent.');
+            break;
+        }
+
+        case 'archive_thread': {
+            const threadId = interaction.channel_id;
+            const info = ctx.threadSessions.get(threadId);
+
+            // Clean up subscriptions if any
+            const cb = ctx.threadCallbacks.get(threadId);
+            if (cb) {
+                ctx.processManager.unsubscribe(cb.sessionId, cb.callback);
+                ctx.threadCallbacks.delete(threadId);
+            }
+            ctx.threadSessions.delete(threadId);
+            ctx.threadLastActivity.delete(threadId);
+
+            // Stop the process if still running
+            if (info && ctx.processManager.isRunning(info.sessionId)) {
+                ctx.processManager.stopProcess(info.sessionId);
+            }
+
+            await acknowledgeButton(interaction, 'Thread archived.');
+            await archiveThread(ctx.config.botToken, threadId);
             break;
         }
 

--- a/server/discord/message-handler.ts
+++ b/server/discord/message-handler.ts
@@ -384,7 +384,7 @@ async function routeToThread(ctx: MessageHandlerContext, threadId: string, _user
             color: 0x95a5a6,
         }, [
             buildActionRow(
-                { label: 'New Session', customId: 'new_session', style: ButtonStyle.PRIMARY, emoji: '➕' },
+                { label: 'Archive Thread', customId: 'archive_thread', style: ButtonStyle.SECONDARY, emoji: '📦' },
             ),
         ]);
         return;

--- a/server/discord/thread-manager.ts
+++ b/server/discord/thread-manager.ts
@@ -89,6 +89,7 @@ export function subscribeForResponseWithEmbed(
     const TYPING_REFRESH_MS = 8000;
     const TYPING_TIMEOUT_MS = 4 * 60 * 1000; // 4 minute safety timeout
     let receivedAnyActivity = false; // tracks any activity (content OR tool use)
+    let sentErrorMessage = false; // dedup: prevent repeated error messages for same session
 
     // Keep typing indicator alive continuously until response completes
     const typingInterval = setInterval(() => {
@@ -96,11 +97,17 @@ export function subscribeForResponseWithEmbed(
         if (!processManager.isRunning(sessionId)) {
             clearTyping();
             log.warn('Process died while typing indicator active', { sessionId, threadId });
-            if (!receivedAnyContent) {
-                sendEmbed(delivery, botToken, threadId, {
-                    description: 'The agent session ended unexpectedly. Send a message to start a new session.',
+            if (!receivedAnyContent && !sentErrorMessage) {
+                sentErrorMessage = true;
+                sendEmbedWithButtons(delivery, botToken, threadId, {
+                    description: 'The agent session ended unexpectedly. Send a message to resume.',
                     color: 0xff3355,
-                }).catch(() => {});
+                    footer: { text: `${agentName} · crashed` },
+                }, [
+                    buildActionRow(
+                        { label: 'Resume', customId: 'resume_thread', style: ButtonStyle.SUCCESS, emoji: '🔄' },
+                    ),
+                ]).catch(() => {});
             }
             threadCallbacks.delete(threadId);
             return;
@@ -266,14 +273,14 @@ export function subscribeForResponseWithEmbed(
                 }
 
                 await sendEmbedWithButtons(delivery, botToken, threadId, {
-                    description: 'Session complete. Send a message to continue, or use the buttons below.',
+                    description: 'Session complete. Send a message to continue the conversation.',
                     color: 0x57f287,
                     ...(fields.length > 0 ? { fields } : {}),
                     footer: { text: `${agentName} · done` },
                 }, [
                     buildActionRow(
-                        { label: 'Resume', customId: 'resume_thread', style: ButtonStyle.SUCCESS, emoji: '🔄' },
-                        { label: 'New Session', customId: 'new_session', style: ButtonStyle.SECONDARY, emoji: '➕' },
+                        { label: 'Continue', customId: 'resume_thread', style: ButtonStyle.SUCCESS, emoji: '💬' },
+                        { label: 'Archive Thread', customId: 'archive_thread', style: ButtonStyle.SECONDARY, emoji: '📦' },
                     ),
                 ]);
             })().catch((err) => {
@@ -283,13 +290,49 @@ export function subscribeForResponseWithEmbed(
 
         if (event.type === 'session_error') {
             clearTyping();
-            const errEvent = event as { error?: { message?: string; errorType?: string } };
-            const errMsg = errEvent.error?.message || 'Unknown error';
+            if (sentErrorMessage) return; // dedup: only show one error per session lifecycle
+            sentErrorMessage = true;
+
+            const errEvent = event as { error?: { message?: string; errorType?: string; recoverable?: boolean } };
+            const errorType = errEvent.error?.errorType || 'unknown';
+
+            // Differentiated messages per error type
+            let description: string;
+            let title: string;
+            let color: number;
+            switch (errorType) {
+                case 'context_exhausted':
+                    title = 'Context Limit Reached';
+                    description = 'The conversation ran out of context space. The session will restart with fresh context — send a message to continue.';
+                    color = 0xf0b232; // yellow/warning
+                    break;
+                case 'credits_exhausted':
+                    title = 'Credits Exhausted';
+                    description = 'Session paused — credits have been used up. Add credits to resume.';
+                    color = 0xf0b232;
+                    break;
+                case 'crash':
+                    title = 'Session Crashed';
+                    description = 'The agent session crashed unexpectedly. Send a message or press Resume to restart.';
+                    color = 0xff3355;
+                    break;
+                case 'spawn_error':
+                    title = 'Failed to Start';
+                    description = 'The agent session could not be started. This may be a configuration issue.';
+                    color = 0xff3355;
+                    break;
+                default:
+                    title = 'Session Error';
+                    description = (errEvent.error?.message || 'An unexpected error occurred.').slice(0, 4096);
+                    color = 0xff3355;
+                    break;
+            }
+
             sendEmbedWithButtons(delivery, botToken, threadId, {
-                title: 'Session Error',
-                description: errMsg.slice(0, 4096),
-                color: 0xff3355,
-                footer: { text: `${agentName} · ${errEvent.error?.errorType || 'error'}` },
+                title,
+                description,
+                color,
+                footer: { text: `${agentName} · ${errorType}` },
             }, [
                 buildActionRow(
                     { label: 'Resume', customId: 'resume_thread', style: ButtonStyle.SUCCESS, emoji: '🔄' },
@@ -543,7 +586,6 @@ export async function archiveStaleThreads(
             }, [
                 buildActionRow(
                     { label: 'Resume', customId: 'resume_thread', style: ButtonStyle.SUCCESS, emoji: '🔄' },
-                    { label: 'New Session', customId: 'new_session', style: ButtonStyle.SECONDARY, emoji: '➕' },
                 ),
             ]);
 

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -441,6 +441,16 @@ export class ProcessManager {
             const meta = this.sessionMeta.get(session.id);
             if (meta && meta.turnCount >= MAX_TURNS_BEFORE_CONTEXT_RESET) {
                 log.info(`Context reset: killing session ${session.id} after ${meta.turnCount} turns`);
+                this.eventBus.emit(session.id, {
+                    type: 'session_error',
+                    session_id: session.id,
+                    error: {
+                        message: 'Session context limit reached — restarting with fresh context.',
+                        errorType: 'context_exhausted',
+                        severity: 'info',
+                        recoverable: true,
+                    },
+                } as ClaudeStreamEvent);
                 const cp = this.processes.get(session.id);
                 cp?.kill();
                 this.processes.delete(session.id);

--- a/server/process/types.ts
+++ b/server/process/types.ts
@@ -140,7 +140,7 @@ export interface SessionErrorRecoveryEvent extends BaseStreamEvent {
     type: 'session_error';
     error: {
         message: string;
-        errorType: 'spawn_error' | 'credits_exhausted' | 'timeout' | 'crash' | 'unknown';
+        errorType: 'spawn_error' | 'credits_exhausted' | 'context_exhausted' | 'timeout' | 'crash' | 'unknown';
         severity: 'info' | 'warning' | 'error' | 'fatal';
         recoverable: boolean;
     };

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -148,7 +148,7 @@ export type ErrorSeverity = 'info' | 'warning' | 'error' | 'fatal';
 /** Structured error info for session failure recovery events. */
 export interface SessionErrorInfo {
     message: string;
-    errorType: 'spawn_error' | 'credits_exhausted' | 'timeout' | 'crash' | 'unknown';
+    errorType: 'spawn_error' | 'credits_exhausted' | 'context_exhausted' | 'timeout' | 'crash' | 'unknown';
     severity: ErrorSeverity;
     recoverable: boolean;
     sessionStatus?: string;


### PR DESCRIPTION
## Summary
- Emit `context_exhausted` error type when context reset triggers in process manager
- Show differentiated Discord error messages based on error type (context/credits/crash/spawn)
- Add `sentErrorMessage` dedup flag to prevent repeated "session ended unexpectedly" spam
- Replace "New Session" button with "Archive Thread" button + handler
- Rename "Resume" to "Continue" on session complete messages

Closes #1119, closes #1122, closes #1123

## Test plan
- [x] TypeScript compiles clean
- [x] 23/23 Discord tests pass
- [x] 146/146 spec checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)