### PR TITLE
ci: split workflows into separate files

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,48 @@
+name: Checks
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    name: Checks (ubuntu-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Governance tier check
+        if: github.event_name == 'pull_request'
+        run: bun run governance:check
+        env:
+          GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          GITHUB_ACTOR: ${{ github.actor }}
+
+      - name: Spec check (strict — warnings fail the build)
+        run: bun run spec:check -- --strict
+
+      - name: Spec coverage (100% required)
+        run: bun run spec:coverage:require
+
+      - name: Build client
+        run: bun run build:client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,31 +22,6 @@ permissions:
   contents: read
 
 jobs:
-  checks:
-    name: Checks (ubuntu-only)
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: ./.github/actions/setup-workspace
-
-      - name: Governance tier check
-        if: github.event_name == 'pull_request'
-        run: bun run governance:check
-        env:
-          GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          GITHUB_ACTOR: ${{ github.actor }}
-
-      - name: Spec check (strict — warnings fail the build)
-        run: bun run spec:check -- --strict
-
-      - name: Spec coverage (100% required)
-        run: bun run spec:coverage:require
-
-      - name: Build client
-        run: bun run build:client
-
   build:
     name: Build & Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -71,33 +46,10 @@ jobs:
         # use 30s per-test timeout there to avoid flaky failures (default 10s via bunfig).
         run: bun test ${{ matrix.os == 'windows-latest' && '--timeout 30000' || '' }}
 
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: ./.github/actions/setup-workspace
-
-      - name: Server tests with coverage
-        run: bun test --coverage --coverage-reporter=lcov --coverage-dir=coverage/server
-
-      - name: Client tests with coverage
-        run: cd client && npx vitest run --coverage
-        continue-on-error: true
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de  # v5
-        with:
-          files: coverage/server/lcov.info,coverage/client/lcov.info
-          flags: server,client
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-
   review:
     name: PR Review
     runs-on: ubuntu-latest
-    needs: [build, checks]
+    needs: [build]
     if: always() && github.event_name == 'pull_request'
     permissions:
       pull-requests: write
@@ -108,37 +60,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BUILD_RESULT: ${{ needs.build.result }}
-          CHECKS_RESULT: ${{ needs.checks.result }}
         run: |
-          if [ "$BUILD_RESULT" = "success" ] && [ "$CHECKS_RESULT" = "success" ]; then
+          if [ "$BUILD_RESULT" = "success" ]; then
             gh pr review "$PR_NUMBER" \
               --approve \
-              --body "All CI checks passed (tsc, tests, spec, client build) across ubuntu, macos, and windows."
+              --body "All CI checks passed (tsc, tests) across ubuntu, macos, and windows."
           else
             gh pr review "$PR_NUMBER" \
               --request-changes \
               --body "CI checks failed. Please review the build logs and fix the issues before merging."
           fi
-
-  # E2E tests temporarily disabled to conserve CI minutes.
-  # Uncomment when GitHub Actions credits are replenished.
-  # e2e:
-  #   name: E2E Tests
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 20
-  #   needs: build
-  #
-  #   steps:
-  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-  #     - uses: ./.github/actions/setup-workspace
-  #
-  #     - name: Build client
-  #       run: bun run build:client
-  #
-  #     - name: Install Playwright
-  #       run: npx playwright install chromium --with-deps
-  #
-  #     - name: Run E2E tests
-  #       run: npx playwright test --config=playwright.config.js
-  #       env:
-  #         CI: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,46 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Server tests with coverage
+        run: bun test --coverage --coverage-reporter=lcov --coverage-dir=coverage/server
+
+      - name: Client tests with coverage
+        run: cd client && npx vitest run --coverage
+        continue-on-error: true
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de  # v5
+        with:
+          files: coverage/server/lcov.info,coverage/client/lcov.info
+          flags: server,client
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,45 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# E2E tests temporarily disabled to conserve CI minutes.
+# Uncomment the job below when GitHub Actions credits are replenished.
+jobs: {}
+  # e2e:
+  #   name: E2E Tests
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 20
+  #
+  #   steps:
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+  #     - uses: ./.github/actions/setup-workspace
+  #
+  #     - name: Build client
+  #       run: bun run build:client
+  #
+  #     - name: Install Playwright
+  #       run: npx playwright install chromium --with-deps
+  #
+  #     - name: Run E2E tests
+  #       run: npx playwright test --config=playwright.config.js
+  #       env:
+  #         CI: true


### PR DESCRIPTION
## Summary

- **Split the monolithic `ci.yml` into four focused workflow files** for better parallelism and clearer separation of concerns. Each workflow runs independently with the same trigger configuration (push/PR to main, paths-ignore for docs/markdown).

- **`ci.yml`** — Build matrix (ubuntu, macos, windows) + PR review job
- **`checks.yml`** — Governance tier check, spec check, spec coverage, client build (ubuntu-only)
- **`coverage.yml`** — Test coverage collection and Codecov upload
- **`e2e.yml`** — Playwright E2E tests (currently disabled, preserved as commented-out job)

Builds on #1131 (`ci/optimize-workflow-minutes`). The `checks` job introduced there is now its own workflow, and the `review` job depends only on `build` since `checks` runs independently.

### Why separate files?

- Workflows run in parallel by default — no `needs` dependency between unrelated jobs
- Each workflow gets its own status check in PRs, making failures easier to identify
- Easier to disable/enable individual workflows without touching shared config

## Test plan

- [x] Verify `ci.yml` runs build matrix (3 OS) and review job correctly
- [x] Verify `checks.yml` runs governance, spec check, spec coverage, and client build on ubuntu
- [x] Verify `coverage.yml` runs coverage collection and Codecov upload
- [x] Verify `e2e.yml` is a no-op (disabled job)
- [x] Verify all four workflows trigger on the same events (push/PR to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)