### PR TITLE
ci: trim workflow minutes to stay under budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ["v*"]
     paths-ignore:
       - "docs/**"
       - "**/*.md"
@@ -23,13 +24,33 @@ permissions:
 
 jobs:
   build:
+    name: Build & Test (ubuntu)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: ./.github/actions/setup-workspace
+
+      - name: TypeScript check
+        run: bun x tsc --noEmit --skipLibCheck
+
+      - name: Run database migrations
+        run: bun run migrate:up
+
+      - name: Unit tests
+        run: bun test
+
+  # macOS (10x multiplier) and Windows (2x) only run on release tags to save CI minutes
+  build-cross-platform:
     name: Build & Test (${{ matrix.os }})
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -64,7 +85,7 @@ jobs:
           if [ "$BUILD_RESULT" = "success" ]; then
             gh pr review "$PR_NUMBER" \
               --approve \
-              --body "All CI checks passed (tsc, tests) across ubuntu, macos, and windows."
+              --body "All CI checks passed (tsc, tests) on ubuntu. Cross-platform tests (macOS, Windows) run on release tags only."
           else
             gh pr review "$PR_NUMBER" \
               --request-changes \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,23 +1,10 @@
 name: CodeQL Analysis
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "LICENSE"
-      - ".github/ISSUE_TEMPLATE/**"
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "LICENSE"
-      - ".github/ISSUE_TEMPLATE/**"
   schedule:
     # Run weekly on Monday at 6am UTC
     - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 permissions:
   actions: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,13 +1,6 @@
 name: Coverage
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "LICENSE"
-      - ".github/ISSUE_TEMPLATE/**"
   pull_request:
     branches: [main]
     paths-ignore:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,10 +1,11 @@
 name: Security Scanning
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Run weekly on Monday at 7am UTC (after CodeQL)
+    - cron: "0 7 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,13 +1,6 @@
 name: Stats
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "LICENSE"
-      - ".github/ISSUE_TEMPLATE/**"
   pull_request:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
## Summary
- **CI:** macOS (10x multiplier) and Windows (2x) now only run on release tags (`v*`). Ubuntu runs on every push/PR as before.
- **CodeQL:** Removed push/PR triggers, kept weekly schedule + manual dispatch only.
- **Coverage:** Removed push-to-main trigger, kept PR + manual dispatch.
- **Stats:** Removed push-to-main trigger, kept PR + manual dispatch.
- **Security:** Removed push-to-main trigger, added weekly schedule, kept PR + manual dispatch.

## Motivation
At 1,935 / 2,000 included minutes with ~29 days until reset. A single push to main was burning ~50+ billed minutes across all workflows. This brings it down to ~15-20.

## Test plan
- [ ] Verify Ubuntu CI still runs on this PR
- [ ] Verify macOS/Windows jobs are skipped (not a tag push)
- [ ] Verify CodeQL does not trigger on this PR
- [ ] Confirm next tag release still runs full cross-platform matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)