### PR TITLE
fix: add logging to silent catch blocks

### DIFF
--- a/server/a2a/client.ts
+++ b/server/a2a/client.ts
@@ -258,8 +258,8 @@ export async function invokeRemoteAgent(
                     error: pollResult.state === 'failed' ? (responseText ?? 'Task failed') : null,
                 };
             }
-        } catch {
-            // Poll failed — retry
+        } catch (err) {
+            log.debug('A2A poll attempt failed, retrying', { error: err instanceof Error ? err.message : String(err) });
         }
 
         await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));

--- a/server/performance/collector.ts
+++ b/server/performance/collector.ts
@@ -105,8 +105,8 @@ export class PerformanceCollector {
             this.db.query(
                 `INSERT INTO performance_metrics (metric, labels, value, unit) VALUES (?, ?, ?, ?)`,
             ).run('db_slow_query', operation, durationMs, 'ms');
-        } catch {
-            // Non-critical — don't let metrics recording break the caller
+        } catch (err) {
+            log.debug('Failed to record slow query metric', { error: err instanceof Error ? err.message : String(err) });
         }
     }
 
@@ -295,8 +295,8 @@ export class PerformanceCollector {
             if (result.changes > 0) {
                 log.info('Pruned old metrics', { deleted: result.changes });
             }
-        } catch {
-            // Non-critical
+        } catch (err) {
+            log.warn('Failed to prune old metrics', { error: err instanceof Error ? err.message : String(err) });
         }
     }
 }

--- a/server/process/claude-process.ts
+++ b/server/process/claude-process.ts
@@ -234,7 +234,7 @@ async function readStream(
                 }
             }
         }
-    } catch {
-        // Stream closed
+    } catch (err) {
+        log.debug('Claude process stream ended', { error: err instanceof Error ? err.message : String(err) });
     }
 }


### PR DESCRIPTION
## Summary
- Added `log.debug` to A2A client poll retry catch block — network/auth errors during polling were completely invisible
- Added `log.debug` to performance collector slow query recording — metrics DB errors were swallowed
- Added `log.warn` to performance collector metric pruning — schema/lock errors had no signal
- Added `log.debug` to Claude process stream catch — unexpected stream errors were indistinguishable from clean closes

All logging is debug/warn level to avoid noise while ensuring failures are diagnosable.

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` passes
- [x] `bun test` passes with 0 failures
- [x] `bun run spec:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)