### PR TITLE
feat: auto-link Discord users to cross-platform contacts

### DIFF
--- a/server/__tests__/contact-auto-link.test.ts
+++ b/server/__tests__/contact-auto-link.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import { findContactByPlatformId } from '../db/contacts';
+import {
+    resolveDiscordContact,
+    contactCache,
+    CONTACT_CACHE_TTL,
+} from '../discord/contact-linker';
+
+let db: Database;
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+    contactCache.clear();
+});
+
+afterEach(() => {
+    db.close();
+});
+
+describe('Discord contact auto-link', () => {
+    test('creates contact on first message from a Discord user', () => {
+        const contactId = resolveDiscordContact(db, '123456', 'testuser');
+
+        expect(contactId).toBeTruthy();
+
+        // Verify the contact was created with a Discord platform link
+        const contact = findContactByPlatformId(db, 'default', 'discord', '123456');
+        expect(contact).not.toBeNull();
+        expect(contact!.displayName).toBe('testuser');
+        expect(contact!.id).toBe(contactId!);
+        expect(contact!.links).toBeDefined();
+        expect(contact!.links!.length).toBe(1);
+        expect(contact!.links![0].platform).toBe('discord');
+        expect(contact!.links![0].platformId).toBe('123456');
+    });
+
+    test('returns cached contact on subsequent messages', () => {
+        const first = resolveDiscordContact(db, '123456', 'testuser');
+        const second = resolveDiscordContact(db, '123456', 'testuser');
+
+        expect(first).toBe(second);
+
+        // Verify only one contact exists (no duplicates)
+        const rows = db.query(
+            "SELECT COUNT(*) as cnt FROM contacts WHERE display_name = 'testuser'",
+        ).get() as { cnt: number };
+        expect(rows.cnt).toBe(1);
+    });
+
+    test('returns existing contact from DB when cache is empty', () => {
+        const first = resolveDiscordContact(db, '123456', 'testuser');
+
+        // Clear cache to force DB lookup
+        contactCache.clear();
+
+        const second = resolveDiscordContact(db, '123456', 'testuser');
+        expect(second).toBe(first);
+
+        // Still only one contact
+        const rows = db.query(
+            "SELECT COUNT(*) as cnt FROM contacts WHERE display_name = 'testuser'",
+        ).get() as { cnt: number };
+        expect(rows.cnt).toBe(1);
+    });
+
+    test('cache expires after TTL', () => {
+        const contactId = resolveDiscordContact(db, '123456', 'testuser');
+
+        // Manually expire the cache entry
+        const entry = contactCache.get('123456');
+        expect(entry).toBeDefined();
+        entry!.resolvedAt = Date.now() - CONTACT_CACHE_TTL - 1;
+
+        // Should do a fresh DB lookup (but still return the same contact)
+        const second = resolveDiscordContact(db, '123456', 'testuser');
+        expect(second).toBe(contactId);
+
+        // Verify cache was refreshed
+        const refreshed = contactCache.get('123456');
+        expect(refreshed).toBeDefined();
+        expect(Date.now() - refreshed!.resolvedAt).toBeLessThan(1000);
+    });
+
+    test('handles different Discord users independently', () => {
+        const contact1 = resolveDiscordContact(db, 'user-a', 'alice');
+        const contact2 = resolveDiscordContact(db, 'user-b', 'bob');
+
+        expect(contact1).not.toBe(contact2);
+        expect(contact1).toBeTruthy();
+        expect(contact2).toBeTruthy();
+
+        const rows = db.query(
+            'SELECT COUNT(*) as cnt FROM contacts',
+        ).get() as { cnt: number };
+        expect(rows.cnt).toBe(2);
+    });
+
+    test('does not create duplicate contacts for same Discord user', () => {
+        // Simulate multiple rapid calls (cache populated on first)
+        resolveDiscordContact(db, '123456', 'testuser');
+        contactCache.clear();
+        resolveDiscordContact(db, '123456', 'testuser');
+        contactCache.clear();
+        resolveDiscordContact(db, '123456', 'testuser');
+
+        const rows = db.query(
+            'SELECT COUNT(*) as cnt FROM contacts',
+        ).get() as { cnt: number };
+        expect(rows.cnt).toBe(1);
+
+        const linkRows = db.query(
+            "SELECT COUNT(*) as cnt FROM contact_platform_links WHERE platform = 'discord' AND platform_id = '123456'",
+        ).get() as { cnt: number };
+        expect(linkRows.cnt).toBe(1);
+    });
+
+    test('handles DB errors gracefully when called from message handler', () => {
+        // Close the DB to simulate an error
+        db.close();
+
+        // resolveDiscordContact itself throws on DB error,
+        // but the message handler wraps it in try/catch
+        expect(() => resolveDiscordContact(db, '123456', 'testuser')).toThrow();
+
+        // Re-open for afterEach cleanup
+        db = new Database(':memory:');
+    });
+});

--- a/server/discord/contact-linker.ts
+++ b/server/discord/contact-linker.ts
@@ -1,0 +1,60 @@
+/**
+ * Auto-link Discord users to cross-platform contacts.
+ *
+ * On each incoming message, resolves or creates a contact record
+ * for the Discord author, linking their Discord ID to the unified
+ * contact identity system.
+ */
+
+import type { Database } from 'bun:sqlite';
+import { findContactByPlatformId, createContact, addPlatformLink } from '../db/contacts';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('DiscordContactLinker');
+
+/** Default tenant ID used for single-tenant deployments. */
+const DEFAULT_TENANT_ID = 'default';
+
+/** Cache TTL in milliseconds (5 minutes). */
+export const CONTACT_CACHE_TTL = 5 * 60 * 1000;
+
+interface CachedContact {
+    contactId: string;
+    resolvedAt: number;
+}
+
+/** In-memory cache to avoid DB lookups on every message. */
+export const contactCache = new Map<string, CachedContact>();
+
+/**
+ * Resolve or create a contact for a Discord user.
+ *
+ * Checks cache first, then DB lookup by platform ID. If no contact
+ * exists, creates one and links the Discord ID. Returns the contact
+ * ID or null if an error occurs.
+ */
+export function resolveDiscordContact(
+    db: Database,
+    authorId: string,
+    username: string,
+): string | null {
+    // Check cache first
+    const cached = contactCache.get(authorId);
+    if (cached && Date.now() - cached.resolvedAt < CONTACT_CACHE_TTL) {
+        return cached.contactId;
+    }
+
+    // Lookup by platform ID
+    const existing = findContactByPlatformId(db, DEFAULT_TENANT_ID, 'discord', authorId);
+    if (existing) {
+        contactCache.set(authorId, { contactId: existing.id, resolvedAt: Date.now() });
+        return existing.id;
+    }
+
+    // Create new contact and link
+    const contact = createContact(db, DEFAULT_TENANT_ID, username);
+    addPlatformLink(db, DEFAULT_TENANT_ID, contact.id, 'discord', authorId);
+    contactCache.set(authorId, { contactId: contact.id, resolvedAt: Date.now() });
+    log.info('Created contact for Discord user', { authorId, username, contactId: contact.id });
+    return contact.id;
+}

--- a/server/discord/message-handler.ts
+++ b/server/discord/message-handler.ts
@@ -36,6 +36,7 @@ import {
     subscribeForInlineResponse,
     resolveDefaultAgent,
 } from './thread-manager';
+import { resolveDiscordContact } from './contact-linker';
 
 const log = createLogger('DiscordMessageHandler');
 
@@ -99,6 +100,16 @@ const permDenyCooldowns = new Map<string, number>();
 export async function handleMessage(ctx: MessageHandlerContext, data: DiscordMessageData): Promise<void> {
     // Ignore bot messages
     if (data.author.bot) return;
+
+    // Auto-link Discord user to contact identity (best-effort, non-blocking)
+    try {
+        resolveDiscordContact(ctx.db, data.author.id, data.author.username);
+    } catch (err) {
+        log.warn('Failed to resolve Discord contact', {
+            authorId: data.author.id,
+            error: err instanceof Error ? err.message : String(err),
+        });
+    }
 
     const text = data.content;
     if (!text) return;


### PR DESCRIPTION
## Summary
- Adds `server/discord/contact-linker.ts` with `resolveDiscordContact()` — looks up or creates a contact record for each Discord user, linking their Discord ID via the existing contacts DB API
- Integrates into `handleMessage()` in `server/discord/message-handler.ts` — runs after the bot check, wrapped in try/catch so failures never block message processing
- Includes 5-minute in-memory cache (`contactCache`) to avoid DB lookups on every message

## Test plan
- [x] 7 tests in `server/__tests__/contact-auto-link.test.ts` — all passing
  - Creates contact on first message from a Discord user
  - Returns cached contact on subsequent messages
  - Returns existing contact from DB when cache is empty
  - Cache expires after TTL
  - Handles different Discord users independently
  - Does not create duplicate contacts for same Discord user
  - Handles DB errors gracefully (throws, caught by message handler)
- [x] `bun x tsc --noEmit` passes with no errors

Closes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)