### PR TITLE
feat: Discord reaction listener for reputation feedback

### DIFF
--- a/server/__tests__/discord-reaction-handler.test.ts
+++ b/server/__tests__/discord-reaction-handler.test.ts
@@ -1,0 +1,236 @@
+import { test, expect, beforeEach, afterEach, describe } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import { ReputationScorer } from '../reputation/scorer';
+import {
+    handleReaction,
+    reactionRateLimit,
+    RATE_LIMIT_MAX,
+    type ReactionHandlerContext,
+} from '../discord/reaction-handler';
+import type { DiscordReactionData } from '../discord/types';
+import type { MentionSessionInfo } from '../discord/message-handler';
+import type { ThreadSessionInfo } from '../discord/thread-manager';
+
+let db: Database;
+let scorer: ReputationScorer;
+
+function seedAgent(id: string = 'agent-1', name: string = 'Test Agent'): void {
+    db.query('INSERT OR IGNORE INTO agents (id, name) VALUES (?, ?)').run(id, name);
+}
+
+function seedProject(id: string = 'proj-1', name: string = 'test-project'): void {
+    db.query('INSERT OR IGNORE INTO projects (id, name, working_dir) VALUES (?, ?, ?)').run(id, name, '/tmp/test');
+}
+
+function seedSession(id: string, agentId: string = 'agent-1', projectId: string = 'proj-1'): void {
+    db.query('INSERT OR IGNORE INTO sessions (id, agent_id, project_id) VALUES (?, ?, ?)').run(id, agentId, projectId);
+}
+
+function makeReaction(overrides: Partial<DiscordReactionData> = {}): DiscordReactionData {
+    return {
+        user_id: 'user-123',
+        channel_id: 'channel-456',
+        message_id: 'msg-789',
+        emoji: { id: null, name: '\u{1F44D}' },
+        ...overrides,
+    };
+}
+
+function makeContext(overrides: Partial<ReactionHandlerContext> = {}): ReactionHandlerContext {
+    return {
+        db,
+        botUserId: 'bot-user-id',
+        scorer,
+        mentionSessions: new Map(),
+        threadSessions: new Map(),
+        ...overrides,
+    };
+}
+
+function getFeedbackCount(): number {
+    const row = db.query('SELECT COUNT(*) as count FROM response_feedback').get() as { count: number };
+    return row.count;
+}
+
+function getLatestFeedback(): { sentiment: string; agent_id: string; session_id: string; submitted_by: string; source: string } | null {
+    return db.query('SELECT * FROM response_feedback ORDER BY created_at DESC LIMIT 1').get() as {
+        sentiment: string; agent_id: string; session_id: string; submitted_by: string; source: string;
+    } | null;
+}
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+    seedAgent('agent-1');
+    seedProject('proj-1');
+    seedSession('session-1', 'agent-1');
+    scorer = new ReputationScorer(db);
+    reactionRateLimit.clear();
+});
+
+afterEach(() => {
+    db.close();
+});
+
+describe('handleReaction', () => {
+    test('positive emoji submits positive feedback via mention session', () => {
+        const mentionSessions = new Map<string, MentionSessionInfo>();
+        mentionSessions.set('msg-789', { sessionId: 'session-1', agentName: 'Test Agent', agentModel: 'test' });
+
+        const ctx = makeContext({ mentionSessions });
+        handleReaction(ctx, makeReaction({ emoji: { id: null, name: '\u{1F44D}' } }));
+
+        expect(getFeedbackCount()).toBe(1);
+        const fb = getLatestFeedback();
+        expect(fb?.sentiment).toBe('positive');
+        expect(fb?.agent_id).toBe('agent-1');
+        expect(fb?.session_id).toBe('session-1');
+        expect(fb?.source).toBe('discord');
+        expect(fb?.submitted_by).toBe('discord:user-123');
+    });
+
+    test('negative emoji submits negative feedback via mention session', () => {
+        const mentionSessions = new Map<string, MentionSessionInfo>();
+        mentionSessions.set('msg-789', { sessionId: 'session-1', agentName: 'Test Agent', agentModel: 'test' });
+
+        const ctx = makeContext({ mentionSessions });
+        handleReaction(ctx, makeReaction({ emoji: { id: null, name: '\u{1F44E}' } }));
+
+        expect(getFeedbackCount()).toBe(1);
+        const fb = getLatestFeedback();
+        expect(fb?.sentiment).toBe('negative');
+    });
+
+    test('positive emoji submits feedback via thread session', () => {
+        const threadSessions = new Map<string, ThreadSessionInfo>();
+        threadSessions.set('channel-456', { sessionId: 'session-1', agentName: 'Test Agent', agentModel: 'test', ownerUserId: 'user-123' });
+
+        const ctx = makeContext({ threadSessions });
+        handleReaction(ctx, makeReaction());
+
+        expect(getFeedbackCount()).toBe(1);
+        const fb = getLatestFeedback();
+        expect(fb?.sentiment).toBe('positive');
+        expect(fb?.agent_id).toBe('agent-1');
+    });
+
+    test('non-feedback emojis are ignored', () => {
+        const mentionSessions = new Map<string, MentionSessionInfo>();
+        mentionSessions.set('msg-789', { sessionId: 'session-1', agentName: 'Test Agent', agentModel: 'test' });
+
+        const ctx = makeContext({ mentionSessions });
+        handleReaction(ctx, makeReaction({ emoji: { id: null, name: '\u{2764}' } })); // ❤️
+        handleReaction(ctx, makeReaction({ emoji: { id: null, name: '\u{1F525}' } })); // 🔥
+        handleReaction(ctx, makeReaction({ emoji: { id: 'custom-123', name: 'custom_emoji' } }));
+
+        expect(getFeedbackCount()).toBe(0);
+    });
+
+    test('bot reactions are ignored', () => {
+        const mentionSessions = new Map<string, MentionSessionInfo>();
+        mentionSessions.set('msg-789', { sessionId: 'session-1', agentName: 'Test Agent', agentModel: 'test' });
+
+        const ctx = makeContext({ mentionSessions });
+        handleReaction(ctx, makeReaction({ user_id: 'bot-user-id' }));
+
+        expect(getFeedbackCount()).toBe(0);
+    });
+
+    test('rate limiting prevents excessive reactions', () => {
+        const mentionSessions = new Map<string, MentionSessionInfo>();
+        mentionSessions.set('msg-789', { sessionId: 'session-1', agentName: 'Test Agent', agentModel: 'test' });
+
+        const ctx = makeContext({ mentionSessions });
+
+        // Send RATE_LIMIT_MAX reactions — all should succeed
+        for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+            handleReaction(ctx, makeReaction({ message_id: `msg-${i}` }));
+        }
+
+        // Need to add each message to mentionSessions
+        for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+            mentionSessions.set(`msg-${i}`, { sessionId: 'session-1', agentName: 'Test Agent', agentModel: 'test' });
+        }
+
+        // Clear feedback and rate limit, re-do properly
+        db.query('DELETE FROM response_feedback').run();
+        reactionRateLimit.clear();
+
+        for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+            handleReaction(ctx, makeReaction({ message_id: `msg-${i}` }));
+        }
+        expect(getFeedbackCount()).toBe(RATE_LIMIT_MAX);
+
+        // Next reaction should be rate limited
+        mentionSessions.set('msg-extra', { sessionId: 'session-1', agentName: 'Test Agent', agentModel: 'test' });
+        handleReaction(ctx, makeReaction({ message_id: 'msg-extra' }));
+        expect(getFeedbackCount()).toBe(RATE_LIMIT_MAX); // no increase
+    });
+
+    test('unknown message IDs are handled gracefully', () => {
+        const ctx = makeContext();
+        // No sessions mapped — should silently return
+        handleReaction(ctx, makeReaction({ message_id: 'unknown-msg' }));
+        expect(getFeedbackCount()).toBe(0);
+    });
+
+    test('missing scorer skips feedback gracefully', () => {
+        const mentionSessions = new Map<string, MentionSessionInfo>();
+        mentionSessions.set('msg-789', { sessionId: 'session-1', agentName: 'Test Agent', agentModel: 'test' });
+
+        const ctx = makeContext({ mentionSessions, scorer: null });
+        handleReaction(ctx, makeReaction());
+
+        expect(getFeedbackCount()).toBe(0);
+    });
+
+    test('records reputation event alongside feedback', () => {
+        const mentionSessions = new Map<string, MentionSessionInfo>();
+        mentionSessions.set('msg-789', { sessionId: 'session-1', agentName: 'Test Agent', agentModel: 'test' });
+
+        const ctx = makeContext({ mentionSessions });
+        handleReaction(ctx, makeReaction());
+
+        // Check reputation event was recorded
+        const events = scorer.getEvents('agent-1', 10);
+        expect(events.length).toBeGreaterThanOrEqual(1);
+        const feedbackEvent = events.find(e => e.event_type === 'feedback_received');
+        expect(feedbackEvent).toBeDefined();
+        expect(feedbackEvent?.score_impact).toBe(2);
+    });
+
+    test('negative reaction records negative reputation impact', () => {
+        const mentionSessions = new Map<string, MentionSessionInfo>();
+        mentionSessions.set('msg-789', { sessionId: 'session-1', agentName: 'Test Agent', agentModel: 'test' });
+
+        const ctx = makeContext({ mentionSessions });
+        handleReaction(ctx, makeReaction({ emoji: { id: null, name: '\u{1F44E}' } }));
+
+        const events = scorer.getEvents('agent-1', 10);
+        const feedbackEvent = events.find(e => e.event_type === 'feedback_received');
+        expect(feedbackEvent).toBeDefined();
+        expect(feedbackEvent?.score_impact).toBe(-2);
+    });
+
+    test('different users have independent rate limits', () => {
+        const mentionSessions = new Map<string, MentionSessionInfo>();
+        for (let i = 0; i < RATE_LIMIT_MAX + 2; i++) {
+            mentionSessions.set(`msg-a-${i}`, { sessionId: 'session-1', agentName: 'Test Agent', agentModel: 'test' });
+            mentionSessions.set(`msg-b-${i}`, { sessionId: 'session-1', agentName: 'Test Agent', agentModel: 'test' });
+        }
+
+        const ctx = makeContext({ mentionSessions });
+
+        // User A sends max reactions
+        for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+            handleReaction(ctx, makeReaction({ user_id: 'user-a', message_id: `msg-a-${i}` }));
+        }
+        expect(getFeedbackCount()).toBe(RATE_LIMIT_MAX);
+
+        // User B should still be able to react
+        handleReaction(ctx, makeReaction({ user_id: 'user-b', message_id: 'msg-b-0' }));
+        expect(getFeedbackCount()).toBe(RATE_LIMIT_MAX + 1);
+    });
+});

--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -368,6 +368,7 @@ export async function bootstrapServices(db: Database, startTime: number): Promis
             },
             workTaskService,
         );
+        discordBridge.setReputationScorer(reputationScorer);
         discordBridge.start();
         shutdownCoordinator.registerService('DiscordBridge', discordBridge, 20);
         log.info('Discord bridge initialized');

--- a/server/discord/bridge.ts
+++ b/server/discord/bridge.ts
@@ -24,8 +24,9 @@
 import type { Database } from 'bun:sqlite';
 import type { ProcessManager } from '../process/manager';
 import type { WorkTaskService } from '../work/service';
-import type { DiscordBridgeConfig, DiscordInteractionData, DiscordMessageData } from './types';
+import type { DiscordBridgeConfig, DiscordInteractionData, DiscordMessageData, DiscordReactionData } from './types';
 import type { EventCallback } from '../process/interfaces';
+import type { ReputationScorer } from '../reputation/scorer';
 import { DiscordGateway } from './gateway';
 import { getAgent } from '../db/agents';
 import { getSession } from '../db/sessions';
@@ -45,6 +46,7 @@ import {
     removeReaction as removeReactionImpl,
 } from './embeds';
 import { muteUser as muteUserImpl, unmuteUser as unmuteUserImpl } from './permissions';
+import { handleReaction as handleReactionImpl, type ReactionHandlerContext } from './reaction-handler';
 import type { ThreadSessionInfo, ThreadCallbackInfo } from './thread-manager';
 import {
     subscribeForResponseWithEmbed as subscribeImpl,
@@ -90,6 +92,9 @@ export class DiscordBridge {
     /** Users who have interacted at least once — used for first-interaction welcome tips. */
     private interactedUsers: Set<string> = new Set();
 
+    /** Reputation scorer for reaction feedback. Set via setReputationScorer(). */
+    private reputationScorer: ReputationScorer | null = null;
+
     /** Debounce timer for updateSlashCommands — coalesces rapid agent changes. */
     private slashCommandDebounceTimer: ReturnType<typeof setTimeout> | null = null;
     private static readonly SLASH_COMMAND_DEBOUNCE_MS = 2_000;
@@ -121,6 +126,9 @@ export class DiscordBridge {
                 this.handleInteraction(data).catch(err => {
                     log.error('Error handling Discord interaction', { error: err instanceof Error ? err.message : String(err) });
                 });
+            },
+            onReactionAdd: (data) => {
+                this.handleReaction(data);
             },
             onReady: (sessionId, botUserId) => {
                 if (botUserId) {
@@ -269,7 +277,23 @@ export class DiscordBridge {
         }, DiscordBridge.SLASH_COMMAND_DEBOUNCE_MS);
     }
 
+    /** Wire up the reputation scorer for reaction-based feedback. */
+    setReputationScorer(scorer: ReputationScorer): void {
+        this.reputationScorer = scorer;
+    }
+
     // ── Delegation methods ──────────────────────────────────────────────
+
+    private handleReaction(data: DiscordReactionData): void {
+        const ctx: ReactionHandlerContext = {
+            db: this.db,
+            botUserId: this.botUserId,
+            scorer: this.reputationScorer,
+            mentionSessions: this.mentionSessions,
+            threadSessions: this.threadSessions,
+        };
+        handleReactionImpl(ctx, data);
+    }
 
     private async handleInteraction(interaction: DiscordInteractionData): Promise<void> {
         const ctx: InteractionContext = {

--- a/server/discord/gateway.ts
+++ b/server/discord/gateway.ts
@@ -5,6 +5,7 @@ import type {
     DiscordReadyData,
     DiscordMessageData,
     DiscordInteractionData,
+    DiscordReactionData,
 } from './types';
 import { GatewayOp, GatewayIntent } from './types';
 import { createLogger } from '../lib/logger';
@@ -21,6 +22,7 @@ export interface GatewayDispatchHandlers {
     onMessage(data: DiscordMessageData): void;
     onInteraction(data: DiscordInteractionData): void;
     onReady(sessionId: string, botUserId: string | null): void;
+    onReactionAdd?(data: DiscordReactionData): void;
 }
 
 /**
@@ -224,6 +226,12 @@ export class DiscordGateway {
                 this.handlers.onInteraction(data);
                 break;
             }
+
+            case 'MESSAGE_REACTION_ADD': {
+                const data = payload.d as DiscordReactionData;
+                this.handlers.onReactionAdd?.(data);
+                break;
+            }
         }
     }
 
@@ -232,7 +240,7 @@ export class DiscordGateway {
     private identify(): void {
         // GUILDS is always needed for the bot to receive guild dispatch events.
         // GUILD_MEMBERS is added when public mode is enabled (for role data).
-        let intents = GatewayIntent.GUILDS | GatewayIntent.GUILD_MESSAGES | GatewayIntent.MESSAGE_CONTENT;
+        let intents = GatewayIntent.GUILDS | GatewayIntent.GUILD_MESSAGES | GatewayIntent.GUILD_MESSAGE_REACTIONS | GatewayIntent.MESSAGE_CONTENT;
         if (this.config.publicMode) {
             intents |= GatewayIntent.GUILD_MEMBERS;
         }

--- a/server/discord/reaction-handler.ts
+++ b/server/discord/reaction-handler.ts
@@ -1,0 +1,174 @@
+/**
+ * Discord reaction handler — maps emoji reactions on bot messages
+ * to reputation feedback submissions.
+ *
+ * Supported emojis:
+ *   👍 → positive feedback
+ *   👎 → negative feedback
+ *
+ * Rate limited to 5 reactions per user per minute.
+ */
+
+import type { Database } from 'bun:sqlite';
+import type { DiscordReactionData } from './types';
+import type { MentionSessionInfo } from './message-handler';
+import type { ThreadSessionInfo } from './thread-manager';
+import type { ReputationScorer } from '../reputation/scorer';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('DiscordReactionHandler');
+
+/** Maps emoji names to sentiment values. */
+const FEEDBACK_EMOJIS: Record<string, 'positive' | 'negative'> = {
+    '\u{1F44D}': 'positive', // 👍
+    '\u{1F44E}': 'negative', // 👎
+};
+
+/** Per-user rate limiting: userId → timestamps of recent reactions. */
+const reactionRateLimit = new Map<string, number[]>();
+const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+const RATE_LIMIT_MAX = 5; // max 5 feedback reactions per minute
+
+/** Context needed by the reaction handler. */
+export interface ReactionHandlerContext {
+    db: Database;
+    botUserId: string | null;
+    scorer: ReputationScorer | null;
+    /** Maps bot reply message IDs → session info for mention-reply context. */
+    mentionSessions: Map<string, MentionSessionInfo>;
+    /** Maps thread channel IDs → thread session info. */
+    threadSessions: Map<string, ThreadSessionInfo>;
+}
+
+/**
+ * Handle an incoming MESSAGE_REACTION_ADD event.
+ *
+ * Looks up the session associated with the reacted-to message,
+ * then submits feedback to the response_feedback table and records
+ * a reputation event.
+ */
+export function handleReaction(ctx: ReactionHandlerContext, data: DiscordReactionData): void {
+    // Ignore reactions from the bot itself
+    if (data.user_id === ctx.botUserId) return;
+
+    // Check if the emoji is one we care about
+    const sentiment = FEEDBACK_EMOJIS[data.emoji.name];
+    if (!sentiment) return;
+
+    // Rate limit check
+    if (!checkReactionRateLimit(data.user_id)) {
+        log.debug('Reaction rate limited', { userId: data.user_id });
+        return;
+    }
+
+    // Look up session for this message
+    const sessionInfo = resolveSession(ctx, data);
+    if (!sessionInfo) {
+        log.debug('No session found for reacted message', {
+            messageId: data.message_id,
+            channelId: data.channel_id,
+        });
+        return;
+    }
+
+    // Require a reputation scorer to record feedback
+    if (!ctx.scorer) {
+        log.debug('Reputation scorer not available, skipping reaction feedback');
+        return;
+    }
+
+    const { sessionId, agentId } = sessionInfo;
+
+    // Insert feedback into response_feedback table
+    const feedbackId = crypto.randomUUID();
+    try {
+        ctx.db.query(`
+            INSERT INTO response_feedback (id, agent_id, session_id, source, sentiment, submitted_by)
+            VALUES (?, ?, ?, 'discord', ?, ?)
+        `).run(
+            feedbackId,
+            agentId,
+            sessionId,
+            sentiment,
+            `discord:${data.user_id}`,
+        );
+    } catch (err) {
+        log.error('Failed to insert reaction feedback', {
+            error: err instanceof Error ? err.message : String(err),
+            messageId: data.message_id,
+        });
+        return;
+    }
+
+    // Record reputation event
+    const scoreImpact = sentiment === 'positive' ? 2 : -2;
+    ctx.scorer.recordEvent({
+        agentId,
+        eventType: 'feedback_received',
+        scoreImpact,
+        metadata: { feedbackId, sentiment, source: 'discord_reaction' },
+    });
+
+    log.info('Reaction feedback recorded', {
+        feedbackId,
+        agentId,
+        sessionId,
+        sentiment,
+        userId: data.user_id,
+        messageId: data.message_id,
+    });
+}
+
+/** Resolve the session and agent ID for a reacted-to message. */
+function resolveSession(
+    ctx: ReactionHandlerContext,
+    data: DiscordReactionData,
+): { sessionId: string; agentId: string } | null {
+    // Check mention sessions (bot reply messages in channels)
+    const mentionInfo = ctx.mentionSessions.get(data.message_id);
+    if (mentionInfo) {
+        // Mention sessions don't store agentId directly — look up from session
+        const session = ctx.db.query('SELECT agent_id FROM sessions WHERE id = ?').get(mentionInfo.sessionId) as { agent_id: string } | null;
+        if (session) {
+            return { sessionId: mentionInfo.sessionId, agentId: session.agent_id };
+        }
+    }
+
+    // Check thread sessions (the reaction is in a thread we're tracking)
+    const threadInfo = ctx.threadSessions.get(data.channel_id);
+    if (threadInfo) {
+        const session = ctx.db.query('SELECT agent_id FROM sessions WHERE id = ?').get(threadInfo.sessionId) as { agent_id: string } | null;
+        if (session) {
+            return { sessionId: threadInfo.sessionId, agentId: session.agent_id };
+        }
+    }
+
+    return null;
+}
+
+/** Check per-user reaction rate limit. Returns true if allowed. */
+function checkReactionRateLimit(userId: string): boolean {
+    const now = Date.now();
+    let timestamps = reactionRateLimit.get(userId);
+
+    if (!timestamps) {
+        timestamps = [];
+        reactionRateLimit.set(userId, timestamps);
+    }
+
+    // Remove expired timestamps
+    const cutoff = now - RATE_LIMIT_WINDOW_MS;
+    while (timestamps.length > 0 && timestamps[0] < cutoff) {
+        timestamps.shift();
+    }
+
+    if (timestamps.length >= RATE_LIMIT_MAX) {
+        return false;
+    }
+
+    timestamps.push(now);
+    return true;
+}
+
+// Exported for testing
+export { FEEDBACK_EMOJIS, checkReactionRateLimit, resolveSession, reactionRateLimit, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS };

--- a/server/discord/types.ts
+++ b/server/discord/types.ts
@@ -189,5 +189,15 @@ export const GatewayIntent = {
     GUILDS: 1 << 0,
     GUILD_MEMBERS: 1 << 1,
     GUILD_MESSAGES: 1 << 9,
+    GUILD_MESSAGE_REACTIONS: 1 << 10,
     MESSAGE_CONTENT: 1 << 15,
 } as const;
+
+/** Payload received from Discord MESSAGE_REACTION_ADD dispatch event. */
+export interface DiscordReactionData {
+    user_id: string;
+    channel_id: string;
+    message_id: string;
+    guild_id?: string;
+    emoji: { id: string | null; name: string };
+}

--- a/specs/discord/bridge.spec.md
+++ b/specs/discord/bridge.spec.md
@@ -1,6 +1,6 @@
 ---
 module: discord-bridge
-version: 11
+version: 12
 status: active
 files:
   - server/discord/bridge.ts
@@ -18,6 +18,7 @@ files:
   - server/discord/types.ts
   - server/discord/message-formatter.ts
   - server/discord/gateway.ts
+  - server/discord/reaction-handler.ts
 db_tables:
   - sessions
   - session_messages
@@ -65,6 +66,7 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | `removeReaction` | `(channelId, messageId, emoji: string)` | `Promise<void>` | Remove a bot reaction from a message. Best-effort |
 | `muteUser` | `(userId: string)` | `void` | Mute a user from bot interactions (admin action) |
 | `unmuteUser` | `(userId: string)` | `void` | Unmute a previously muted user (admin action) |
+| `setReputationScorer` | `(scorer: ReputationScorer)` | `void` | Wire up the reputation scorer for reaction-based feedback |
 
 ### Exported Functions (from commands.ts)
 
@@ -180,7 +182,7 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 
 | Export | Kind | Description |
 |--------|------|-------------|
-| `GatewayDispatchHandlers` | Interface | Callbacks for gateway dispatch events: `onMessage`, `onInteraction`, `onReady` |
+| `GatewayDispatchHandlers` | Interface | Callbacks for gateway dispatch events: `onMessage`, `onInteraction`, `onReady`, `onReactionAdd?` |
 | `DiscordGateway` | Class | Manages the Discord Gateway WebSocket connection, heartbeat, identify/resume lifecycle, and reconnection. Dispatch events are forwarded to the bridge via `GatewayDispatchHandlers` |
 
 #### DiscordGateway Constructor
@@ -198,6 +200,12 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | `stop` | `()` | `void` | Close the WebSocket and clear heartbeat timer |
 | `updatePresence` | `(statusText?: string, activityType?: number)` | `void` | Update bot presence on the live gateway connection |
 
+### Exported Functions (from reaction-handler.ts)
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `handleReaction` | `(ctx: ReactionHandlerContext, data: DiscordReactionData)` | `void` | Handle a MESSAGE_REACTION_ADD event — maps emoji reactions to reputation feedback |
+
 ### Exported Types (from extracted modules)
 
 | Type | Source | Description |
@@ -208,6 +216,7 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | `ThreadSessionInfo` | `thread-manager.ts` | Thread-to-session mapping info (sessionId, agentName, agentModel, ownerUserId, topic?) |
 | `MentionSessionInfo` | `message-handler.ts` | Session info for mention-reply context in channels (sessionId, agentName, agentModel) |
 | `ThreadCallbackInfo` | `thread-manager.ts` | Active subscription info per thread (sessionId, callback) |
+| `ReactionHandlerContext` | `reaction-handler.ts` | Context object for reaction handler (db, botUserId, scorer, mentionSessions, threadSessions) |
 | `assertInteractionToken` | `embeds.ts` | Validate a Discord interaction token |
 
 ### Exported Types (from types.ts)
@@ -224,7 +233,8 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | `DiscordInteractionOption` | `{ name, type, value?, options?: DiscordInteractionOption[] }` — recursive option type for subcommands and subcommand groups |
 | `DiscordInteractionData` | Slash command interaction payload from gateway |
 | `GatewayOp` | Constants for gateway opcodes (DISPATCH=0, HEARTBEAT=1, IDENTIFY=2, PRESENCE_UPDATE=3, RESUME=6, RECONNECT=7, INVALID_SESSION=9, HELLO=10, HEARTBEAT_ACK=11) |
-| `GatewayIntent` | Bit flags: `GUILDS` (1<<0), `GUILD_MEMBERS` (1<<1), `GUILD_MESSAGES` (1<<9), `MESSAGE_CONTENT` (1<<15) |
+| `GatewayIntent` | Bit flags: `GUILDS` (1<<0), `GUILD_MEMBERS` (1<<1), `GUILD_MESSAGES` (1<<9), `GUILD_MESSAGE_REACTIONS` (1<<10), `MESSAGE_CONTENT` (1<<15) |
+| `DiscordReactionData` | `{ user_id, channel_id, message_id, guild_id?, emoji: { id, name } }` — payload from MESSAGE_REACTION_ADD |
 | `PermissionLevel` | Constants: `BLOCKED=0, BASIC=1, STANDARD=2, ADMIN=3` |
 | `ComponentType` | Constants for Discord component types: `ACTION_ROW=1, BUTTON=2` |
 | `ButtonStyle` | Constants for Discord button styles: `PRIMARY=1, SECONDARY=2, SUCCESS=3, DANGER=4` |
@@ -245,7 +255,7 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 6. **Session resume**: On reconnection, if a `sessionId` exists, a RESUME is sent instead of IDENTIFY. On INVALID_SESSION with `resumable=false`, the session ID is cleared and IDENTIFY is used
 7. **INVALID_SESSION delay**: After receiving INVALID_SESSION, the bridge waits 1-5 seconds (random) before re-identifying, per Discord documentation
 8. **Reconnection backoff**: Exponential backoff with `delay = min(1000 * 2^attempt, 60000)`. Maximum 10 reconnect attempts before giving up and setting `running = false`
-9. **Gateway intents**: Requests `GUILD_MESSAGES` and `MESSAGE_CONTENT` intents during IDENTIFY. When `publicMode` is enabled, also requests `GUILDS` and `GUILD_MEMBERS` for role data
+9. **Gateway intents**: Requests `GUILD_MESSAGES`, `GUILD_MESSAGE_REACTIONS`, and `MESSAGE_CONTENT` intents during IDENTIFY. When `publicMode` is enabled, also requests `GUILDS` and `GUILD_MEMBERS` for role data
 10. **Bot presence**: Set via the `presence` field in IDENTIFY payload. Configurable via `DISCORD_STATUS` and `DISCORD_ACTIVITY_TYPE` env vars. Can be updated at runtime via `updatePresence()`
 
 ### Channel Message Handling (Passive Mode)
@@ -282,6 +292,12 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 29. **Typing indicators**: A typing indicator is sent when a message is received and periodically refreshed (every 8s) while the agent is responding, since Discord typing indicators expire after ~10 seconds
 30. **Message reactions**: Thread titles are updated with a ✓ prefix when the session completes
 31. **Stale thread auto-archive**: Threads inactive for 2 hours are automatically archived with a closing message. The stale check runs every 10 minutes. Thread sessions and subscriptions are cleaned up on archive
+
+### Reaction Feedback
+
+32. **Reaction-based reputation feedback**: When a user reacts with a feedback emoji (👍 or 👎) on a bot message, the reaction is mapped to a `response_feedback` record with source `discord`. The session is resolved from `mentionSessions` (for channel replies) or `threadSessions` (for thread messages). Bot self-reactions are ignored. Non-feedback emojis are silently ignored
+33. **Reaction rate limiting**: Each user is limited to 5 feedback reactions per 60-second sliding window. Rate limits are per-user, independent of each other. Rate-limited reactions are silently dropped
+34. **Reputation event recording**: Each feedback reaction also records a reputation event via `ReputationScorer.recordEvent()` with `eventType: 'feedback_received'` and `scoreImpact: +2` (positive) or `-2` (negative)
 
 ### Commands
 
@@ -444,6 +460,7 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | `server/lib/logger.ts` | `createLogger` |
 | `server/lib/prompt-injection.ts` | `scanForInjection` |
 | `server/work/service.ts` | `WorkTaskService` (optional, for work_intake mode) |
+| `server/reputation/scorer.ts` | `ReputationScorer` (optional, for reaction feedback) |
 
 ### Consumed By
 
@@ -485,3 +502,4 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | 2026-03-10 | corvid-agent | v9: `/admin` slash command with subcommand groups for managing channels (add/remove/list), users (add/remove/list), roles (set/remove/list), bridge mode, and public mode — all from within Discord using native mentions. `DiscordInteractionOption` recursive type for nested subcommands. Audit logging on every config mutation. `/help` updated with Admin Configuration section. 20 new tests |
 | 2026-03-11 | corvid-agent | v10: Decomposed bridge.ts (2688→367 lines) into 6 extracted modules: `commands.ts` (slash command registration & handling), `admin-commands.ts` (/admin subcommands), `embeds.ts` (Discord API helpers & embed builders), `message-handler.ts` (message routing & dispatch), `permissions.ts` (RBAC & rate limiting), `thread-manager.ts` (thread lifecycle & streaming). Bridge.ts retained as thin orchestration layer. No behavioral changes — pure refactoring. Closes #932 |
 | 2026-03-14 | corvid-agent | v11: Added `/tasks`, `/schedule`, `/config` slash commands. `/tasks` shows active work tasks with status emojis and queue counts. `/schedule` shows active schedules with Discord relative timestamps for next/last runs. `/config` is admin-only ephemeral embed showing mode, channels, and permission settings. Updated `/help` embed. 6 new tests. Closes #894 |
+| 2026-03-16 | corvid-agent | v12: Discord reaction listener for reputation feedback. Added `GUILD_MESSAGE_REACTIONS` intent, `MESSAGE_REACTION_ADD` dispatch handler, `reaction-handler.ts` module with emoji-to-sentiment mapping, per-user rate limiting (5/min), session resolution from mentionSessions and threadSessions, `response_feedback` insertion, and reputation event recording. `setReputationScorer()` setter on DiscordBridge. 11 new tests. Closes #1161 |


### PR DESCRIPTION
## Summary

- Wire Discord emoji reactions (👍/👎) on bot messages to `response_feedback` records and reputation scoring
- Add `GUILD_MESSAGE_REACTIONS` gateway intent and `MESSAGE_REACTION_ADD` dispatch handler
- Create `reaction-handler.ts` with per-user rate limiting (5 reactions/min), session resolution from both `mentionSessions` and `threadSessions`, and reputation event recording via `ReputationScorer`
- Expose `setReputationScorer()` on `DiscordBridge` and wire it in `bootstrap.ts`

## Test plan

- [x] 11 unit tests covering: positive/negative emoji feedback, non-feedback emoji ignored, bot self-reactions ignored, rate limiting, unknown message graceful handling, missing scorer graceful handling, reputation event recording, independent per-user rate limits
- [x] `bun x tsc` passes with no errors
- [x] `bun run spec:check` passes (148/148 specs, 391/391 file coverage)

Closes #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)