### PR TITLE
chore: release v0.35.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version to v0.35.1 (patch release)
- Includes fix from #1193: merge `process.env` into SDK MCP server environment so external MCP servers (like Figma) work correctly during `/session` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)