### PR TITLE
docs: add troubleshooting, configuration, and CLI reference

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,382 @@
+# CLI Reference
+
+The `corvid-agent` CLI provides commands for managing agents, sessions, and configuration. It communicates with a running corvid-agent server.
+
+```bash
+corvid-agent [command] [options]
+```
+
+Global options:
+
+| Flag | Description |
+|------|-------------|
+| `--help`, `-h` | Show help (works on any command) |
+| `--version`, `-v` | Show version |
+| `--agent <id>` | Agent ID override |
+| `--project <id>` | Project ID override |
+| `--model <model>` | Model override |
+
+---
+
+## Table of Contents
+
+- [Interactive REPL](#interactive-repl)
+- [init](#init)
+- [demo](#demo)
+- [chat](#chat)
+- [status](#status)
+- [agent](#agent)
+- [session](#session)
+- [config](#config)
+- [login](#login)
+- [logout](#logout)
+
+---
+
+## Interactive REPL
+
+Start an interactive chat session with an agent.
+
+```bash
+corvid-agent
+corvid-agent --agent <id>
+```
+
+| Option | Description |
+|--------|-------------|
+| `--agent <id>` | Agent to chat with. If omitted, uses the default or prompts to pick one. |
+
+### REPL commands
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show available commands |
+| `/agent` | Switch to a different agent |
+| `/clear` | Clear conversation history |
+| `/status` | Show server status |
+| `/quit`, `/exit` | Exit the REPL |
+| `!<cmd>` | Run a shell command (e.g. `!ls -la`) |
+
+### Examples
+
+```bash
+# Start interactive mode with default agent
+corvid-agent
+
+# Start with a specific agent
+corvid-agent --agent abc12345
+```
+
+---
+
+## init
+
+Interactive project setup. Creates `.env`, installs dependencies, and optionally creates your first agent.
+
+```bash
+corvid-agent init [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--mcp` | MCP-only setup: adds corvid-agent as an MCP server to Claude Code, Cursor, VS Code Copilot, and OpenCode. Also installs Agent Skills. |
+| `--full` | Full setup including Angular dashboard build. |
+| `--yes`, `-y` | Non-interactive mode with sensible defaults. Auto-detects Claude CLI and Ollama. |
+
+### What init does
+
+1. **Checks prerequisites** — Bun 1.3+, Git (required); Ollama, Claude CLI, Docker (optional)
+2. **Creates `.env`** — Prompts for API keys, port, network (or uses defaults with `--yes`)
+3. **Installs dependencies** — Runs `bun install`
+4. **Builds dashboard** — Only with `--full`; otherwise prints instructions
+5. **Creates default agent** — Prompts for name (or uses "Assistant" with `--yes`)
+
+If run outside a corvid-agent directory, init offers to clone the repository first.
+
+### Examples
+
+```bash
+# Guided interactive setup
+corvid-agent init
+
+# Full unattended setup
+corvid-agent init --full --yes
+
+# Just add MCP tools to your AI editor
+corvid-agent init --mcp
+```
+
+---
+
+## demo
+
+Run a self-contained demo session. Starts a temporary server (or uses a running one), creates a demo agent, and streams a sample conversation. Everything is cleaned up on exit.
+
+```bash
+corvid-agent demo
+```
+
+No options. The demo uses port 3001 by default (to avoid conflicting with a running server on 3000). If a server is already running on port 3000, it uses that instead.
+
+### Examples
+
+```bash
+corvid-agent demo
+```
+
+---
+
+## chat
+
+Send a one-shot message to an agent and stream the response.
+
+```bash
+corvid-agent chat "<prompt>" [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--agent <id>` | Agent ID. If omitted, uses the default or prompts to pick one. |
+| `--project <id>` | Project ID. If omitted, auto-detects from the current working directory. |
+| `--model <model>` | Model override for this message. |
+
+The command connects via WebSocket, sends the prompt, streams the response (including tool use and thinking indicators), then exits.
+
+### Examples
+
+```bash
+# Ask a question
+corvid-agent chat "What files are in this project?"
+
+# Use a specific agent
+corvid-agent chat "Fix the bug in auth.ts" --agent abc12345
+
+# Override the model
+corvid-agent chat "Summarize recent changes" --model claude-sonnet-4-20250514
+```
+
+---
+
+## status
+
+Check server health and display status information.
+
+```bash
+corvid-agent status
+```
+
+Shows:
+
+- Server status and URL
+- Uptime
+- Active sessions count
+- AlgoChat enabled/disabled
+- Scheduler status (active schedules, running executions)
+- Workflow status (total workflows, active runs)
+
+### Examples
+
+```bash
+corvid-agent status
+```
+
+---
+
+## agent
+
+Manage agents.
+
+```bash
+corvid-agent agent <action> [id] [options]
+```
+
+### Actions
+
+#### `agent list`
+
+List all agents in a table showing ID, name, model, provider, permission mode, AlgoChat status, and whether each is the default.
+
+```bash
+corvid-agent agent list
+```
+
+#### `agent get <id>`
+
+Show details for a specific agent: name, model, permission mode, description, AlgoChat status, wallet address, and creation date.
+
+```bash
+corvid-agent agent get <id>
+```
+
+#### `agent create`
+
+Create a new agent.
+
+```bash
+corvid-agent agent create --name <name> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--name <name>` | Agent name (required) |
+| `--description <text>` | Agent description |
+| `--model <model>` | Model to use (e.g. `claude-sonnet-4-20250514`) |
+| `--system-prompt <text>` | System prompt for the agent |
+
+### Examples
+
+```bash
+corvid-agent agent list
+corvid-agent agent get abc12345
+corvid-agent agent create --name "Reviewer" --model claude-sonnet-4-20250514
+corvid-agent agent create --name "Writer" --description "Writes documentation"
+```
+
+---
+
+## session
+
+Manage sessions.
+
+```bash
+corvid-agent session <action> [id]
+```
+
+### Actions
+
+#### `session list`
+
+List all sessions in a table showing ID, status, agent, source, turn count, cost, and creation date.
+
+```bash
+corvid-agent session list
+```
+
+#### `session get <id>`
+
+Show session details: status, agent, project, source, turns, cost, creation date, and initial prompt (truncated).
+
+```bash
+corvid-agent session get <id>
+```
+
+#### `session stop <id>`
+
+Stop a running session.
+
+```bash
+corvid-agent session stop <id>
+```
+
+#### `session resume <id>`
+
+Resume a stopped session.
+
+```bash
+corvid-agent session resume <id>
+```
+
+### Examples
+
+```bash
+corvid-agent session list
+corvid-agent session get abc12345
+corvid-agent session stop abc12345
+corvid-agent session resume abc12345
+```
+
+---
+
+## config
+
+Manage CLI configuration. Config is stored in `~/.corvid/config.json`.
+
+```bash
+corvid-agent config [action] [key] [value]
+```
+
+### Actions
+
+#### `config show`
+
+Show all config values. This is the default when no action is given.
+
+```bash
+corvid-agent config
+corvid-agent config show
+```
+
+#### `config get <key>`
+
+Get a specific config value.
+
+```bash
+corvid-agent config get <key>
+```
+
+#### `config set <key> <value>`
+
+Set a config value. Use `"null"` to clear a value.
+
+```bash
+corvid-agent config set <key> <value>
+```
+
+### Valid keys
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `serverUrl` | Server URL | `http://127.0.0.1:3000` |
+| `authToken` | Authentication token | — |
+| `defaultAgent` | Default agent ID | — |
+| `defaultProject` | Default project ID | — |
+| `defaultModel` | Default model override | — |
+
+### Examples
+
+```bash
+corvid-agent config
+corvid-agent config get serverUrl
+corvid-agent config set serverUrl http://localhost:3578
+corvid-agent config set defaultAgent abc123
+corvid-agent config set authToken null    # clear the token
+```
+
+---
+
+## login
+
+Log in to CorvidAgent Cloud using the device authorization flow. Opens a browser, displays a user code, and waits for authorization.
+
+```bash
+corvid-agent login [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--server <url>` | Server URL (default: from config or `http://127.0.0.1:3000`) |
+
+The token is saved to `~/.corvid/config.json`.
+
+### Examples
+
+```bash
+corvid-agent login
+corvid-agent login --server https://your-server.example.com
+```
+
+---
+
+## logout
+
+Log out by removing the saved authentication token from `~/.corvid/config.json`.
+
+```bash
+corvid-agent logout
+```
+
+### Examples
+
+```bash
+corvid-agent logout
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,367 @@
+# Configuration Reference
+
+All configuration is done via environment variables in a `.env` file at the project root. Bun loads `.env` automatically — no extra packages needed.
+
+```bash
+cp .env.example .env
+```
+
+Or run `corvid-agent init` for guided setup.
+
+For the annotated source, see [.env.example](../.env.example).
+
+---
+
+## Table of Contents
+
+- [Minimal Configuration](#minimal-configuration)
+- [AI Provider](#ai-provider)
+- [Server](#server)
+- [Logging](#logging)
+- [Algorand / AlgoChat](#algorand--algochat)
+- [Localnet URL Overrides](#localnet-url-overrides)
+- [Wallet Security](#wallet-security)
+- [Spending Limits](#spending-limits)
+- [Rate Limiting](#rate-limiting)
+- [Agent Sessions](#agent-sessions)
+- [Ollama](#ollama)
+- [Multi-Model Provider Routing](#multi-model-provider-routing)
+- [Council Model Override](#council-model-override)
+- [GitHub Integration](#github-integration)
+- [Work Tasks](#work-tasks)
+- [Web Search](#web-search)
+- [Notifications](#notifications)
+- [Telegram Bridge](#telegram-bridge)
+- [Discord Bridge](#discord-bridge)
+- [Voice](#voice)
+- [Billing](#billing)
+- [Observability](#observability)
+- [Sandbox](#sandbox)
+- [Multi-Tenant](#multi-tenant)
+- [Database Backups](#database-backups)
+- [Directory Browsing Security](#directory-browsing-security)
+- [MCP Stdio Mode](#mcp-stdio-mode)
+
+---
+
+## Minimal Configuration
+
+To get started, you only need one AI provider. Everything else has sensible defaults.
+
+**Claude API (recommended):**
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+**Claude Code CLI (uses your existing subscription):**
+
+No environment variables needed — if the `claude` CLI is on your PATH, corvid-agent uses it automatically.
+
+**Local only (Ollama):**
+
+```bash
+ENABLED_PROVIDERS=ollama
+```
+
+---
+
+## AI Provider
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `ANTHROPIC_API_KEY` | Anthropic API key for Claude models | — | No (one provider needed) |
+
+When no `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` is set, the system auto-restricts to Ollama and validates connectivity on startup. If Claude Code CLI is installed (`claude` on PATH), it is used automatically without an API key.
+
+---
+
+## Server
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `PORT` | HTTP server port | `3000` | No |
+| `BIND_HOST` | Bind address. `127.0.0.1` = localhost only (safe default). Set to `0.0.0.0` for Docker/VM — requires `API_KEY`. | `127.0.0.1` | No |
+| `API_KEY` | API key for HTTP/WS authentication. Required when `BIND_HOST` is not localhost. | — | Conditional |
+| `ADMIN_API_KEY` | Separate API key for elevated admin operations. | — | No |
+| `ALLOWED_ORIGINS` | Comma-separated allowed CORS origins. | `*` on localhost | No |
+| `PUBLIC_URL` | Public URL for device auth flow callbacks. | — | No |
+
+---
+
+## Logging
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `LOG_LEVEL` | Log verbosity: `debug`, `info`, `warn`, `error` | `info` | No |
+| `LOG_FORMAT` | Output format: `text` (human-readable) or `json` (structured) | `text` | No |
+
+---
+
+## Algorand / AlgoChat
+
+On-chain identity and messaging via Algorand. Optional for local development.
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `ALGOCHAT_MNEMONIC` | 25-word Algorand mnemonic for the agent's wallet | — | No |
+| `ALGORAND_NETWORK` | Network: `localnet`, `testnet`, `mainnet` | `localnet` | No |
+| `AGENT_NETWORK` | Network for agent sub-wallets | Value of `ALGORAND_NETWORK` | No |
+| `ALGOCHAT_SYNC_INTERVAL` | Polling interval for new messages (ms) | `30000` | No |
+| `ALGOCHAT_DEFAULT_AGENT_ID` | Default agent profile ID (UUID). Auto-created if blank. | — | No |
+| `ALGOCHAT_PSK_URI` | Pre-shared key URI for encrypted channels | — | No |
+| `ALGOCHAT_OWNER_ADDRESSES` | Comma-separated Algorand addresses authorized as owner | — | No |
+| `ALGORAND_INDEXER_URL` | Indexer URL for on-chain reputation verification | `https://mainnet-idx.algonode.cloud` | No |
+
+---
+
+## Localnet URL Overrides
+
+For Docker/container deployments where localhost points to the container, not the host.
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `LOCALNET_ALGOD_URL` | Algod URL for localnet | `http://localhost:4001` | No |
+| `LOCALNET_KMD_URL` | KMD URL for localnet | `http://localhost:4002` | No |
+| `LOCALNET_INDEXER_URL` | Indexer URL for localnet | `http://localhost:8980` | No |
+
+On Docker Desktop (macOS/Windows), use `http://host.docker.internal:<port>`. On Linux Docker, add `--add-host=host.docker.internal:host-gateway` to your run command.
+
+---
+
+## Wallet Security
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `WALLET_ENCRYPTION_KEY` | AES-256 encryption key for agent sub-wallets at rest | Derived from `ALGOCHAT_MNEMONIC` on localnet | Conditional |
+| `WALLET_KEYSTORE_PATH` | Path to the wallet keystore file | `./wallet-keystore.json` | No |
+
+`WALLET_ENCRYPTION_KEY` is required on testnet/mainnet if `ALGOCHAT_MNEMONIC` is set.
+
+---
+
+## Spending Limits
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `DAILY_ALGO_LIMIT_MICRO` | Daily ALGO spending cap in microALGOs | `10000000` (10 ALGO) | No |
+
+---
+
+## Rate Limiting
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `RATE_LIMIT_GET` | Global per-IP GET requests per minute | `600` | No |
+| `RATE_LIMIT_MUTATION` | Global per-IP mutation requests per minute | `60` | No |
+
+Per-endpoint rate limiting is enabled by default. Different auth tiers receive different limits:
+
+| Tier | Reads | Mutations |
+|------|-------|-----------|
+| Public | `RATE_LIMIT_GET / 2` | `RATE_LIMIT_MUTATION / 2` |
+| User | `RATE_LIMIT_GET` | `RATE_LIMIT_MUTATION` |
+| Admin | `RATE_LIMIT_GET * 2` | `RATE_LIMIT_MUTATION * 2` |
+
+Exempt paths: `/api/health`, `/webhooks/github`, `/ws`, `/.well-known/agent-card.json`.
+
+All responses include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers.
+
+---
+
+## Agent Sessions
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `AGENT_TIMEOUT_MS` | Session timeout in milliseconds | `1800000` (30 min) | No |
+
+---
+
+## Ollama
+
+Local LLM provider. Only needed if using Ollama.
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `OLLAMA_HOST` | Ollama API URL | `http://localhost:11434` | No |
+| `OLLAMA_MAX_PARALLEL` | Max concurrent requests | `1` | No |
+| `OLLAMA_NUM_CTX` | Context window size per request | `16384` | No |
+| `OLLAMA_NUM_PREDICT` | Max tokens to predict per response | `2048` | No |
+| `OLLAMA_NUM_GPU` | Number of GPU layers (`-1` = all) | `-1` | No |
+| `OLLAMA_NUM_BATCH` | Batch size for prompt processing | `512` | No |
+| `OLLAMA_REQUEST_TIMEOUT` | Request timeout in ms | `1800000` (30 min) | No |
+
+---
+
+## Multi-Model Provider Routing
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `ENABLED_PROVIDERS` | Comma-separated list: `anthropic`, `ollama` | Auto-detected from available keys | No |
+
+Set `ENABLED_PROVIDERS=ollama` for 100% local mode.
+
+---
+
+## Council Model Override
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `COUNCIL_MODEL` | Model for council chairman/synthesis (e.g. `qwen3:32b`) | Same as agent model | No |
+
+Only applies to council sessions with `councilRole=chairman`.
+
+---
+
+## GitHub Integration
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `GH_TOKEN` | GitHub token for work tasks, PRs, webhooks, and mention polling | — | No |
+| `GITHUB_WEBHOOK_SECRET` | HMAC SHA-256 secret for validating incoming webhook payloads | — | No |
+
+The `GH_TOKEN` needs the `repo` scope for PR creation and webhook operations.
+
+---
+
+## Work Tasks
+
+Self-improvement workflow configuration.
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `WORKTREE_BASE_DIR` | Base directory for git worktrees | Sibling `.corvid-worktrees` directory | No |
+| `WORK_MAX_ITERATIONS` | Max validation iterations before marking a task as failed | `3` | No |
+| `WORK_TASK_MAX_PER_DAY` | Max work tasks an agent can create per day | `100` | No |
+
+---
+
+## Web Search
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `BRAVE_SEARCH_API_KEY` | Brave Search API key for `corvid_web_search` and `corvid_deep_research` tools | — | No |
+
+---
+
+## Notifications
+
+All notification channels are optional. Agents can override global settings via the `corvid_configure_notifications` tool.
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `DISCORD_WEBHOOK_URL` | Discord webhook URL for notifications | — | No |
+| `TELEGRAM_BOT_TOKEN` | Telegram bot token (shared with Telegram bridge) | — | No |
+| `TELEGRAM_CHAT_ID` | Telegram chat ID for notifications | — | No |
+| `NOTIFICATION_GITHUB_REPO` | GitHub repo for issue-based notifications | — | No |
+| `WHATSAPP_ACCESS_TOKEN` | WhatsApp access token | — | No |
+| `SIGNAL_API_URL` | Signal messenger API URL (requires signal-cli-rest-api) | — | No |
+| `SIGNAL_SENDER_NUMBER` | Signal sender phone number | — | No |
+
+---
+
+## Telegram Bridge
+
+Bidirectional bridge for talking to agents from Telegram.
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `TELEGRAM_BOT_TOKEN` | Telegram bot token (shared with notifications) | — | No |
+| `TELEGRAM_ALLOWED_USER_IDS` | Comma-separated Telegram numeric user IDs (empty = allow all) | — | No |
+
+---
+
+## Discord Bridge
+
+Bidirectional bridge for talking to agents from Discord.
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `DISCORD_BOT_TOKEN` | Discord bot token (requires MESSAGE_CONTENT intent) | — | No |
+| `DISCORD_CHANNEL_ID` | Discord channel ID to listen in | — | No |
+
+---
+
+## Voice
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `OPENAI_API_KEY` | OpenAI API key for TTS/STT in Telegram voice notes | — | No |
+
+---
+
+## Billing
+
+Optional Stripe integration.
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `STRIPE_SECRET_KEY` | Stripe secret key | — | No |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret | — | No |
+
+---
+
+## Observability
+
+Optional OpenTelemetry tracing.
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint for trace export | — (tracing disabled) | No |
+| `OTEL_SERVICE_NAME` | Service name for traces | `corvid-agent` | No |
+
+---
+
+## Sandbox
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `SANDBOX_ENABLED` | Enable Docker container sandboxing for agent execution | `false` | No |
+
+---
+
+## Multi-Tenant
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `MULTI_TENANT` | Enable multi-tenant isolation and billing | `false` | No |
+
+When enabled:
+
+- `POST /api/tenants/register` becomes available (public, no auth)
+- Each tenant gets isolated agents, sessions, projects, and work tasks
+- API keys are mapped to tenants via the `api_keys` table
+- Tenant members get RBAC roles (owner, operator, viewer)
+- Plan-based limits are enforced (agent count, session count, etc.)
+
+When false (default): single-tenant mode, all data uses `tenant_id='default'`.
+
+---
+
+## Database Backups
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `BACKUP_DIR` | Directory for database backup files | `./backups` | No |
+| `BACKUP_MAX_KEEP` | Maximum number of backup files to keep | `10` | No |
+
+---
+
+## Directory Browsing Security
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `ALLOWED_BROWSE_ROOTS` | Comma-separated additional directories the `/api/browse-dirs` endpoint may serve | Home directory + registered project dirs | No |
+
+---
+
+## MCP Stdio Mode
+
+Only needed when running corvid-agent as an MCP stdio server for external clients.
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `CORVID_AGENT_ID` | Agent ID for MCP stdio mode | — | No |
+| `CORVID_API_URL` | API URL for MCP stdio mode | `http://localhost:3000` | No |
+
+Set up MCP integration with `corvid-agent init --mcp`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,373 @@
+# Troubleshooting
+
+Common issues and how to resolve them. For quick setup help, see the [Quickstart](quickstart.md).
+
+---
+
+## Table of Contents
+
+- [Server won't start](#server-wont-start)
+- [Agent doesn't respond](#agent-doesnt-respond)
+- [PR creation fails](#pr-creation-fails)
+- [Dashboard issues](#dashboard-issues)
+- [AlgoChat issues](#algochat-issues)
+- [Session issues](#session-issues)
+- [Common error messages](#common-error-messages)
+- [Getting help](#getting-help)
+
+---
+
+## Server won't start
+
+### Port already in use
+
+```
+error: Failed to start server on port 3000
+```
+
+Another process is using port 3000. Find and stop it, or use a different port:
+
+```bash
+# Find what's using port 3000
+lsof -i :3000
+
+# Use a different port
+PORT=3001 bun run dev
+```
+
+### Missing dependencies
+
+```
+error: Cannot find module '...'
+```
+
+Run `bun install` to install dependencies. If the error persists, delete `node_modules` and reinstall:
+
+```bash
+rm -rf node_modules
+bun install
+```
+
+### Bun version too old
+
+```
+error: Unsupported Bun version
+```
+
+corvid-agent requires Bun 1.3 or later. Check your version and update:
+
+```bash
+bun --version
+bun upgrade
+```
+
+### Database locked
+
+```
+error: SQLITE_BUSY: database is locked
+```
+
+Another corvid-agent process is using the database. Check for and stop other instances:
+
+```bash
+# Find other corvid-agent processes
+ps aux | grep corvid-agent
+
+# Or check for processes holding the DB file open
+lsof corvid-agent.db
+```
+
+If the database is corrupted, you can reset it by deleting `corvid-agent.db` and restarting. This removes all local data (agents, sessions, schedules).
+
+### Missing .env file
+
+```
+warn: No .env file found
+```
+
+Copy the example and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+Or run `corvid-agent init` for guided setup.
+
+---
+
+## Agent doesn't respond
+
+### No AI provider configured
+
+If no `ANTHROPIC_API_KEY` is set, no Claude Code CLI is installed, and no Ollama is running, the agent has no model to use. Configure at least one provider:
+
+| Provider | What to set |
+|----------|-------------|
+| Claude API | `ANTHROPIC_API_KEY=sk-ant-...` in `.env` |
+| Claude Code CLI | Install [Claude Code](https://claude.com/claude-code) (uses your subscription) |
+| Ollama | Install [Ollama](https://ollama.com) and pull a model 8B+ |
+
+### Invalid or expired API key
+
+Verify your Anthropic API key is valid:
+
+```bash
+curl -s https://api.anthropic.com/v1/messages \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01"
+```
+
+A 401 response means the key is invalid or expired. Generate a new one at [console.anthropic.com](https://console.anthropic.com).
+
+### Model unavailable
+
+If using a specific model that is not available on your plan or provider, the agent will fail silently. Check the server logs (the terminal running `bun run dev`) for model-related errors.
+
+### Ollama not running
+
+For local-only mode, verify Ollama is running and has a model available:
+
+```bash
+# Check Ollama is running
+curl http://localhost:11434/api/tags
+
+# List available models
+ollama list
+
+# Pull a model if none are available (8B+ recommended)
+ollama pull llama3.1:8b
+```
+
+If Ollama is running on a non-default host, set `OLLAMA_HOST` in `.env`.
+
+### Server not reachable from CLI
+
+The CLI connects to the server URL in its config (default: `http://127.0.0.1:3000`). Verify the server is running:
+
+```bash
+corvid-agent status
+```
+
+If the server is on a different URL:
+
+```bash
+corvid-agent config set serverUrl http://localhost:3001
+```
+
+---
+
+## PR creation fails
+
+### GH_TOKEN missing
+
+```
+error: GitHub token not configured
+```
+
+Set a GitHub personal access token in `.env`:
+
+```bash
+GH_TOKEN=ghp_your_token_here
+```
+
+The token needs the `repo` scope for creating PRs.
+
+### GH_TOKEN expired or insufficient permissions
+
+Verify your token works:
+
+```bash
+gh auth status
+```
+
+If the token is expired, generate a new one at [github.com/settings/tokens](https://github.com/settings/tokens) with the `repo` scope.
+
+### No push access to the target repository
+
+The agent needs write (push) access to the repository. Verify:
+
+- You are a collaborator or member of the org that owns the repo
+- The token has the `repo` scope
+- Branch protection rules allow the push
+
+### Rate limiting
+
+GitHub has API rate limits. If the agent is making many requests, it may hit the limit. Check your remaining quota:
+
+```bash
+curl -s -H "Authorization: token $GH_TOKEN" https://api.github.com/rate_limit | jq '.rate'
+```
+
+---
+
+## Dashboard issues
+
+### Blank page
+
+The Angular dashboard needs to be built before it can be served:
+
+```bash
+bun run build:client
+```
+
+Then restart the server. The dashboard should be available at `http://localhost:3000`.
+
+### Build errors
+
+If `bun run build:client` fails, check that Node.js dependencies are installed:
+
+```bash
+cd client
+bun install
+cd ..
+bun run build:client
+```
+
+### CORS errors in browser console
+
+If you see CORS errors, the browser is trying to reach the API from a different origin. Set `ALLOWED_ORIGINS` in `.env`:
+
+```bash
+# Allow a specific origin
+ALLOWED_ORIGINS=http://localhost:4200
+
+# Allow multiple origins
+ALLOWED_ORIGINS=http://localhost:4200,https://yourdomain.com
+```
+
+By default, CORS is permissive (`*`) when `BIND_HOST` is localhost.
+
+### WebSocket connection failures
+
+The dashboard uses WebSocket connections for real-time updates. If the connection drops:
+
+- Check that the server is still running
+- Check for proxy or firewall rules blocking WebSocket upgrades
+- If behind a reverse proxy (nginx, Caddy), ensure WebSocket passthrough is configured
+
+---
+
+## AlgoChat issues
+
+### Localnet not running
+
+```
+error: Failed to connect to Algorand localnet
+```
+
+AlgoChat on localnet requires AlgoKit's localnet (Docker-based):
+
+```bash
+# Install AlgoKit if needed
+pipx install algokit
+
+# Start localnet
+algokit localnet start
+
+# Verify it's running
+curl http://localhost:4001/versions
+```
+
+Docker must be running for localnet to work.
+
+### Wallet not funded
+
+On localnet, wallets are automatically funded from the default faucet. If you see insufficient-funds errors:
+
+1. Verify localnet is running: `algokit localnet status`
+2. Restart localnet: `algokit localnet reset`
+3. Restart the corvid-agent server
+
+On testnet, you need to fund your wallet from the [Algorand testnet dispenser](https://bank.testnet.algorand.network/).
+
+### Invalid mnemonic
+
+```
+error: Invalid mnemonic
+```
+
+The `ALGOCHAT_MNEMONIC` must be a valid 25-word Algorand mnemonic. Generate one with:
+
+```bash
+algokit task wallet new
+```
+
+### Docker networking (container deployments)
+
+When running corvid-agent inside Docker, `localhost` points to the container, not the host. Set the localnet URL overrides in `.env`:
+
+```bash
+LOCALNET_ALGOD_URL=http://host.docker.internal:4001
+LOCALNET_KMD_URL=http://host.docker.internal:4002
+LOCALNET_INDEXER_URL=http://host.docker.internal:8980
+```
+
+On Linux Docker, also add `--add-host=host.docker.internal:host-gateway` to your `docker run` command.
+
+---
+
+## Session issues
+
+### Session timeout
+
+Sessions time out after 30 minutes of inactivity by default. To change this:
+
+```bash
+# In .env — set to 1 hour (in milliseconds)
+AGENT_TIMEOUT_MS=3600000
+```
+
+### Stuck sessions
+
+If a session shows as "running" but is not producing output:
+
+1. Check server logs for errors
+2. Stop the session via CLI or API:
+
+```bash
+corvid-agent session stop <session-id>
+```
+
+3. If the session cannot be stopped, restart the server
+
+### Session not found
+
+Session IDs are UUIDs. You can use a prefix (first 8 characters) in the CLI:
+
+```bash
+# List sessions to find the ID
+corvid-agent session list
+
+# Use the full ID or prefix
+corvid-agent session get abc12345
+```
+
+---
+
+## Common error messages
+
+| Error | Meaning | Fix |
+|-------|---------|-----|
+| `ECONNREFUSED` | Server is not running | Start the server: `bun run dev` |
+| `401 Unauthorized` | API key is missing or invalid | Set `API_KEY` in `.env` and `authToken` in CLI config |
+| `403 Forbidden` | Insufficient permissions | Check your role (owner/operator/viewer) |
+| `404 Not Found` | Resource doesn't exist | Verify the ID and that the resource was created |
+| `429 Too Many Requests` | Rate limit exceeded | Wait and retry; check `X-RateLimit-Reset` header |
+| `SQLITE_BUSY` | Database lock contention | Stop other corvid-agent processes |
+| `WebSocket error` | Connection to server lost | Check server is running; check network |
+| `Model not found` | Requested model unavailable | Check provider config and model name |
+
+---
+
+## Getting help
+
+If your issue is not covered here:
+
+1. Check the server logs — the terminal running `bun run dev` shows all activity and errors
+2. Run `corvid-agent status` to verify server health
+3. Search existing issues: [github.com/CorvidLabs/corvid-agent/issues](https://github.com/CorvidLabs/corvid-agent/issues)
+4. Open a new issue with:
+   - What you expected to happen
+   - What actually happened
+   - Server logs (relevant section)
+   - Your OS, Bun version (`bun --version`), and provider configuration


### PR DESCRIPTION
## Summary

Closes #1182 — fills the remaining documentation gaps in the onboarding flow (epic #595).

- **docs/troubleshooting.md** — Comprehensive guide covering 8 categories: server startup, agent response, PR creation, dashboard, AlgoChat, sessions, common error messages, and how to get help. Expands on the 4 scenarios previously in quickstart.md.
- **docs/configuration.md** — Browsable reference for all environment variables from .env.example (209 lines), organized into 25 sections with tables showing name, description, default, and required status. Includes minimal vs full config guidance.
- **docs/cli-reference.md** — Full CLI command reference for all 10 commands (interactive REPL, init, demo, chat, status, agent, session, config, login, logout) with usage, flags, REPL commands, and examples. Derived from actual source code in cli/commands/.

## Test plan

- [x] Verify `bun x tsc --noEmit --skipLibCheck` passes (confirmed locally)
- [x] Review docs for accuracy against source code
- [x] Check all internal links resolve correctly
- [x] Confirm style matches existing docs (quickstart.md, api-reference.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)