### PR TITLE
fix: add missing memory tools to MCP package and fix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ corvid-screenshots/
 *.swo
 *~
 .vscode/settings.json
+.claude/settings.json
 .idea/
 playwright-report/
 coverage/

--- a/packages/corvid-agent-mcp/src/server.ts
+++ b/packages/corvid-agent-mcp/src/server.ts
@@ -321,6 +321,89 @@ export function createCorvidMcpServer(config: CorvidMcpServerConfig): McpServer 
     },
   );
 
+  // ── Save Memory ──────────────────────────────────────────────
+
+  server.tool(
+    'corvid_save_memory',
+    'Save a memory with a key. Memories are stored locally and written on-chain for persistence.',
+    {
+      key: z.string().describe('Unique key for this memory'),
+      content: z.string().describe('The memory content to save'),
+    },
+    async ({ key, content }) => {
+      try {
+        const result = await client.post('/api/mcp/save-memory', { key, content });
+        return textResult(JSON.stringify(result, null, 2));
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  // ── Recall Memory ──────────────────────────────────────────────
+
+  server.tool(
+    'corvid_recall_memory',
+    'Recall a memory by key, search by query, or list recent memories.',
+    {
+      key: z.string().optional().describe('Exact key to recall'),
+      query: z.string().optional().describe('Search query to find matching memories'),
+    },
+    async ({ key, query }) => {
+      try {
+        const body: Record<string, unknown> = {};
+        if (key) body.key = key;
+        if (query) body.query = query;
+        const result = await client.post('/api/mcp/recall-memory', body);
+        return textResult(JSON.stringify(result, null, 2));
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  // ── Read On-Chain Memories ──────────────────────────────────────
+
+  server.tool(
+    'corvid_read_on_chain_memories',
+    'Read memories stored on-chain (Algorand). These are the permanent, immutable copies.',
+    {
+      search: z.string().optional().describe('Search term to filter memories'),
+      limit: z.number().optional().describe('Maximum number of memories to return (default 50)'),
+    },
+    async ({ search, limit }) => {
+      try {
+        const body: Record<string, unknown> = {};
+        if (search) body.search = search;
+        if (limit) body.limit = limit;
+        const result = await client.post('/api/mcp/read-on-chain-memories', body);
+        return textResult(JSON.stringify(result, null, 2));
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
+  // ── Sync On-Chain Memories ──────────────────────────────────────
+
+  server.tool(
+    'corvid_sync_on_chain_memories',
+    'Sync on-chain memories back to local SQLite. Restores memories that exist on-chain but are missing locally.',
+    {
+      limit: z.number().optional().describe('Maximum number of on-chain memories to sync (default 200)'),
+    },
+    async ({ limit }) => {
+      try {
+        const body: Record<string, unknown> = {};
+        if (limit) body.limit = limit;
+        const result = await client.post('/api/mcp/sync-on-chain-memories', body);
+        return textResult(JSON.stringify(result, null, 2));
+      } catch (err) {
+        return handleError(err);
+      }
+    },
+  );
+
   // ── Server Health ──────────────────────────────────────────────
 
   server.tool(

--- a/packages/corvid-agent-mcp/tsup.config.ts
+++ b/packages/corvid-agent-mcp/tsup.config.ts
@@ -9,10 +9,4 @@ export default defineConfig({
   splitting: false,
   treeshake: true,
   outDir: 'dist',
-  banner: ({ format }) => {
-    if (format === 'esm') {
-      return { js: '#!/usr/bin/env node' };
-    }
-    return {};
-  },
 });


### PR DESCRIPTION
## Summary
- Add 4 missing memory tool wrappers to the external MCP package: `corvid_save_memory`, `corvid_recall_memory`, `corvid_read_on_chain_memories`, `corvid_sync_on_chain_memories` (14 → 18 tools)
- Fix ESM build failure caused by duplicate shebang from tsup banner config
- Gitignore `.claude/settings.json` (contains machine-specific absolute paths)

## Context
The MCP package shipped in v0.36.0 with only 14 tools. The server API routes for memory operations existed but never got MCP tool wrappers in the external package — meaning I literally couldn't use the features I built. This fixes that.

## Test plan
- [x] `bun run build` succeeds in `packages/corvid-agent-mcp`
- [x] MCP server responds to `tools/list` with all 18 tools
- [x] `bun x tsc --noEmit` passes
- [x] 31 MCP server tests pass (0 failures)
- [x] MCP server responds to `initialize` over stdio

🤖 Generated with [Claude Code](https://claude.com/claude-code)