### PR TITLE
docs: add JSDoc to exported functions in server/lib/

### DIFF
--- a/server/lib/errors.ts
+++ b/server/lib/errors.ts
@@ -9,11 +9,25 @@
 
 // ── Base class ──────────────────────────────────────────────────────────────────
 
+/**
+ * Base error class for all application-level errors.
+ *
+ * Carries a machine-readable `code`, an HTTP `statusCode`, and optional
+ * structured `context` for the global error-handling middleware.
+ */
 export class AppError extends Error {
     readonly code: string;
     readonly statusCode: number;
     readonly context?: Record<string, unknown>;
 
+    /**
+     * @param message - Human-readable error description (logged server-side, not sent to clients).
+     * @param opts - Error metadata.
+     * @param opts.code - Machine-readable error code (e.g. 'VALIDATION_ERROR').
+     * @param opts.statusCode - HTTP status code to return.
+     * @param opts.context - Optional structured data for logging/debugging.
+     * @param opts.cause - Optional underlying error that caused this one.
+     */
     constructor(
         message: string,
         opts: { code: string; statusCode: number; context?: Record<string, unknown>; cause?: unknown },
@@ -26,48 +40,86 @@ export class AppError extends Error {
     }
 }
 
+/** Request validation error (400 Bad Request). */
 export class ValidationError extends AppError {
     readonly detail: string;
+    /**
+     * @param message - Description of the validation failure.
+     * @param context - Optional structured context for logging.
+     */
     constructor(message: string, context?: Record<string, unknown>) {
         super(message, { code: 'VALIDATION_ERROR', statusCode: 400, context });
         this.detail = message;
     }
 }
 
+/** Authentication failure (401 Unauthorized). */
 export class AuthenticationError extends AppError {
+    /**
+     * @param message - Description of the authentication failure.
+     * @param context - Optional structured context for logging.
+     */
     constructor(message: string, context?: Record<string, unknown>) {
         super(message, { code: 'AUTHENTICATION_ERROR', statusCode: 401, context });
     }
 }
 
+/** Insufficient permissions (403 Forbidden). */
 export class AuthorizationError extends AppError {
+    /**
+     * @param message - Description of the authorization failure.
+     * @param context - Optional structured context for logging.
+     */
     constructor(message: string, context?: Record<string, unknown>) {
         super(message, { code: 'AUTHORIZATION_ERROR', statusCode: 403, context });
     }
 }
 
+/** Resource not found (404 Not Found). */
 export class NotFoundError extends AppError {
+    /**
+     * @param resource - The type of resource (e.g. 'Agent', 'Session').
+     * @param id - Optional resource identifier for the error message.
+     * @param context - Optional structured context for logging.
+     */
     constructor(resource: string, id?: string, context?: Record<string, unknown>) {
         const msg = id ? `${resource} ${id} not found` : `${resource} not found`;
         super(msg, { code: 'NOT_FOUND', statusCode: 404, context });
     }
 }
 
+/** Resource conflict (409 Conflict). */
 export class ConflictError extends AppError {
+    /**
+     * @param message - Description of the conflict.
+     * @param context - Optional structured context for logging.
+     */
     constructor(message: string, context?: Record<string, unknown>) {
         super(message, { code: 'CONFLICT', statusCode: 409, context });
     }
 }
 
+/** Rate limit exceeded (429 Too Many Requests). */
 export class RateLimitError extends AppError {
     readonly retryAfter?: number;
+    /**
+     * @param message - Description of the rate limit violation.
+     * @param opts - Optional retry and context metadata.
+     * @param opts.retryAfter - Seconds until the client should retry.
+     * @param opts.context - Optional structured context for logging.
+     */
     constructor(message: string = 'Too many requests', opts?: { retryAfter?: number; context?: Record<string, unknown> }) {
         super(message, { code: 'RATE_LIMITED', statusCode: 429, context: opts?.context });
         this.retryAfter = opts?.retryAfter;
     }
 }
 
+/** Feature not yet implemented (501 Not Implemented). */
 export class NotImplementedError extends AppError {
+    /**
+     * @param feature - Name of the unimplemented feature.
+     * @param context - Optional additional context string.
+     */
     constructor(feature: string, context?: string) {
         const message = context
             ? `Not implemented: ${feature} — ${context}`
@@ -76,7 +128,13 @@ export class NotImplementedError extends AppError {
     }
 }
 
+/** Failure in an external dependency (502 Bad Gateway). */
 export class ExternalServiceError extends AppError {
+    /**
+     * @param service - Name of the external service that failed.
+     * @param message - Description of the failure.
+     * @param context - Optional structured context for logging.
+     */
     constructor(service: string, message: string, context?: Record<string, unknown>) {
         super(`${service}: ${message}`, {
             code: 'EXTERNAL_SERVICE_ERROR',
@@ -86,6 +144,12 @@ export class ExternalServiceError extends AppError {
     }
 }
 
+/**
+ * Type guard to check if an unknown error is an {@link AppError}.
+ *
+ * @param err - The value to check.
+ * @returns `true` if `err` is an instance of `AppError`.
+ */
 export function isAppError(err: unknown): err is AppError {
     return err instanceof AppError;
 }

--- a/server/lib/resilience.ts
+++ b/server/lib/resilience.ts
@@ -9,7 +9,11 @@ import { AppError } from './errors';
 
 // ── CircuitOpenError ────────────────────────────────────────────────────
 
+/** Thrown when a call is rejected because the circuit breaker is in the OPEN state. */
 export class CircuitOpenError extends AppError {
+    /**
+     * @param message - Optional custom message (defaults to a standard circuit-open message).
+     */
     constructor(message = 'Circuit breaker is OPEN — call rejected') {
         super(message, { code: 'CIRCUIT_OPEN', statusCode: 503 });
     }
@@ -35,6 +39,11 @@ export interface RetryOptions {
 /**
  * Retry `fn` with exponential backoff.
  * Formula: `min(baseDelayMs * multiplier^attempt, maxDelayMs) + random_jitter`
+ *
+ * @param fn - The async function to attempt.
+ * @param options - Retry behavior configuration (see {@link RetryOptions}).
+ * @returns The result of `fn` on the first successful attempt.
+ * @throws The last error if all attempts are exhausted, or immediately if `retryIf` returns false.
  */
 export async function withRetry<T>(
     fn: () => Promise<T>,
@@ -87,6 +96,13 @@ export interface CircuitBreakerOptions {
     successThreshold?: number;
 }
 
+/**
+ * Circuit breaker pattern implementation.
+ *
+ * Tracks failures and opens the circuit after a threshold is reached,
+ * rejecting subsequent calls until a reset timeout elapses. After the
+ * timeout, allows a probe call (HALF_OPEN) and closes on success.
+ */
 export class CircuitBreaker {
     private state: CircuitState = 'CLOSED';
     private failureCount = 0;
@@ -97,12 +113,21 @@ export class CircuitBreaker {
     private readonly resetTimeoutMs: number;
     private readonly successThreshold: number;
 
+    /**
+     * @param options - Circuit breaker thresholds and timing (see {@link CircuitBreakerOptions}).
+     */
     constructor(options: CircuitBreakerOptions = {}) {
         this.failureThreshold = options.failureThreshold ?? 3;
         this.resetTimeoutMs = options.resetTimeoutMs ?? 60_000;
         this.successThreshold = options.successThreshold ?? 1;
     }
 
+    /**
+     * Get the current circuit state, lazily transitioning OPEN → HALF_OPEN
+     * when the reset timeout has elapsed.
+     *
+     * @returns The current {@link CircuitState}.
+     */
     getState(): CircuitState {
         // Lazily transition OPEN → HALF_OPEN when the timeout has elapsed
         if (this.state === 'OPEN' && Date.now() - this.lastFailureTime >= this.resetTimeoutMs) {
@@ -112,6 +137,7 @@ export class CircuitBreaker {
         return this.state;
     }
 
+    /** Reset the circuit to CLOSED with all counters zeroed. */
     reset(): void {
         this.state = 'CLOSED';
         this.failureCount = 0;
@@ -119,6 +145,14 @@ export class CircuitBreaker {
         this.lastFailureTime = 0;
     }
 
+    /**
+     * Execute `fn` through the circuit breaker.
+     *
+     * @param fn - The async function to execute.
+     * @returns The result of `fn`.
+     * @throws {CircuitOpenError} If the circuit is OPEN.
+     * @throws Re-throws any error from `fn` after recording the failure.
+     */
     async execute<T>(fn: () => Promise<T>): Promise<T> {
         const currentState = this.getState();
 

--- a/server/lib/response.ts
+++ b/server/lib/response.ts
@@ -10,7 +10,13 @@ import { createLogger } from './logger';
 
 const log = createLogger('Response');
 
-/** Return a JSON response with an optional HTTP status (default 200). */
+/**
+ * Return a JSON response with an optional HTTP status (default 200).
+ *
+ * @param data - The payload to serialize as JSON.
+ * @param status - HTTP status code (default 200).
+ * @returns A `Response` with `Content-Type: application/json`.
+ */
 export function json(data: unknown, status: number = 200): Response {
     return new Response(JSON.stringify(data), {
         status,
@@ -18,22 +24,43 @@ export function json(data: unknown, status: number = 200): Response {
     });
 }
 
-/** Convenience: 400 Bad Request with a JSON error body. */
+/**
+ * Convenience: 400 Bad Request with a JSON error body.
+ *
+ * @param message - The error message to include in the response.
+ * @returns A 400 `Response` with `{ error: message }`.
+ */
 export function badRequest(message: string): Response {
     return json({ error: message }, 400);
 }
 
-/** Convenience: 404 Not Found with a JSON error body. */
+/**
+ * Convenience: 404 Not Found with a JSON error body.
+ *
+ * @param message - The error message to include in the response.
+ * @returns A 404 `Response` with `{ error: message }`.
+ */
 export function notFound(message: string): Response {
     return json({ error: message }, 404);
 }
 
-/** Convenience: 503 Service Unavailable with a JSON error body. */
+/**
+ * Convenience: 503 Service Unavailable with a JSON error body.
+ *
+ * @param message - The error message to include in the response.
+ * @returns A 503 `Response` with `{ error: message }`.
+ */
 export function unavailable(message: string): Response {
     return json({ error: message }, 503);
 }
 
-/** Convenience: 500 error with a timestamp (used by the global error handler). */
+/**
+ * Return a generic 500 Internal Server Error response.
+ * Logs the full error server-side but never exposes details to the client.
+ *
+ * @param err - The thrown error to log internally.
+ * @returns A 500 `Response` with a generic error message and timestamp.
+ */
 export function serverError(err: unknown): Response {
     // Log the full error server-side for debugging — never send to client.
     // Logging is isolated so CodeQL doesn't taint-track through the return value.
@@ -49,12 +76,23 @@ function logInternalError(err: unknown): void {
     log.error('Internal server error', { error: message, stack });
 }
 
-/** Extract a human-readable error message from an unknown thrown value. */
+/**
+ * Extract a human-readable error message from an unknown thrown value.
+ *
+ * @param err - The thrown value to extract a message from.
+ * @returns The error's `.message` if it's an `Error`, otherwise `String(err)`.
+ */
 export function errorMessage(err: unknown): string {
     return err instanceof Error ? err.message : String(err);
 }
 
-/** Safely parse a numeric query parameter, returning the default if NaN or missing. */
+/**
+ * Safely parse a numeric query parameter, returning the default if NaN or missing.
+ *
+ * @param value - The raw query parameter string (or null if absent).
+ * @param defaultValue - The fallback value when `value` is null or not a number.
+ * @returns The parsed number, or `defaultValue` if parsing fails.
+ */
 export function safeNumParam(value: string | null, defaultValue: number): number {
     if (value === null) return defaultValue;
     const parsed = Number(value);
@@ -66,7 +104,14 @@ export function safeNumParam(value: string | null, defaultValue: number): number
  *
  * Maps any `AppError` subclass to the correct HTTP status and a consistent
  * JSON body `{ error, code }`. Falls back to 500 for unknown errors.
- * Use in catch blocks: `catch (err) { return handleRouteError(err); }`
+ *
+ * @param err - The thrown error to handle.
+ * @returns A `Response` with the appropriate HTTP status and JSON error body.
+ *
+ * @example
+ * ```ts
+ * catch (err) { return handleRouteError(err); }
+ * ```
  */
 export function handleRouteError(err: unknown): Response {
     if (isAppError(err)) {

--- a/server/lib/secure-wipe.ts
+++ b/server/lib/secure-wipe.ts
@@ -13,6 +13,8 @@
  * Zero-fill a Uint8Array or Buffer in place.
  * Uses crypto.getRandomValues first (to defeat optimizer dead-store elimination),
  * then fills with zeros.
+ *
+ * @param buf - The buffer to wipe. No-op if null or undefined.
  */
 export function wipeBuffer(buf: Uint8Array | ArrayBuffer | null | undefined): void {
     if (!buf) return;
@@ -25,6 +27,8 @@ export function wipeBuffer(buf: Uint8Array | ArrayBuffer | null | undefined): vo
 
 /**
  * Wipe multiple buffers. Convenience for finally blocks.
+ *
+ * @param bufs - The buffers to wipe. Null/undefined entries are skipped.
  */
 export function wipeBuffers(...bufs: Array<Uint8Array | ArrayBuffer | null | undefined>): void {
     for (const buf of bufs) {
@@ -35,6 +39,10 @@ export function wipeBuffers(...bufs: Array<Uint8Array | ArrayBuffer | null | und
 /**
  * Execute an async operation with a buffer, ensuring the buffer is wiped
  * in the finally block regardless of success or failure.
+ *
+ * @param buf - The sensitive buffer to use during the operation.
+ * @param operation - The async function to execute with the buffer.
+ * @returns The result of `operation`.
  */
 export async function withSecureBuffer<T>(
     buf: Uint8Array,


### PR DESCRIPTION
## Summary
- Added comprehensive JSDoc with `@param` and `@returns` tags to all exported functions in 4 `server/lib/` files:
  - `errors.ts` — all error class constructors + `isAppError` type guard
  - `response.ts` — `json`, `badRequest`, `notFound`, `unavailable`, `serverError`, `errorMessage`, `safeNumParam`, `handleRouteError`
  - `secure-wipe.ts` — `wipeBuffer`, `wipeBuffers`, `withSecureBuffer`
  - `resilience.ts` — `withRetry`, `CircuitBreaker` class + methods, `CircuitOpenError`
- No functional changes — documentation only

Closes #1087

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` passes
- [x] 101 tests pass across the 4 affected test files (0 failures)
- [x] `bun run spec:check` — 151/151 passed, 442/442 file coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)