### PR TITLE
chore: update documented stats (7836 unit tests, 326 files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">
   <img src="https://img.shields.io/badge/Angular-21-dd0031?logo=angular" alt="Angular 21">
-  <img src="https://img.shields.io/badge/tests-7787%20unit%20%7C%20360%20E2E-brightgreen" alt="7718 Unit | 360 E2E Tests">
+  <img src="https://img.shields.io/badge/tests-7836%20unit%20%7C%20360%20E2E-brightgreen" alt="7718 Unit | 360 E2E Tests">
   <img src="https://img.shields.io/badge/spec%20coverage-100%25-brightgreen" alt="Spec Coverage 100%">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>
 </p>

--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -40,7 +40,7 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Database tables | 93 |
 | Database migrations | 16 (squashed baseline) |
 | MCP tools | 46 corvid_* handlers |
-| Unit tests | 7,787 across 324 files |
+| Unit tests | 7,836 across 326 files |
 | E2E tests | 360 across 31 Playwright specs |
 | Security tests | 232 dedicated |
 | Module specs | 153 .spec.md files |


### PR DESCRIPTION
## Summary
- Update test count badges and docs to reflect current counts after response quality scoring tests were added via #1207

## Test plan
- [x] `bun run stats:check` passes after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)