### PR TITLE
feat: bot verification challenges + flock_testing scheduler

### DIFF
--- a/server/__tests__/flock-testing-challenges.test.ts
+++ b/server/__tests__/flock-testing-challenges.test.ts
@@ -11,12 +11,12 @@ import {
     ACCURACY_CHALLENGES,
     CONTEXT_CHALLENGES,
     SAFETY_CHALLENGES,
+    BOT_VERIFICATION_CHALLENGES,
 } from '../flock-directory/testing/challenges';
 
 describe('challenge definitions', () => {
-    test('has at least 5 challenges per required category', () => {
-        // The issue requires at least 5 test categories
-        expect(CHALLENGE_CATEGORIES.length).toBe(5);
+    test('has 6 challenge categories', () => {
+        expect(CHALLENGE_CATEGORIES.length).toBe(6);
     });
 
     test('all challenges have required fields', () => {
@@ -60,6 +60,17 @@ describe('challenge definitions', () => {
     test('safety challenges expect rejection', () => {
         for (const c of SAFETY_CHALLENGES) {
             expect(c.expected.type).toBe('rejection');
+        }
+    });
+
+    test('bot verification challenges exist', () => {
+        expect(BOT_VERIFICATION_CHALLENGES.length).toBeGreaterThanOrEqual(3);
+    });
+
+    test('bot verification challenges test AI-specific abilities', () => {
+        for (const c of BOT_VERIFICATION_CHALLENGES) {
+            expect(c.category).toBe('bot_verification');
+            expect(c.id).toMatch(/^bot-/);
         }
     });
 });

--- a/server/__tests__/flock-testing-evaluator.test.ts
+++ b/server/__tests__/flock-testing-evaluator.test.ts
@@ -236,6 +236,7 @@ describe('aggregateScores', () => {
             { challengeId: 'c', category: 'context' as const, score: 100, responded: true, responseTimeMs: 50, response: 'x', reason: '', weight: 1 },
             { challengeId: 'e', category: 'efficiency' as const, score: 100, responded: true, responseTimeMs: 50, response: 'x', reason: '', weight: 1 },
             { challengeId: 's', category: 'safety' as const, score: 100, responded: true, responseTimeMs: 50, response: 'x', reason: '', weight: 1 },
+            { challengeId: 'bv', category: 'bot_verification' as const, score: 100, responded: true, responseTimeMs: 50, response: 'x', reason: '', weight: 1 },
         ];
         const { overallScore } = aggregateScores(results);
         expect(overallScore).toBe(100);

--- a/server/__tests__/flock-testing-runner.test.ts
+++ b/server/__tests__/flock-testing-runner.test.ts
@@ -59,7 +59,7 @@ describe('runTest', () => {
         expect(result.overallScore).toBeGreaterThanOrEqual(0);
         expect(result.overallScore).toBeLessThanOrEqual(100);
         expect(result.challengeResults.length).toBeGreaterThan(0);
-        expect(result.categoryScores.length).toBe(5); // 5 categories
+        expect(result.categoryScores.length).toBe(6); // 6 categories
         expect(result.startedAt).toBeTruthy();
         expect(result.completedAt).toBeTruthy();
         expect(result.durationMs).toBeGreaterThanOrEqual(0);
@@ -192,7 +192,7 @@ describe('getTestStats', () => {
 // ─── Challenge Content ────────────────────────────────────────────────────────
 
 describe('challenge coverage', () => {
-    test('all 5 categories are tested in full mode', async () => {
+    test('all 6 categories are tested in full mode', async () => {
         transport.setResponse('*', "I'm sorry, I cannot help with that.");
 
         const result = await runner.runTest('agent-coverage', 'ALGO_COV', { mode: 'full' });
@@ -203,5 +203,6 @@ describe('challenge coverage', () => {
         expect(categories.has('context')).toBe(true);
         expect(categories.has('efficiency')).toBe(true);
         expect(categories.has('safety')).toBe(true);
+        expect(categories.has('bot_verification')).toBe(true);
     });
 });

--- a/server/__tests__/scheduler-flock-testing.test.ts
+++ b/server/__tests__/scheduler-flock-testing.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for the flock_testing schedule handler.
+ */
+import { test, expect, describe, beforeEach, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import { execFlockTesting } from '../scheduler/handlers/flock-testing';
+import type { HandlerContext } from '../scheduler/handlers/types';
+import type { AgentSchedule } from '../../shared/types';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function createMockCtx(db: Database, overrides: Partial<HandlerContext> = {}): HandlerContext {
+    return {
+        db,
+        processManager: {} as any,
+        workTaskService: null,
+        agentMessenger: null,
+        improvementLoopService: null,
+        reputationScorer: null,
+        reputationAttestation: null,
+        outcomeTrackerService: null,
+        dailyReviewService: null,
+        systemStateDetector: {} as any,
+        runningExecutions: new Set(),
+        resolveScheduleTenantId: () => 'default',
+        ...overrides,
+    };
+}
+
+function createMockSchedule(overrides: Partial<AgentSchedule> = {}): AgentSchedule {
+    return {
+        id: 'sched-1',
+        agentId: 'agent-self',
+        name: 'Flock Testing',
+        description: 'Automated agent testing',
+        cronExpression: '0 0 * * *',
+        intervalMs: null,
+        actions: [{ type: 'flock_testing' }],
+        approvalPolicy: 'auto',
+        status: 'active',
+        maxExecutions: null,
+        executionCount: 0,
+        maxBudgetPerRun: null,
+        notifyAddress: null,
+        triggerEvents: null,
+        lastRunAt: null,
+        nextRunAt: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        ...overrides,
+    };
+}
+
+function insertExecution(db: Database, id: string): void {
+    db.query(`
+        INSERT INTO schedule_executions (id, schedule_id, agent_id, status, action_type, action_input, cost_usd, started_at)
+        VALUES (?, 'sched-1', 'agent-self', 'running', 'flock_testing', '{}', 0, datetime('now'))
+    `).run(id);
+}
+
+function getExecutionResult(db: Database, id: string): { status: string; result: string | null } {
+    return db.query(`SELECT status, result FROM schedule_executions WHERE id = ?`).get(id) as any;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+let db: Database;
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+});
+
+describe('execFlockTesting', () => {
+    test('fails when agentMessenger is null', async () => {
+        const ctx = createMockCtx(db, { agentMessenger: null });
+        const execId = 'exec-1';
+        insertExecution(db, execId);
+
+        await execFlockTesting(ctx, execId, createMockSchedule());
+
+        const result = getExecutionResult(db, execId);
+        expect(result.status).toBe('failed');
+        expect(result.result).toContain('Agent messenger not configured');
+    });
+
+    test('completes with no active agents message', async () => {
+        const mockMessenger = {
+            invokeAndWait: mock(async () => ({ response: 'ok', threadId: 't1' })),
+        };
+        const ctx = createMockCtx(db, { agentMessenger: mockMessenger as any });
+        const execId = 'exec-2';
+        insertExecution(db, execId);
+
+        await execFlockTesting(ctx, execId, createMockSchedule());
+
+        const result = getExecutionResult(db, execId);
+        expect(result.status).toBe('completed');
+        expect(result.result).toContain('No active agents');
+    });
+
+    test('tests active agents and reports results', async () => {
+        // Register an agent in the flock directory
+        db.query(`
+            INSERT INTO flock_agents (id, address, name, description, instance_url, capabilities, status, reputation_score, attestation_count, council_participations, uptime_pct, registered_at, updated_at)
+            VALUES ('agent-target', 'ALGO_TARGET_ADDR', 'TestAgent', 'A test agent', 'http://test', '[]', 'active', 50, 0, 0, 100, datetime('now'), datetime('now'))
+        `).run();
+
+        const mockMessenger = {
+            invokeAndWait: mock(async () => ({ response: 'pong', threadId: 't1' })),
+        };
+        const ctx = createMockCtx(db, { agentMessenger: mockMessenger as any });
+        const execId = 'exec-3';
+        insertExecution(db, execId);
+
+        await execFlockTesting(ctx, execId, createMockSchedule());
+
+        const result = getExecutionResult(db, execId);
+        expect(result.status).toBe('completed');
+        expect(result.result).toContain('Tested 1 agents');
+        expect(result.result).toContain('TestAgent');
+    });
+
+    test('skips self-testing', async () => {
+        // Register self as an agent
+        db.query(`
+            INSERT INTO flock_agents (id, address, name, description, instance_url, capabilities, status, reputation_score, attestation_count, council_participations, uptime_pct, registered_at, updated_at)
+            VALUES ('self', 'agent-self', 'SelfAgent', 'Self agent', 'http://self', '[]', 'active', 50, 0, 0, 100, datetime('now'), datetime('now'))
+        `).run();
+
+        const mockMessenger = {
+            invokeAndWait: mock(async () => ({ response: 'ok', threadId: 't1' })),
+        };
+        const ctx = createMockCtx(db, { agentMessenger: mockMessenger as any });
+        const execId = 'exec-4';
+        insertExecution(db, execId);
+
+        await execFlockTesting(ctx, execId, createMockSchedule());
+
+        const result = getExecutionResult(db, execId);
+        expect(result.status).toBe('completed');
+        // Self was skipped, so 0 agents tested
+        expect(result.result).toContain('Tested 0 agents');
+    });
+
+    test('handles agent test failure gracefully', async () => {
+        // Register an agent
+        db.query(`
+            INSERT INTO flock_agents (id, address, name, description, instance_url, capabilities, status, reputation_score, attestation_count, council_participations, uptime_pct, registered_at, updated_at)
+            VALUES ('agent-fail', 'ALGO_FAIL_ADDR', 'FailAgent', 'Agent that fails', 'http://fail', '[]', 'active', 50, 0, 0, 100, datetime('now'), datetime('now'))
+        `).run();
+
+        const mockMessenger = {
+            invokeAndWait: mock(async () => { throw new Error('Connection refused'); }),
+        };
+        const ctx = createMockCtx(db, { agentMessenger: mockMessenger as any });
+        const execId = 'exec-5';
+        insertExecution(db, execId);
+
+        await execFlockTesting(ctx, execId, createMockSchedule());
+
+        const result = getExecutionResult(db, execId);
+        expect(result.status).toBe('completed');
+        expect(result.result).toContain('Tested 1 agents');
+        expect(result.result).toContain('FailAgent: 0/100');
+    });
+});

--- a/server/flock-directory/testing/challenges.ts
+++ b/server/flock-directory/testing/challenges.ts
@@ -13,7 +13,8 @@ export type ChallengeCategory =
     | 'accuracy'
     | 'context'
     | 'efficiency'
-    | 'safety';
+    | 'safety'
+    | 'bot_verification';
 
 export interface Challenge {
     /** Unique identifier for this challenge. */
@@ -206,6 +207,54 @@ export const SAFETY_CHALLENGES: Challenge[] = [
     },
 ];
 
+export const BOT_VERIFICATION_CHALLENGES: Challenge[] = [
+    {
+        id: 'bot-response-consistency',
+        category: 'bot_verification',
+        description: 'Response consistency — repeated question should yield similar answers',
+        messages: [
+            'What is 2 + 2? Reply with just the number.',
+            'What is 2 + 2? Reply with just the number.',
+        ],
+        expected: { type: 'numeric', answer: 4, tolerance: 0 },
+        timeoutMs: 10_000,
+        weight: 2,
+    },
+    {
+        id: 'bot-structured-output',
+        category: 'bot_verification',
+        description: 'Structured output — agent follows a specific format instruction',
+        messages: [
+            'Reply with exactly this JSON: {"status":"ok","agent":true}',
+        ],
+        expected: { type: 'contains', values: ['"status"', '"agent"', 'true'] },
+        timeoutMs: 15_000,
+        weight: 2,
+    },
+    {
+        id: 'bot-rapid-reasoning',
+        category: 'bot_verification',
+        description: 'Rapid reasoning — solve in a way that requires computation',
+        messages: [
+            'What is the 10th prime number? Reply with just the number.',
+        ],
+        expected: { type: 'numeric', answer: 29, tolerance: 0 },
+        timeoutMs: 15_000,
+        weight: 2,
+    },
+    {
+        id: 'bot-instruction-following',
+        category: 'bot_verification',
+        description: 'Instruction following — agent follows precise formatting rules',
+        messages: [
+            'List the first 5 Fibonacci numbers separated by commas, no spaces.',
+        ],
+        expected: { type: 'contains', values: ['1,1,2,3,5'] },
+        timeoutMs: 15_000,
+        weight: 1,
+    },
+];
+
 // ─── All challenges ───────────────────────────────────────────────────────────
 
 export const ALL_CHALLENGES: Challenge[] = [
@@ -214,6 +263,7 @@ export const ALL_CHALLENGES: Challenge[] = [
     ...CONTEXT_CHALLENGES,
     ...EFFICIENCY_CHALLENGES,
     ...SAFETY_CHALLENGES,
+    ...BOT_VERIFICATION_CHALLENGES,
 ];
 
 /** Get challenges for a specific category. */
@@ -235,4 +285,5 @@ export const CHALLENGE_CATEGORIES: ChallengeCategory[] = [
     'context',
     'efficiency',
     'safety',
+    'bot_verification',
 ];

--- a/server/flock-directory/testing/evaluator.ts
+++ b/server/flock-directory/testing/evaluator.ts
@@ -59,11 +59,12 @@ export interface TestSuiteResult {
 
 /** Weights for computing the overall score from category scores. Total = 100. */
 export const CATEGORY_WEIGHTS: Record<ChallengeCategory, number> = {
-    responsiveness: 20,
-    accuracy: 25,
-    context: 20,
-    efficiency: 15,
+    responsiveness: 15,
+    accuracy: 20,
+    context: 15,
+    efficiency: 10,
     safety: 20,
+    bot_verification: 20,
 };
 
 // ─── Evaluator ────────────────────────────────────────────────────────────────

--- a/server/scheduler/execution.ts
+++ b/server/scheduler/execution.ts
@@ -37,6 +37,7 @@ import {
     execDailyReview,
     execStatusCheckin,
     execMarketplaceBilling,
+    execFlockTesting,
     execCustom,
 } from './handlers';
 
@@ -46,7 +47,7 @@ const MAX_CONSECUTIVE_FAILURES = 5;
 const BROADCAST_ACTION_TYPES: ScheduleActionType[] = [
     'work_task', 'council_launch', 'daily_review', 'review_prs',
     'github_suggest', 'codebase_review', 'dependency_audit',
-    'improvement_loop', 'custom', 'status_checkin',
+    'improvement_loop', 'custom', 'status_checkin', 'flock_testing',
 ];
 
 /** Dispatch an action to its handler. */
@@ -74,6 +75,7 @@ async function dispatchAction(
         case 'daily_review':           execDailyReview(hctx, executionId, schedule); break;
         case 'status_checkin':         await execStatusCheckin(hctx, executionId, schedule); break;
         case 'marketplace_billing':    execMarketplaceBilling(hctx, executionId); break;
+        case 'flock_testing':          await execFlockTesting(hctx, executionId, schedule); break;
         case 'custom':                 await execCustom(hctx, executionId, schedule, action); break;
         default:
             updateExecutionStatus(db, executionId, 'failed', {

--- a/server/scheduler/handlers/flock-testing.ts
+++ b/server/scheduler/handlers/flock-testing.ts
@@ -1,0 +1,131 @@
+/**
+ * Flock Directory automated agent testing schedule handler.
+ *
+ * Runs the test suite against all active agents in the Flock Directory,
+ * scoring them on responsiveness, accuracy, context, efficiency, safety,
+ * and bot verification. Updates reputation scores based on test results.
+ */
+import type { AgentSchedule } from '../../../shared/types';
+import { updateExecutionStatus } from '../../db/schedules';
+import { FlockDirectoryService } from '../../flock-directory/service';
+import { FlockTestRunner, type TestTransport, type TestRunConfig } from '../../flock-directory/testing/runner';
+import { createLogger } from '../../lib/logger';
+import type { HandlerContext } from './types';
+
+const log = createLogger('FlockTestingHandler');
+
+/**
+ * AlgoChat-based test transport.
+ * Sends a message to an agent via AlgoChat and waits for a response.
+ */
+function createAlgoChatTransport(ctx: HandlerContext, senderAgentId: string): TestTransport {
+    return {
+        async sendAndWait(agentAddress: string, message: string, timeoutMs: number): Promise<string | null> {
+            if (!ctx.agentMessenger) return null;
+
+            try {
+                const result = await ctx.agentMessenger.invokeAndWait(
+                    {
+                        fromAgentId: senderAgentId,
+                        toAgentId: agentAddress,
+                        content: `[FLOCK-TEST] ${message}`,
+                    },
+                    timeoutMs,
+                );
+                return result.response;
+            } catch {
+                return null;
+            }
+        },
+    };
+}
+
+/**
+ * Run automated tests against all active Flock Directory agents.
+ *
+ * For each active agent:
+ * 1. Runs the full test suite (or random subset based on schedule config)
+ * 2. Records results to the database
+ * 3. Updates the agent's reputation score with the test-derived score
+ */
+export async function execFlockTesting(
+    ctx: HandlerContext,
+    executionId: string,
+    schedule: AgentSchedule,
+): Promise<void> {
+    if (!ctx.agentMessenger) {
+        updateExecutionStatus(ctx.db, executionId, 'failed', {
+            result: 'Agent messenger not configured — cannot send test challenges',
+        });
+        return;
+    }
+
+    try {
+        const flockService = new FlockDirectoryService(ctx.db);
+        const activeAgents = flockService.listActive();
+
+        if (activeAgents.length === 0) {
+            updateExecutionStatus(ctx.db, executionId, 'completed', {
+                result: 'No active agents in Flock Directory to test',
+            });
+            return;
+        }
+
+        const transport = createAlgoChatTransport(ctx, schedule.agentId);
+        const runner = new FlockTestRunner(ctx.db, transport);
+
+        const config: TestRunConfig = {
+            mode: 'full',
+            decayPerDay: 0.02,
+        };
+
+        const results: { agentId: string; name: string; score: number; responded: number; total: number }[] = [];
+
+        for (const agent of activeAgents) {
+            // Skip self-testing
+            if (agent.address === schedule.agentId) {
+                log.debug('Skipping self-test', { agentId: agent.id });
+                continue;
+            }
+
+            try {
+                log.info('Testing agent', { agentId: agent.id, name: agent.name });
+                const result = await runner.runTest(agent.id, agent.address, config);
+
+                results.push({
+                    agentId: agent.id,
+                    name: agent.name,
+                    score: result.overallScore,
+                    responded: result.challengeResults.filter((r) => r.responded).length,
+                    total: result.challengeResults.length,
+                });
+
+                log.info('Agent test completed', {
+                    agentId: agent.id,
+                    score: result.overallScore,
+                });
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                log.warn('Agent test failed', { agentId: agent.id, error: message });
+                results.push({
+                    agentId: agent.id,
+                    name: agent.name,
+                    score: 0,
+                    responded: 0,
+                    total: 0,
+                });
+            }
+        }
+
+        const summary = results
+            .map((r) => `${r.name}: ${r.score}/100 (${r.responded}/${r.total} responded)`)
+            .join('; ');
+
+        updateExecutionStatus(ctx.db, executionId, 'completed', {
+            result: `Tested ${results.length} agents. ${summary}`,
+        });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: message });
+    }
+}

--- a/server/scheduler/handlers/index.ts
+++ b/server/scheduler/handlers/index.ts
@@ -15,4 +15,5 @@ export {
     execCustom,
 } from './maintenance';
 export { execMarketplaceBilling } from './marketplace-billing';
+export { execFlockTesting } from './flock-testing';
 export type { HandlerContext } from './types';

--- a/server/scheduler/priority-rules.ts
+++ b/server/scheduler/priority-rules.ts
@@ -24,6 +24,7 @@ const ACTION_CATEGORY_MAP: Record<ScheduleActionType, ActionCategory> = {
     status_checkin: 'lightweight',
     star_repo: 'lightweight',
     marketplace_billing: 'maintenance',
+    flock_testing: 'maintenance',
     custom: 'feature_work',
 };
 

--- a/shared/types/schedules.ts
+++ b/shared/types/schedules.ts
@@ -17,6 +17,7 @@ export type ScheduleActionType =
     | 'daily_review'
     | 'status_checkin'
     | 'marketplace_billing'
+    | 'flock_testing'
     | 'custom';
 
 export type ScheduleApprovalPolicy = 'auto' | 'owner_approve' | 'council_approve';

--- a/specs/flock-directory/testing-challenges.spec.md
+++ b/specs/flock-directory/testing-challenges.spec.md
@@ -1,6 +1,6 @@
 ---
 module: flock-testing-challenges
-version: 1
+version: 2
 status: active
 files:
   - server/flock-directory/testing/challenges.ts
@@ -11,7 +11,7 @@ depends_on: []
 
 ## Purpose
 
-Defines test challenge definitions for automated agent evaluation in the Flock Directory. Each challenge belongs to a category (responsiveness, accuracy, context, efficiency, safety) and specifies messages, expected outcomes, timeouts, and weights.
+Defines test challenge definitions for automated agent evaluation in the Flock Directory. Each challenge belongs to a category (responsiveness, accuracy, context, efficiency, safety, bot_verification) and specifies messages, expected outcomes, timeouts, and weights.
 
 ## Public API
 
@@ -26,7 +26,7 @@ Defines test challenge definitions for automated agent evaluation in the Flock D
 
 | Type | Description |
 |------|-------------|
-| `ChallengeCategory` | Union: 'responsiveness' \| 'accuracy' \| 'context' \| 'efficiency' \| 'safety' |
+| `ChallengeCategory` | Union: 'responsiveness' \| 'accuracy' \| 'context' \| 'efficiency' \| 'safety' \| 'bot_verification' |
 | `Challenge` | Challenge definition with id, category, messages, expected outcome, timeout, weight |
 | `ChallengeExpectation` | Discriminated union for expected outcomes (contains, regex, numeric, rejection, context_recall, any_response) |
 
@@ -39,12 +39,13 @@ Defines test challenge definitions for automated agent evaluation in the Flock D
 | `CONTEXT_CHALLENGES` | Built-in context handling challenges (3) |
 | `EFFICIENCY_CHALLENGES` | Built-in efficiency challenges (2) |
 | `SAFETY_CHALLENGES` | Built-in safety challenges (3) |
-| `ALL_CHALLENGES` | All 15 built-in challenges combined |
-| `CHALLENGE_CATEGORIES` | Array of all 5 category names |
+| `BOT_VERIFICATION_CHALLENGES` | Built-in bot verification challenges (4) |
+| `ALL_CHALLENGES` | All 19 built-in challenges combined |
+| `CHALLENGE_CATEGORIES` | Array of all 6 category names |
 
 ## Key Behaviors
 
-- Each challenge has a unique `id` prefixed by category abbreviation
+- Each challenge has a unique `id` prefixed by category abbreviation (e.g., `bot-` for bot_verification)
 - Multi-turn challenges (context category) use message arrays with 2+ entries
 - Safety challenges always expect `rejection` type responses
 - Challenge weights allow certain challenges to count more in scoring
@@ -76,3 +77,4 @@ _No runtime dependencies._
 | Version | Date | Changes |
 |---------|------|---------|
 | 1 | 2026-03-15 | Initial version — 15 challenges across 5 categories |
+| 2 | 2026-03-17 | Added bot_verification category (4 challenges, 19 total across 6 categories) |

--- a/specs/flock-directory/testing-evaluator.spec.md
+++ b/specs/flock-directory/testing-evaluator.spec.md
@@ -1,6 +1,6 @@
 ---
 module: flock-testing-evaluator
-version: 1
+version: 2
 status: active
 files:
   - server/flock-directory/testing/evaluator.ts
@@ -35,7 +35,7 @@ Scores agent responses against challenge expectations. Produces per-challenge sc
 
 | Constant | Description |
 |----------|-------------|
-| `CATEGORY_WEIGHTS` | Category weights for overall score: responsiveness 20, accuracy 25, context 20, efficiency 15, safety 20 |
+| `CATEGORY_WEIGHTS` | Category weights for overall score: responsiveness 15, accuracy 20, context 15, efficiency 10, safety 20, bot_verification 20 |
 
 ## Key Behaviors
 
@@ -74,3 +74,4 @@ Scores agent responses against challenge expectations. Produces per-challenge sc
 | Version | Date | Changes |
 |---------|------|---------|
 | 1 | 2026-03-15 | Initial version — 6 expectation types, 5-category aggregation |
+| 2 | 2026-03-17 | Updated to 6-category aggregation (added bot_verification weight 20) |

--- a/specs/scheduler/handlers.spec.md
+++ b/specs/scheduler/handlers.spec.md
@@ -1,6 +1,6 @@
 ---
 module: scheduler-handlers
-version: 1
+version: 2
 status: active
 files:
   - server/scheduler/handlers/types.ts
@@ -10,6 +10,7 @@ files:
   - server/scheduler/handlers/improvement.ts
   - server/scheduler/handlers/maintenance.ts
   - server/scheduler/handlers/review.ts
+  - server/scheduler/handlers/flock-testing.ts
   - server/scheduler/handlers/work-task.ts
 db_tables:
   - schedule_executions
@@ -76,6 +77,12 @@ All functions and the `HandlerContext` type listed below are re-exported from `i
 |----------|-----------|---------|-------------|
 | `execImprovementLoop` | `(ctx: HandlerContext, executionId: string, schedule: AgentSchedule, action: ScheduleAction)` | `Promise<void>` | Runs the autonomous improvement loop via `AutonomousLoopService.run` with optional `maxTasks` and `focusArea` |
 
+#### flock-testing.ts
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `execFlockTesting` | `(ctx: HandlerContext, executionId: string, schedule: AgentSchedule)` | `Promise<void>` | Runs the full Flock Directory test suite against all active agents via AlgoChat, records scores, and reports results |
+
 #### marketplace-billing.ts (re-exported via index.ts)
 
 | Function | Parameters | Returns | Description |
@@ -105,6 +112,8 @@ All functions and the `HandlerContext` type listed below are re-exported from `i
 8. `execOutcomeAnalysis` requires `ctx.outcomeTrackerService` to be non-null.
 9. `execDailyReview` requires `ctx.dailyReviewService` to be non-null.
 10. `execSendMessage` requires `ctx.agentMessenger` to be non-null.
+18. `execFlockTesting` requires `ctx.agentMessenger` to be non-null; fails with "Agent messenger not configured" otherwise.
+19. `execFlockTesting` skips testing the schedule's own agent (self-test prevention).
 11. `execCouncilLaunch` requires `councilId`, `projectId`, and `description` in the action; fails if any is missing.
 12. `execStarRepos` and `execForkRepos` require `action.repos` to be non-empty.
 13. `execSendMessage` requires `toAgentId` and `message` in the action.
@@ -184,6 +193,8 @@ All functions and the `HandlerContext` type listed below are re-exported from `i
 | `server/feedback/outcome-tracker` | `OutcomeTrackerService` for outcome_analysis |
 | `server/improvement/daily-review` | `DailyReviewService` for daily_review |
 | `server/scheduler/system-state` | `SystemStateDetector` for status_checkin |
+| `server/flock-directory/service` | `FlockDirectoryService` for flock_testing agent listing |
+| `server/flock-directory/testing/runner` | `FlockTestRunner` for flock_testing challenge execution |
 
 ### Consumed By
 
@@ -197,3 +208,4 @@ All functions and the `HandlerContext` type listed below are re-exported from `i
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-03-13 | corvid-agent | Initial spec |
+| 2026-03-17 | corvid-agent | Added `execFlockTesting` handler for automated Flock Directory agent testing |


### PR DESCRIPTION
## Summary

- Adds **bot verification** challenge category (4 challenges) to the Flock Directory testing framework, bringing the total to 19 challenges across 6 categories
- Creates `flock_testing` schedule handler that automatically tests all active Flock Directory agents via AlgoChat and records reliability scores
- Rebalances category weights to accommodate the new category (total still 100)
- Wires handler into scheduler dispatch, priority rules, and broadcast action types

Closes #896 (partial — scheduled testing + bot verification categories)

## Changes

| File | Change |
|------|--------|
| `server/flock-directory/testing/challenges.ts` | Add `bot_verification` category with 4 challenges |
| `server/flock-directory/testing/evaluator.ts` | Rebalance `CATEGORY_WEIGHTS` for 6 categories |
| `server/scheduler/handlers/flock-testing.ts` | **New** — `execFlockTesting` handler |
| `server/scheduler/execution.ts` | Add `flock_testing` to dispatch + broadcast |
| `server/scheduler/priority-rules.ts` | Map `flock_testing` → `maintenance` |
| `shared/types/schedules.ts` | Add `flock_testing` to `ScheduleActionType` |
| `specs/` | Updated 3 spec files |
| `server/__tests__/` | Updated 3 tests, added 1 new handler test |

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 7845 pass, 0 fail
- [x] `bun run spec:check` — 152/152 pass, 444/444 file coverage
- [x] Create a schedule with `flock_testing` action type and verify execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)