### PR TITLE
docs: update README, CHANGELOG, and version for v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.37.0] - 2026-03-18
+
+### Added
+- **Bot verification challenges** — challenge-response system for verifying bot identities in flock testing (#1211)
+- **Auto-escalate stalled sessions** — structured metadata for escalation when sessions stall (#1209)
+- **Cheerleading detection** — detect and score low-quality cheerleading responses (#1205, #1207)
+- **Forward Discord image attachments** — images sent in Discord are forwarded to agent context (#1199)
+- **On-chain memory fallback** — `recall_memory` falls back to on-chain reader with full txid display (#1206)
+
+### Fixed
+- **Session recovery logging** — no more silent error swallowing on Continue button (#1214)
+- **`/session` channel fix** — threads now created in the correct channel (#1214)
+- **Wallet address validation** — validate wallet address format from query params (#1210)
+- **MCP package build** — add missing memory tools to MCP package (#1203)
+
+### Docs
+- Sync API reference and README with codebase (#1212)
+- Document exports for memory-brain-viewer spec (#1213)
+- Add JSDoc @param/@returns to server/lib/ exported functions (#1204)
+- Update CHANGELOG with v0.33.0 through v0.36.0 entries (#1202)
+
+### Tests
+- Add runtime tests for resumeProcess external MCP loading (#1201)
+
 ## [0.36.0] - 2026-03-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.36.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.37.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Update version badge in README from 0.36.0 → 0.37.0
- Update package.json version to 0.37.0
- Add v0.37.0 CHANGELOG entry with all changes since v0.36.0

## Test plan
- [x] CI passes
- [x] Version badge renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)