### PR TITLE
docs: use case gallery with examples and demos

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,6 +4,18 @@ Get corvid-agent running and have an AI agent open a real PR on a test repo.
 
 ---
 
+## Choose your path
+
+| I want to... | Command | Time | API keys needed? |
+|--------------|---------|------|-----------------|
+| **Try it instantly** | `git clone && bun run try` | 30 sec | No |
+| **See a CLI demo** | `corvid-agent demo` | 1 min | No |
+| **Set up for real** | `corvid-agent init` | 5 min | Yes |
+
+**New here?** Start with `bun run try` — it launches a sandbox with an in-memory database, a pre-created agent, and the dashboard. No `.env` or API keys needed. When you're ready for the real thing, come back to step 1 below.
+
+---
+
 ## 1. Install and start (2 minutes)
 
 ```bash

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,18 +1,22 @@
 # Use Cases
 
-Practical examples showing how to use corvid-agent for common development workflows. Each example includes API calls you can copy and paste.
+Practical examples showing how to use corvid-agent for common workflows. Each example includes setup instructions, example interactions, and tips.
 
-> **Prerequisites:** A running corvid-agent server (`bun run dev`) with at least one agent and project configured. See the [quickstart](quickstart.md) if you haven't set that up yet.
+> **Just want to try it?** Run `bun run try` for a zero-config sandbox — no API keys needed.
+>
+> **Ready to set up for real?** See the [quickstart](quickstart.md) to get running in 5 minutes.
 
 ---
 
-## 1. Daily PR Reviews
+## Developer Workflow
 
-Have an agent review every open pull request each morning before your team starts work.
+### 1. Daily PR Reviews
 
-### Setup
+**Problem:** Your team merges 5-10 PRs a day. Reviews pile up. Bugs slip through.
 
-Create a schedule that runs at 8 AM on weekdays:
+**Solution:** Schedule an agent to review every open PR each morning before standup.
+
+#### Setup
 
 ```bash
 curl -X POST http://localhost:3000/api/schedules \
@@ -29,38 +33,47 @@ curl -X POST http://localhost:3000/api/schedules \
   }'
 ```
 
-### What the agent does
+#### Example interaction
 
-1. Lists open PRs via the `corvid_github_list_prs` tool
-2. Reads each diff with `corvid_github_pr_diff`
-3. Analyzes code for bugs, performance issues, and style
-4. Posts review comments with `corvid_github_create_review`
-5. Reports a summary back to the session
+```
+Agent: I found 3 open PRs on my-org/my-repo. Starting reviews.
 
-### Tips
+PR #142 — "Add user avatar upload"
+  ✓ Clean implementation overall
+  ⚠ Missing file size validation in upload handler (line 47) —
+    an attacker could upload a 10GB file and crash the server.
+  ⚠ No content-type check — should verify it's actually an image.
+  → Requesting changes with inline suggestions.
+
+PR #143 — "Fix date formatting in reports"
+  ✓ Simple fix, well-tested. Approving.
+
+PR #144 — "Refactor auth middleware"
+  ✓ Good separation of concerns
+  ⚠ The new `validateToken()` swallows errors silently (line 23).
+    Consider logging or re-throwing.
+  → Approving with comment.
+
+Summary: 3 PRs reviewed. 1 approved, 1 approved with comment, 1 needs changes.
+```
+
+#### Tips
 
 - Assign the "Code Reviewer" skill bundle for more focused reviews
 - Set `approvalPolicy` to `"owner"` if you want to approve each review before it posts
-- Use a persona with traits like `["thorough", "constructive", "concise"]` for better review tone
+- Use a persona with traits like `["thorough", "constructive", "concise"]`
 
 ---
 
-## 2. Fix CI Failures Automatically
+### 2. Fix CI Failures Automatically
 
-When CI goes red, trigger an agent to diagnose and fix the issue.
+**Problem:** CI breaks at 2 AM. Nobody notices until morning standup. Half a day lost.
 
-### Setup — on-demand
+**Solution:** Point an agent at the failure and let it diagnose and fix it.
+
+#### Setup — on-demand
 
 ```bash
-# Start a session pointed at the failing branch
-curl -X POST http://localhost:3000/api/sessions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "agentId": "AGENT_ID",
-    "projectId": "PROJECT_ID"
-  }'
-
-# Tell the agent what to fix
 curl -X POST http://localhost:3000/api/sessions/SESSION_ID/resume \
   -H "Content-Type: application/json" \
   -d '{
@@ -68,9 +81,7 @@ curl -X POST http://localhost:3000/api/sessions/SESSION_ID/resume \
   }'
 ```
 
-### Setup — automated via work tasks
-
-For self-directed fixes, use the work task pipeline:
+#### Setup — automated via work tasks
 
 ```bash
 curl -X POST http://localhost:3000/api/work-tasks \
@@ -84,7 +95,27 @@ curl -X POST http://localhost:3000/api/work-tasks \
   }'
 ```
 
-The work task pipeline:
+#### Example interaction
+
+```
+Agent: Checking CI status for feature/auth...
+
+Found 2 failing tests in server/auth/middleware.test.ts:
+  ✗ "should reject expired tokens" — TypeError: Cannot read property 'exp' of undefined
+  ✗ "should refresh near-expiry tokens" — same root cause
+
+Root cause: The `decodeToken()` function returns `null` for malformed tokens,
+but the middleware assumes it always returns an object. This was introduced in
+commit a3f2e1b which changed the return type.
+
+Fix: Added null check at middleware.ts:34 before accessing token properties.
+
+Running tests... 47/47 passed ✓
+Opening PR: "fix: handle null token in auth middleware" → PR #156 created.
+```
+
+#### How the work task pipeline works
+
 1. Creates an isolated git worktree
 2. Spawns a new agent session in it
 3. Runs validation (`tsc --noEmit` + `bun test`)
@@ -93,11 +124,13 @@ The work task pipeline:
 
 ---
 
-## 3. Write Tests for Untested Code
+### 3. Write Tests for Untested Code
 
-Point an agent at files with low coverage and let it generate meaningful test suites.
+**Problem:** Coverage is at 60%. Nobody has time to write tests for existing code.
 
-### One-shot
+**Solution:** Schedule an agent to find and test the biggest gaps weekly.
+
+#### One-shot
 
 ```bash
 curl -X POST http://localhost:3000/api/work-tasks \
@@ -111,7 +144,7 @@ curl -X POST http://localhost:3000/api/work-tasks \
   }'
 ```
 
-### Scheduled coverage improvement
+#### Scheduled coverage improvement
 
 ```bash
 curl -X POST http://localhost:3000/api/schedules \
@@ -128,19 +161,41 @@ curl -X POST http://localhost:3000/api/schedules \
   }'
 ```
 
-### Tips
+#### Example interaction
 
-- The agent uses `corvid_code_symbols` to understand the code structure before writing tests
+```
+Agent: Analyzing server/billing/service.ts (342 lines, 12 exported functions).
+Using corvid_code_symbols to map the module structure.
+
+Found 12 functions, 0 existing tests. Writing tests for:
+  - calculateInvoice() — core billing logic, highest impact
+  - applyDiscount() — has 4 edge cases (expired, stacked, percentage, flat)
+  - processRefund() — touches payment state, needs careful error handling
+
+Created server/billing/service.test.ts with 28 test cases:
+  ✓ 14 happy-path tests
+  ✓ 8 edge-case tests (empty cart, negative discount, zero-amount refund, etc.)
+  ✓ 6 error-handling tests (network failure, invalid currency, etc.)
+
+Running tests... 28/28 passed ✓
+Opening PR: "test: add billing service tests (28 cases)" → PR #161 created.
+```
+
+#### Tips
+
+- The agent uses `corvid_code_symbols` to understand code structure before writing tests
 - It follows existing test patterns in your repo automatically
 - Use `approvalPolicy: "owner"` so you can review tests before they merge
 
 ---
 
-## 4. Triage and Label New Issues
+### 4. Triage and Label New Issues
 
-Monitor your issue tracker and automatically categorize incoming issues.
+**Problem:** Issues pile up unlabeled. Contributors don't know what to work on.
 
-### Setup
+**Solution:** Run triage every 30 minutes to categorize and respond to new issues.
+
+#### Setup
 
 ```bash
 curl -X POST http://localhost:3000/api/schedules \
@@ -157,50 +212,171 @@ curl -X POST http://localhost:3000/api/schedules \
   }'
 ```
 
-### What the agent does
+#### Example interaction
 
-1. Lists recent issues with `corvid_github_list_issues`
-2. Reads each issue body and any linked context
-3. Adds labels with `corvid_github_add_labels`
-4. Posts a triage comment with `corvid_github_create_comment`
-5. For bugs it can reproduce, it may start a fix automatically
+```
+Agent: Found 2 new unlabeled issues.
 
-### Tips
+#89 — "Login page crashes on Safari 17"
+  Labels: bug, browser-compat
+  Complexity: M
+  Comment: "Thanks for reporting! This looks like a Safari-specific issue with the
+  new CSS nesting syntax. I'll investigate the auth/login.css file. In the meantime,
+  Chrome and Firefox should work fine as a workaround."
 
-- Combine with the `@mention` polling feature — set `GH_POLL_REPOS=my-org/my-repo` in `.env` and the agent responds when mentioned in issues or PRs
+#90 — "Add dark mode support"
+  Labels: enhancement, ui
+  Complexity: L
+  Comment: "Great suggestion! Dark mode would require updates to the theme system
+  and all component styles. I've labeled this as a large enhancement. A good first
+  step would be creating a design spec for the color palette."
+```
+
+#### Tips
+
+- Combine with `GH_POLL_REPOS=my-org/my-repo` in `.env` so the agent responds when @mentioned in issues
 - Give the agent a persona like "Triage Lead" with traits `["organized", "responsive", "helpful"]`
 
 ---
 
-## 5. Multi-Agent Architecture Review
+### 5. Release Manager
 
-Assemble a council of agents with different expertise to review a complex decision.
+**Problem:** Releases involve changelogs, version bumps, release notes, and tag creation. It's tedious and error-prone.
 
-### Setup
+**Solution:** Let an agent handle the release checklist.
 
-First, create agents with different skill profiles:
+#### Setup
 
 ```bash
-# Security-focused agent
-curl -X POST http://localhost:3000/api/agents \
+curl -X POST http://localhost:3000/api/sessions/SESSION_ID/resume \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "security-reviewer",
-    "model": "claude-sonnet-4-20250514",
-    "systemPrompt": "You are a security engineer. Focus on authentication, authorization, input validation, and OWASP Top 10 vulnerabilities."
-  }'
-
-# Performance-focused agent
-curl -X POST http://localhost:3000/api/agents \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "perf-reviewer",
-    "model": "claude-sonnet-4-20250514",
-    "systemPrompt": "You are a performance engineer. Focus on query efficiency, memory usage, caching, and scalability."
+    "prompt": "Prepare a release for v2.1.0. Generate a changelog from commits since the last tag, bump the version in package.json, update CHANGELOG.md, and create a PR titled \"chore: release v2.1.0\"."
   }'
 ```
 
-Then convene a council:
+#### Example interaction
+
+```
+Agent: Preparing release v2.1.0...
+
+Commits since v2.0.0 (last tag): 23 commits by 4 authors.
+
+Changelog:
+  ## v2.1.0
+  ### Features
+  - Add dark mode toggle (#142)
+  - Support CSV export in reports (#138)
+  ### Fixes
+  - Fix Safari login crash (#89)
+  - Handle null token in auth middleware (#156)
+  ### Internal
+  - Add billing service tests (#161)
+  - Upgrade dependencies (#159)
+
+Updated package.json: 2.0.0 → 2.1.0
+Updated CHANGELOG.md with the above.
+PR created: "chore: release v2.1.0" → PR #165
+```
+
+---
+
+## Community & Communication
+
+### 6. Discord Support Agent
+
+**Problem:** Users ask the same questions in your Discord. Core team time gets consumed by support.
+
+**Solution:** Connect an agent to Discord that answers questions, points to docs, and escalates when it can't help.
+
+#### Setup
+
+Add to `.env`:
+
+```bash
+DISCORD_BOT_TOKEN=your-bot-token
+DISCORD_CHANNEL_ID=your-support-channel-id
+```
+
+Configure the agent with a helpful support persona:
+
+```bash
+curl -X PUT http://localhost:3000/api/agents/AGENT_ID/persona \
+  -H "Content-Type: application/json" \
+  -d '{
+    "archetype": "Support Engineer",
+    "traits": ["patient", "helpful", "precise"],
+    "voiceGuidelines": "Always link to relevant docs. If unsure, say so and tag a human."
+  }'
+```
+
+#### Example interaction (in Discord)
+
+```
+User: How do I set up webhooks?
+
+Agent: Webhooks are configured in Settings → Integrations → Webhooks.
+Here's the quickstart: https://docs.example.com/webhooks
+
+You'll need to:
+1. Create a webhook endpoint in your app
+2. Add the URL in the dashboard
+3. Select which events to subscribe to
+
+The most common events are `invoice.paid` and `subscription.updated`.
+Let me know if you run into issues!
+```
+
+#### Tips
+
+- Set up a dedicated support agent with a "Support" skill bundle
+- Use `corvid_web_search` to help the agent find relevant docs
+- The agent only responds when @mentioned or in designated channels
+
+---
+
+### 7. Cross-Channel Announcements
+
+**Problem:** You post updates on Discord, then copy them to Telegram, then update the blog. Triple the work.
+
+**Solution:** Tell an agent to draft and post announcements across channels.
+
+#### Setup
+
+```bash
+curl -X POST http://localhost:3000/api/sessions/SESSION_ID/resume \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "We just shipped v2.1.0 with dark mode and CSV export. Draft a short announcement and post it to our Discord and Telegram channels."
+  }'
+```
+
+#### Example interaction
+
+```
+Agent: Here's the announcement I'll post:
+
+  🚀 v2.1.0 is live!
+  • Dark mode — toggle in Settings
+  • CSV export — download any report as CSV
+  • Bug fixes for Safari login and auth tokens
+  Full changelog: https://github.com/my-org/my-repo/releases/tag/v2.1.0
+
+Posted to Discord #announcements ✓
+Posted to Telegram updates channel ✓
+```
+
+---
+
+## Algorand & Web3
+
+### 8. On-Chain Governance
+
+**Problem:** Your DAO needs structured decision-making. Informal chat votes don't create an audit trail.
+
+**Solution:** Use multi-agent councils with on-chain attestations.
+
+#### Setup
 
 ```bash
 curl -X POST http://localhost:3000/api/councils \
@@ -209,23 +385,170 @@ curl -X POST http://localhost:3000/api/councils \
     "topic": "Should we migrate from REST to GraphQL for the dashboard API?",
     "chairmanId": "AGENT_ID_1",
     "participantIds": ["AGENT_ID_2", "AGENT_ID_3"],
-    "governanceTier": "standard",
+    "governanceTier": "weighted",
     "discussionRounds": 2
   }'
 ```
 
-### How councils work
+#### Example interaction
 
-1. **Responding** — Each agent independently states its position
-2. **Discussing** — Agents respond to each other's points (configurable rounds)
-3. **Reviewing** — The chairman reviews all positions
-4. **Synthesizing** — Final recommendation with reasoning
+```
+Council: "Should we migrate from REST to GraphQL?"
 
-### Tips
+security-agent (weight: 1.2):
+  "GraphQL introduces new attack vectors — query complexity attacks,
+  introspection leaks. If we migrate, we need depth limiting and
+  persisted queries. I vote NO unless we budget for security hardening."
+
+perf-agent (weight: 1.0):
+  "GraphQL would reduce over-fetching on the dashboard — currently 12
+  REST calls on page load. A single GraphQL query could cut that to 1.
+  I vote YES with a phased migration."
+
+Chairman synthesis:
+  "2-1 in favor (weighted: 1.0 vs 1.2). Recommendation: Proceed with
+  a phased migration, starting with read-only queries. Security hardening
+  (depth limiting, persisted queries) is a prerequisite for phase 2."
+
+Decision hash recorded on Algorand: txid ABC123...
+```
+
+#### Tips
 
 - Use `governanceTier: "weighted"` to weight votes by agent reputation
-- Enable `onChainMode: "attestation"` to record the decision hash on Algorand
-- Councils work well for: architecture decisions, migration planning, security reviews, API design
+- Enable `onChainMode: "attestation"` for an immutable audit trail on Algorand
+- Councils work well for: architecture decisions, migration planning, security reviews
+
+---
+
+### 9. Agent-to-Agent Messaging (AlgoChat)
+
+**Problem:** Your agents run on different machines. They need to coordinate without a central server.
+
+**Solution:** Enable AlgoChat — agents communicate via Algorand transactions, creating a verifiable message trail.
+
+#### Setup
+
+Add to `.env`:
+
+```bash
+ALGOCHAT_MNEMONIC=your 25 word mnemonic here
+ALGORAND_NETWORK=localnet
+```
+
+Then agents can message each other:
+
+```bash
+curl -X POST http://localhost:3000/api/sessions/SESSION_ID/resume \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Send a message to the security-agent asking it to review the latest PR on my-org/my-repo."
+  }'
+```
+
+#### Example interaction
+
+```
+Agent: Sending AlgoChat message to security-agent...
+
+To: security-agent (ALGO_ADDR_ABC...)
+Message: "Hey security-agent — PR #142 on my-org/my-repo adds user avatar
+uploads. Can you review it for security issues? Specifically check file
+validation and upload size limits."
+
+Message sent ✓ (txid: XYZ789...)
+
+[Later]
+security-agent replies: "Reviewed PR #142. Found 2 issues: no file size
+limit (could cause DoS) and missing content-type validation. Posted review
+comments. Recommending changes."
+```
+
+---
+
+## Personal & Team Productivity
+
+### 10. Research Agent
+
+**Problem:** You need to evaluate 3 competing libraries before picking one. That's hours of reading docs and comparing.
+
+**Solution:** Have an agent research, compare, and summarize.
+
+#### Setup
+
+```bash
+curl -X POST http://localhost:3000/api/sessions/SESSION_ID/resume \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Compare Drizzle ORM, Prisma, and Kysely for our TypeScript + SQLite stack. Consider: type safety, query performance, migration support, bundle size, and community activity. Give me a recommendation."
+  }'
+```
+
+#### Example interaction
+
+```
+Agent: Researching ORMs for TypeScript + SQLite...
+
+| Feature        | Drizzle        | Prisma         | Kysely         |
+|---------------|----------------|----------------|----------------|
+| Type safety   | Excellent      | Excellent      | Excellent      |
+| SQLite support| Native         | Via adapter    | Native         |
+| Bundle size   | 35 KB          | 1.8 MB (engine)| 28 KB         |
+| Migrations    | Push + generate| Prisma migrate | Manual/3rd-party|
+| Query style   | SQL-like       | Builder pattern| SQL-like       |
+| GitHub stars  | 28K            | 41K            | 12K            |
+
+Recommendation: **Drizzle** — best fit for your stack. Native SQLite
+support, tiny bundle, SQL-like syntax that your team already knows.
+Prisma's engine adds 1.8 MB and an extra process. Kysely is solid but
+has weaker migration tooling.
+
+Trade-off: Prisma has the largest community and best docs. If your team
+values documentation over bundle size, it's a defensible choice.
+```
+
+---
+
+### 11. Documentation Keeper
+
+**Problem:** Code changes but docs don't. READMEs go stale. API references drift.
+
+**Solution:** Schedule an agent to check docs against code weekly.
+
+#### Setup
+
+```bash
+curl -X POST http://localhost:3000/api/schedules \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "AGENT_ID",
+    "name": "docs-sync",
+    "cronExpression": "0 9 * * 1",
+    "actions": [{
+      "type": "custom",
+      "prompt": "Compare the API reference in docs/api-reference.md against the actual route handlers in server/routes/. Find any endpoints that are documented but removed, or exist but are undocumented. Open a PR to fix any drift."
+    }],
+    "approvalPolicy": "owner"
+  }'
+```
+
+#### Example interaction
+
+```
+Agent: Comparing docs/api-reference.md against 44 route files...
+
+Found 3 discrepancies:
+  ✗ DELETE /api/sessions/:id — documented but removed in v2.0.0
+  ✗ POST /api/agents/:id/skills — exists but undocumented
+  ✗ GET /api/health/trends — response schema changed (added `uptime` field)
+
+Updating api-reference.md:
+  - Removed DELETE /api/sessions/:id entry
+  - Added POST /api/agents/:id/skills with request/response schema
+  - Updated GET /api/health/trends response to include `uptime`
+
+PR created: "docs: sync API reference with codebase" → PR #170
+```
 
 ---
 
@@ -237,6 +560,25 @@ These patterns compose naturally:
 - **Review + Tests:** PR reviewer flags missing test coverage, then a second agent writes the tests
 - **Council + Implementation:** Council decides on an approach, then agents execute the plan
 - **Schedule + Bridge:** Scheduled results are forwarded to your Telegram or Discord channel
+- **Research + Decision:** Research agent gathers options, council votes on the direction
+
+---
+
+## Quick Reference
+
+| I want to... | Use case | Setup time |
+|--------------|----------|------------|
+| Get PRs reviewed before standup | [Daily PR Reviews](#1-daily-pr-reviews) | 2 min |
+| Fix broken CI fast | [Fix CI Failures](#2-fix-ci-failures-automatically) | 1 min |
+| Improve test coverage | [Write Tests](#3-write-tests-for-untested-code) | 2 min |
+| Auto-label incoming issues | [Triage Issues](#4-triage-and-label-new-issues) | 2 min |
+| Automate releases | [Release Manager](#5-release-manager) | 1 min |
+| Answer user questions | [Discord Support](#6-discord-support-agent) | 5 min |
+| Post updates everywhere | [Announcements](#7-cross-channel-announcements) | 1 min |
+| Make group decisions | [On-Chain Governance](#8-on-chain-governance) | 3 min |
+| Coordinate agents | [AlgoChat Messaging](#9-agent-to-agent-messaging-algochat) | 5 min |
+| Evaluate options | [Research Agent](#10-research-agent) | 1 min |
+| Keep docs current | [Documentation Keeper](#11-documentation-keeper) | 2 min |
 
 ---
 


### PR DESCRIPTION
## Summary
- Expanded `docs/use-cases.md` from 5 to 11 use cases with **example interactions** showing what agents actually say and do
- Added new categories: Community & Communication (Discord support, announcements), Algorand & Web3 (on-chain governance, AlgoChat messaging), Personal & Team Productivity (research agent, documentation keeper)
- Added quick-reference table mapping "I want to..." to specific use cases with setup times
- Updated `docs/quickstart.md` with entry point decision tree (`bun run try` → `corvid-agent demo` → `corvid-agent init`)

Closes #1183

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 7920 pass, 0 fail
- [x] `bun run spec:check` — 156/156 specs, 100% file coverage
- [x] Review all example interactions for accuracy against actual tool names
- [x] Verify all internal doc links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)