### PR TITLE
feat: tiered corvid_send_message access for scheduler sessions

### DIFF
--- a/server/__tests__/scheduler-tool-gating.test.ts
+++ b/server/__tests__/scheduler-tool-gating.test.ts
@@ -9,12 +9,33 @@ import {
     SCHEDULER_MAX_ISSUES_PER_SESSION,
     SCHEDULER_MAX_PRS_PER_SESSION,
     SCHEDULER_MAX_PR_COMMENTS_PER_SESSION,
+    SCHEDULER_MAX_MESSAGES_PER_SESSION,
 } from '../mcp/scheduler-tool-gating';
 
 describe('isToolBlockedForScheduler', () => {
-    test('always blocks corvid_send_message regardless of action type', () => {
-        expect(isToolBlockedForScheduler('corvid_send_message', 'custom')).toBe(true);
-        expect(isToolBlockedForScheduler('corvid_send_message', 'daily_review')).toBe(true);
+    test('allows corvid_send_message for send_message action', () => {
+        expect(isToolBlockedForScheduler('corvid_send_message', 'send_message')).toBe(false);
+    });
+
+    test('allows corvid_send_message for status_checkin action', () => {
+        expect(isToolBlockedForScheduler('corvid_send_message', 'status_checkin')).toBe(false);
+    });
+
+    test('allows corvid_send_message for daily_review action', () => {
+        expect(isToolBlockedForScheduler('corvid_send_message', 'daily_review')).toBe(false);
+    });
+
+    test('allows corvid_send_message for custom action', () => {
+        expect(isToolBlockedForScheduler('corvid_send_message', 'custom')).toBe(false);
+    });
+
+    test('blocks corvid_send_message for non-allowed action types', () => {
+        expect(isToolBlockedForScheduler('corvid_send_message', 'work_task')).toBe(true);
+        expect(isToolBlockedForScheduler('corvid_send_message', 'review_prs')).toBe(true);
+        expect(isToolBlockedForScheduler('corvid_send_message', 'improvement_loop')).toBe(true);
+    });
+
+    test('blocks corvid_send_message when no action type provided', () => {
         expect(isToolBlockedForScheduler('corvid_send_message')).toBe(true);
     });
 
@@ -151,6 +172,21 @@ describe('checkSchedulerRateLimit', () => {
         expect(result).not.toBeNull();
     });
 
+    test('allows up to max messages per session', () => {
+        const usage = new Map<string, number>();
+        for (let i = 0; i < SCHEDULER_MAX_MESSAGES_PER_SESSION; i++) {
+            expect(checkSchedulerRateLimit('corvid_send_message', usage)).toBeNull();
+        }
+        expect(usage.get('corvid_send_message')).toBe(SCHEDULER_MAX_MESSAGES_PER_SESSION);
+    });
+
+    test('blocks after exceeding message limit', () => {
+        const usage = new Map<string, number>([['corvid_send_message', SCHEDULER_MAX_MESSAGES_PER_SESSION]]);
+        const result = checkSchedulerRateLimit('corvid_send_message', usage);
+        expect(result).not.toBeNull();
+        expect(result).toContain('rate limit');
+    });
+
     test('returns null for tools without rate limits', () => {
         const usage = new Map<string, number>();
         expect(checkSchedulerRateLimit('corvid_save_memory', usage)).toBeNull();
@@ -168,15 +204,19 @@ describe('checkSchedulerRateLimit', () => {
 
 describe('constants', () => {
     test('SCHEDULER_ALWAYS_BLOCKED contains expected tools', () => {
-        expect(SCHEDULER_ALWAYS_BLOCKED.has('corvid_send_message')).toBe(true);
         expect(SCHEDULER_ALWAYS_BLOCKED.has('corvid_grant_credits')).toBe(true);
         expect(SCHEDULER_ALWAYS_BLOCKED.has('corvid_credit_config')).toBe(true);
         expect(SCHEDULER_ALWAYS_BLOCKED.has('corvid_github_fork_repo')).toBe(true);
         expect(SCHEDULER_ALWAYS_BLOCKED.has('corvid_ask_owner')).toBe(true);
     });
 
-    test('SCHEDULER_GATED_TOOLS contains 3 tools', () => {
-        expect(SCHEDULER_GATED_TOOLS.size).toBe(3);
+    test('corvid_send_message is gated, not always blocked', () => {
+        expect(SCHEDULER_ALWAYS_BLOCKED.has('corvid_send_message')).toBe(false);
+        expect(SCHEDULER_GATED_TOOLS.has('corvid_send_message')).toBe(true);
+    });
+
+    test('SCHEDULER_GATED_TOOLS contains 4 tools', () => {
+        expect(SCHEDULER_GATED_TOOLS.size).toBe(4);
     });
 
     test('SCHEDULER_ESCALATION_LABEL is agent-escalation', () => {

--- a/server/mcp/scheduler-tool-gating.ts
+++ b/server/mcp/scheduler-tool-gating.ts
@@ -14,7 +14,6 @@ import type { ScheduleActionType } from '../../shared/types/schedules';
 
 /** Tools that are never appropriate for automated scheduler sessions. */
 export const SCHEDULER_ALWAYS_BLOCKED = new Set([
-    'corvid_send_message',
     'corvid_grant_credits',
     'corvid_credit_config',
     'corvid_github_fork_repo',
@@ -29,6 +28,7 @@ export const SCHEDULER_GATED_TOOLS: ReadonlyMap<string, ReadonlySet<ScheduleActi
     ['corvid_github_create_issue', new Set<ScheduleActionType>(['daily_review', 'improvement_loop', 'custom'])],
     ['corvid_github_create_pr', new Set<ScheduleActionType>(['work_task', 'improvement_loop', 'codebase_review'])],
     ['corvid_github_comment_on_pr', new Set<ScheduleActionType>(['review_prs', 'daily_review'])],
+    ['corvid_send_message', new Set<ScheduleActionType>(['send_message', 'status_checkin', 'daily_review', 'custom'])],
 ]);
 
 /** Max issues a single scheduler session may create (rate limiting). */
@@ -39,6 +39,9 @@ export const SCHEDULER_MAX_PRS_PER_SESSION = 3;
 
 /** Max PR comments a single scheduler session may create (rate limiting). */
 export const SCHEDULER_MAX_PR_COMMENTS_PER_SESSION = 5;
+
+/** Max messages a single scheduler session may send (rate limiting). */
+export const SCHEDULER_MAX_MESSAGES_PER_SESSION = 3;
 
 /** Orgs that scheduled sessions are allowed to create issues/PRs in. */
 export const SCHEDULER_ALLOWED_ORGS = new Set(['CorvidLabs', 'corvid-agent']);
@@ -83,6 +86,7 @@ const SCHEDULER_RATE_LIMITS: Record<string, number> = {
     corvid_github_create_issue: SCHEDULER_MAX_ISSUES_PER_SESSION,
     corvid_github_create_pr: SCHEDULER_MAX_PRS_PER_SESSION,
     corvid_github_comment_on_pr: SCHEDULER_MAX_PR_COMMENTS_PER_SESSION,
+    corvid_send_message: SCHEDULER_MAX_MESSAGES_PER_SESSION,
 };
 
 /**

--- a/specs/mcp/sdk-tools.spec.md
+++ b/specs/mcp/sdk-tools.spec.md
@@ -31,18 +31,19 @@ Creates the MCP server that exposes all `corvid_*` tools to Claude agent session
 
 | Constant | Type | Description |
 |----------|------|-------------|
-| `SCHEDULER_ALWAYS_BLOCKED` | `Set<string>` | 5 tool names never available in scheduler mode: `corvid_send_message`, `corvid_grant_credits`, `corvid_credit_config`, `corvid_github_fork_repo`, `corvid_ask_owner` |
-| `SCHEDULER_GATED_TOOLS` | `ReadonlyMap<string, ReadonlySet<ScheduleActionType>>` | Tools blocked by default in scheduler mode but allowed for specific action types (3 entries) |
+| `SCHEDULER_ALWAYS_BLOCKED` | `Set<string>` | 4 tool names never available in scheduler mode: `corvid_grant_credits`, `corvid_credit_config`, `corvid_github_fork_repo`, `corvid_ask_owner` |
+| `SCHEDULER_GATED_TOOLS` | `ReadonlyMap<string, ReadonlySet<ScheduleActionType>>` | Tools blocked by default in scheduler mode but allowed for specific action types (4 entries) |
 | `SCHEDULER_MAX_ISSUES_PER_SESSION` | `number` | Max issues a single scheduler session may create (3) |
 | `SCHEDULER_MAX_PRS_PER_SESSION` | `number` | Max PRs a single scheduler session may create (3) |
 | `SCHEDULER_MAX_PR_COMMENTS_PER_SESSION` | `number` | Max PR comments a single scheduler session may create (5) |
+| `SCHEDULER_MAX_MESSAGES_PER_SESSION` | `number` | Max messages a single scheduler session may send (3) |
 | `SCHEDULER_ALLOWED_ORGS` | `Set<string>` | Orgs that scheduled sessions may create issues/PRs in: `CorvidLabs`, `corvid-agent` |
 | `SCHEDULER_ESCALATION_LABEL` | `string` | Label automatically applied to issues created by scheduled sessions: `'agent-escalation'` |
 
 ## Invariants
 
 1. **DEFAULT_ALLOWED_TOOLS**: 35 tools available to all agents when `mcp_tool_permissions` is NULL. Privileged tools (`corvid_grant_credits`, `corvid_credit_config`) are excluded from this set
-2. **Tiered scheduler tool gating**: Uses `SCHEDULER_ALWAYS_BLOCKED` (5 tools: `corvid_send_message`, `corvid_grant_credits`, `corvid_credit_config`, `corvid_github_fork_repo`, `corvid_ask_owner`) and `SCHEDULER_GATED_TOOLS` (3 tools allowed for specific action types: `corvid_github_create_issue` for daily_review/improvement_loop/custom, `corvid_github_create_pr` for work_task/improvement_loop/codebase_review, `corvid_github_comment_on_pr` for review_prs/daily_review). Defined in `scheduler-tool-gating.ts`
+2. **Tiered scheduler tool gating**: Uses `SCHEDULER_ALWAYS_BLOCKED` (4 tools: `corvid_grant_credits`, `corvid_credit_config`, `corvid_github_fork_repo`, `corvid_ask_owner`) and `SCHEDULER_GATED_TOOLS` (4 tools allowed for specific action types: `corvid_github_create_issue` for daily_review/improvement_loop/custom, `corvid_github_create_pr` for work_task/improvement_loop/codebase_review, `corvid_github_comment_on_pr` for review_prs/daily_review, `corvid_send_message` for send_message/status_checkin/daily_review/custom). Defined in `scheduler-tool-gating.ts`
 3. **Permission resolution**: Web-source sessions get all tools. Non-web sessions are filtered by `ctx.resolvedToolPermissions` (agent base + skill bundle tools + project bundle tools). If no permissions are set, `DEFAULT_ALLOWED_TOOLS` is used
 4. **Scheduler mode filtering**: When `ctx.schedulerMode` is true, `isToolBlockedForScheduler(toolName, ctx.schedulerActionType)` determines which tools are removed. Always-blocked tools are removed unconditionally; gated tools are allowed only when the action type is in the tool's allowed set
 5. **Plugin tool injection**: Optional `pluginTools` parameter allows dynamically loaded plugin tools to be added to the MCP server alongside built-in tools
@@ -67,13 +68,13 @@ Creates the MCP server that exposes all `corvid_*` tools to Claude agent session
 
 - **Given** a scheduler-initiated session (`ctx.schedulerMode = true`, any action type)
 - **When** `createCorvidMcpServer` is called
-- **Then** always-blocked tools (`corvid_send_message`, `corvid_grant_credits`, etc.) are removed from the final set
+- **Then** always-blocked tools (`corvid_grant_credits`, `corvid_credit_config`, etc.) are removed from the final set
 
 ### Scenario: Scheduler-mode session (gated tool allowed)
 
 - **Given** a scheduler-initiated session (`ctx.schedulerMode = true`, `ctx.schedulerActionType = 'daily_review'`)
 - **When** `createCorvidMcpServer` is called
-- **Then** `corvid_github_create_issue` is included (allowed for daily_review), but `corvid_github_create_pr` is excluded (not allowed for daily_review)
+- **Then** `corvid_github_create_issue` and `corvid_send_message` are included (allowed for daily_review), but `corvid_github_create_pr` is excluded (not allowed for daily_review)
 
 ### Scenario: Web-source session
 
@@ -112,3 +113,4 @@ Creates the MCP server that exposes all `corvid_*` tools to Claude agent session
 | 2026-02-19 | corvid-agent | Initial spec |
 | 2026-02-24 | corvid-agent | Updated dependency path after tool-handlers refactor (#233) |
 | 2026-03-05 | corvid-agent | Document scheduler-tool-gating exports: 3 functions, 7 constants (#591) |
+| 2026-03-18 | corvid-agent | Move corvid_send_message from always-blocked to gated with tiered access (#1155) |


### PR DESCRIPTION
## Summary

- Move `corvid_send_message` from `SCHEDULER_ALWAYS_BLOCKED` to `SCHEDULER_GATED_TOOLS` with tiered access for `send_message`, `status_checkin`, `daily_review`, and `custom` action types
- Add `SCHEDULER_MAX_MESSAGES_PER_SESSION` (3) rate limit to prevent message flooding
- Update spec and tests to reflect the new gating behavior (42 tests pass)

## Why

Schedules currently can't report results via AlgoChat or coordinate with other agents because `corvid_send_message` is unconditionally blocked. This change enables messaging for action types that naturally need it (status reports, daily reviews, custom workflows) while keeping it blocked for action types where messaging is inappropriate (work_task, review_prs, improvement_loop).

## Guardrails

- Rate limited to 3 messages per session
- Only allowed for 4 specific action types (send_message, status_checkin, daily_review, custom)
- Combined with existing 5-minute minimum schedule interval and max concurrent executions

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit --skipLibCheck`)
- [x] 7928 tests pass, 0 fail across 330 files
- [x] 156/156 specs pass (100% file coverage)
- [x] 42 scheduler-tool-gating tests pass (includes new tiered access + rate limit tests)

Closes #1155

🤖 Generated with [Claude Code](https://claude.com/claude-code)