### PR TITLE
fix: add GitHub owner rule to CLAUDE.md (#1229)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,14 @@ When scheduling autonomous work, follow this allocation:
 - **5-10%** — External OSS contributions (claude-code, MCP ecosystem, A2A)
 - **0%** — Off-limits repos listed above
 
+## GitHub Owner
+
+The canonical owner for this repository is **`CorvidLabs`** (the organization), NOT `corvid-agent` (the bot's GitHub username).
+
+**All GitHub API calls must use `owner: "CorvidLabs"`** when targeting repos in this org. The bot's username `corvid-agent` is NOT an org that owns repositories — using it will return empty/wrong results.
+
+When in doubt, resolve from `git remote get-url origin` which returns `CorvidLabs/corvid-agent`.
+
 ## Security Rules
 
 ### External Network Calls


### PR DESCRIPTION
## Summary

- Adds a `## GitHub Owner` section to CLAUDE.md explicitly stating that all GitHub API calls must use `owner: "CorvidLabs"`, not `corvid-agent` (the bot username)
- Prevents recurrence of #1229 where the agent queried the wrong org and falsely reported "0 open PRs"

Companion to #1230 which adds code-level validation warnings.

Closes #1229

## Test plan

- [x] Verify CLAUDE.md renders correctly
- [x] Verify agent sessions load the new rule in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)