### PR TITLE
Fix URL in spec validation step of checks.yml

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,7 +39,7 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
 
       - name: Spec validation (strict + 100% coverage)
-        # https://github.com/marketplace/actions/specsync
+        # https://github.com/marketplace/actions/spec-sync
         uses: CorvidLabs/spec-sync@v1
         with:
           strict: 'true'


### PR DESCRIPTION
This pull request includes a minor update to the workflow documentation in `.github/workflows/checks.yml`. The change corrects the link to the marketplace action used for spec validation.

* Updated the comment to reference the correct GitHub Marketplace action URL for `spec-sync` in the workflow configuration.