### PR TITLE
feat: strip dev-only files from install artifact

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -150,6 +150,16 @@ else
     info "Cloned to $INSTALL_DIR"
 fi
 
+# ─── Step 2b: Remove dev-only files ─────────────────────────────────────────
+
+step "Cleaning up development files"
+
+# Remove dev/contributor-only directories and files that aren't needed at runtime
+rm -rf specs/ tests/ .claude/ CLAUDE.md docs/
+# Remove dev scripts but keep install.sh and setup.sh
+find scripts/ -type f ! -name 'install.sh' ! -name 'setup.sh' -delete 2>/dev/null || true
+info "Removed development files (specs, tests, docs, dev scripts)"
+
 # ─── Step 3: Environment setup ──────────────────────────────────────────────
 
 step "Configuring environment"


### PR DESCRIPTION
## Summary
- Adds a post-install cleanup step that removes dev-only files (specs/, tests/, docs/, .claude/, CLAUDE.md, and dev-only scripts) from the install artifact after `git clone`, giving end users a lean runtime-only installation.
- Docker installs already exclude these files via Dockerfile COPY directives; this brings non-Docker installs to parity.
- Tracks #1236 as the long-term issue for install artifact hygiene.

## Test plan
- [x] Run the install script on a fresh clone and verify specs/, tests/, docs/, .claude/, CLAUDE.md, and dev-only scripts are absent from the resulting directory
- [x] Verify `bun run start` works correctly after cleanup (no missing runtime files)
- [x] Verify Docker build still works unchanged
- [x] Run `bun run spec:check` on the source repo to confirm no spec regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)