### PR TITLE
feat: build release tarball in CI for clean installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,34 @@ jobs:
             echo "CHANGELOG_EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Build release tarball
+        env:
+          TAG: ${{ steps.tag.outputs.version }}
+        run: |
+          STAGING="$(mktemp -d)/corvid-agent"
+          mkdir -p "$STAGING"
+
+          # Copy runtime files only
+          cp -r server/    "$STAGING/server"
+          cp -r shared/    "$STAGING/shared"
+          cp -r client/    "$STAGING/client"
+          cp -r patches/   "$STAGING/patches"
+          cp package.json  "$STAGING/package.json"
+          cp bun.lock      "$STAGING/bun.lock"
+          cp .env.example  "$STAGING/.env.example"
+          cp README.md     "$STAGING/README.md"
+          cp LICENSE        "$STAGING/LICENSE"
+          mkdir -p "$STAGING/scripts"
+          cp scripts/install.sh "$STAGING/scripts/install.sh"
+          cp scripts/setup.sh   "$STAGING/scripts/setup.sh"
+
+          # Create tarball from staging parent dir
+          tar -czf "corvid-agent-${TAG}.tar.gz" -C "$(dirname "$STAGING")" corvid-agent
+
+          echo "Tarball contents:"
+          tar -tzf "corvid-agent-${TAG}.tar.gz" | head -30
+          ls -lh "corvid-agent-${TAG}.tar.gz"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2
         with:
@@ -97,3 +125,4 @@ jobs:
           body: ${{ steps.changelog.outputs.changelog }}
           prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
           generate_release_notes: false
+          files: corvid-agent-${{ steps.tag.outputs.version }}.tar.gz

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -136,18 +136,65 @@ else
     fi
 fi
 
-# ─── Step 2: Clone or update ────────────────────────────────────────────────
+# ─── Step 2: Install or update ──────────────────────────────────────────────
 
 step "Getting corvid-agent"
 
+REPO="CorvidLabs/corvid-agent"
+
+# Fetch latest release tarball URL from GitHub API
+get_latest_tarball_url() {
+    local api_url="https://api.github.com/repos/${REPO}/releases/latest"
+    local release_json
+    release_json=$(curl -fsSL "$api_url" 2>/dev/null) || return 1
+    echo "$release_json" | grep -o '"browser_download_url": *"[^"]*corvid-agent-[^"]*\.tar\.gz"' \
+        | head -1 | cut -d'"' -f4
+}
+
 if [[ -d "$INSTALL_DIR/.git" ]]; then
-    info "Found existing install at $INSTALL_DIR"
+    # ── Existing git install (developer/contributor) ──
+    info "Found existing git install at $INSTALL_DIR"
     cd "$INSTALL_DIR"
     git pull --ff-only origin main 2>/dev/null || warn "Could not fast-forward — using existing version"
+elif [[ -d "$INSTALL_DIR" ]]; then
+    # ── Existing tarball install — upgrade in place ──
+    info "Found existing install at $INSTALL_DIR"
+    TARBALL_URL=$(get_latest_tarball_url)
+    if [[ -n "$TARBALL_URL" ]]; then
+        TMPDIR_DL="$(mktemp -d)"
+        info "Downloading latest release..."
+        curl -fsSL "$TARBALL_URL" -o "$TMPDIR_DL/corvid-agent.tar.gz" \
+            || fail "Failed to download release tarball"
+        # Extract over existing dir, preserving .env and user data
+        tar -xzf "$TMPDIR_DL/corvid-agent.tar.gz" --strip-components=1 -C "$INSTALL_DIR"
+        rm -rf "$TMPDIR_DL"
+        cd "$INSTALL_DIR"
+        info "Updated to latest release"
+    else
+        warn "No release found — keeping existing version"
+        cd "$INSTALL_DIR"
+    fi
 else
-    git clone https://github.com/CorvidLabs/corvid-agent.git "$INSTALL_DIR"
-    cd "$INSTALL_DIR"
-    info "Cloned to $INSTALL_DIR"
+    # ── Fresh install ──
+    TARBALL_URL=$(get_latest_tarball_url)
+    if [[ -n "$TARBALL_URL" ]]; then
+        mkdir -p "$INSTALL_DIR"
+        TMPDIR_DL="$(mktemp -d)"
+        info "Downloading latest release..."
+        curl -fsSL "$TARBALL_URL" -o "$TMPDIR_DL/corvid-agent.tar.gz" \
+            || fail "Failed to download release tarball"
+        tar -xzf "$TMPDIR_DL/corvid-agent.tar.gz" --strip-components=1 -C "$INSTALL_DIR"
+        rm -rf "$TMPDIR_DL"
+        cd "$INSTALL_DIR"
+        info "Installed to $INSTALL_DIR"
+    else
+        # No releases yet — fall back to git clone
+        warn "No release tarball found — falling back to git clone"
+        warn "This includes dev files; future updates will use release tarballs"
+        git clone https://github.com/${REPO}.git "$INSTALL_DIR"
+        cd "$INSTALL_DIR"
+        info "Cloned to $INSTALL_DIR"
+    fi
 fi
 
 # ─── Step 3: Environment setup ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds a "Build release tarball" step to the release workflow that packages only runtime files (server/, shared/, client/, patches/, package.json, bun.lock, .env.example, README.md, LICENSE, scripts/install.sh, scripts/setup.sh) into a `corvid-agent-<version>.tar.gz` attached to each GitHub Release
- Updates `install.sh` to download the release tarball instead of `git clone` for new installs — end users never see specs, tests, docs, or dev scripts
- Existing git installs (developers/contributors) still use `git pull` as before
- Falls back to git clone if no releases exist yet

Supersedes the post-clone cleanup approach in #1237. Closes #1236.

## Test plan

- [x] Verify release workflow syntax is valid (CI will check)
- After next release tag, confirm tarball is attached to the GitHub Release
- Confirm tarball contains only runtime files (no specs/, tests/, docs/, .claude/)
- Test fresh install path: `curl | bash` downloads tarball and extracts correctly
- Test upgrade path: existing tarball install gets updated in place, .env preserved
- Test developer path: existing git install still does `git pull`
- Test fallback: with no releases, falls back to git clone with warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)