### PR TITLE
feat: Discord status and dashboard embeds

### DIFF
--- a/server/__tests__/discord-command-handlers.test.ts
+++ b/server/__tests__/discord-command-handlers.test.ts
@@ -21,9 +21,12 @@ import { handleComponentInteraction } from '../discord/command-handlers/componen
 import {
     handleAgentsCommand,
     handleStatusCommand,
+    handleDashboardCommand,
     handleConfigCommand,
     handleQuickstartCommand,
     handleHelpCommand,
+    formatUptime,
+    measureDbLatency,
 } from '../discord/command-handlers/info-commands';
 import {
     handleCouncilCommand,
@@ -608,16 +611,112 @@ describe('handleAgentsCommand', () => {
 });
 
 describe('handleStatusCommand', () => {
-    test('shows active session count', async () => {
+    test('shows rich status embed with key metrics', async () => {
         const ctx = createTestContext();
         ctx.threadSessions.set('thread-1', { sessionId: 's1', agentName: 'A', agentModel: 'm', ownerUserId: 'u' });
         ctx.threadSessions.set('thread-2', { sessionId: 's2', agentName: 'B', agentModel: 'm', ownerUserId: 'u' });
+        createAgent(db, { name: 'TestAgent', model: 'test-model' });
 
         const interaction = makeInteraction('status');
         await handleStatusCommand(ctx, interaction);
 
-        const content = capturedResponse!.data?.content as string;
-        expect(content).toContain('2');
+        const embeds = capturedResponse!.data?.embeds as Array<{
+            title: string;
+            fields: Array<{ name: string; value: string }>;
+            timestamp: string;
+        }>;
+        expect(embeds[0].title).toBe('System Status');
+        const fieldNames = embeds[0].fields.map(f => f.name);
+        expect(fieldNames).toContain('Version');
+        expect(fieldNames).toContain('Uptime');
+        expect(fieldNames).toContain('DB Latency');
+        expect(fieldNames).toContain('Agents');
+        expect(fieldNames).toContain('Active Sessions');
+        expect(fieldNames).toContain('Tasks');
+        expect(fieldNames).toContain('Schedules');
+
+        const sessionsField = embeds[0].fields.find(f => f.name === 'Active Sessions');
+        expect(sessionsField!.value).toBe('2');
+
+        const agentsField = embeds[0].fields.find(f => f.name === 'Agents');
+        expect(agentsField!.value).toBe('1');
+
+        expect(embeds[0].timestamp).toBeDefined();
+    });
+});
+
+describe('handleDashboardCommand', () => {
+    test('returns multi-embed dashboard', async () => {
+        const ctx = createTestContext();
+        createAgent(db, { name: 'AlphaBot', model: 'claude-opus-4-6' });
+        createAgent(db, { name: 'BetaBot', model: 'claude-sonnet-4' });
+
+        const interaction = makeInteraction('dashboard');
+        await handleDashboardCommand(ctx, interaction);
+
+        const embeds = capturedResponse!.data?.embeds as Array<{ title: string }>;
+        expect(embeds).toHaveLength(4);
+        expect(embeds[0].title).toContain('System Overview');
+        expect(embeds[1].title).toBe('Agents');
+        expect(embeds[2].title).toBe('Work Pipeline');
+        expect(embeds[3].title).toBe('Schedules');
+    });
+
+    test('shows agents with active session indicators', async () => {
+        const ctx = createTestContext();
+        createAgent(db, { name: 'ActiveBot', model: 'test-model' });
+        createAgent(db, { name: 'IdleBot', model: 'test-model' });
+        ctx.threadSessions.set('thread-1', { sessionId: 's1', agentName: 'ActiveBot', agentModel: 'test-model', ownerUserId: 'u' });
+
+        const interaction = makeInteraction('dashboard');
+        await handleDashboardCommand(ctx, interaction);
+
+        const embeds = capturedResponse!.data?.embeds as Array<{ title: string; description: string }>;
+        const agentEmbed = embeds.find(e => e.title === 'Agents')!;
+        // ActiveBot should have green indicator, IdleBot should have grey
+        expect(agentEmbed.description).toContain('ActiveBot');
+        expect(agentEmbed.description).toContain('IdleBot');
+    });
+
+    test('shows empty states gracefully', async () => {
+        const ctx = createTestContext();
+        const interaction = makeInteraction('dashboard');
+        await handleDashboardCommand(ctx, interaction);
+
+        const embeds = capturedResponse!.data?.embeds as Array<{ title: string; description: string }>;
+        const agentEmbed = embeds.find(e => e.title === 'Agents')!;
+        expect(agentEmbed.description).toContain('No agents configured');
+
+        const workEmbed = embeds.find(e => e.title === 'Work Pipeline')!;
+        expect(workEmbed.description).toContain('No active tasks');
+
+        const schedEmbed = embeds.find(e => e.title === 'Schedules')!;
+        expect(schedEmbed.description).toContain('No active schedules');
+    });
+});
+
+describe('formatUptime', () => {
+    test('formats minutes only', () => {
+        expect(formatUptime(300)).toBe('5m');
+    });
+
+    test('formats hours and minutes', () => {
+        expect(formatUptime(3660)).toBe('1h 1m');
+    });
+
+    test('formats days, hours, and minutes', () => {
+        expect(formatUptime(90060)).toBe('1d 1h 1m');
+    });
+
+    test('formats zero', () => {
+        expect(formatUptime(0)).toBe('0m');
+    });
+});
+
+describe('measureDbLatency', () => {
+    test('returns non-negative number', () => {
+        const latency = measureDbLatency(db);
+        expect(latency).toBeGreaterThanOrEqual(0);
     });
 });
 
@@ -1213,6 +1312,27 @@ describe('handleInteraction dispatch', () => {
 
         const content = capturedResponse!.data?.content as string;
         expect(content).toContain('Unknown command');
+    });
+
+    test('dispatches /dashboard command', async () => {
+        const ctx = createTestContext();
+        const interaction = makeInteraction('dashboard');
+
+        await handleInteraction(ctx, interaction);
+
+        const embeds = capturedResponse!.data?.embeds as Array<{ title: string }>;
+        expect(embeds).toHaveLength(4);
+        expect(embeds[0].title).toContain('System Overview');
+    });
+
+    test('dispatches /status command with rich embed', async () => {
+        const ctx = createTestContext();
+        const interaction = makeInteraction('status');
+
+        await handleInteraction(ctx, interaction);
+
+        const embeds = capturedResponse!.data?.embeds as Array<{ title: string }>;
+        expect(embeds[0].title).toBe('System Status');
     });
 
     test('ignores non-command interactions', async () => {

--- a/server/discord/command-handlers/info-commands.ts
+++ b/server/discord/command-handlers/info-commands.ts
@@ -2,7 +2,7 @@
  * Discord informational command handlers.
  *
  * Handles `/agents`, `/status`, `/tasks`, `/schedule`, `/config`,
- * `/quickstart`, and `/help` commands.
+ * `/quickstart`, `/dashboard`, and `/help` commands.
  */
 
 import type { InteractionContext } from '../commands';
@@ -14,6 +14,8 @@ import { listActiveSchedules } from '../../db/schedules';
 import {
     respondToInteraction,
     respondToInteractionEmbed,
+    respondToInteractionEmbeds,
+    type DiscordEmbed,
 } from '../embeds';
 
 export async function handleAgentsCommand(
@@ -29,13 +31,67 @@ export async function handleAgentsCommand(
     await respondToInteraction(interaction, `Available agents:\n${lines.join('\n')}`);
 }
 
+/** Format seconds into a human-readable uptime string. */
+export function formatUptime(seconds: number): string {
+    const d = Math.floor(seconds / 86400);
+    const h = Math.floor((seconds % 86400) / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    if (d > 0) return `${d}d ${h}h ${m}m`;
+    if (h > 0) return `${h}h ${m}m`;
+    return `${m}m`;
+}
+
+/** Measure DB latency with a trivial query. */
+export function measureDbLatency(db: import('bun:sqlite').Database): number {
+    const start = performance.now();
+    db.query('SELECT 1').get();
+    return Math.round((performance.now() - start) * 100) / 100;
+}
+
+/** Get server version from package.json. */
+function getVersion(): string {
+    try {
+        return (require('../../../package.json') as { version: string }).version;
+    } catch {
+        return 'unknown';
+    }
+}
+
 export async function handleStatusCommand(
     ctx: InteractionContext,
     interaction: DiscordInteractionData,
 ): Promise<void> {
+    const version = getVersion();
+    const uptimeSeconds = Math.floor(process.uptime());
+    const dbLatency = measureDbLatency(ctx.db);
+
+    const agents = listAgents(ctx.db);
     const activeSessions = ctx.threadSessions.size;
-    await respondToInteraction(interaction,
-        `Active thread sessions: **${activeSessions}**\nUse \`/session\` to start a new conversation.`);
+    const activeTaskCount = countActiveTasks(ctx.db);
+    const pendingTaskCount = countPendingTasks(ctx.db);
+
+    const schedules = listActiveSchedules(ctx.db);
+    const scheduleCount = schedules.length;
+
+    const fields: Array<{ name: string; value: string; inline?: boolean }> = [
+        { name: 'Version', value: `v${version}`, inline: true },
+        { name: 'Uptime', value: formatUptime(uptimeSeconds), inline: true },
+        { name: 'DB Latency', value: `${dbLatency}ms`, inline: true },
+        { name: 'Agents', value: String(agents.length), inline: true },
+        { name: 'Active Sessions', value: String(activeSessions), inline: true },
+        { name: 'Tasks', value: `${activeTaskCount} active \u00b7 ${pendingTaskCount} pending`, inline: true },
+        { name: 'Schedules', value: `${scheduleCount} active`, inline: true },
+    ];
+
+    const statusColor = dbLatency < 100 ? 0x57f287 : dbLatency < 500 ? 0xfee75c : 0xed4245;
+
+    await respondToInteractionEmbed(interaction, {
+        title: 'System Status',
+        color: statusColor,
+        fields,
+        footer: { text: 'Use /dashboard for a full overview' },
+        timestamp: new Date().toISOString(),
+    });
 }
 
 export async function handleTasksCommand(
@@ -180,6 +236,98 @@ export async function handleQuickstartCommand(
     });
 }
 
+export async function handleDashboardCommand(
+    ctx: InteractionContext,
+    interaction: DiscordInteractionData,
+): Promise<void> {
+    const version = getVersion();
+    const uptimeSeconds = Math.floor(process.uptime());
+    const dbLatency = measureDbLatency(ctx.db);
+
+    const agents = listAgents(ctx.db);
+    const activeSessions = ctx.threadSessions.size;
+    const activeTaskCount = countActiveTasks(ctx.db);
+    const pendingTaskCount = countPendingTasks(ctx.db);
+    const activeTasks = getActiveWorkTasks(ctx.db);
+    const schedules = listActiveSchedules(ctx.db);
+
+    const statusColor = dbLatency < 100 ? 0x57f287 : dbLatency < 500 ? 0xfee75c : 0xed4245;
+
+    // Embed 1: System overview
+    const overviewEmbed: DiscordEmbed = {
+        title: 'Dashboard — System Overview',
+        color: statusColor,
+        fields: [
+            { name: 'Version', value: `v${version}`, inline: true },
+            { name: 'Uptime', value: formatUptime(uptimeSeconds), inline: true },
+            { name: 'DB Latency', value: `${dbLatency}ms`, inline: true },
+        ],
+        timestamp: new Date().toISOString(),
+    };
+
+    // Embed 2: Agent roster — mark agents with active thread sessions
+    const activeAgentNames = new Set<string>();
+    for (const info of ctx.threadSessions.values()) {
+        activeAgentNames.add(info.agentName);
+    }
+
+    const agentLines = agents.length > 0
+        ? agents.slice(0, 10).map(a => {
+            const indicator = activeAgentNames.has(a.name) ? '\u{1F7E2}' : '\u{26AA}';
+            return `${indicator} **${a.name}** \u2014 ${a.model || 'no model'}`;
+        })
+        : ['_No agents configured._'];
+
+    const agentEmbed: DiscordEmbed = {
+        title: 'Agents',
+        description: agentLines.join('\n'),
+        color: 0x5865f2,
+        fields: [
+            { name: 'Total', value: String(agents.length), inline: true },
+            { name: 'Active Sessions', value: String(activeSessions), inline: true },
+        ],
+    };
+
+    // Embed 3: Work pipeline
+    const statusEmoji: Record<string, string> = {
+        running: '\u{1F7E2}', branching: '\u{1F7E1}', validating: '\u{1F535}',
+        queued: '\u{23F3}', paused: '\u{23F8}',
+    };
+
+    const taskLines = activeTasks.slice(0, 5).map(t => {
+        const emoji = statusEmoji[t.status] || '\u{26AA}';
+        const desc = t.description.slice(0, 60) + (t.description.length > 60 ? '...' : '');
+        return `${emoji} **${t.status}** \u2014 ${desc}`;
+    });
+
+    const workEmbed: DiscordEmbed = {
+        title: 'Work Pipeline',
+        description: taskLines.length > 0 ? taskLines.join('\n') : '_No active tasks._',
+        color: 0xeb459e,
+        fields: [
+            { name: 'Active', value: String(activeTaskCount), inline: true },
+            { name: 'Pending', value: String(pendingTaskCount), inline: true },
+        ],
+    };
+
+    // Embed 4: Schedule health
+    const scheduleLines = schedules.slice(0, 8).map(s => {
+        const nextRun = s.nextRunAt
+            ? `<t:${Math.floor(new Date(s.nextRunAt).getTime() / 1000)}:R>`
+            : 'not scheduled';
+        return `\u2022 **${s.name}** \u2014 next: ${nextRun} \u00b7 runs: ${s.executionCount}`;
+    });
+
+    const scheduleEmbed: DiscordEmbed = {
+        title: 'Schedules',
+        description: scheduleLines.length > 0 ? scheduleLines.join('\n') : '_No active schedules._',
+        color: 0x57f287,
+        footer: { text: `${schedules.length} schedule${schedules.length === 1 ? '' : 's'} active` },
+    };
+
+    await respondToInteractionEmbeds(interaction, [overviewEmbed, agentEmbed, workEmbed, scheduleEmbed]);
+}
+
 export async function handleHelpCommand(
     interaction: DiscordInteractionData,
 ): Promise<void> {
@@ -200,7 +348,8 @@ export async function handleHelpCommand(
                 name: 'Information',
                 value: [
                     '`/agents` — List all available agents and models',
-                    '`/status` — Show active sessions and bot status',
+                    '`/status` — Show system status and key metrics',
+                    '`/dashboard` — Comprehensive system overview',
                     '`/tasks` — View active work tasks and queue status',
                     '`/schedule` — Show schedule status and next runs',
                     '`/help` — Show this help message',

--- a/server/discord/commands.ts
+++ b/server/discord/commands.ts
@@ -27,6 +27,7 @@ import { handleSessionCommand, handleWorkCommand } from './command-handlers/sess
 import {
     handleAgentsCommand,
     handleStatusCommand,
+    handleDashboardCommand,
     handleTasksCommand,
     handleScheduleCommand,
     handleConfigCommand,
@@ -102,7 +103,8 @@ export async function registerSlashCommands(
             ],
         },
         { name: 'agents', description: 'List all available agents', type: 1 },
-        { name: 'status', description: 'Show bot status and active sessions', type: 1 },
+        { name: 'status', description: 'Show system status and key metrics', type: 1 },
+        { name: 'dashboard', description: 'Comprehensive system overview with agents, tasks, and schedules', type: 1 },
         { name: 'tasks', description: 'View active work tasks and queue status', type: 1 },
         { name: 'schedule', description: 'Show schedule status and next runs', type: 1 },
         {
@@ -342,6 +344,9 @@ export async function handleInteraction(
             break;
         case 'status':
             await handleStatusCommand(ctx, interaction);
+            break;
+        case 'dashboard':
+            await handleDashboardCommand(ctx, interaction);
             break;
         case 'tasks':
             await handleTasksCommand(ctx, interaction);

--- a/server/discord/embeds.ts
+++ b/server/discord/embeds.ts
@@ -142,6 +142,37 @@ export async function respondToInteractionEmbed(
     }
 }
 
+export async function respondToInteractionEmbeds(
+    interaction: DiscordInteractionData,
+    embeds: DiscordEmbed[],
+    ephemeral = false,
+): Promise<void> {
+    assertSnowflake(interaction.id, 'interaction ID');
+    assertInteractionToken(interaction.token);
+    const response = await fetch(
+        `https://discord.com/api/v10/interactions/${interaction.id}/${interaction.token}/callback`,
+        {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                type: InteractionCallbackType.CHANNEL_MESSAGE,
+                data: {
+                    embeds,
+                    ...(ephemeral ? { flags: 64 } : {}),
+                },
+            }),
+        },
+    );
+
+    if (!response.ok) {
+        const error = await response.text();
+        log.error('Failed to respond to Discord interaction with embeds', {
+            status: response.status,
+            error: error.slice(0, 200),
+        });
+    }
+}
+
 export async function acknowledgeButton(interaction: DiscordInteractionData, message: string): Promise<void> {
     assertSnowflake(interaction.id, 'interaction ID');
     assertInteractionToken(interaction.token);


### PR DESCRIPTION
## Summary
- Enhanced `/status` command: rich embed with version, uptime, DB latency, agent count, active sessions, task/schedule counts, and color-coded health indicator
- New `/dashboard` command: multi-embed overview with system overview, agent roster (with active session indicators), work pipeline status, and schedule health
- Added `respondToInteractionEmbeds` helper for multi-embed interaction responses
- Updated `/help` to list new `/dashboard` command

Closes #892

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` passes
- [x] All 8,119 tests pass (0 fail)
- [x] New tests for `handleStatusCommand` (rich embed fields, session count)
- [x] New tests for `handleDashboardCommand` (4 embeds, agent indicators, empty states)
- [x] New tests for `formatUptime` (minutes, hours, days)
- [x] New test for `measureDbLatency` (non-negative)
- [x] Integration dispatch tests for `/status` and `/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)