### PR TITLE
docs: sync stale counts across 6 documentation files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,10 +112,10 @@ server/           Bun HTTP + WebSocket server
   discord/        Bidirectional Discord bridge (raw WebSocket)
   github/         GitHub API operations (PRs, issues, reviews)
   lib/            Shared utilities (logger, crypto, validation, dedup)
-  mcp/            MCP tool server and 41 corvid_* tool handlers
+  mcp/            MCP tool server and 46 corvid_* tool handlers
   middleware/     Auth, CORS, rate limiting, startup validation
   process/        Agent lifecycle (SDK + Ollama, persona/skill injection)
-  routes/         REST API route handlers (44 modules)
+  routes/         REST API route handlers (47 modules)
   scheduler/      Cron/interval execution engine
   telegram/       Bidirectional Telegram bridge (long-polling, voice)
   voice/          TTS (OpenAI) and STT (Whisper) with caching

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ DISCORD_BOT_TOKEN=your-bot-token      # talk to agents from Discord
 SLACK_BOT_TOKEN=xoxb-your-bot-token   # talk to agents from Slack
 ```
 
-See `.env.example` for the full list of 30+ configuration options.
+See `.env.example` for the full list of 60+ configuration options.
 
 ---
 
@@ -151,7 +151,7 @@ Every PR runs the full suite. Every module has a spec. Every spec is validated i
 | Metric | Count |
 |--------|-------|
 | MCP tools | **46** corvid_* tool handlers |
-| API endpoints | **279** across 46 route modules |
+| API endpoints | **~300** across 47 route modules |
 | DB migrations | **16** (squashed baseline + incremental, 90+ tables) |
 | Test:code ratio | **1.14×** — more test code than production code |
 
@@ -388,7 +388,7 @@ server/          Bun HTTP + WebSocket server
   providers/     Multi-model cost-aware routing
   public/        Static assets served by the HTTP server
   reputation/    Reputation and trust scoring
-  routes/        REST API routes (46 route modules)
+  routes/        REST API routes (47 route modules)
   sandbox/       Container sandboxing for isolated execution
   scheduler/     Cron/interval execution engine
   selftest/      Self-test and validation utilities
@@ -438,7 +438,7 @@ Tools are permission-scoped per agent via skill bundles and agent-level allowlis
 
 ## API
 
-~300 REST endpoints and a WebSocket interface across 46 route modules.
+~300 REST endpoints and a WebSocket interface across 47 route modules.
 
 **[API Reference](docs/api-reference.md)** — detailed docs with request/response examples for workflows, councils, marketplace, reputation, and billing.
 

--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -36,7 +36,7 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 |--------|-------|
 | TypeScript LOC | 182,301 |
 | Server modules | 47 |
-| API routes | 44 modules (~205 endpoints) |
+| API routes | 47 modules (~300 endpoints) |
 | Database tables | 93 |
 | Database migrations | 16 (squashed baseline) |
 | MCP tools | 46 corvid_* handlers |
@@ -67,8 +67,8 @@ algochat/        21 files — On-chain identity, wallets, PSK messaging, agent d
 councils/        3 files  — Multi-agent deliberation, governance tiers, synthesis
 work/            1 file   — Self-improvement pipeline (worktrees, validation, PRs)
 process/         —          Session lifecycle, SDK + Ollama, approval flow, personas
-mcp/             17 files — 41 corvid_* tool handlers
-routes/          44 files — REST API (~205 endpoints)
+mcp/             17 files — 46 corvid_* tool handlers
+routes/          47 files — REST API (~300 endpoints)
 db/              —          SQLite schema, 11 migrations, 93 tables
 reputation/      5 files  — Scoring, attestation, verification, identity proofs
 memory/          8 files  — Vector embeddings, FTS5 search, decay, sync

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -68,7 +68,7 @@ The agent runs until it finishes or you stop it. Sessions can be paused and resu
 
 ## Tool System (MCP)
 
-Agents interact with the world through **44 MCP tools**. Each tool is a function the LLM can call:
+Agents interact with the world through **46 MCP tools**. Each tool is a function the LLM can call:
 
 | Category | Examples |
 |----------|----------|

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -1,6 +1,6 @@
 # MCP Setup Guide
 
-CorvidAgent exposes **44 MCP tools** (`corvid_*`) via standard [Model Context Protocol](https://modelcontextprotocol.io) stdio transport. This means it works with any MCP-compatible AI assistant.
+CorvidAgent exposes **46 MCP tools** (`corvid_*`) via standard [Model Context Protocol](https://modelcontextprotocol.io) stdio transport. This means it works with any MCP-compatible AI assistant.
 
 ## Quick Setup
 
@@ -200,7 +200,7 @@ The stdio server exposes 4 core tools: `corvid_send_message`, `corvid_save_memor
 
 The full `corvid-agent-mcp` npm package exposes 14 tools including agents, sessions, work tasks, and projects.
 
-When connected via the web dashboard or Claude Agent SDK, all 38 tools are available.
+When connected via the web dashboard or Claude Agent SDK, all 46 tools are available.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -232,7 +232,7 @@ corvid-agent server (Bun, port 3000)
   |-- Dashboard (Angular 21)
   |-- REST API + WebSocket
   |-- Agent sessions (Claude SDK / Ollama)
-  |-- 44 MCP tools (GitHub, memory, messaging, code analysis, ...)
+  |-- 46 MCP tools (GitHub, memory, messaging, code analysis, ...)
   |-- SQLite database (sessions, agents, schedules, wallets, ...)
   |-- AlgoChat (optional on-chain messaging via Algorand)
 ```


### PR DESCRIPTION
## Summary
- **MCP tools:** 44→46 in quickstart, how-it-works, mcp-setup (README already correct)
- **Route modules:** 44→47 in deep-dive, CONTRIBUTING; 46→47 in README
- **API endpoints:** ~205→~300 in deep-dive; 279→~300 in README
- **Config options:** 30+→60+ in README (actual .env.example has 64 variables)
- **MCP sub-counts:** 38→46 in mcp-setup.md (web dashboard tools)

All numbers verified against `bun run stats:check` (all green) and direct file counts.

## Files changed
- `README.md` — endpoint count, route modules, config options
- `docs/deep-dive.md` — route modules, endpoints, MCP handler count
- `docs/quickstart.md` — MCP tools count in architecture diagram
- `docs/how-it-works.md` — MCP tools count
- `docs/mcp-setup.md` — MCP tools count, web dashboard tool count
- `CONTRIBUTING.md` — MCP handler count, route module count

## Test plan
- [x] `bun run stats:check` — all green
- [x] `bun run spec:check` — 157/157 passed, 0 failed

**Reviewer:** @0xLeif

🤖 Generated with [Claude Code](https://claude.com/claude-code)