### PR TITLE
docs: update README, CHANGELOG, and version for v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.39.0] - 2026-03-19
+
+### Added
+- **ARC-69 on-chain memory storage** — store agent memories as ARC-69 ASAs on localnet AlgoChat (#1256)
+- **MCP over Streamable HTTP** — expose MCP tools over Streamable HTTP at `/mcp` (#1255)
+- **Memory MCP tools for CLI** — expose memory MCP tools to Claude Code CLI sessions (#1243)
+- **Brain viewer storage types + observations** — brain viewer storage types and memory observations system (#1259)
+
+### Fixed
+- **ARC-69 memory storage silent fallback** — remove silent fallback from ARC-69 memory storage (#1257)
+- **MCP tool loading race condition** — resolve MCP tool loading race condition (#1253, #1254)
+- **SpecSync wrapper for local execution** — add specsync wrapper for local `spec:check` execution (#1246)
+
+### Docs
+- Audience-specific guides for non-programmers, businesses, and enterprise (#1250, #1252)
+- Add 16 missing API endpoint groups to api-reference (#1258)
+- Sync stale counts across README, deep-dive, quickstart, mcp-setup, contributing (#1247)
+
+### Tests
+- Add coverage for repo-map, cheerleading detector, external MCP (#1251)
+
 ## [0.38.0] - 2026-03-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.38.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.39.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version from 0.38.0 to 0.39.0 in `package.json` and README badge
- Add v0.39.0 changelog entry covering 12 commits: ARC-69 on-chain memory, MCP over Streamable HTTP, memory MCP tools for CLI, brain viewer observations, bug fixes, docs, and test coverage

## Test plan
- [x] `bun x tsc` passes with no errors
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)