### PR TITLE
feat: chat-first UI — simple chat interface for everyone

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -1,7 +1,12 @@
 import { Routes } from '@angular/router';
 
 export const routes: Routes = [
-    { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
+    { path: '', redirectTo: 'chat', pathMatch: 'full' },
+    {
+        path: 'chat',
+        loadComponent: () =>
+            import('./features/chat-home/chat-home.component').then((m) => m.ChatHomeComponent),
+    },
     {
         path: 'dashboard',
         loadComponent: () =>
@@ -197,5 +202,5 @@ export const routes: Routes = [
         loadComponent: () =>
             import('./features/brain-viewer/brain-viewer.component').then((m) => m.BrainViewerComponent),
     },
-    { path: '**', redirectTo: 'dashboard' },
+    { path: '**', redirectTo: 'chat' },
 ];

--- a/client/src/app/core/services/widget-layout.service.ts
+++ b/client/src/app/core/services/widget-layout.service.ts
@@ -1,5 +1,4 @@
-import { Injectable, inject, signal, computed } from '@angular/core';
-import { AudienceService, type Audience } from './audience.service';
+import { Injectable, signal, computed } from '@angular/core';
 
 export type WidgetId =
     | 'metrics'
@@ -21,41 +20,21 @@ export interface WidgetConfig {
 
 const STORAGE_KEY = 'corvid_widget_layout';
 
-/** Default widget sets per audience */
-const AUDIENCE_DEFAULTS: Record<Audience, WidgetConfig[]> = {
-    normal: [
-        { id: 'agents', label: 'My Agents', visible: true },
-        { id: 'activity', label: 'Recent Activity', visible: true },
-        { id: 'quick-actions', label: 'Quick Actions', visible: true },
-    ],
-    developer: [
-        { id: 'metrics', label: 'Metrics', visible: true },
-        { id: 'agents', label: 'Agent Activity', visible: true },
-        { id: 'spending-chart', label: 'Spending Trend', visible: true },
-        { id: 'session-chart', label: 'Sessions Breakdown', visible: true },
-        { id: 'agent-usage-chart', label: 'Agent Usage', visible: true },
-        { id: 'activity', label: 'Recent Activity', visible: true },
-        { id: 'quick-actions', label: 'Quick Actions', visible: true },
-        { id: 'system-status', label: 'System Status', visible: true },
-    ],
-    enterprise: [
-        { id: 'metrics', label: 'Metrics', visible: true },
-        { id: 'agents', label: 'Agent Activity', visible: true },
-        { id: 'spending-chart', label: 'Spending Trend', visible: true },
-        { id: 'session-chart', label: 'Sessions Breakdown', visible: true },
-        { id: 'agent-usage-chart', label: 'Agent Usage', visible: true },
-        { id: 'flock', label: 'Flock Directory', visible: true },
-        { id: 'comparison', label: 'Agent Comparison', visible: true },
-        { id: 'activity', label: 'Recent Activity', visible: true },
-        { id: 'quick-actions', label: 'Quick Actions', visible: true },
-        { id: 'system-status', label: 'System Status', visible: true },
-    ],
-};
+const DEFAULT_WIDGETS: WidgetConfig[] = [
+    { id: 'metrics', label: 'Metrics', visible: true },
+    { id: 'agents', label: 'Agent Activity', visible: true },
+    { id: 'spending-chart', label: 'Spending Trend', visible: true },
+    { id: 'session-chart', label: 'Sessions Breakdown', visible: true },
+    { id: 'agent-usage-chart', label: 'Agent Usage', visible: true },
+    { id: 'activity', label: 'Recent Activity', visible: true },
+    { id: 'quick-actions', label: 'Quick Actions', visible: true },
+    { id: 'system-status', label: 'System Status', visible: true },
+    { id: 'flock', label: 'Flock Directory', visible: true },
+    { id: 'comparison', label: 'Agent Comparison', visible: true },
+];
 
 @Injectable({ providedIn: 'root' })
 export class WidgetLayoutService {
-    private readonly audienceService = inject(AudienceService);
-
     /** Current widget layout — order + visibility */
     readonly widgets = signal<WidgetConfig[]>(this.load());
 
@@ -85,40 +64,17 @@ export class WidgetLayoutService {
         this.save(list);
     }
 
-    /** Reset to audience defaults */
+    /** Reset to defaults */
     resetToDefaults(): void {
-        const defaults = AUDIENCE_DEFAULTS[this.audienceService.audience()];
-        this.widgets.set(defaults.map((w) => ({ ...w })));
+        const defaults = DEFAULT_WIDGETS.map((w) => ({ ...w }));
+        this.widgets.set(defaults);
         this.save(defaults);
-    }
-
-    /** Re-initialize when audience changes (call from dashboard) */
-    syncWithAudience(): void {
-        const stored = this.loadStored();
-        if (!stored) {
-            this.resetToDefaults();
-            return;
-        }
-        // Merge: keep stored order/visibility but add any new widgets from defaults
-        const defaults = AUDIENCE_DEFAULTS[this.audienceService.audience()];
-        const defaultIds = new Set(defaults.map((d) => d.id));
-        const storedIds = new Set(stored.map((s) => s.id));
-        // Keep stored widgets that are valid for this audience
-        const merged = stored.filter((s) => defaultIds.has(s.id));
-        // Add any new defaults not in stored
-        for (const d of defaults) {
-            if (!storedIds.has(d.id)) {
-                merged.push({ ...d });
-            }
-        }
-        this.widgets.set(merged);
-        this.save(merged);
     }
 
     private load(): WidgetConfig[] {
         const stored = this.loadStored();
         if (stored) return stored;
-        return AUDIENCE_DEFAULTS[this.audienceService.audience()].map((w) => ({ ...w }));
+        return DEFAULT_WIDGETS.map((w) => ({ ...w }));
     }
 
     private loadStored(): WidgetConfig[] | null {
@@ -128,7 +84,6 @@ export class WidgetLayoutService {
             if (!raw) return null;
             const parsed = JSON.parse(raw);
             if (!Array.isArray(parsed) || parsed.length === 0) return null;
-            // Validate shape
             if (!parsed.every((w: unknown) =>
                 typeof w === 'object' && w !== null && 'id' in w && 'label' in w && 'visible' in w,
             )) return null;

--- a/client/src/app/features/chat-home/chat-home.component.ts
+++ b/client/src/app/features/chat-home/chat-home.component.ts
@@ -1,0 +1,304 @@
+import {
+    Component,
+    ChangeDetectionStrategy,
+    inject,
+    signal,
+    OnInit,
+    ViewChild,
+    ElementRef,
+    AfterViewInit,
+} from '@angular/core';
+import { Router } from '@angular/router';
+import { AgentService } from '../../core/services/agent.service';
+import { ProjectService } from '../../core/services/project.service';
+import { SessionService } from '../../core/services/session.service';
+import { NotificationService } from '../../core/services/notification.service';
+import type { Agent } from '../../core/models/agent.model';
+
+@Component({
+    selector: 'app-chat-home',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    template: `
+        <div class="chat-home">
+            <div class="chat-home__center">
+                <h1 class="chat-home__title">CorvidAgent</h1>
+                <p class="chat-home__subtitle">What would you like to work on?</p>
+
+                <div class="chat-home__input-card">
+                    <textarea
+                        class="chat-home__textarea"
+                        #promptInput
+                        [value]="prompt()"
+                        (input)="onPromptInput($event)"
+                        (keydown)="onKeydown($event)"
+                        placeholder="Ask anything..."
+                        rows="3"
+                        [disabled]="launching()"
+                        aria-label="Chat prompt"
+                    ></textarea>
+                    <div class="chat-home__actions">
+                        <div class="chat-home__agent-picker">
+                            <label for="agentSelect" class="chat-home__picker-label">Agent</label>
+                            <select
+                                id="agentSelect"
+                                class="chat-home__select"
+                                [value]="selectedAgentId()"
+                                (change)="onAgentChange($event)"
+                            >
+                                <option value="">Default</option>
+                                @for (agent of agents(); track agent.id) {
+                                    <option [value]="agent.id">{{ agent.name }}</option>
+                                }
+                            </select>
+                        </div>
+                        <button
+                            class="chat-home__send"
+                            [disabled]="!prompt().trim() || launching()"
+                            (click)="onSend()"
+                        >
+                            {{ launching() ? 'Starting...' : 'Send' }}
+                        </button>
+                    </div>
+                </div>
+
+                <div class="chat-home__hints">
+                    @for (hint of hints; track hint) {
+                        <button class="chat-home__hint" (click)="useHint(hint)">{{ hint }}</button>
+                    }
+                </div>
+            </div>
+        </div>
+    `,
+    styles: `
+        :host {
+            display: flex;
+            flex: 1;
+            min-height: 0;
+        }
+        .chat-home {
+            display: flex;
+            flex: 1;
+            align-items: center;
+            justify-content: center;
+            padding: 2rem;
+            background: var(--bg-deep);
+        }
+        .chat-home__center {
+            width: 100%;
+            max-width: 640px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .chat-home__title {
+            font-size: 1.75rem;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin: 0 0 0.5rem;
+            letter-spacing: 0.02em;
+        }
+        .chat-home__subtitle {
+            color: var(--text-secondary);
+            font-size: 0.9rem;
+            margin: 0 0 1.5rem;
+        }
+        .chat-home__input-card {
+            width: 100%;
+            background: var(--bg-surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg, 12px);
+            overflow: hidden;
+            transition: border-color 0.15s;
+        }
+        .chat-home__input-card:focus-within {
+            border-color: var(--accent-cyan);
+            box-shadow: 0 0 0 1px var(--accent-cyan), var(--glow-cyan);
+        }
+        .chat-home__textarea {
+            width: 100%;
+            padding: 1rem 1rem 0.5rem;
+            border: none;
+            background: transparent;
+            color: var(--text-primary);
+            font-family: inherit;
+            font-size: 0.9rem;
+            line-height: 1.5;
+            resize: none;
+            outline: none;
+        }
+        .chat-home__textarea::placeholder {
+            color: var(--text-tertiary);
+        }
+        .chat-home__textarea:disabled {
+            opacity: 0.5;
+        }
+        .chat-home__actions {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0.5rem 1rem 0.75rem;
+            gap: 0.75rem;
+        }
+        .chat-home__agent-picker {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        .chat-home__picker-label {
+            font-size: 0.7rem;
+            font-weight: 600;
+            color: var(--text-tertiary);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+        .chat-home__select {
+            padding: 0.3rem 0.5rem;
+            border: 1px solid var(--border);
+            border-radius: var(--radius, 6px);
+            background: var(--bg-input, var(--bg-deep));
+            color: var(--text-primary);
+            font-family: inherit;
+            font-size: 0.8rem;
+            cursor: pointer;
+        }
+        .chat-home__select:focus {
+            outline: none;
+            border-color: var(--accent-cyan);
+        }
+        .chat-home__send {
+            padding: 0.45rem 1.25rem;
+            border: 1px solid var(--accent-cyan);
+            border-radius: var(--radius, 6px);
+            background: transparent;
+            color: var(--accent-cyan);
+            font-family: inherit;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            cursor: pointer;
+            transition: background 0.15s, box-shadow 0.15s;
+        }
+        .chat-home__send:hover:not(:disabled) {
+            background: var(--accent-cyan-dim);
+            box-shadow: var(--glow-cyan);
+        }
+        .chat-home__send:disabled {
+            opacity: 0.3;
+            cursor: not-allowed;
+        }
+        .chat-home__hints {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1.25rem;
+            justify-content: center;
+        }
+        .chat-home__hint {
+            padding: 0.4rem 0.75rem;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: transparent;
+            color: var(--text-secondary);
+            font-family: inherit;
+            font-size: 0.75rem;
+            cursor: pointer;
+            transition: border-color 0.15s, color 0.15s;
+        }
+        .chat-home__hint:hover {
+            border-color: var(--accent-cyan);
+            color: var(--accent-cyan);
+        }
+        @media (max-width: 480px) {
+            .chat-home { padding: 1rem; }
+            .chat-home__title { font-size: 1.25rem; }
+            .chat-home__actions { flex-direction: column; align-items: stretch; }
+            .chat-home__agent-picker { justify-content: space-between; }
+        }
+    `,
+})
+export class ChatHomeComponent implements OnInit, AfterViewInit {
+    private readonly router = inject(Router);
+    private readonly agentService = inject(AgentService);
+    private readonly projectService = inject(ProjectService);
+    private readonly sessionService = inject(SessionService);
+    private readonly notify = inject(NotificationService);
+
+    @ViewChild('promptInput') private promptInput?: ElementRef<HTMLTextAreaElement>;
+
+    readonly agents = signal<Agent[]>([]);
+    readonly prompt = signal('');
+    readonly selectedAgentId = signal('');
+    readonly launching = signal(false);
+
+    readonly hints = [
+        'Review my latest PR',
+        'Fix the failing tests',
+        'Explain this codebase',
+        'Refactor for readability',
+    ];
+
+    async ngOnInit(): Promise<void> {
+        await Promise.all([
+            this.agentService.loadAgents(),
+            this.projectService.loadProjects(),
+        ]);
+        this.agents.set(this.agentService.agents());
+    }
+
+    ngAfterViewInit(): void {
+        setTimeout(() => this.promptInput?.nativeElement.focus());
+    }
+
+    onPromptInput(event: Event): void {
+        this.prompt.set((event.target as HTMLTextAreaElement).value);
+    }
+
+    onAgentChange(event: Event): void {
+        this.selectedAgentId.set((event.target as HTMLSelectElement).value);
+    }
+
+    onKeydown(event: KeyboardEvent): void {
+        if (event.key === 'Enter' && !event.shiftKey) {
+            event.preventDefault();
+            this.onSend();
+        }
+    }
+
+    useHint(hint: string): void {
+        this.prompt.set(hint);
+        this.promptInput?.nativeElement.focus();
+    }
+
+    async onSend(): Promise<void> {
+        const text = this.prompt().trim();
+        if (!text || this.launching()) return;
+
+        this.launching.set(true);
+
+        try {
+            // Ensure we have a project — use first available or create a default
+            let projectId = this.projectService.projects()[0]?.id;
+            if (!projectId) {
+                const project = await this.projectService.createProject({
+                    name: 'Default',
+                    description: 'Auto-created project',
+                    workingDir: '.',
+                });
+                projectId = project.id;
+            }
+
+            const session = await this.sessionService.createSession({
+                projectId,
+                agentId: this.selectedAgentId() || undefined,
+                initialPrompt: text,
+                name: text.slice(0, 60),
+            });
+
+            this.router.navigate(['/sessions', session.id]);
+        } catch (e) {
+            this.notify.error('Failed to start session', String(e));
+            this.launching.set(false);
+        }
+    }
+}

--- a/client/src/app/features/dashboard/dashboard.component.ts
+++ b/client/src/app/features/dashboard/dashboard.component.ts
@@ -15,7 +15,6 @@ import { ApiService } from '../../core/services/api.service';
 import { NotificationService } from '../../core/services/notification.service';
 import { WelcomeWizardComponent } from './welcome-wizard.component';
 import { SkeletonComponent } from '../../shared/components/skeleton.component';
-import { AudienceService } from '../../core/services/audience.service';
 import { WidgetLayoutService, type WidgetId } from '../../core/services/widget-layout.service';
 import type { ServerWsMessage } from '@shared/ws-protocol';
 import type { FlockAgent } from '@shared/types/flock-directory';
@@ -76,19 +75,9 @@ interface SessionStats { byAgent: AgentSessionStat[]; bySource: { source: string
             </div>
         } @else {
         <div class="dashboard">
-            <!-- Top bar: audience switcher + customize toggle -->
+            <!-- Top bar: customize toggle -->
             <div class="dash-toolbar">
-                <div class="view-toggle">
-                    <button class="view-toggle__btn"
-                            [attr.data-active]="audienceService.isNormal()"
-                            (click)="switchAudience('normal')">Creator</button>
-                    <button class="view-toggle__btn"
-                            [attr.data-active]="audienceService.isDeveloper()"
-                            (click)="switchAudience('developer')">Developer</button>
-                    <button class="view-toggle__btn"
-                            [attr.data-active]="audienceService.isEnterprise()"
-                            (click)="switchAudience('enterprise')">Enterprise</button>
-                </div>
+                <span class="dash-toolbar__title">Dashboard</span>
                 <button class="customize-btn" (click)="layoutService.customizing.set(!layoutService.customizing())">
                     {{ layoutService.customizing() ? 'Done' : 'Customize' }}
                 </button>
@@ -122,20 +111,6 @@ interface SessionStats { byAgent: AgentSessionStat[]; bySource: { source: string
                             </div>
                         }
                     </div>
-                </div>
-            }
-
-            <!-- Chat-first hero for Creator mode -->
-            @if (audienceService.isNormal() && agentSummaries().length > 0) {
-                <div class="creator-hero">
-                    <h2 class="creator-hero__title">What would you like to build?</h2>
-                    <p class="creator-hero__desc">Tell your agent what you need and it will handle the rest.</p>
-                    <div class="creator-hero__prompts">
-                        @for (suggestion of promptSuggestions; track suggestion) {
-                            <button class="creator-hero__prompt-btn" (click)="startChatWithPrompt(suggestion)">{{ suggestion }}</button>
-                        }
-                    </div>
-                    <button class="creator-hero__start-btn" (click)="navigateTo('/sessions/new')">+ Start a Conversation</button>
                 </div>
             }
 
@@ -204,7 +179,7 @@ interface SessionStats { byAgent: AgentSessionStat[]; bySource: { source: string
                             @if (agentSummaries().length > 0) {
                                 <div class="section">
                                     <div class="section__header">
-                                        <h3>{{ audienceService.isNormal() ? 'My Agents' : 'Agent Activity' }}</h3>
+                                        <h3>Agent Activity</h3>
                                         <a class="section__link" routerLink="/agents">View all agents</a>
                                     </div>
                                     <div class="agent-grid">
@@ -428,15 +403,11 @@ interface SessionStats { byAgent: AgentSessionStat[]; bySource: { source: string
                                 <h3>Quick Actions</h3>
                                 <div class="quick-actions">
                                     <button class="action-btn" (click)="navigateTo('/sessions/new')">+ New Conversation</button>
-                                    @if (!audienceService.isNormal()) {
-                                        <button class="action-btn" (click)="navigateTo('/councils')">Launch Council</button>
-                                    }
+                                    <button class="action-btn" (click)="navigateTo('/councils')">Launch Council</button>
                                     <button class="action-btn" (click)="navigateTo('/work-tasks')">Create Work Task</button>
-                                    @if (!audienceService.isNormal()) {
-                                        <button class="action-btn action-btn--selftest" [disabled]="selfTestRunning()" (click)="runSelfTest()">
-                                            {{ selfTestRunning() ? 'Running...' : 'Run Self-Test' }}
-                                        </button>
-                                    }
+                                    <button class="action-btn action-btn--selftest" [disabled]="selfTestRunning()" (click)="runSelfTest()">
+                                        {{ selfTestRunning() ? 'Running...' : 'Run Self-Test' }}
+                                    </button>
                                 </div>
                             </div>
                         }
@@ -582,6 +553,7 @@ interface SessionStats { byAgent: AgentSessionStat[]; bySource: { source: string
 
         /* Toolbar */
         .dash-toolbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; gap: .5rem; flex-wrap: wrap; }
+        .dash-toolbar__title { font-size: 1.1rem; font-weight: 700; color: var(--text-primary); margin: 0; }
         .view-toggle {
             display: flex; gap: .25rem;
             background: var(--bg-surface); border: 1px solid var(--border);
@@ -1008,7 +980,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private readonly apiService = inject(ApiService);
     private readonly router = inject(Router);
     private readonly notify = inject(NotificationService);
-    protected readonly audienceService = inject(AudienceService);
+
     protected readonly layoutService = inject(WidgetLayoutService);
 
     protected readonly algochatStatus = this.sessionService.algochatStatus;
@@ -1239,11 +1211,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
     ngOnDestroy(): void {
         this.unsubscribeWs?.();
-    }
-
-    protected switchAudience(audience: 'normal' | 'developer' | 'enterprise'): void {
-        this.audienceService.setAudience(audience);
-        this.layoutService.syncWithAudience();
     }
 
     protected onWizardComplete(): void {

--- a/client/src/app/features/dashboard/welcome-wizard.component.ts
+++ b/client/src/app/features/dashboard/welcome-wizard.component.ts
@@ -5,7 +5,6 @@ import { AgentService } from '../../core/services/agent.service';
 import { ProjectService } from '../../core/services/project.service';
 import { SessionService } from '../../core/services/session.service';
 import { ApiService } from '../../core/services/api.service';
-import { AudienceService, type Audience } from '../../core/services/audience.service';
 import type { ProviderInfo } from '../../core/models/agent.model';
 import { firstValueFrom } from 'rxjs';
 
@@ -24,39 +23,9 @@ interface AgentTemplate {
     description: string;
     icon: string;
     skillBundleIds: string[];
-    audience: Audience[];
 }
 
 const TEMPLATES: AgentTemplate[] = [
-    // Normal user templates
-    {
-        id: 'website-builder',
-        name: 'Website Builder',
-        suggestedName: 'WebBuilder',
-        description: 'Builds websites, landing pages, and portfolios. Just describe what you want.',
-        icon: '[]',
-        skillBundleIds: ['preset-full-stack'],
-        audience: ['normal'],
-    },
-    {
-        id: 'app-creator',
-        name: 'App Creator',
-        suggestedName: 'AppMaker',
-        description: 'Creates apps and tools from your ideas. Habit trackers, dashboards, calculators.',
-        icon: '<>',
-        skillBundleIds: ['preset-full-stack'],
-        audience: ['normal'],
-    },
-    {
-        id: 'assistant',
-        name: 'Personal Assistant',
-        suggestedName: 'Assistant',
-        description: 'Research, writing, analysis, and automation. Your AI helper for everyday tasks.',
-        icon: '>>',
-        skillBundleIds: ['preset-researcher', 'preset-memory-manager'],
-        audience: ['normal'],
-    },
-    // Developer templates
     {
         id: 'full-stack',
         name: 'Full Stack Developer',
@@ -64,7 +33,6 @@ const TEMPLATES: AgentTemplate[] = [
         description: 'Reads and edits code, manages PRs and issues, creates work tasks. The all-rounder.',
         icon: '{}',
         skillBundleIds: ['preset-full-stack'],
-        audience: ['developer', 'enterprise'],
     },
     {
         id: 'code-reviewer',
@@ -73,7 +41,6 @@ const TEMPLATES: AgentTemplate[] = [
         description: 'Reviews pull requests, catches bugs, and provides actionable feedback.',
         icon: '?!',
         skillBundleIds: ['preset-code-reviewer', 'preset-github-ops'],
-        audience: ['developer', 'enterprise'],
     },
     {
         id: 'researcher',
@@ -82,7 +49,6 @@ const TEMPLATES: AgentTemplate[] = [
         description: 'Deep web research, information gathering, and knowledge management.',
         icon: '>>',
         skillBundleIds: ['preset-researcher', 'preset-memory-manager'],
-        audience: ['developer', 'enterprise'],
     },
     {
         id: 'devops',
@@ -91,7 +57,6 @@ const TEMPLATES: AgentTemplate[] = [
         description: 'CI/CD automation, infrastructure tasks, deployment pipelines, and repo management.',
         icon: '#!',
         skillBundleIds: ['preset-devops', 'preset-github-ops'],
-        audience: ['developer', 'enterprise'],
     },
     {
         id: 'custom',
@@ -100,7 +65,6 @@ const TEMPLATES: AgentTemplate[] = [
         description: 'Start from scratch. Pick your own name, model, and skills.',
         icon: '**',
         skillBundleIds: [],
-        audience: ['developer', 'enterprise'],
     },
 ];
 
@@ -132,34 +96,10 @@ const TEMPLATES: AgentTemplate[] = [
             </div>
 
             @switch (step()) {
-                @case ('audience') {
+                @case ('create') {
                     <div class="wizard__step wizard__step--wide">
-                        <h2 class="step__title">How will you use Corvid?</h2>
-                        <p class="step__desc">This shapes your dashboard. You can change it anytime in Settings.</p>
-
-                        <div class="audience-grid">
-                            <button class="audience-card"
-                                    [attr.data-selected]="selectedAudience() === 'normal'"
-                                    (click)="selectedAudience.set('normal')">
-                                <span class="audience-card__icon">&gt;_</span>
-                                <span class="audience-card__name">Creator</span>
-                                <span class="audience-card__desc">I have ideas but don't code. Show me the simple view with just agents and chat.</span>
-                            </button>
-                            <button class="audience-card"
-                                    [attr.data-selected]="selectedAudience() === 'developer'"
-                                    (click)="selectedAudience.set('developer')">
-                                <span class="audience-card__icon">{{ '{' }}{{ '}' }}</span>
-                                <span class="audience-card__name">Developer</span>
-                                <span class="audience-card__desc">I write code. Show me metrics, sessions, logs, and developer tools.</span>
-                            </button>
-                            <button class="audience-card"
-                                    [attr.data-selected]="selectedAudience() === 'enterprise'"
-                                    (click)="selectedAudience.set('enterprise')">
-                                <span class="audience-card__icon">::</span>
-                                <span class="audience-card__name">Enterprise</span>
-                                <span class="audience-card__desc">I manage teams. Show me governance, security, spending, and full config.</span>
-                            </button>
-                        </div>
+                        <h2 class="step__title">Create Your First Agent</h2>
+                        <p class="step__desc">Pick a template, then customize.</p>
 
                         @if (!healthReady()) {
                             <div class="wizard__warning">
@@ -171,23 +111,8 @@ const TEMPLATES: AgentTemplate[] = [
                             </div>
                         }
 
-                        <div class="wizard__actions">
-                            <button class="wizard__btn wizard__btn--primary"
-                                    [disabled]="!selectedAudience()"
-                                    (click)="confirmAudience()">
-                                Next
-                            </button>
-                        </div>
-                    </div>
-                }
-
-                @case ('create') {
-                    <div class="wizard__step wizard__step--wide">
-                        <h2 class="step__title">Create Your First Agent</h2>
-                        <p class="step__desc">Pick a template, then customize.</p>
-
                         <div class="template-grid">
-                            @for (t of filteredTemplates(); track t.id) {
+                            @for (t of TEMPLATES; track t.id) {
                                 <button class="template-card"
                                         [attr.data-selected]="selectedTemplate()?.id === t.id"
                                         (click)="selectTemplate(t)">
@@ -246,17 +171,12 @@ const TEMPLATES: AgentTemplate[] = [
                                 }
 
                                 <div class="wizard__actions">
-                                    <button type="button" class="wizard__btn" (click)="step.set('audience')">Back</button>
                                     <button type="submit" class="wizard__btn wizard__btn--primary"
                                             [disabled]="form.invalid || creating()">
                                         {{ creating() ? 'Creating...' : 'Create Agent' }}
                                     </button>
                                 </div>
                             </form>
-                        } @else {
-                            <div class="wizard__actions">
-                                <button type="button" class="wizard__btn" (click)="step.set('audience')">Back</button>
-                            </div>
                         }
                     </div>
                 }
@@ -273,18 +193,14 @@ const TEMPLATES: AgentTemplate[] = [
                                 <span class="done__value done__value--ok">{{ createdAgentName() }}</span>
                             </div>
                             <div class="done__row">
-                                <span class="done__label">Mode</span>
-                                <span class="done__value">{{ selectedAudience() === 'normal' ? 'Creator' : selectedAudience() === 'developer' ? 'Developer' : 'Enterprise' }}</span>
-                            </div>
-                            <div class="done__row">
                                 <span class="done__label">LLM</span>
                                 <span class="done__value" [class.done__value--ok]="health()?.llm" [class.done__value--warn]="!health()?.llm">{{ health()?.llm ? 'Connected' : 'Not configured' }}</span>
                             </div>
                         </div>
 
                         <div class="done__actions">
-                            <button class="wizard__btn wizard__btn--primary" (click)="startSession()">
-                                Start a Conversation
+                            <button class="wizard__btn wizard__btn--primary" (click)="startChat()">
+                                Start Chatting
                             </button>
                             <button class="wizard__btn" (click)="goToDashboard()">
                                 Go to Dashboard
@@ -372,52 +288,6 @@ const TEMPLATES: AgentTemplate[] = [
             margin: 0 0 1.25rem;
             font-size: 0.8rem;
             color: var(--text-tertiary);
-        }
-
-        /* Audience cards */
-        .audience-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr 1fr;
-            gap: 0.65rem;
-            margin-bottom: 1.25rem;
-            text-align: left;
-        }
-        .audience-card {
-            display: flex;
-            flex-direction: column;
-            gap: 0.3rem;
-            padding: 1rem;
-            background: var(--bg-raised);
-            border: 1px solid var(--border);
-            border-radius: var(--radius);
-            cursor: pointer;
-            font-family: inherit;
-            color: var(--text-primary);
-            transition: border-color 0.15s, background 0.15s;
-        }
-        .audience-card:hover {
-            border-color: var(--border-bright);
-            background: var(--bg-hover);
-        }
-        .audience-card[data-selected="true"] {
-            border-color: var(--accent-cyan);
-            background: rgba(0, 229, 255, 0.06);
-            box-shadow: var(--glow-cyan);
-        }
-        .audience-card__icon {
-            font-size: 1.1rem;
-            font-weight: 700;
-            color: var(--accent-cyan);
-            font-family: monospace;
-        }
-        .audience-card__name {
-            font-size: 0.85rem;
-            font-weight: 600;
-        }
-        .audience-card__desc {
-            font-size: 0.7rem;
-            color: var(--text-tertiary);
-            line-height: 1.35;
         }
 
         /* Template Grid */
@@ -640,7 +510,6 @@ const TEMPLATES: AgentTemplate[] = [
             .wizard { padding: 1rem; }
             .wizard__logo { font-size: 0.25rem; }
             .wizard__step { padding: 1rem; }
-            .audience-grid { grid-template-columns: 1fr; }
             .template-grid { grid-template-columns: 1fr; }
             .field-row { grid-template-columns: 1fr; }
         }
@@ -653,12 +522,12 @@ export class WelcomeWizardComponent implements OnInit {
     protected readonly projectService = inject(ProjectService);
     private readonly sessionService = inject(SessionService);
     private readonly apiService = inject(ApiService);
-    private readonly audienceService = inject(AudienceService);
 
     readonly agentCreated = output<void>();
 
-    protected readonly steps = ['audience', 'create', 'done'];
-    protected readonly step = signal<'audience' | 'create' | 'done'>('audience');
+    protected readonly TEMPLATES = TEMPLATES;
+    protected readonly steps = ['create', 'done'];
+    protected readonly step = signal<'create' | 'done'>('create');
     protected readonly stepIndex = signal(0);
     protected readonly health = signal<HealthStatus | null>(null);
     protected readonly healthReady = signal(false);
@@ -667,8 +536,6 @@ export class WelcomeWizardComponent implements OnInit {
     protected readonly creating = signal(false);
     protected readonly createdAgentName = signal('');
     protected readonly selectedTemplate = signal<AgentTemplate | null>(null);
-    protected readonly selectedAudience = signal<Audience | null>(null);
-    protected readonly filteredTemplates = signal<AgentTemplate[]>([]);
     private createdAgentId = '';
 
     protected readonly form = this.fb.nonNullable.group({
@@ -722,15 +589,6 @@ export class WelcomeWizardComponent implements OnInit {
         }
     }
 
-    protected confirmAudience(): void {
-        const audience = this.selectedAudience();
-        if (!audience) return;
-        this.audienceService.setAudience(audience);
-        this.filteredTemplates.set(TEMPLATES.filter((t) => t.audience.includes(audience)));
-        this.step.set('create');
-        this.stepIndex.set(1);
-    }
-
     protected selectTemplate(template: AgentTemplate): void {
         this.selectedTemplate.set(template);
         if (template.suggestedName) {
@@ -770,7 +628,7 @@ export class WelcomeWizardComponent implements OnInit {
 
             this.agentCreated.emit();
             this.step.set('done');
-            this.stepIndex.set(2);
+            this.stepIndex.set(1);
         } finally {
             this.creating.set(false);
         }
@@ -797,10 +655,8 @@ export class WelcomeWizardComponent implements OnInit {
         ).join(' ');
     }
 
-    protected startSession(): void {
-        this.router.navigate(['/sessions/new'], {
-            queryParams: { agentId: this.createdAgentId },
-        });
+    protected startChat(): void {
+        this.router.navigate(['/chat']);
     }
 
     protected goToDashboard(): void {

--- a/client/src/app/shared/components/sidebar.component.ts
+++ b/client/src/app/shared/components/sidebar.component.ts
@@ -8,12 +8,10 @@ import {
     AfterViewInit,
     OnDestroy,
     signal,
-    effect,
 } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive, NavigationEnd } from '@angular/router';
 import { filter, Subscription } from 'rxjs';
 import { KeyboardShortcutsService } from '../../core/services/keyboard-shortcuts.service';
-import { AudienceService } from '../../core/services/audience.service';
 
 /** Section definition with routes for auto-expand */
 interface SidebarSection {
@@ -25,7 +23,7 @@ interface SidebarSection {
 }
 
 const SECTIONS: SidebarSection[] = [
-    { key: 'core', label: 'Core', collapsible: false, defaultCollapsed: false, routes: ['/dashboard', '/agents', '/projects', '/models', '/personas', '/skill-bundles'] },
+    { key: 'core', label: 'Core', collapsible: false, defaultCollapsed: false, routes: ['/chat', '/dashboard', '/agents', '/projects', '/models', '/personas', '/skill-bundles'] },
     { key: 'sessions', label: 'Sessions', collapsible: true, defaultCollapsed: false, routes: ['/sessions', '/work-tasks', '/councils'] },
     { key: 'automation', label: 'Automation', collapsible: true, defaultCollapsed: true, routes: ['/schedules', '/workflows', '/webhooks', '/mention-polling'] },
     { key: 'integrations', label: 'Integrations', collapsible: true, defaultCollapsed: true, routes: ['/mcp-servers'] },
@@ -56,18 +54,24 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
             aria-label="Main navigation"
             #sidebarEl>
             <ul class="sidebar__list">
-                <!-- Core (always visible) -->
+                <!-- Core -->
                 <li class="sidebar__section">
                     <span class="sidebar__section-label">Core</span>
                 </li>
                 <li>
                     <a
                         class="sidebar__link"
-                        routerLink="/dashboard"
+                        routerLink="/chat"
                         routerLinkActive="sidebar__link--active"
                         aria-current="page"
-                        title="Dashboard"
+                        title="Chat"
                         #firstLink>
+                        <span class="sidebar__label">Chat</span>
+                        <span class="sidebar__abbr">Ch</span>
+                    </a>
+                </li>
+                <li>
+                    <a class="sidebar__link" routerLink="/dashboard" routerLinkActive="sidebar__link--active" title="Dashboard">
                         <span class="sidebar__label">Dashboard</span>
                         <span class="sidebar__abbr">D</span>
                     </a>
@@ -84,30 +88,24 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
                         <span class="sidebar__abbr">P</span>
                     </a>
                 </li>
-                @if (audienceService.isCoreLinkVisible('/models')) {
                 <li>
                     <a class="sidebar__link" routerLink="/models" routerLinkActive="sidebar__link--active" title="Models">
                         <span class="sidebar__label">Models</span>
                         <span class="sidebar__abbr">M</span>
                     </a>
                 </li>
-                }
-                @if (audienceService.isCoreLinkVisible('/personas')) {
                 <li>
                     <a class="sidebar__link" routerLink="/personas" routerLinkActive="sidebar__link--active" title="Personas">
                         <span class="sidebar__label">Personas</span>
                         <span class="sidebar__abbr">Ps</span>
                     </a>
                 </li>
-                }
-                @if (audienceService.isCoreLinkVisible('/skill-bundles')) {
                 <li>
                     <a class="sidebar__link" routerLink="/skill-bundles" routerLinkActive="sidebar__link--active" title="Skill Bundles">
                         <span class="sidebar__label">Skill Bundles</span>
                         <span class="sidebar__abbr">Sk</span>
                     </a>
                 </li>
-                }
 
                 <!-- Sessions (collapsible) -->
                 <li class="sidebar__section sidebar__section--collapsible">
@@ -149,7 +147,6 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
                     </ul>
                 </li>
 
-                @if (audienceService.isSectionVisible('automation')) {
                 <!-- Automation (collapsible, collapsed by default) -->
                 <li class="sidebar__section sidebar__section--collapsible">
                     <button
@@ -195,9 +192,7 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
                         </li>
                     </ul>
                 </li>
-                }
 
-                @if (audienceService.isSectionVisible('integrations')) {
                 <!-- Integrations (collapsible, collapsed by default) -->
                 <li class="sidebar__section sidebar__section--collapsible">
                     <button
@@ -225,9 +220,7 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
                         </li>
                     </ul>
                 </li>
-                }
 
-                @if (audienceService.isSectionVisible('monitoring')) {
                 <!-- Monitoring (collapsible) -->
                 <li class="sidebar__section sidebar__section--collapsible">
                     <button
@@ -273,9 +266,7 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
                         </li>
                     </ul>
                 </li>
-                }
 
-                @if (audienceService.isSectionVisible('community')) {
                 <!-- Community (collapsible, collapsed by default) -->
                 <li class="sidebar__section sidebar__section--collapsible">
                     <button
@@ -309,9 +300,7 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
                         </li>
                     </ul>
                 </li>
-                }
 
-                @if (audienceService.isSectionVisible('config')) {
                 <!-- Config (collapsible, collapsed by default) -->
                 <li class="sidebar__section sidebar__section--collapsible">
                     <button
@@ -375,7 +364,6 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
                         </li>
                     </ul>
                 </li>
-                }
             </ul>
             <button
                 class="sidebar__help-btn"
@@ -677,21 +665,9 @@ export class SidebarComponent implements AfterViewInit, OnDestroy {
 
     private readonly router = inject(Router);
     private readonly shortcutsService = inject(KeyboardShortcutsService);
-    protected readonly audienceService = inject(AudienceService);
     private readonly firstLink = viewChild<ElementRef<HTMLAnchorElement>>('firstLink');
     private readonly sidebarEl = viewChild<ElementRef<HTMLElement>>('sidebarEl');
     private routerSub: Subscription | null = null;
-
-    /** Auto-collapse sidebar when audience changes (skip initial) */
-    private initialAudience = this.audienceService.audience();
-    private readonly audienceEffect = effect(() => {
-        const audience = this.audienceService.audience();
-        if (audience === this.initialAudience) return;
-        this.initialAudience = audience;
-        const shouldCollapse = audience === 'normal';
-        this.collapsed.set(shouldCollapse);
-        localStorage.setItem('sidebar_collapsed', String(shouldCollapse));
-    });
 
     /** Reference to the hamburger button for focus return — set by parent */
     private hamburgerRef: HTMLElement | null = null;
@@ -787,23 +763,12 @@ export class SidebarComponent implements AfterViewInit, OnDestroy {
         }
     }
 
-    /** Sync sidebar collapse state when audience changes */
-    syncCollapseWithAudience(): void {
-        const shouldCollapse = this.audienceService.audience() === 'normal';
-        // Only auto-collapse if user hasn't explicitly set a preference
-        const stored = typeof localStorage !== 'undefined' ? localStorage.getItem('sidebar_collapsed') : null;
-        if (stored === null) {
-            this.collapsed.set(shouldCollapse);
-        }
-    }
-
     private loadCollapsed(): boolean {
         if (typeof localStorage !== 'undefined') {
             const stored = localStorage.getItem('sidebar_collapsed');
             if (stored !== null) return stored === 'true';
         }
-        // Default: collapsed for normal audience, expanded otherwise
-        return this.audienceService.audience() === 'normal';
+        return false;
     }
 
     /** Load section states from localStorage, falling back to defaults */

--- a/specs/client/sidebar-navigation.spec.md
+++ b/specs/client/sidebar-navigation.spec.md
@@ -1,10 +1,11 @@
 ---
 module: sidebar-navigation
-version: 1
+version: 2
 status: active
 files:
   - client/src/app/shared/components/sidebar.component.ts
   - client/src/app/app.routes.ts
+  - client/src/app/features/chat-home/chat-home.component.ts
 db_tables: []
 depends_on: []
 ---
@@ -15,6 +16,8 @@ depends_on: []
 
 Provides the main navigation sidebar for the web client. The `SidebarComponent` renders navigation links to all top-level routes, supports responsive mobile overlay mode, and persists a collapsed/expanded state in localStorage. The `routes` array defines all lazy-loaded Angular routes for the application.
 
+The default landing page is `/chat` — a simple, centered chat interface (`ChatHomeComponent`) with an agent picker and prompt input. All features are visible to all users; there is no audience segmentation.
+
 ## Public API
 
 ### Exported Classes
@@ -22,6 +25,7 @@ Provides the main navigation sidebar for the web client. The `SidebarComponent` 
 | Class | Description |
 |-------|-------------|
 | `SidebarComponent` | Angular component rendering the main navigation sidebar with responsive collapse and mobile overlay |
+| `ChatHomeComponent` | Chat-first landing page with centered prompt input, agent picker, and quick-start hints |
 
 ### Exported Variables
 
@@ -37,14 +41,17 @@ Provides the main navigation sidebar for the web client. The `SidebarComponent` 
 4. **Escape key closes sidebar**: Pressing Escape closes the sidebar overlay when open
 5. **Route lazy loading**: All routes use `loadComponent` with dynamic imports for code splitting
 6. **All top-level routes have sidebar entries**: Every routable feature must have a link in the sidebar. Missing nav entries make features unreachable
-7. **Grouped navigation sections**: Links are organized into labeled groups separated by visual dividers with section labels. The **complete** set of 17 sidebar entries is:
-   - **Dashboard** (standalone)
-   - **Core**: Agents, Projects, Models
+7. **No audience gating**: All sidebar sections and links are visible to all users. There is no creator/developer/enterprise segmentation.
+8. **Chat-first default**: The root path `/` redirects to `/chat`. The wildcard route also redirects to `/chat`. The sidebar lists Chat as the first link.
+9. **Grouped navigation sections**: Links are organized into labeled groups with collapsible sections. The **complete** set includes:
+   - **Core**: Chat, Dashboard, Agents, Projects, Models, Personas, Skill Bundles
    - **Sessions**: Conversations, Work Tasks, Councils
    - **Automation**: Schedules, Workflows, Webhooks, Polling
-   - **Monitoring**: Feed, Analytics, Logs
-   - **Config**: Wallets, Settings
-8. **Client rebuild required**: After any change to sidebar or route files, `bun run build:client` must be run. The server serves static files from `client/dist/` — a stale build will silently show the old sidebar
+   - **Integrations**: MCP Servers
+   - **Monitoring**: Feed, Analytics, Logs, Brain Viewer
+   - **Community**: Reputation, Marketplace
+   - **Config**: Allowlist, GH Allowlist, Repo Blocklist, Wallets, Spending, Settings, Security
+10. **Client rebuild required**: After any change to sidebar or route files, `bun run build:client` must be run. The server serves static files from `client/dist/` — a stale build will silently show the old sidebar
 
 ## Behavioral Examples
 
@@ -90,3 +97,4 @@ Provides the main navigation sidebar for the web client. The `SidebarComponent` 
 | 2026-02-20 | corvid-agent | Initial spec |
 | 2026-02-20 | corvid-agent | Added invariants #6 and #7: all routes must have sidebar entries, grouped into sections |
 | 2026-02-21 | corvid-agent | Added invariant #8 (client rebuild required); enumerated all 17 sidebar entries in invariant #7 to prevent regression |
+| 2026-03-19 | corvid-agent | Chat-first redesign: removed audience segmentation, added ChatHomeComponent as default landing page, all sections visible to all users |


### PR DESCRIPTION
## Summary

- **Replaces audience-segmented dashboard** (creator/developer/enterprise) with a **simple chat-first landing page** at `/chat`
- New `ChatHomeComponent`: centered prompt input, agent picker dropdown, quick-start hint buttons — type a message, pick an agent, start chatting
- **Removed audience gating** from sidebar, dashboard, wizard, and widget layout — all features visible to all users
- Welcome wizard simplified: skips audience selection step, shows all agent templates
- Sidebar: Chat is now the first link, all sections always visible

## What changed

| File | Change |
|------|--------|
| `chat-home.component.ts` | **New** — chat landing page with agent picker |
| `app.routes.ts` | Default + wildcard → `/chat` |
| `sidebar.component.ts` | Removed `AudienceService`, all sections visible, Chat link at top |
| `widget-layout.service.ts` | Removed audience-based defaults, single widget set |
| `dashboard.component.ts` | Removed audience switcher, creator-hero, audience gates |
| `welcome-wizard.component.ts` | Removed audience step, all templates available |
| `sidebar-navigation.spec.md` | Updated for chat-first direction |

## Test plan

- [x] Visit `/` — should redirect to `/chat` with centered prompt UI
- [x] Type a prompt, select an agent, hit Send — should create session and navigate to session view
- [x] Visit `/dashboard` — should show all widgets (no audience switcher)
- [x] Sidebar shows all sections without audience gating
- [x] Welcome wizard (when no agents) goes straight to template selection
- [x] Mobile responsive: chat-home and sidebar work on small viewports
- [x] `bun run build:client` succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)