### PR TITLE
feat: glassmorphism UI refresh + Discord embed color passthrough

### DIFF
--- a/client/src/app/features/agents/agent-list.component.ts
+++ b/client/src/app/features/agents/agent-list.component.ts
@@ -188,13 +188,13 @@ const INACTIVE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
         .loading, .empty { color: var(--text-tertiary); font-size: 0.85rem; }
 
         /* Search */
-        .search-bar { margin-bottom: 0.75rem; }
+        .search-bar { margin-bottom: 0.85rem; }
         .search-input {
-            width: 100%; padding: 0.5rem 0.75rem; border: 1px solid var(--border-bright); border-radius: var(--radius);
-            font-size: 0.85rem; font-family: inherit; background: var(--bg-input); color: var(--text-primary);
-            box-sizing: border-box;
+            width: 100%; padding: 0.6rem 0.85rem; border: 1px solid rgba(255, 255, 255, 0.05); border-radius: var(--radius-lg, 10px);
+            font-size: 0.85rem; font-family: inherit; background: rgba(12, 13, 20, 0.6); color: var(--text-primary);
+            box-sizing: border-box; transition: border-color 0.2s, box-shadow 0.2s;
         }
-        .search-input:focus { border-color: var(--accent-cyan); box-shadow: var(--glow-cyan); outline: none; }
+        .search-input:focus { border-color: rgba(0, 229, 255, 0.4); box-shadow: 0 0 0 1px rgba(0, 229, 255, 0.1), 0 0 20px rgba(0, 229, 255, 0.05); outline: none; }
 
         /* Filters */
         .filters { display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap; margin-bottom: 1.25rem; }
@@ -221,15 +221,43 @@ const INACTIVE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
         /* Agent Grid */
         .agent-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-            gap: 0.75rem;
+            grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+            gap: 0.85rem;
         }
         .agent-card {
-            display: block; background: var(--bg-surface); border: 1px solid var(--border);
-            border-radius: var(--radius-lg); padding: 1rem; text-decoration: none; color: inherit;
-            transition: border-color 0.15s, box-shadow 0.15s; cursor: pointer;
+            display: block;
+            background: rgba(15, 16, 24, 0.6);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+            border: 1px solid rgba(255, 255, 255, 0.05);
+            border-radius: var(--radius-xl, 16px);
+            padding: 1.1rem;
+            text-decoration: none;
+            color: inherit;
+            transition: border-color 0.25s, box-shadow 0.25s, transform 0.2s, background 0.25s;
+            cursor: pointer;
+            position: relative;
         }
-        .agent-card:hover { border-color: var(--agent-accent, var(--accent-cyan)); box-shadow: 0 0 12px rgba(0, 229, 255, 0.08); }
+        .agent-card::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            border-radius: inherit;
+            padding: 1px;
+            background: linear-gradient(135deg, rgba(0, 229, 255, 0.3), rgba(255, 0, 170, 0.15), rgba(0, 255, 136, 0.1));
+            -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+            -webkit-mask-composite: xor;
+            mask-composite: exclude;
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.3s;
+        }
+        .agent-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3), 0 0 20px rgba(0, 229, 255, 0.06);
+            background: rgba(15, 16, 24, 0.75);
+        }
+        .agent-card:hover::before { opacity: 1; }
         .agent-card__avatar { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid var(--border-bright); flex-shrink: 0; }
         .agent-card__icon { font-size: 1.2rem; line-height: 1; flex-shrink: 0; }
         .agent-card__top { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 0.35rem; }
@@ -255,12 +283,13 @@ const INACTIVE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
         .agent-card__footer { display: flex; justify-content: space-between; align-items: center; padding-top: 0.4rem; border-top: 1px solid var(--border); }
         .agent-card__perm { font-size: 0.65rem; color: var(--text-tertiary); text-transform: capitalize; }
         .agent-card__start-btn {
-            padding: 0.5rem 0.75rem; min-height: 44px; font-size: 0.6rem; font-weight: 600; font-family: inherit;
+            padding: 0.5rem 0.85rem; min-height: 44px; font-size: 0.6rem; font-weight: 600; font-family: inherit;
             text-transform: uppercase; letter-spacing: 0.05em; cursor: pointer;
-            background: transparent; border: 1px solid var(--accent-cyan); border-radius: var(--radius-sm);
-            color: var(--accent-cyan); transition: all 0.15s; display: flex; align-items: center;
+            background: linear-gradient(135deg, rgba(0, 229, 255, 0.1), rgba(0, 229, 255, 0.05));
+            border: none; border-radius: var(--radius, 6px);
+            color: var(--accent-cyan); transition: all 0.2s; display: flex; align-items: center;
         }
-        .agent-card__start-btn:hover { background: var(--accent-cyan-dim); box-shadow: var(--glow-cyan); }
+        .agent-card__start-btn:hover { background: linear-gradient(135deg, rgba(0, 229, 255, 0.2), rgba(0, 229, 255, 0.1)); box-shadow: 0 0 16px rgba(0, 229, 255, 0.12); }
 
         @media (max-width: 768px) {
             .agent-grid { grid-template-columns: 1fr; }

--- a/client/src/app/features/chat-home/chat-home.component.ts
+++ b/client/src/app/features/chat-home/chat-home.component.ts
@@ -27,7 +27,9 @@ import { OnboardingComponent } from './onboarding.component';
             <app-onboarding (done)="onboardingSkipped.set(true)" />
         } @else {
         <div class="chat-home">
+            <div class="chat-home__bg-glow" aria-hidden="true"></div>
             <div class="chat-home__center">
+                <div class="chat-home__logo-mark" aria-hidden="true">C</div>
                 <h1 class="chat-home__title">CorvidAgent</h1>
                 <p class="chat-home__subtitle">What would you like to work on?</p>
 
@@ -63,14 +65,23 @@ import { OnboardingComponent } from './onboarding.component';
                             [disabled]="!prompt().trim() || launching()"
                             (click)="onSend()"
                         >
-                            {{ launching() ? 'Starting...' : 'Send' }}
+                            @if (launching()) {
+                                <span class="chat-home__send-spinner"></span>
+                                Starting...
+                            } @else {
+                                Send
+                                <span class="chat-home__send-arrow">&rarr;</span>
+                            }
                         </button>
                     </div>
                 </div>
 
                 <div class="chat-home__hints">
                     @for (hint of hints; track hint) {
-                        <button class="chat-home__hint" (click)="useHint(hint)">{{ hint }}</button>
+                        <button class="chat-home__hint" (click)="useHint(hint)">
+                            <span class="chat-home__hint-icon">&rsaquo;</span>
+                            {{ hint }}
+                        </button>
                     }
                 </div>
             </div>
@@ -90,6 +101,24 @@ import { OnboardingComponent } from './onboarding.component';
             justify-content: center;
             padding: 2rem;
             background: var(--bg-deep);
+            position: relative;
+            overflow: hidden;
+        }
+        .chat-home__bg-glow {
+            position: absolute;
+            top: -30%;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 600px;
+            height: 600px;
+            background: radial-gradient(
+                circle,
+                rgba(0, 229, 255, 0.06) 0%,
+                rgba(255, 0, 170, 0.03) 40%,
+                transparent 70%
+            );
+            pointer-events: none;
+            animation: subtlePulse 8s ease-in-out infinite;
         }
         .chat-home__center {
             width: 100%;
@@ -97,40 +126,66 @@ import { OnboardingComponent } from './onboarding.component';
             display: flex;
             flex-direction: column;
             align-items: center;
+            position: relative;
+            z-index: 1;
+        }
+        .chat-home__logo-mark {
+            width: 56px;
+            height: 56px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: var(--radius-xl, 16px);
+            background: linear-gradient(135deg, rgba(0, 229, 255, 0.12), rgba(255, 0, 170, 0.08));
+            border: 1px solid rgba(0, 229, 255, 0.2);
+            font-size: 1.5rem;
+            font-weight: 800;
+            color: var(--accent-cyan);
+            text-shadow: 0 0 16px rgba(0, 229, 255, 0.5);
+            margin-bottom: 1rem;
+            box-shadow: 0 4px 24px rgba(0, 229, 255, 0.1);
         }
         .chat-home__title {
-            font-size: 1.75rem;
+            font-size: 2rem;
             font-weight: 700;
-            color: var(--text-primary);
-            margin: 0 0 0.5rem;
-            letter-spacing: 0.02em;
+            margin: 0 0 0.4rem;
+            letter-spacing: 0.03em;
+            background: linear-gradient(135deg, var(--accent-cyan), var(--accent-magenta));
+            background-size: 200% 200%;
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            animation: gradientShift 6s ease infinite;
         }
         .chat-home__subtitle {
             color: var(--text-secondary);
             font-size: 0.9rem;
-            margin: 0 0 1.5rem;
+            margin: 0 0 2rem;
         }
         .chat-home__input-card {
             width: 100%;
-            background: var(--bg-surface);
-            border: 1px solid var(--border);
-            border-radius: var(--radius-lg, 12px);
+            background: rgba(15, 16, 24, 0.7);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.06));
+            border-radius: var(--radius-xl, 16px);
             overflow: hidden;
-            transition: border-color 0.15s;
+            transition: border-color 0.25s, box-shadow 0.25s;
+            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
         }
         .chat-home__input-card:focus-within {
-            border-color: var(--accent-cyan);
-            box-shadow: 0 0 0 1px var(--accent-cyan), var(--glow-cyan);
+            border-color: rgba(0, 229, 255, 0.4);
+            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(0, 229, 255, 0.15), 0 0 30px rgba(0, 229, 255, 0.06);
         }
         .chat-home__textarea {
             width: 100%;
-            padding: 1rem 1rem 0.5rem;
+            padding: 1.25rem 1.25rem 0.5rem;
             border: none;
             background: transparent;
             color: var(--text-primary);
             font-family: inherit;
             font-size: 0.9rem;
-            line-height: 1.5;
+            line-height: 1.6;
             resize: none;
             outline: none;
         }
@@ -144,7 +199,7 @@ import { OnboardingComponent } from './onboarding.component';
             display: flex;
             align-items: center;
             justify-content: space-between;
-            padding: 0.5rem 1rem 0.75rem;
+            padding: 0.5rem 1.25rem 0.85rem;
             gap: 0.75rem;
         }
         .chat-home__agent-picker {
@@ -160,7 +215,7 @@ import { OnboardingComponent } from './onboarding.component';
             letter-spacing: 0.05em;
         }
         .chat-home__select {
-            padding: 0.3rem 0.5rem;
+            padding: 0.35rem 0.6rem;
             border: 1px solid var(--border);
             border-radius: var(--radius, 6px);
             background: var(--bg-input, var(--bg-deep));
@@ -168,16 +223,20 @@ import { OnboardingComponent } from './onboarding.component';
             font-family: inherit;
             font-size: 0.8rem;
             cursor: pointer;
+            transition: border-color 0.15s;
         }
         .chat-home__select:focus {
             outline: none;
             border-color: var(--accent-cyan);
         }
         .chat-home__send {
-            padding: 0.45rem 1.25rem;
-            border: 1px solid var(--accent-cyan);
-            border-radius: var(--radius, 6px);
-            background: transparent;
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.5rem 1.4rem;
+            border: none;
+            border-radius: var(--radius-lg, 10px);
+            background: linear-gradient(135deg, rgba(0, 229, 255, 0.15), rgba(0, 229, 255, 0.08));
             color: var(--accent-cyan);
             font-family: inherit;
             font-size: 0.8rem;
@@ -185,43 +244,83 @@ import { OnboardingComponent } from './onboarding.component';
             text-transform: uppercase;
             letter-spacing: 0.05em;
             cursor: pointer;
-            transition: background 0.15s, box-shadow 0.15s;
+            transition: background 0.2s, box-shadow 0.2s, transform 0.1s;
         }
         .chat-home__send:hover:not(:disabled) {
-            background: var(--accent-cyan-dim);
-            box-shadow: var(--glow-cyan);
+            background: linear-gradient(135deg, rgba(0, 229, 255, 0.25), rgba(0, 229, 255, 0.12));
+            box-shadow: 0 0 20px rgba(0, 229, 255, 0.15);
+        }
+        .chat-home__send:active:not(:disabled) {
+            transform: scale(0.97);
         }
         .chat-home__send:disabled {
             opacity: 0.3;
             cursor: not-allowed;
         }
+        .chat-home__send-arrow {
+            font-size: 1rem;
+            line-height: 1;
+            transition: transform 0.15s;
+        }
+        .chat-home__send:hover:not(:disabled) .chat-home__send-arrow {
+            transform: translateX(2px);
+        }
+        .chat-home__send-spinner {
+            width: 12px;
+            height: 12px;
+            border: 2px solid rgba(0, 229, 255, 0.2);
+            border-top-color: var(--accent-cyan);
+            border-radius: 50%;
+            animation: spin 0.6s linear infinite;
+        }
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
         .chat-home__hints {
             display: flex;
             flex-wrap: wrap;
             gap: 0.5rem;
-            margin-top: 1.25rem;
+            margin-top: 1.5rem;
             justify-content: center;
         }
         .chat-home__hint {
-            padding: 0.4rem 0.75rem;
-            border: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            gap: 0.3rem;
+            padding: 0.45rem 0.85rem;
+            border: 1px solid rgba(255, 255, 255, 0.06);
             border-radius: 999px;
-            background: transparent;
+            background: rgba(15, 16, 24, 0.5);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
             color: var(--text-secondary);
             font-family: inherit;
             font-size: 0.75rem;
             cursor: pointer;
-            transition: border-color 0.15s, color 0.15s;
+            transition: border-color 0.2s, color 0.2s, background 0.2s, transform 0.15s;
         }
         .chat-home__hint:hover {
-            border-color: var(--accent-cyan);
+            border-color: rgba(0, 229, 255, 0.3);
+            color: var(--accent-cyan);
+            background: rgba(0, 229, 255, 0.05);
+            transform: translateY(-1px);
+        }
+        .chat-home__hint-icon {
+            font-size: 0.9rem;
+            line-height: 1;
+            color: var(--text-tertiary);
+            transition: color 0.2s;
+        }
+        .chat-home__hint:hover .chat-home__hint-icon {
             color: var(--accent-cyan);
         }
         @media (max-width: 480px) {
             .chat-home { padding: 1rem; }
-            .chat-home__title { font-size: 1.25rem; }
+            .chat-home__title { font-size: 1.5rem; }
+            .chat-home__logo-mark { width: 44px; height: 44px; font-size: 1.2rem; }
             .chat-home__actions { flex-direction: column; align-items: stretch; }
             .chat-home__agent-picker { justify-content: space-between; }
+            .chat-home__bg-glow { width: 300px; height: 300px; }
         }
     `,
 })

--- a/client/src/app/features/chat-home/onboarding.component.ts
+++ b/client/src/app/features/chat-home/onboarding.component.ts
@@ -175,32 +175,38 @@ const TEMPLATES: AgentTemplate[] = [
             align-items: center;
             gap: 0.5rem;
             padding: 1.25rem 1rem;
-            background: var(--bg-raised);
-            border: 1px solid var(--border);
-            border-radius: var(--radius, 6px);
+            background: rgba(15, 16, 24, 0.6);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+            border: 1px solid rgba(255, 255, 255, 0.05);
+            border-radius: var(--radius-lg, 10px);
             color: var(--text-secondary);
             font-family: inherit;
             cursor: pointer;
-            transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
+            transition: border-color 0.25s, background 0.25s, box-shadow 0.25s, transform 0.2s;
             text-align: center;
+            position: relative;
         }
         .tpl-card:hover {
-            border-color: var(--accent-cyan);
-            background: var(--accent-cyan-dim);
-            box-shadow: 0 0 16px rgba(0, 229, 255, 0.12);
+            border-color: rgba(0, 229, 255, 0.3);
+            background: rgba(0, 229, 255, 0.06);
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3), 0 0 20px rgba(0, 229, 255, 0.08);
+            transform: translateY(-2px);
         }
         .tpl-card__icon {
-            width: 40px;
-            height: 40px;
+            width: 44px;
+            height: 44px;
             display: flex;
             align-items: center;
             justify-content: center;
-            background: var(--accent-cyan-dim);
-            border-radius: 8px;
+            background: linear-gradient(135deg, rgba(0, 229, 255, 0.12), rgba(255, 0, 170, 0.06));
+            border: 1px solid rgba(0, 229, 255, 0.15);
+            border-radius: 12px;
             font-size: 0.7rem;
             font-weight: 800;
             color: var(--accent-cyan);
             letter-spacing: 0.05em;
+            box-shadow: 0 2px 12px rgba(0, 229, 255, 0.08);
         }
         .tpl-card__name {
             font-size: 0.82rem;
@@ -275,13 +281,13 @@ const TEMPLATES: AgentTemplate[] = [
             transition: background 0.15s, box-shadow 0.15s;
         }
         .btn--primary {
-            background: transparent;
+            background: linear-gradient(135deg, rgba(0, 229, 255, 0.12), rgba(0, 229, 255, 0.06));
             color: var(--accent-cyan);
-            border-color: var(--accent-cyan);
+            border-color: rgba(0, 229, 255, 0.3);
         }
         .btn--primary:hover:not(:disabled) {
-            background: var(--accent-cyan-dim);
-            box-shadow: 0 0 12px rgba(0, 229, 255, 0.25);
+            background: linear-gradient(135deg, rgba(0, 229, 255, 0.2), rgba(0, 229, 255, 0.1));
+            box-shadow: 0 0 20px rgba(0, 229, 255, 0.15);
         }
         .btn--primary:disabled { opacity: 0.4; cursor: not-allowed; }
         .btn--ghost {

--- a/client/src/app/shared/components/activity-rail.component.ts
+++ b/client/src/app/shared/components/activity-rail.component.ts
@@ -69,8 +69,8 @@ import type { Session } from '../../core/models/session.model';
         .rail {
             width: 36px;
             min-width: 36px;
-            background: var(--bg-surface);
-            border-left: 1px solid var(--border);
+            background: linear-gradient(180deg, rgba(15, 16, 24, 0.95) 0%, rgba(10, 10, 18, 0.98) 100%);
+            border-left: 1px solid rgba(255, 255, 255, 0.04);
             display: flex;
             flex-direction: column;
             transition: width 0.2s ease, min-width 0.2s ease;

--- a/client/src/app/shared/components/sidebar.component.ts
+++ b/client/src/app/shared/components/sidebar.component.ts
@@ -390,10 +390,10 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
         }
         .sidebar {
             width: 200px;
-            background: var(--bg-surface);
+            background: linear-gradient(180deg, rgba(15, 16, 24, 0.95) 0%, rgba(10, 10, 18, 0.98) 100%);
             min-height: 100%;
             padding: 1rem 0;
-            border-right: 1px solid var(--border);
+            border-right: 1px solid rgba(255, 255, 255, 0.04);
             display: flex;
             flex-direction: column;
             transition: width 0.2s ease;
@@ -422,7 +422,7 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
         }
         .sidebar__link--active {
             color: var(--accent-cyan);
-            background: var(--bg-raised);
+            background: linear-gradient(90deg, rgba(0, 229, 255, 0.08) 0%, transparent 100%);
             border-left: 3px solid var(--accent-cyan);
             text-shadow: 0 0 8px rgba(0, 229, 255, 0.3);
         }

--- a/client/src/app/shared/components/top-nav.component.ts
+++ b/client/src/app/shared/components/top-nav.component.ts
@@ -204,9 +204,11 @@ const TABS: NavTab[] = [
             align-items: center;
             justify-content: space-between;
             height: 48px;
-            padding: 0 1rem;
-            background: var(--bg-surface);
-            border-bottom: 1px solid var(--border);
+            padding: 0 1.25rem;
+            background: linear-gradient(180deg, rgba(15, 16, 24, 0.95) 0%, rgba(10, 10, 18, 0.98) 100%);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.04);
             position: relative;
             z-index: 100;
         }
@@ -224,8 +226,12 @@ const TABS: NavTab[] = [
             font-family: 'Dogica Pixel', 'Dogica', monospace;
             font-size: 1rem;
             font-weight: 700;
-            color: var(--accent-cyan);
-            text-shadow: 0 0 10px rgba(0, 229, 255, 0.35);
+            background: linear-gradient(135deg, var(--accent-cyan), var(--accent-magenta));
+            background-size: 200% 200%;
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            animation: gradientShift 8s ease infinite;
             letter-spacing: 0.06em;
         }
         .topnav__tabs {
@@ -262,6 +268,7 @@ const TABS: NavTab[] = [
             color: var(--accent-cyan);
             border-bottom-color: var(--accent-cyan);
             text-shadow: 0 0 8px rgba(0, 229, 255, 0.25);
+            background: linear-gradient(180deg, transparent 0%, rgba(0, 229, 255, 0.04) 100%);
         }
         .topnav__tab-chevron {
             font-size: 0.6rem;
@@ -276,13 +283,20 @@ const TABS: NavTab[] = [
             position: absolute;
             top: 100%;
             left: 0;
-            min-width: 180px;
-            background: var(--bg-raised);
-            border: 1px solid var(--border-bright);
-            border-radius: var(--radius, 6px);
-            padding: 0.35rem 0;
+            min-width: 190px;
+            background: rgba(22, 24, 34, 0.92);
+            backdrop-filter: blur(16px);
+            -webkit-backdrop-filter: blur(16px);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: var(--radius-lg, 10px);
+            padding: 0.4rem 0;
             z-index: 200;
-            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+            box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(0, 229, 255, 0.04);
+            animation: dropdownIn 0.15s ease-out;
+        }
+        @keyframes dropdownIn {
+            from { opacity: 0; transform: translateY(-4px); }
+            to { opacity: 1; transform: translateY(0); }
         }
         .topnav__dropdown-item {
             display: block;
@@ -368,20 +382,21 @@ const TABS: NavTab[] = [
             display: flex;
             align-items: center;
             gap: 0.5rem;
-            padding: 0.3rem 0.6rem;
-            background: var(--bg-input, #1a1a2e);
-            border: 1px solid var(--border, #333);
-            border-radius: var(--radius, 6px);
+            padding: 0.3rem 0.7rem;
+            background: rgba(12, 13, 20, 0.6);
+            border: 1px solid rgba(255, 255, 255, 0.05);
+            border-radius: var(--radius-lg, 10px);
             color: var(--text-tertiary);
             font-family: inherit;
             font-size: 0.7rem;
             cursor: pointer;
-            transition: border-color 0.15s, color 0.15s;
+            transition: border-color 0.2s, color 0.2s, box-shadow 0.2s;
             min-width: 160px;
         }
         .topnav__search-btn:hover {
-            border-color: var(--accent-cyan);
+            border-color: rgba(0, 229, 255, 0.3);
             color: var(--text-secondary);
+            box-shadow: 0 0 12px rgba(0, 229, 255, 0.06);
         }
         .topnav__search-label {
             flex: 1;

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -89,10 +89,21 @@
     --glow-magenta: 0 0 8px rgba(255, 0, 170, 0.25);
     --glow-green: 0 0 8px rgba(0, 255, 136, 0.25);
 
+    /* Glassmorphism */
+    --glass-bg: rgba(15, 16, 24, 0.6);
+    --glass-border: rgba(255, 255, 255, 0.06);
+    --glass-blur: 12px;
+
+    /* Gradients */
+    --gradient-cyan-magenta: linear-gradient(135deg, var(--accent-cyan), var(--accent-magenta));
+    --gradient-cyan-green: linear-gradient(135deg, var(--accent-cyan), var(--accent-green));
+    --gradient-surface: linear-gradient(180deg, var(--bg-surface) 0%, var(--bg-deep) 100%);
+
     /* Radius */
     --radius-sm: 3px;
     --radius: 6px;
-    --radius-lg: 8px;
+    --radius-lg: 10px;
+    --radius-xl: 16px;
 
     /* Typography scale (rem based on 8-10px root) */
     --text-2xl: 2rem;
@@ -245,6 +256,63 @@ button:active:not(:disabled) {
 @keyframes shimmer {
     0% { background-position: -200% 0; }
     100% { background-position: 200% 0; }
+}
+
+@keyframes gradientShift {
+    0% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+    100% { background-position: 0% 50%; }
+}
+
+@keyframes pulseGlow {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 1; }
+}
+
+@keyframes subtlePulse {
+    0%, 100% { box-shadow: 0 0 0 0 transparent; }
+    50% { box-shadow: 0 0 20px rgba(0, 229, 255, 0.08); }
+}
+
+/* ── Glassmorphism utility ── */
+.glass {
+    background: var(--glass-bg);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+    border: 1px solid var(--glass-border);
+}
+
+/* ── Gradient text utility ── */
+.gradient-text {
+    background: var(--gradient-cyan-magenta);
+    background-size: 200% 200%;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    animation: gradientShift 6s ease infinite;
+}
+
+/* ── Gradient border card ── */
+.gradient-border {
+    position: relative;
+    border: none !important;
+}
+.gradient-border::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(135deg, rgba(0, 229, 255, 0.3), rgba(255, 0, 170, 0.15), rgba(0, 255, 136, 0.1));
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity var(--transition-slow);
+}
+.gradient-border:hover::before {
+    opacity: 1;
 }
 
 /* ── Responsive table wrapper ── */

--- a/server/__tests__/discord-command-handlers.test.ts
+++ b/server/__tests__/discord-command-handlers.test.ts
@@ -399,7 +399,7 @@ describe('handleComponentInteraction', () => {
         const interaction = makeComponentInteraction('resume_thread');
         await handleComponentInteraction(ctx, interaction);
 
-        expect(ctx.subscribeForResponseWithEmbed).toHaveBeenCalledWith('sess-1', '100000000000000001', 'TestAgent', 'test-model', undefined);
+        expect(ctx.subscribeForResponseWithEmbed).toHaveBeenCalledWith('sess-1', '100000000000000001', 'TestAgent', 'test-model', undefined, undefined);
     });
 
     test('resume_thread — skips subscribe if callback exists', async () => {

--- a/server/db/discord-mention-sessions.ts
+++ b/server/db/discord-mention-sessions.ts
@@ -33,8 +33,12 @@ export function getMentionSession(
     botMessageId: string,
 ): MentionSessionInfo | null {
     const row = db.query(
-        'SELECT * FROM discord_mention_sessions WHERE bot_message_id = ?',
-    ).get(botMessageId) as MentionSessionRow | null;
+        `SELECT m.*, a.display_color
+         FROM discord_mention_sessions m
+         LEFT JOIN sessions s ON s.id = m.session_id
+         LEFT JOIN agents a ON a.id = s.agent_id
+         WHERE m.bot_message_id = ?`,
+    ).get(botMessageId) as (MentionSessionRow & { display_color: string | null }) | null;
 
     if (!row) return null;
 
@@ -43,6 +47,7 @@ export function getMentionSession(
         agentName: row.agent_name,
         agentModel: row.agent_model,
         projectName: row.project_name || undefined,
+        displayColor: row.display_color ?? undefined,
     };
 }
 

--- a/server/discord/bridge.ts
+++ b/server/discord/bridge.ts
@@ -200,8 +200,9 @@ export class DiscordBridge {
                 ).get(session.projectId);
                 projectName = projectRow?.name;
             }
-            this.threadSessions.set(threadId, { sessionId, agentName, agentModel, ownerUserId: '', projectName });
-            this.subscribeForResponseWithEmbed(sessionId, threadId, agentName, agentModel, projectName);
+            const displayColor = agent?.displayColor;
+            this.threadSessions.set(threadId, { sessionId, agentName, agentModel, ownerUserId: '', projectName, displayColor });
+            this.subscribeForResponseWithEmbed(sessionId, threadId, agentName, agentModel, projectName, displayColor);
             log.info('Auto-subscribed Discord thread for resumed session', { threadId, sessionId });
         };
         this.processManager.subscribeAll(this.globalEventCallback);
@@ -316,8 +317,8 @@ export class DiscordBridge {
             threadLastActivity: this.threadLastActivity,
             createStandaloneThread: (channelId, name) =>
                 createStandaloneThreadImpl(this.config.botToken, channelId, name),
-            subscribeForResponseWithEmbed: (sid, tid, an, am, pn) =>
-                this.subscribeForResponseWithEmbed(sid, tid, an, am, pn),
+            subscribeForResponseWithEmbed: (sid, tid, an, am, pn, dc) =>
+                this.subscribeForResponseWithEmbed(sid, tid, an, am, pn, dc),
             sendTaskResult: (cid, task, uid) =>
                 this.sendTaskResult(cid, task, uid),
             muteUser: (uid) => this.muteUser(uid),
@@ -348,11 +349,11 @@ export class DiscordBridge {
         await handleMessageImpl(ctx, data);
     }
 
-    private subscribeForResponseWithEmbed(sessionId: string, threadId: string, agentName: string, agentModel: string, projectName?: string): void {
+    private subscribeForResponseWithEmbed(sessionId: string, threadId: string, agentName: string, agentModel: string, projectName?: string, displayColor?: string | null): void {
         subscribeImpl(
             this.processManager, this.delivery, this.config.botToken,
             this.db, this.threadCallbacks, sessionId, threadId, agentName, agentModel,
-            projectName,
+            projectName, displayColor,
         );
     }
 

--- a/server/discord/command-handlers/component-handlers.ts
+++ b/server/discord/command-handlers/component-handlers.ts
@@ -58,7 +58,7 @@ export async function handleComponentInteraction(
 
             // Resubscribe for responses
             if (!ctx.threadCallbacks.has(threadId)) {
-                ctx.subscribeForResponseWithEmbed(info.sessionId, threadId, info.agentName, info.agentModel, info.projectName);
+                ctx.subscribeForResponseWithEmbed(info.sessionId, threadId, info.agentName, info.agentModel, info.projectName, info.displayColor);
             }
             ctx.threadLastActivity.set(threadId, Date.now());
 

--- a/server/discord/command-handlers/session-commands.ts
+++ b/server/discord/command-handlers/session-commands.ts
@@ -19,6 +19,7 @@ import {
     sendEmbedWithButtons,
     buildActionRow,
     agentColor,
+    hexColorToInt,
     buildFooterText,
 } from '../embeds';
 
@@ -127,16 +128,17 @@ export async function handleSessionCommand(
         ownerUserId: userId,
         topic,
         projectName: project.name,
+        displayColor: agent.displayColor,
     });
     ctx.threadLastActivity.set(threadId, Date.now());
 
     ctx.processManager.startProcess(session, topic);
-    ctx.subscribeForResponseWithEmbed(session.id, threadId, agent.name, agent.model || 'unknown', project.name);
+    ctx.subscribeForResponseWithEmbed(session.id, threadId, agent.name, agent.model || 'unknown', project.name, agent.displayColor);
 
     // Post a welcome embed with Stop button in the thread
     sendEmbedWithButtons(ctx.delivery, ctx.config.botToken, threadId, {
         description: `**${agent.name}** is working on: ${topic}`,
-        color: agentColor(agent.name),
+        color: hexColorToInt(agent.displayColor) ?? agentColor(agent.name),
         footer: { text: buildFooterText({ agentName: agent.name, agentModel: agent.model || 'unknown', sessionId: session.id, projectName: project.name }) },
     }, [
         buildActionRow(

--- a/server/discord/commands.ts
+++ b/server/discord/commands.ts
@@ -291,7 +291,7 @@ export interface InteractionContext {
     threadCallbacks: Map<string, ThreadCallbackInfo>;
     threadLastActivity: Map<string, number>;
     createStandaloneThread: (channelId: string, name: string) => Promise<string | null>;
-    subscribeForResponseWithEmbed: (sessionId: string, threadId: string, agentName: string, agentModel: string, projectName?: string) => void;
+    subscribeForResponseWithEmbed: (sessionId: string, threadId: string, agentName: string, agentModel: string, projectName?: string, displayColor?: string | null) => void;
     sendTaskResult: (channelId: string, task: import('../../shared/types/work-tasks').WorkTask, mentionUserId?: string) => Promise<void>;
     muteUser: (userId: string) => void;
     unmuteUser: (userId: string) => void;

--- a/server/discord/embeds.ts
+++ b/server/discord/embeds.ts
@@ -489,6 +489,18 @@ export async function removeReaction(botToken: string, channelId: string, messag
     }
 }
 
+/**
+ * Convert a hex color string (e.g. '#ff00aa' or 'ff00aa') to a Discord
+ * embed color integer.  Returns `null` for invalid input so callers can
+ * fall back to the hash-based color.
+ */
+export function hexColorToInt(hex: string | null | undefined): number | null {
+    if (!hex) return null;
+    const cleaned = hex.replace(/^#/, '');
+    if (!/^[0-9a-fA-F]{6}$/.test(cleaned)) return null;
+    return parseInt(cleaned, 16);
+}
+
 /** Generate a consistent color for an agent name. */
 export function agentColor(name: string): number {
     let hash = 0;

--- a/server/discord/message-handler.ts
+++ b/server/discord/message-handler.ts
@@ -89,6 +89,7 @@ export interface MentionSessionInfo {
     agentName: string;
     agentModel: string;
     projectName?: string;
+    displayColor?: string | null;
 }
 
 /** Context needed by the message handler to access bridge state. */
@@ -452,14 +453,15 @@ async function handleMentionReply(ctx: MessageHandlerContext, channelId: string,
 
     const agentName = agent.name;
     const agentModel = agent.model || 'unknown';
+    const agentDisplayColor = agent.displayColor;
     const projectNameForFooter = project.name;
     subscribeForAdaptiveInlineResponse(
         ctx.processManager, ctx.delivery, ctx.config.botToken,
         session.id, channelId, messageId, agentName, agentModel,
         (botMessageId) => {
-            trackMentionSession(ctx.db, ctx.mentionSessions, botMessageId, { sessionId: session.id, agentName, agentModel, projectName: projectNameForFooter });
+            trackMentionSession(ctx.db, ctx.mentionSessions, botMessageId, { sessionId: session.id, agentName, agentModel, projectName: projectNameForFooter, displayColor: agentDisplayColor });
         },
-        projectNameForFooter,
+        projectNameForFooter, agentDisplayColor,
     );
 }
 
@@ -478,7 +480,7 @@ async function handleMentionReplyResume(
     const cleanText = resolveMentions(text, mentions, ctx.botUserId);
     if (!cleanText) return;
 
-    const { sessionId, agentName, agentModel, projectName } = sessionInfo;
+    const { sessionId, agentName, agentModel, projectName, displayColor } = sessionInfo;
     const session = getSession(ctx.db, sessionId);
 
     if (!session) {
@@ -500,9 +502,9 @@ async function handleMentionReplyResume(
         ctx.processManager, ctx.delivery, ctx.config.botToken,
         sessionId, channelId, messageId, agentName, agentModel,
         (botMessageId) => {
-            trackMentionSession(ctx.db, ctx.mentionSessions, botMessageId, { sessionId, agentName, agentModel, projectName });
+            trackMentionSession(ctx.db, ctx.mentionSessions, botMessageId, { sessionId, agentName, agentModel, projectName, displayColor });
         },
-        projectName,
+        projectName, displayColor,
     );
 }
 
@@ -562,6 +564,7 @@ async function resumeExpiredThreadSession(
         ownerUserId: previousInfo.ownerUserId,
         topic: previousInfo.topic,
         projectName: project.name,
+        displayColor: agent.displayColor,
     });
     ctx.threadLastActivity.set(threadId, Date.now());
 
@@ -577,7 +580,7 @@ async function resumeExpiredThreadSession(
     subscribeForResponseWithEmbed(
         ctx.processManager, ctx.delivery, ctx.config.botToken,
         ctx.db, ctx.threadCallbacks, newSession.id, threadId, agent.name, agent.model || 'unknown',
-        project.name,
+        project.name, agent.displayColor,
     );
 
     // Brief non-blocking notification
@@ -601,7 +604,7 @@ async function routeToThread(ctx: MessageHandlerContext, threadId: string, _user
         if (!threadInfo) return;
     }
 
-    const { sessionId, agentName, agentModel, projectName } = threadInfo;
+    const { sessionId, agentName, agentModel, projectName, displayColor } = threadInfo;
 
     const session = getSession(ctx.db, sessionId);
     if (!session) {
@@ -630,7 +633,7 @@ async function routeToThread(ctx: MessageHandlerContext, threadId: string, _user
         subscribeForResponseWithEmbed(
             ctx.processManager, ctx.delivery, ctx.config.botToken,
             ctx.db, ctx.threadCallbacks, sessionId, threadId, agentName, agentModel,
-            projectName,
+            projectName, displayColor,
         );
         return;
     }
@@ -638,6 +641,6 @@ async function routeToThread(ctx: MessageHandlerContext, threadId: string, _user
     subscribeForResponseWithEmbed(
         ctx.processManager, ctx.delivery, ctx.config.botToken,
         ctx.db, ctx.threadCallbacks, sessionId, threadId, agentName, agentModel,
-        projectName,
+        projectName, displayColor,
     );
 }

--- a/server/discord/thread-manager.ts
+++ b/server/discord/thread-manager.ts
@@ -21,6 +21,7 @@ import {
     buildActionRow,
     sendTypingIndicator,
     agentColor,
+    hexColorToInt,
     assertSnowflake,
     splitEmbedDescription,
     buildFooterText,
@@ -57,6 +58,7 @@ export interface ThreadSessionInfo {
     ownerUserId: string;
     topic?: string;
     projectName?: string;
+    displayColor?: string | null;
 }
 
 export interface ThreadCallbackInfo {
@@ -79,6 +81,7 @@ export function subscribeForResponseWithEmbed(
     agentName: string,
     agentModel: string,
     projectName?: string,
+    displayColor?: string | null,
 ): void {
     // Unsubscribe the previous callback for this thread to prevent duplicates
     const prev = threadCallbacks.get(threadId);
@@ -144,7 +147,7 @@ export function subscribeForResponseWithEmbed(
         clearTimeout(typingSafetyTimeout);
     };
 
-    const color = agentColor(agentName);
+    const color = hexColorToInt(displayColor) ?? agentColor(agentName);
 
     const flush = async () => {
         if (!buffer) return;
@@ -413,6 +416,7 @@ export function subscribeForInlineResponse(
     agentModel: string,
     onBotMessage?: (botMessageId: string) => void,
     projectName?: string,
+    displayColor?: string | null,
 ): void {
     let buffer = '';
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -420,7 +424,7 @@ export function subscribeForInlineResponse(
     const TYPING_REFRESH_MS = 8000;
     const TYPING_TIMEOUT_MS = 4 * 60 * 1000; // 4 minute safety timeout
     let receivedAnyActivity = false; // tracks any activity (content OR tool use)
-    const color = agentColor(agentName);
+    const color = hexColorToInt(displayColor) ?? agentColor(agentName);
 
     // Keep typing indicator alive continuously until response completes
     const typingInterval = setInterval(() => {
@@ -543,6 +547,7 @@ export function subscribeForAdaptiveInlineResponse(
     agentModel: string,
     onBotMessage?: (botMessageId: string) => void,
     projectName?: string,
+    displayColor?: string | null,
 ): void {
     let buffer = '';
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -552,7 +557,7 @@ export function subscribeForAdaptiveInlineResponse(
     const TYPING_REFRESH_MS = 8000;
     const TYPING_TIMEOUT_MS = 4 * 60 * 1000;
     let receivedAnyActivity = false;
-    const color = agentColor(agentName);
+    const color = hexColorToInt(displayColor) ?? agentColor(agentName);
 
     // Progress embed state — only created when tool use is detected
     let progressMessageId: string | null = null;
@@ -713,6 +718,7 @@ export function subscribeForInlineProgressResponse(
     agentModel: string,
     onBotMessage?: (botMessageId: string) => void,
     projectName?: string,
+    displayColor?: string | null,
 ): void {
     let buffer = '';
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -722,7 +728,7 @@ export function subscribeForInlineProgressResponse(
     const TYPING_REFRESH_MS = 8000;
     const TYPING_TIMEOUT_MS = 4 * 60 * 1000; // 4 minute safety timeout
     let receivedAnyActivity = false;
-    const color = agentColor(agentName);
+    const color = hexColorToInt(displayColor) ?? agentColor(agentName);
     let progressMessageId: string | null = null;
 
     // Post the initial progress embed immediately
@@ -870,13 +876,13 @@ export function tryRecoverThread(
 ): ThreadSessionInfo | null {
     try {
         const row = db.query(
-            `SELECT s.id, s.agent_id, s.initial_prompt, a.name as agent_name, a.model as agent_model, p.name as project_name
+            `SELECT s.id, s.agent_id, s.initial_prompt, a.name as agent_name, a.model as agent_model, a.display_color, p.name as project_name
              FROM sessions s
              LEFT JOIN agents a ON a.id = s.agent_id
              LEFT JOIN projects p ON p.id = s.project_id
              WHERE s.name = ? AND s.source = 'discord'
              ORDER BY s.created_at DESC LIMIT 1`,
-        ).get(`Discord thread:${threadId}`) as { id: string; agent_id: string; initial_prompt: string; agent_name: string; agent_model: string; project_name: string | null } | null;
+        ).get(`Discord thread:${threadId}`) as { id: string; agent_id: string; initial_prompt: string; agent_name: string; agent_model: string; display_color: string | null; project_name: string | null } | null;
 
         if (!row) return null;
 
@@ -887,6 +893,7 @@ export function tryRecoverThread(
             ownerUserId: '',
             topic: row.initial_prompt || undefined,
             projectName: row.project_name || undefined,
+            displayColor: row.display_color ?? undefined,
         };
         threadSessions.set(threadId, info);
         log.info('Recovered thread session from DB', { threadId, sessionId: row.id });
@@ -910,13 +917,13 @@ export function recoverActiveThreadSubscriptions(
 ): void {
     try {
         const rows = db.query(
-            `SELECT s.id, s.name, a.name as agent_name, a.model as agent_model, p.name as project_name
+            `SELECT s.id, s.name, a.name as agent_name, a.model as agent_model, a.display_color, p.name as project_name
              FROM sessions s
              LEFT JOIN agents a ON a.id = s.agent_id
              LEFT JOIN projects p ON p.id = s.project_id
              WHERE s.source = 'discord' AND s.status = 'running'
                AND s.name LIKE 'Discord thread:%'`,
-        ).all() as { id: string; name: string; agent_name: string; agent_model: string; project_name: string | null }[];
+        ).all() as { id: string; name: string; agent_name: string; agent_model: string; display_color: string | null; project_name: string | null }[];
 
         let recovered = 0;
         for (const row of rows) {
@@ -930,6 +937,7 @@ export function recoverActiveThreadSubscriptions(
                     agentModel: row.agent_model || 'unknown',
                     ownerUserId: '',
                     projectName: row.project_name || undefined,
+                    displayColor: row.display_color ?? undefined,
                 });
             }
 
@@ -937,6 +945,7 @@ export function recoverActiveThreadSubscriptions(
                 processManager, delivery, botToken, db, threadCallbacks,
                 row.id, threadId, row.agent_name || 'Agent', row.agent_model || 'unknown',
                 row.project_name || undefined,
+                row.display_color,
             );
             recovered++;
         }

--- a/specs/discord/bridge.spec.md
+++ b/specs/discord/bridge.spec.md
@@ -145,6 +145,8 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | `editEmbed` | `(delivery, botToken, channelId, messageId, embed)` | `Promise<void>` | Edit an existing embed message in-place via PATCH |
 | `agentColor` | `(name: string)` | `number` | Generate a consistent embed color for an agent name |
 | `buildFooterText` | `(ctx: FooterContext)` | `string` | Build a clean footer: `agentName` or `agentName · status` |
+| `buildFooterWithStats` | `(ctx: FooterContext, stats?: FooterStats)` | `string` | Build footer with session context AND run stats (files, turns, tools, commits) |
+| `hexColorToInt` | `(hex: string)` | `number \| null` | Convert a hex color string (e.g. '#ff00aa') to a Discord embed color integer |
 | `assertSnowflake` | `(value, label)` | `void` | Validate a Discord snowflake ID |
 | `extractMentionsFromEmbed` | `(embed)` | `string \| undefined` | Extract Discord mentions from embed description for top-level content field notifications |
 | `sendEmbedWithFiles` | `(delivery, botToken, channelId, embed, files)` | `Promise<string \| null>` | Send an embed with file attachments via multipart/form-data |
@@ -172,10 +174,10 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
-| `subscribeForResponseWithEmbed` | `(pm, delivery, botToken, threadCallbacks, sessionId, threadId, agentName, agentModel)` | `void` | Subscribe to agent events and stream responses as embeds |
-| `subscribeForInlineResponse` | `(pm, delivery, botToken, sessionId, channelId, replyToId, agentName, agentModel)` | `void` | Subscribe for inline reply responses (one-off @mention) |
-| `subscribeForAdaptiveInlineResponse` | `(pm, delivery, botToken, sessionId, channelId, replyToId, agentName, agentModel, onBotMessage?, projectName?)` | `void` | Adaptive UX subscriber: starts lightweight (typing only), upgrades to progress embed on tool use |
-| `subscribeForInlineProgressResponse` | `(pm, delivery, botToken, sessionId, channelId, replyToId, agentName, agentModel, onBotMessage?, projectName?)` | `void` | Edit-in-place progress subscriber: posts progress embed immediately, edits with tool status |
+| `subscribeForResponseWithEmbed` | `(pm, delivery, botToken, db, threadCallbacks, sessionId, threadId, agentName, agentModel, projectName?, displayColor?)` | `void` | Subscribe to agent events and stream responses as embeds |
+| `subscribeForInlineResponse` | `(pm, delivery, botToken, sessionId, channelId, replyToId, agentName, agentModel, displayColor?)` | `void` | Subscribe for inline reply responses (one-off @mention) |
+| `subscribeForAdaptiveInlineResponse` | `(pm, delivery, botToken, sessionId, channelId, replyToId, agentName, agentModel, onBotMessage?, projectName?, displayColor?)` | `void` | Adaptive UX subscriber: starts lightweight (typing only), upgrades to progress embed on tool use |
+| `subscribeForInlineProgressResponse` | `(pm, delivery, botToken, sessionId, channelId, replyToId, agentName, agentModel, onBotMessage?, projectName?, displayColor?)` | `void` | Edit-in-place progress subscriber: posts progress embed immediately, edits with tool status |
 | `tryRecoverThread` | `(db, threadSessions, threadId)` | `ThreadSessionInfo \| null` | Try to recover a thread-session mapping from the DB |
 | `recoverActiveThreadSubscriptions` | `(db, pm, delivery, botToken, threadSessions, threadCallbacks)` | `void` | Re-subscribe to all active Discord sessions on startup |
 | `archiveStaleThreads` | `(pm, delivery, botToken, lastActivity, sessions, callbacks, thresholdMs)` | `Promise<void>` | Archive threads idle beyond threshold |
@@ -266,6 +268,7 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | `InteractionContext` | `commands.ts` | Context object for interaction handler delegation |
 | `DiscordEmbed` | `embeds.ts` | Embed object shape (title, description, color, fields, footer, timestamp, image?, thumbnail?) |
 | `FooterContext` | `embeds.ts` | Metadata for building rich embed footers (agentName, agentModel?, status?) |
+| `FooterStats` | `embeds.ts` | Optional run statistics for embed footers (filesChanged?, turns?, tools?, commits?) |
 | `DiscordFileAttachment` | `embeds.ts` | File attachment for Discord uploads (name, data, contentType?) |
 | `MessageHandlerContext` | `message-handler.ts` | Context object for message handler delegation |
 | `ThreadSessionInfo` | `thread-manager.ts` | Thread-to-session mapping info (sessionId, agentName, agentModel, ownerUserId, topic?, projectName?) |


### PR DESCRIPTION
## Summary
- **Frontend modernization**: Glassmorphic cards with backdrop blur, gradient borders on hover, animated gradient title, modern hover/lift states across chat home, agent list, top nav, sidebar, activity rail, and onboarding components
- **Discord embed colors**: Agent `displayColor` now passes through to embed colors via new `hexColorToInt()` utility, so each agent's configured color shows in Discord embeds instead of the hash-based fallback
- **Spec fix**: Documents `FooterStats`, `buildFooterWithStats`, `hexColorToInt` exports and updates subscriber signatures — fixes the failing Checks CI on main (3 undocumented export warnings in strict mode)

## Test plan
- [x] `bun x tsc --noEmit` — compiles clean
- [x] `bun run spec:check` — 161 specs, 0 warnings
- [x] Visual check of frontend at localhost:3000
- [x] Verify Discord embeds use agent display colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)