### PR TITLE
chore: update README unit test count (8208 → 8213)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <img src="https://img.shields.io/badge/runtime-Bun_1.3-f9f1e1?logo=bun" alt="Bun">
   <img src="https://img.shields.io/badge/Angular-21-dd0031?logo=angular" alt="Angular 21">
-  <img src="https://img.shields.io/badge/tests-8213%20unit%20%7C%20360%20E2E-brightgreen" alt="8208 Unit | 360 E2E Tests">
+  <img src="https://img.shields.io/badge/tests-8213%20unit%20%7C%20360%20E2E-brightgreen" alt="8213 Unit | 360 E2E Tests">
   <img src="https://img.shields.io/badge/spec%20coverage-100%25-brightgreen" alt="Spec Coverage 100%">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>
 </p>
@@ -188,7 +188,7 @@ Everything runs locally on your computer. Your code stays yours. The only extern
 
 | Metric | Value |
 |--------|-------|
-| Unit tests | **8,208** across 341 files |
+| Unit tests | **8,213** across 342 files |
 | E2E tests | **360** across 31 Playwright specs |
 | Module specs | **162** with automated specsync validation (100% file coverage) |
 | Test:code ratio | **1.14×** — more test code than production code |
@@ -306,7 +306,7 @@ See [SECURITY.md](SECURITY.md) for the full security model and responsible discl
 ### Testing
 
 ```bash
-bun test              # ~8208 server tests
+bun test              # ~8213 server tests
 cd client && npx vitest run   # Angular component tests
 bun run test:e2e      # 360 Playwright tests
 bun run spec:check    # Module spec validation


### PR DESCRIPTION
## Summary
- Updates unit test count in README badge, stats table, and code block to reflect current 8,213 tests across 342 files

## Test plan
- [x] `bun run stats:check` passes
- [x] Badge, table, and code block all consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)