### PR TITLE
fix: make flock register idempotent for duplicate addresses

### DIFF
--- a/server/__tests__/flock-directory-service.test.ts
+++ b/server/__tests__/flock-directory-service.test.ts
@@ -42,9 +42,11 @@ describe('register', () => {
         expect(agent.lastHeartbeat).toBeTruthy();
     });
 
-    test('enforces unique address', () => {
-        svc.register({ address: 'ALGO_UNIQUE', name: 'Agent1' });
-        expect(() => svc.register({ address: 'ALGO_UNIQUE', name: 'Agent2' })).toThrow();
+    test('re-registration with same address updates existing record', () => {
+        const first = svc.register({ address: 'ALGO_UNIQUE', name: 'Agent1' });
+        const second = svc.register({ address: 'ALGO_UNIQUE', name: 'Agent2' });
+        expect(second.id).toBe(first.id);
+        expect(second.name).toBe('Agent2');
     });
 
     test('defaults capabilities to empty array', () => {

--- a/server/flock-directory/service.ts
+++ b/server/flock-directory/service.ts
@@ -117,8 +117,32 @@ export class FlockDirectoryService {
         return this.onChainClient;
     }
 
-    /** Register a new agent in the directory. Returns the created agent. */
+    /** Register a new agent in the directory. Returns the created agent.
+     *  If the address is already registered, updates the existing record and
+     *  sends a heartbeat instead of failing with a UNIQUE constraint error.
+     */
     register(input: RegisterFlockAgentInput): FlockAgent {
+        // Check for existing registration by address (idempotent)
+        const existing = this.getByAddress(input.address);
+        if (existing) {
+            // Update name/description/capabilities if provided, reactivate if deregistered
+            const capabilities = JSON.stringify(input.capabilities ?? existing.capabilities);
+            const now = new Date().toISOString();
+            this.db.query(`
+                UPDATE flock_agents
+                SET name = ?, description = ?, instance_url = ?, capabilities = ?,
+                    status = 'active', last_heartbeat = ?, updated_at = ?
+                WHERE id = ?
+            `).run(
+                input.name ?? existing.name,
+                input.description ?? existing.description,
+                input.instanceUrl ?? existing.instanceUrl,
+                capabilities, now, now, existing.id,
+            );
+            log.info('Agent re-registered (existing address)', { id: existing.id, address: input.address });
+            return this.getById(existing.id)!;
+        }
+
         const id = crypto.randomUUID();
         const capabilities = JSON.stringify(input.capabilities ?? []);
         const now = new Date().toISOString();


### PR DESCRIPTION
## Summary
- Flock register was crashing with `UNIQUE constraint failed: flock_agents.address` when trying to register an address that already exists
- Now handles duplicates gracefully: updates the existing record (name, description, capabilities) and reactivates it
- Matches the existing `selfRegister()` behavior which already handled this case
- Updated test to verify idempotent re-registration instead of expecting a throw

## Test plan
- [x] All 39 flock directory service tests pass
- [ ] Register an agent via the UI — verify 201 response
- [ ] Re-register the same address — verify it updates instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)