### PR TITLE
feat: add corvid_browser MCP tool for agent browser automation

### DIFF
--- a/server/algochat/init.ts
+++ b/server/algochat/init.ts
@@ -25,6 +25,7 @@ import type { ResponsePollingService } from '../notifications/response-poller';
 import type { UsageMeter } from '../billing/meter';
 import type { HealthMonitorService } from '../health/monitor';
 import type { MentionPollingService } from '../polling/service';
+import type { BrowserService } from '../browser/service';
 import type { AlgoChatConfig } from './config';
 import type { AlgoChatState } from '../bootstrap';
 import { initAlgoChatService } from './service';
@@ -69,6 +70,7 @@ export interface AlgoChatInitDeps {
     healthMonitorService: HealthMonitorService;
     mentionPollingService: MentionPollingService;
     flockDirectoryService: FlockDirectoryService;
+    browserService?: BrowserService;
 }
 
 /**
@@ -79,7 +81,7 @@ export async function initAlgoChat(deps: AlgoChatInitDeps): Promise<void> {
     const { db, server, processManager, algochatConfig, algochatState, workTaskService,
         schedulerService, workflowService, notificationService, questionDispatcher,
         reputationScorer, reputationAttestation, reputationVerifier, astParserService,
-        permissionBroker, shutdownCoordinator, flockDirectoryService } = deps;
+        permissionBroker, shutdownCoordinator, flockDirectoryService, browserService } = deps;
 
     if (!algochatConfig.enabled) {
         log.info('AlgoChat disabled');
@@ -180,6 +182,7 @@ export async function initAlgoChat(deps: AlgoChatInitDeps): Promise<void> {
         permissionBroker,
         processManager,
         flockDirectoryService,
+        browserService,
     });
 
     // Forward AlgoChat events to WebSocket clients

--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -57,6 +57,7 @@ import { OllamaProvider } from './providers/ollama/provider';
 import { AstParserService } from './ast/service';
 import { PermissionBroker } from './permissions/broker';
 import { FlockDirectoryService } from './flock-directory/service';
+import { BrowserService } from './browser/service';
 import { listProjects, createProject } from './db/projects';
 import { initObservability } from './observability/index';
 
@@ -139,6 +140,9 @@ export interface ServiceContainer {
 
     // Agent directory
     flockDirectoryService: FlockDirectoryService;
+
+    // Browser automation
+    browserService: BrowserService;
 }
 
 /**
@@ -267,6 +271,7 @@ export async function bootstrapServices(db: Database, startTime: number): Promis
     const marketplaceService = new MarketplaceService(db);
     const marketplaceFederation = new MarketplaceFederation(db);
     const flockDirectoryService = new FlockDirectoryService(db);
+    const browserService = new BrowserService();
 
     const reputationScorer = new ReputationScorer(db);
     const reputationAttestation = new ReputationAttestation(db);
@@ -471,5 +476,6 @@ export async function bootstrapServices(db: Database, startTime: number): Promis
         slackBridge,
         permissionBroker,
         flockDirectoryService,
+        browserService,
     };
 }

--- a/server/browser/service.ts
+++ b/server/browser/service.ts
@@ -1,0 +1,280 @@
+/**
+ * BrowserService — Manages a persistent Playwright browser instance that
+ * agents can use for browser automation via the corvid_browser MCP tool.
+ *
+ * Uses the system Chrome installation (channel: 'chrome') to avoid
+ * downloading additional browser binaries. Lazily launched on first use,
+ * shared across all agent sessions.
+ *
+ * @module
+ */
+import { type Browser, type BrowserContext, chromium, type Page } from 'playwright';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('BrowserService');
+
+/** Max pages allowed at once to prevent runaway tab creation. */
+const MAX_PAGES = 20;
+/** Page navigation timeout (ms). */
+const NAV_TIMEOUT = 30_000;
+export interface BrowserTab {
+  id: number;
+  url: string;
+  title: string;
+}
+
+export class BrowserService {
+  private browser: Browser | null = null;
+  private context: BrowserContext | null = null;
+  private pages: Map<number, Page> = new Map();
+  private nextTabId = 1;
+  private launching = false;
+
+  /** Launch the browser if not already running. */
+  async ensureBrowser(): Promise<void> {
+    if (this.browser?.isConnected()) return;
+    if (this.launching) {
+      // Wait for an in-progress launch
+      while (this.launching) await new Promise((r) => setTimeout(r, 100));
+      return;
+    }
+    this.launching = true;
+    try {
+      log.info('Launching Chrome browser');
+      this.browser = await chromium.launch({
+        channel: 'chrome',
+        headless: true,
+        args: ['--no-sandbox', '--disable-gpu'],
+      });
+      this.context = await this.browser.newContext({
+        viewport: { width: 1280, height: 900 },
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      });
+      this.pages.clear();
+      this.nextTabId = 1;
+      log.info('Chrome browser launched');
+    } catch (err) {
+      log.error('Failed to launch Chrome', { error: err instanceof Error ? err.message : String(err) });
+      this.browser = null;
+      this.context = null;
+      throw err;
+    } finally {
+      this.launching = false;
+    }
+  }
+
+  /** Check if the browser is running. */
+  get isRunning(): boolean {
+    return this.browser?.isConnected() === true;
+  }
+
+  /** List open tabs. */
+  async tabsContext(): Promise<BrowserTab[]> {
+    await this.ensureBrowser();
+    const tabs: BrowserTab[] = [];
+    for (const [id, page] of this.pages) {
+      tabs.push({ id, url: page.url(), title: await page.title().catch(() => '') });
+    }
+    return tabs;
+  }
+
+  /** Create a new tab, optionally navigating to a URL. */
+  async createTab(url?: string): Promise<BrowserTab> {
+    await this.ensureBrowser();
+    if (this.pages.size >= MAX_PAGES) {
+      throw new Error(`Maximum ${MAX_PAGES} tabs reached. Close some tabs first.`);
+    }
+    const page = await this.context!.newPage();
+    const id = this.nextTabId++;
+    this.pages.set(id, page);
+    page.on('close', () => this.pages.delete(id));
+
+    if (url) {
+      await page.goto(url, { timeout: NAV_TIMEOUT, waitUntil: 'domcontentloaded' });
+    }
+    return { id, url: page.url(), title: await page.title().catch(() => '') };
+  }
+
+  /** Close a tab. */
+  async closeTab(tabId: number): Promise<void> {
+    const page = this.getPage(tabId);
+    await page.close();
+    this.pages.delete(tabId);
+  }
+
+  /** Navigate an existing tab to a URL. */
+  async navigate(tabId: number, url: string): Promise<{ url: string; title: string }> {
+    const page = this.getPage(tabId);
+    await page.goto(url, { timeout: NAV_TIMEOUT, waitUntil: 'domcontentloaded' });
+    return { url: page.url(), title: await page.title().catch(() => '') };
+  }
+
+  /** Get the text content of a page. */
+  async getPageText(tabId: number): Promise<string> {
+    const page = this.getPage(tabId);
+    return page.evaluate(() => document.body.innerText).catch(() => '');
+  }
+
+  /** Read page structure — returns a simplified DOM tree. */
+  async readPage(tabId: number, opts?: { selector?: string; maxLength?: number }): Promise<string> {
+    const page = this.getPage(tabId);
+    const selector = opts?.selector ?? 'body';
+    const maxLen = opts?.maxLength ?? 50_000;
+
+    const text = await page.evaluate(
+      ({ sel, max }: { sel: string; max: number }) => {
+        const el = document.querySelector(sel);
+        if (!el) return `No element found for selector: ${sel}`;
+        // Get a simplified representation
+        const lines: string[] = [];
+        const walk = (node: Element, depth: number) => {
+          if (lines.length > 500) return;
+          const tag = node.tagName.toLowerCase();
+          const id = node.id ? `#${node.id}` : '';
+          const cls =
+            node.className && typeof node.className === 'string'
+              ? `.${node.className.split(' ').filter(Boolean).slice(0, 2).join('.')}`
+              : '';
+          const text =
+            node.childNodes.length === 1 && node.childNodes[0].nodeType === 3
+              ? ` "${(node.childNodes[0].textContent ?? '').trim().slice(0, 80)}"`
+              : '';
+          const href = node.getAttribute('href') ? ` href="${node.getAttribute('href')}"` : '';
+          lines.push('  '.repeat(depth) + `<${tag}${id}${cls}${href}>${text}`);
+          for (const child of node.children) walk(child, depth + 1);
+        };
+        walk(el, 0);
+        return lines.join('\n').slice(0, max);
+      },
+      { sel: selector, max: maxLen },
+    );
+
+    return text;
+  }
+
+  /** Find elements matching a CSS selector or text. */
+  async find(tabId: number, query: string): Promise<string> {
+    const page = this.getPage(tabId);
+    // Try as CSS selector first, fall back to text search
+    const results = await page.evaluate((q: string) => {
+      const matches: string[] = [];
+      // CSS selector
+      try {
+        const els = document.querySelectorAll(q);
+        if (els.length > 0) {
+          els.forEach((el, i) => {
+            if (i >= 20) return;
+            const tag = el.tagName.toLowerCase();
+            const text = (el.textContent ?? '').trim().slice(0, 100);
+            matches.push(`[${i}] <${tag}> "${text}"`);
+          });
+          return `Found ${els.length} elements matching selector "${q}":\n${matches.join('\n')}`;
+        }
+      } catch {
+        /* not a valid selector */
+      }
+      // Text search
+      const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+      let count = 0;
+      while (walker.nextNode() && count < 20) {
+        const node = walker.currentNode;
+        if (node.textContent && node.textContent.toLowerCase().includes(q.toLowerCase())) {
+          const parent = node.parentElement;
+          const tag = parent?.tagName.toLowerCase() ?? '?';
+          matches.push(`[${count}] <${tag}> "${node.textContent.trim().slice(0, 100)}"`);
+          count++;
+        }
+      }
+      return matches.length > 0
+        ? `Found ${matches.length} text matches for "${q}":\n${matches.join('\n')}`
+        : `No matches found for "${q}"`;
+    }, query);
+    return results;
+  }
+
+  /** Execute JavaScript in a tab. */
+  async executeJs(tabId: number, code: string): Promise<string> {
+    const page = this.getPage(tabId);
+    const result = await page.evaluate(code).catch((err: Error) => `Error: ${err.message}`);
+    return typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+  }
+
+  /** Take a screenshot of a tab. Returns base64-encoded PNG. */
+  async screenshot(tabId: number, opts?: { fullPage?: boolean }): Promise<Buffer> {
+    const page = this.getPage(tabId);
+    return page.screenshot({ fullPage: opts?.fullPage, type: 'png' });
+  }
+
+  /** Click at coordinates or on a selector. */
+  async click(tabId: number, target: { x: number; y: number } | { selector: string }): Promise<void> {
+    const page = this.getPage(tabId);
+    if ('selector' in target) {
+      await page.click(target.selector, { timeout: 5000 });
+    } else {
+      await page.mouse.click(target.x, target.y);
+    }
+  }
+
+  /** Type text (optionally into a selector). */
+  async type(tabId: number, text: string, selector?: string): Promise<void> {
+    const page = this.getPage(tabId);
+    if (selector) {
+      await page.fill(selector, text);
+    } else {
+      await page.keyboard.type(text);
+    }
+  }
+
+  /** Press a key or key combination. */
+  async press(tabId: number, key: string): Promise<void> {
+    const page = this.getPage(tabId);
+    await page.keyboard.press(key);
+  }
+
+  /** Scroll the page. */
+  async scroll(tabId: number, direction: 'up' | 'down', amount?: number): Promise<void> {
+    const page = this.getPage(tabId);
+    const delta = (amount ?? 500) * (direction === 'up' ? -1 : 1);
+    await page.mouse.wheel(0, delta);
+  }
+
+  /** Fill a form field. */
+  async formInput(tabId: number, selector: string, value: string): Promise<void> {
+    const page = this.getPage(tabId);
+    await page.fill(selector, value);
+  }
+
+  /** Wait for a specified duration or for a selector to appear. */
+  async wait(tabId: number, opts: { ms?: number; selector?: string }): Promise<void> {
+    const page = this.getPage(tabId);
+    if (opts.selector) {
+      await page.waitForSelector(opts.selector, { timeout: opts.ms ?? 10_000 });
+    } else {
+      await page.waitForTimeout(opts.ms ?? 1000);
+    }
+  }
+
+  /** Shut down the browser. */
+  async close(): Promise<void> {
+    if (this.browser) {
+      await this.browser.close().catch(() => {});
+      this.browser = null;
+      this.context = null;
+      this.pages.clear();
+      log.info('Browser closed');
+    }
+  }
+
+  /** Get a page by tab ID, or throw. */
+  private getPage(tabId: number): Page {
+    const page = this.pages.get(tabId);
+    if (!page) {
+      const available = [...this.pages.keys()];
+      throw new Error(
+        `Tab ${tabId} not found. Available tabs: ${available.length > 0 ? available.join(', ') : 'none — create one with tabs_create'}`,
+      );
+    }
+    return page;
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -102,6 +102,7 @@ const {
     astParserService,
     permissionBroker,
     flockDirectoryService,
+    browserService,
     discordBridge,
 } = await bootstrapServices(db, startTime);
 
@@ -112,7 +113,7 @@ const algochatInitDeps: AlgoChatInitDeps = {
     questionDispatcher, reputationScorer, reputationAttestation, reputationVerifier,
     astParserService, permissionBroker, shutdownCoordinator, memorySyncService,
     graduationService, responsePollingService, usageMeter, healthMonitorService,
-    mentionPollingService, flockDirectoryService,
+    mentionPollingService, flockDirectoryService, browserService,
 };
 
 async function switchNetwork(network: 'testnet' | 'mainnet'): Promise<void> {

--- a/server/mcp/sdk-tools.ts
+++ b/server/mcp/sdk-tools.ts
@@ -1,7 +1,7 @@
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod/v4';
 import type { McpToolContext } from './tool-handlers';
-import { handleSendMessage, handleSaveMemory, handleRecallMemory, handleDeleteMemory, handleReadOnChainMemories, handleSyncOnChainMemories, handleListAgents, handleCreateWorkTask, handleCheckWorkStatus, handleListWorkTasks, handleExtendTimeout, handleCheckCredits, handleGrantCredits, handleCreditConfig, handleManageSchedule, handleManageWorkflow, handleWebSearch, handleDeepResearch, handleDiscoverAgent, handleNotifyOwner, handleAskOwner, handleConfigureNotifications, handleGitHubStarRepo, handleGitHubUnstarRepo, handleGitHubForkRepo, handleGitHubListPrs, handleGitHubCreatePr, handleGitHubReviewPr, handleGitHubCreateIssue, handleGitHubListIssues, handleGitHubRepoInfo, handleGitHubGetPrDiff, handleGitHubCommentOnPr, handleGitHubFollowUser, handleCheckReputation, handleCheckHealthTrends, handlePublishAttestation, handleVerifyAgentReputation, handleInvokeRemoteAgent, handleCodeSymbols, handleFindReferences, handleLaunchCouncil, handleFlockDirectory, handleListProjects, handleCurrentProject } from './tool-handlers';
+import { handleSendMessage, handleSaveMemory, handleRecallMemory, handleDeleteMemory, handleReadOnChainMemories, handleSyncOnChainMemories, handleListAgents, handleCreateWorkTask, handleCheckWorkStatus, handleListWorkTasks, handleExtendTimeout, handleCheckCredits, handleGrantCredits, handleCreditConfig, handleManageSchedule, handleManageWorkflow, handleWebSearch, handleDeepResearch, handleDiscoverAgent, handleNotifyOwner, handleAskOwner, handleConfigureNotifications, handleGitHubStarRepo, handleGitHubUnstarRepo, handleGitHubForkRepo, handleGitHubListPrs, handleGitHubCreatePr, handleGitHubReviewPr, handleGitHubCreateIssue, handleGitHubListIssues, handleGitHubRepoInfo, handleGitHubGetPrDiff, handleGitHubCommentOnPr, handleGitHubFollowUser, handleCheckReputation, handleCheckHealthTrends, handlePublishAttestation, handleVerifyAgentReputation, handleInvokeRemoteAgent, handleCodeSymbols, handleFindReferences, handleLaunchCouncil, handleFlockDirectory, handleListProjects, handleCurrentProject, handleBrowser } from './tool-handlers';
 import { handleManageRepoBlocklist } from './tool-handlers/repo-blocklist';
 import { handleLookupContact } from './tool-handlers/contacts';
 import { isToolBlockedForScheduler } from './scheduler-tool-gating';
@@ -54,6 +54,7 @@ const DEFAULT_ALLOWED_TOOLS = new Set([
     'corvid_launch_council',
     'corvid_flock_directory',
     'corvid_lookup_contact',
+    'corvid_browser',
 ]);
 
 /** Tools that require an explicit grant in mcp_tool_permissions. */
@@ -608,6 +609,38 @@ export function createCorvidMcpServer(ctx: McpToolContext, pluginTools?: ReturnT
             },
             async (args) => handleLookupContact(ctx, args),
         ),
+
+        // ─── Browser automation ─────────────────────────────────────────
+        ...(ctx.browserService ? [tool(
+            'corvid_browser',
+            'Perform browser automation using a real Chrome browser. ' +
+            'Always call tabs_context first to see open tabs, then tabs_create to open a new tab. ' +
+            'Actions: tabs_context, tabs_create, close_tab, navigate, get_page_text, read_page, ' +
+            'find, click, type, press, scroll, form_input, javascript, screenshot, wait.',
+            {
+                action: z.enum([
+                    'tabs_context', 'tabs_create', 'close_tab', 'navigate',
+                    'get_page_text', 'read_page', 'find', 'click', 'type', 'press',
+                    'scroll', 'form_input', 'javascript', 'screenshot', 'wait',
+                ]).describe('Browser action to perform'),
+                tab_id: z.number().optional().describe('Tab ID (from tabs_context). Required for most actions.'),
+                url: z.string().optional().describe('URL for navigate or tabs_create'),
+                query: z.string().optional().describe('CSS selector or text to search for (find action)'),
+                selector: z.string().optional().describe('CSS selector for click, type, form_input, read_page, wait'),
+                code: z.string().optional().describe('JavaScript code to execute (javascript action)'),
+                text: z.string().optional().describe('Text to type (type action)'),
+                key: z.string().optional().describe('Key to press, e.g. "Enter", "Tab" (press action)'),
+                value: z.string().optional().describe('Value for form_input'),
+                direction: z.enum(['up', 'down']).optional().describe('Scroll direction (default: down)'),
+                amount: z.number().optional().describe('Scroll amount in pixels (default: 500)'),
+                x: z.number().optional().describe('X coordinate for click'),
+                y: z.number().optional().describe('Y coordinate for click'),
+                full_page: z.boolean().optional().describe('Take full-page screenshot (default: false)'),
+                max_length: z.number().optional().describe('Max chars for read_page (default: 50000)'),
+                ms: z.number().optional().describe('Wait duration in ms (wait action)'),
+            },
+            async (args) => handleBrowser(ctx, args),
+        )] : []),
     ];
 
     // Merge plugin tools if provided

--- a/server/mcp/tool-handlers/browser.ts
+++ b/server/mcp/tool-handlers/browser.ts
@@ -1,0 +1,189 @@
+/**
+ * corvid_browser — Browser automation tool handler.
+ *
+ * Provides agents with browser control via Playwright and the system Chrome.
+ * Actions: tabs_context, tabs_create, close_tab, navigate, get_page_text,
+ * read_page, find, click, type, press, scroll, form_input, javascript,
+ * screenshot, wait.
+ *
+ * @module
+ */
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { createLogger } from '../../lib/logger';
+import type { McpToolContext } from './types';
+import { errorResult, textResult } from './types';
+
+const log = createLogger('McpBrowser');
+
+export async function handleBrowser(
+  ctx: McpToolContext,
+  args: {
+    action: string;
+    tab_id?: number;
+    url?: string;
+    query?: string;
+    selector?: string;
+    code?: string;
+    text?: string;
+    key?: string;
+    value?: string;
+    direction?: string;
+    amount?: number;
+    x?: number;
+    y?: number;
+    full_page?: boolean;
+    max_length?: number;
+    ms?: number;
+  },
+): Promise<CallToolResult> {
+  if (!ctx.browserService) {
+    return errorResult('Browser service is not available. The server may not have Playwright/Chrome installed.');
+  }
+
+  const svc = ctx.browserService;
+
+  try {
+    switch (args.action) {
+      // ─── Tab management ──────────────────────────────────────────
+      case 'tabs_context': {
+        const tabs = await svc.tabsContext();
+        if (tabs.length === 0) {
+          return textResult('No open tabs. Use action "tabs_create" to open one.');
+        }
+        const lines = tabs.map((t) => `Tab ${t.id}: ${t.title || '(untitled)'} — ${t.url}`);
+        return textResult(`Open tabs:\n${lines.join('\n')}`);
+      }
+
+      case 'tabs_create': {
+        ctx.emitStatus?.('Opening new browser tab...');
+        const tab = await svc.createTab(args.url);
+        return textResult(`Created tab ${tab.id}: ${tab.title || '(untitled)'} — ${tab.url}`);
+      }
+
+      case 'close_tab': {
+        if (args.tab_id == null) return errorResult('tab_id is required for close_tab');
+        await svc.closeTab(args.tab_id);
+        return textResult(`Closed tab ${args.tab_id}`);
+      }
+
+      // ─── Navigation ──────────────────────────────────────────────
+      case 'navigate': {
+        if (args.tab_id == null) return errorResult('tab_id is required for navigate');
+        if (!args.url) return errorResult('url is required for navigate');
+        ctx.emitStatus?.(`Navigating to ${args.url}...`);
+        const result = await svc.navigate(args.tab_id, args.url);
+        return textResult(`Navigated to: ${result.title} — ${result.url}`);
+      }
+
+      // ─── Reading ─────────────────────────────────────────────────
+      case 'get_page_text': {
+        if (args.tab_id == null) return errorResult('tab_id is required for get_page_text');
+        ctx.emitStatus?.('Reading page text...');
+        const text = await svc.getPageText(args.tab_id);
+        const truncated = text.length > 50_000 ? text.slice(0, 50_000) + '\n...(truncated)' : text;
+        return textResult(truncated);
+      }
+
+      case 'read_page': {
+        if (args.tab_id == null) return errorResult('tab_id is required for read_page');
+        ctx.emitStatus?.('Reading page structure...');
+        const html = await svc.readPage(args.tab_id, {
+          selector: args.selector,
+          maxLength: args.max_length,
+        });
+        return textResult(html);
+      }
+
+      case 'find': {
+        if (args.tab_id == null) return errorResult('tab_id is required for find');
+        if (!args.query) return errorResult('query is required for find (CSS selector or text)');
+        const found = await svc.find(args.tab_id, args.query);
+        return textResult(found);
+      }
+
+      // ─── Interaction ─────────────────────────────────────────────
+      case 'click': {
+        if (args.tab_id == null) return errorResult('tab_id is required for click');
+        if (args.selector) {
+          await svc.click(args.tab_id, { selector: args.selector });
+        } else if (args.x != null && args.y != null) {
+          await svc.click(args.tab_id, { x: args.x, y: args.y });
+        } else {
+          return errorResult('click requires either selector or x+y coordinates');
+        }
+        return textResult('Clicked');
+      }
+
+      case 'type': {
+        if (args.tab_id == null) return errorResult('tab_id is required for type');
+        if (!args.text) return errorResult('text is required for type');
+        await svc.type(args.tab_id, args.text, args.selector);
+        return textResult(`Typed "${args.text.slice(0, 50)}${args.text.length > 50 ? '...' : ''}"`);
+      }
+
+      case 'press': {
+        if (args.tab_id == null) return errorResult('tab_id is required for press');
+        if (!args.key) return errorResult('key is required for press (e.g. "Enter", "Tab", "Escape")');
+        await svc.press(args.tab_id, args.key);
+        return textResult(`Pressed ${args.key}`);
+      }
+
+      case 'scroll': {
+        if (args.tab_id == null) return errorResult('tab_id is required for scroll');
+        const dir = (args.direction ?? 'down') as 'up' | 'down';
+        await svc.scroll(args.tab_id, dir, args.amount);
+        return textResult(`Scrolled ${dir}`);
+      }
+
+      case 'form_input': {
+        if (args.tab_id == null) return errorResult('tab_id is required for form_input');
+        if (!args.selector) return errorResult('selector is required for form_input');
+        if (args.value == null) return errorResult('value is required for form_input');
+        await svc.formInput(args.tab_id, args.selector, args.value);
+        return textResult(`Filled "${args.selector}" with value`);
+      }
+
+      // ─── Advanced ────────────────────────────────────────────────
+      case 'javascript': {
+        if (args.tab_id == null) return errorResult('tab_id is required for javascript');
+        if (!args.code) return errorResult('code is required for javascript');
+        ctx.emitStatus?.('Executing JavaScript...');
+        const jsResult = await svc.executeJs(args.tab_id, args.code);
+        return textResult(jsResult);
+      }
+
+      case 'screenshot': {
+        if (args.tab_id == null) return errorResult('tab_id is required for screenshot');
+        ctx.emitStatus?.('Taking screenshot...');
+        const buf = await svc.screenshot(args.tab_id, { fullPage: args.full_page });
+        const result: CallToolResult = {
+          content: [
+            {
+              type: 'image',
+              data: buf.toString('base64'),
+              mimeType: 'image/png',
+            },
+          ],
+        };
+        return result;
+      }
+
+      case 'wait': {
+        if (args.tab_id == null) return errorResult('tab_id is required for wait');
+        await svc.wait(args.tab_id, { ms: args.ms, selector: args.selector });
+        return textResult(args.selector ? `Element "${args.selector}" appeared` : `Waited ${args.ms ?? 1000}ms`);
+      }
+
+      default:
+        return errorResult(
+          `Unknown action "${args.action}". Valid actions: tabs_context, tabs_create, close_tab, ` +
+            'navigate, get_page_text, read_page, find, click, type, press, scroll, form_input, ' +
+            'javascript, screenshot, wait',
+        );
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error('Browser action failed', { action: args.action, error: message });
+    return errorResult(`Browser ${args.action} failed: ${message}`);
+  }
+}

--- a/server/mcp/tool-handlers/index.ts
+++ b/server/mcp/tool-handlers/index.ts
@@ -81,6 +81,9 @@ export { handleLookupContact } from './contacts';
 // ─── AST / Code navigation ──────────────────────────────────────────────────
 export { handleCodeSymbols, handleFindReferences } from './ast';
 
+// ─── Browser automation ────────────────────────────────────────────────────
+export { handleBrowser } from './browser';
+
 // ─── Observations (memory graduation) ──────────────────────────────────────
 export {
     handleRecordObservation,

--- a/server/mcp/tool-handlers/types.ts
+++ b/server/mcp/tool-handlers/types.ts
@@ -15,6 +15,7 @@ import type { AstParserService } from '../../ast/service';
 import type { PermissionBroker } from '../../permissions/broker';
 import type { ProcessManager } from '../../process/manager';
 import type { FlockDirectoryService } from '../../flock-directory/service';
+import type { BrowserService } from '../../browser/service';
 import type { SessionInvocationBudget } from '../../a2a/invocation-guard';
 import type { ScheduleActionType } from '../../../shared/types/schedules';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
@@ -77,6 +78,8 @@ export interface McpToolContext {
     flockDirectoryService?: FlockDirectoryService;
     /** Per-session invocation budget for remote agent calls. */
     invocationBudget?: SessionInvocationBudget;
+    /** Browser automation service (Playwright + system Chrome). */
+    browserService?: BrowserService;
 }
 
 export function textResult(text: string): CallToolResult {

--- a/server/process/mcp-service-container.ts
+++ b/server/process/mcp-service-container.ts
@@ -22,6 +22,7 @@ import type { ReputationVerifier } from '../reputation/verifier';
 import type { AstParserService } from '../ast/service';
 import type { PermissionBroker } from '../permissions/broker';
 import type { FlockDirectoryService } from '../flock-directory/service';
+import type { BrowserService } from '../browser/service';
 import type { ProcessManager } from './manager';
 import type { McpToolContext } from '../mcp/tool-handlers';
 import type { OwnerQuestionManager } from './owner-question-manager';
@@ -48,6 +49,7 @@ export interface McpServices {
     permissionBroker?: PermissionBroker;
     processManager?: ProcessManager;
     flockDirectoryService?: FlockDirectoryService;
+    browserService?: BrowserService;
 }
 
 export interface BuildContextOptions {
@@ -119,6 +121,7 @@ export class McpServiceContainer {
             permissionBroker: this.services.permissionBroker,
             processManager: this.services.processManager,
             flockDirectoryService: this.services.flockDirectoryService,
+            browserService: this.services.browserService,
             invocationBudget: new SessionInvocationBudget(),
         };
     }


### PR DESCRIPTION
## Summary
- Adds `corvid_browser` MCP tool giving agents full browser automation via Playwright + system Chrome
- Works from any session source (Discord, AlgoChat, web, etc.) — no Chrome extension bridge dependency
- Browser launches lazily on first use, shared across all agent sessions (headless)
- 15 actions: tabs_context, tabs_create, close_tab, navigate, get_page_text, read_page, find, click, type, press, scroll, form_input, javascript, screenshot, wait
- Conditionally registered — only appears when BrowserService is available

## New files
- `server/browser/service.ts` — BrowserService wrapping Playwright
- `server/mcp/tool-handlers/browser.ts` — Tool handler with action dispatch

## Test plan
- [x] TypeScript compiles clean
- [x] Playwright + system Chrome verified working on VM
- [x] Existing algochat-init tests pass
- [ ] Test from Discord: agent calls `corvid_browser` with tabs_create + navigate
- [ ] Verify screenshot action returns image content

🤖 Generated with [Claude Code](https://claude.com/claude-code)