### PR TITLE
fix: remove non-functional --chrome flag from SDK sessions

### DIFF
--- a/server/process/sdk-process.ts
+++ b/server/process/sdk-process.ts
@@ -9,29 +9,8 @@ import type { McpServerConfig as DbMcpServerConfig } from '../../shared/types';
 import { getMessagingSafetyPrompt, getResponseRoutingPrompt, getWorktreeIsolationPrompt } from '../providers/ollama/tool-prompt-templates';
 import { prependRoutingContext } from './direct-process';
 import { createLogger } from '../lib/logger';
-import { existsSync, readFileSync } from 'fs';
-import { homedir } from 'os';
-import { join } from 'path';
 
 const log = createLogger('SdkProcess');
-
-/**
- * Check if the Chrome extension bridge is configured and enabled.
- * Reads ~/.claude.json to check cachedChromeExtensionInstalled and
- * claudeInChromeDefaultEnabled — these are set by Claude Code when
- * the user completes Chrome extension onboarding.
- */
-function isChromeExtensionAvailable(): boolean {
-    try {
-        const configPath = join(homedir(), '.claude.json');
-        if (!existsSync(configPath)) return false;
-        const config = JSON.parse(readFileSync(configPath, 'utf-8'));
-        return config.cachedChromeExtensionInstalled === true
-            && config.claudeInChromeDefaultEnabled === true;
-    } catch {
-        return false;
-    }
-}
 
 // Environment variables safe to pass to agent subprocesses.
 // Everything else (ALGOCHAT_MNEMONIC, WALLET_ENCRYPTION_KEY, API_KEY, etc.) is excluded.
@@ -252,14 +231,11 @@ export function startSdkProcess(options: SdkProcessOptions): SdkProcess {
         allowDangerouslySkipPermissions: needsBypass || undefined,
         includePartialMessages: true,
         env: buildSafeEnv(project.envVars),
-        // Enable Chrome browser tools only when the extension bridge is detected.
-        // This avoids wasting prompt space with Chrome tool definitions when the
-        // extension isn't running, freeing room for other tools.
-        ...(isChromeExtensionAvailable() ? { extraArgs: { chrome: null } } : {}),
+        // Chrome extension bridge does not work from SDK-spawned subprocesses.
+        // Browser automation is provided by corvid_browser (Playwright) instead.
+        // Do NOT pass extraArgs: { chrome: null } — it injects non-functional
+        // Chrome tool instructions that confuse agents.
     };
-
-    const chromeEnabled = sdkOptions.extraArgs != null;
-    log.info(`Session ${session.id}: Chrome extension ${chromeEnabled ? 'enabled' : 'not detected, skipping'}`);
 
     if (agent?.model) {
         sdkOptions.model = agent.model;


### PR DESCRIPTION
## Summary
- Removes `extraArgs: { chrome: null }` from SDK session options entirely
- The Chrome extension bridge only works for interactive CLI sessions, not SDK subprocesses
- Passing `--chrome` injected non-functional Chrome tool instructions into the system prompt, causing agents to try tools that don't work and report "Chrome extension isn't connected"
- Browser automation is now handled by `corvid_browser` (PR #1289) using Playwright

## Test plan
- [ ] Start a Discord session — agent should NOT mention Chrome extension
- [ ] Agent should see `corvid_browser` tool for browser automation instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)