### PR TITLE
fix: allow Discord messages with only image attachments

### DIFF
--- a/server/discord/message-handler.ts
+++ b/server/discord/message-handler.ts
@@ -131,8 +131,9 @@ export async function handleMessage(ctx: MessageHandlerContext, data: DiscordMes
         });
     }
 
-    const text = data.content;
-    if (!text) return;
+    const text = data.content ?? '';
+    const hasAttachments = (data.attachments?.length ?? 0) > 0;
+    if (!text && !hasAttachments) return;
 
     const userId = data.author.id;
     const channelId = data.channel_id;


### PR DESCRIPTION
## Summary
- Discord messages containing only image attachments (no text) were silently dropped because the message handler returned early when `data.content` was falsy
- Now checks for attachments before bailing out, so image-only messages are properly processed

## Test plan
- [x] TypeScript compiles cleanly (`bun x tsc`)
- [x] All 29 Discord handler tests pass
- [ ] Send an image-only message in Discord and verify the agent processes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)