### PR TITLE
feat: add Discord image sending and image block streaming

### DIFF
--- a/server/discord/thread-manager.ts
+++ b/server/discord/thread-manager.ts
@@ -11,13 +11,14 @@ import type { DiscordBridgeConfig } from './types';
 import { ButtonStyle } from './types';
 import type { EventCallback } from '../process/interfaces';
 import type { DeliveryTracker } from '../lib/delivery-tracker';
-import { extractContentText } from '../process/types';
+import { extractContentText, extractContentImageUrls } from '../process/types';
 import { createLogger } from '../lib/logger';
 import {
     sendEmbed,
     sendReplyEmbed,
     editEmbed,
     sendEmbedWithButtons,
+    sendEmbedWithFiles,
     buildActionRow,
     sendTypingIndicator,
     agentColor,
@@ -26,6 +27,7 @@ import {
     splitEmbedDescription,
     buildFooterText,
     buildFooterWithStats,
+    type DiscordFileAttachment,
 } from './embeds';
 
 const log = createLogger('DiscordThreadManager');
@@ -164,10 +166,34 @@ export function subscribeForResponseWithEmbed(
         }
     };
 
+    /** Download an image URL and send as a Discord file attachment in the thread. */
+    const sendThreadImageUrl = async (imageUrl: string) => {
+        try {
+            const resp = await fetch(imageUrl);
+            if (!resp.ok) {
+                log.warn('Failed to fetch image for Discord thread', { imageUrl, status: resp.status });
+                return;
+            }
+            const data = new Uint8Array(await resp.arrayBuffer());
+            const ct = resp.headers.get('content-type') ?? 'image/png';
+            const ext = ct.includes('jpeg') || ct.includes('jpg') ? 'jpg' : ct.includes('gif') ? 'gif' : ct.includes('webp') ? 'webp' : 'png';
+            const filename = `image.${ext}`;
+            const attachment: DiscordFileAttachment = { name: filename, data, contentType: ct };
+            await sendEmbedWithFiles(delivery, botToken, threadId, {
+                image: { url: `attachment://${filename}` },
+                color,
+                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
+            }, [attachment]);
+        } catch (err) {
+            log.warn('Failed to send image to Discord thread', { imageUrl, error: err instanceof Error ? err.message : String(err) });
+        }
+    };
+
     const callback: EventCallback = (_sid, event) => {
         if (event.type === 'assistant' && event.message) {
             const msg = event.message as { content?: unknown };
-            const content = extractContentText(msg.content as string | import('../process/types').ContentBlock[] | undefined);
+            const contentBlocks = msg.content as string | import('../process/types').ContentBlock[] | undefined;
+            const content = extractContentText(contentBlocks);
 
             if (content) {
                 receivedAnyContent = true;
@@ -175,6 +201,14 @@ export function subscribeForResponseWithEmbed(
                 buffer += content;
                 if (debounceTimer) clearTimeout(debounceTimer);
                 debounceTimer = setTimeout(() => flush(), 1500);
+            }
+
+            // Send any image content blocks as file attachments
+            const imageUrls = extractContentImageUrls(contentBlocks);
+            for (const imageUrl of imageUrls) {
+                receivedAnyContent = true;
+                receivedAnyActivity = true;
+                sendThreadImageUrl(imageUrl);
             }
 
             const now = Date.now();
@@ -643,16 +677,48 @@ export function subscribeForAdaptiveInlineResponse(
         });
     };
 
+    /** Download an image from a URL and send it as a Discord file attachment. */
+    const sendImageUrl = async (imageUrl: string) => {
+        try {
+            const resp = await fetch(imageUrl);
+            if (!resp.ok) {
+                log.warn('Failed to fetch image for Discord', { imageUrl, status: resp.status });
+                return;
+            }
+            const data = new Uint8Array(await resp.arrayBuffer());
+            const ct = resp.headers.get('content-type') ?? 'image/png';
+            const ext = ct.includes('jpeg') || ct.includes('jpg') ? 'jpg' : ct.includes('gif') ? 'gif' : ct.includes('webp') ? 'webp' : 'png';
+            const filename = `image.${ext}`;
+            const attachment: DiscordFileAttachment = { name: filename, data, contentType: ct };
+            await sendEmbedWithFiles(delivery, botToken, channelId, {
+                image: { url: `attachment://${filename}` },
+                color,
+                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
+            }, [attachment]);
+        } catch (err) {
+            log.warn('Failed to send image to Discord', { imageUrl, error: err instanceof Error ? err.message : String(err) });
+        }
+    };
+
     const adaptiveCallback: EventCallback = (_sid, event) => {
         if (event.type === 'assistant' && event.message) {
             const msg = event.message as { content?: unknown };
-            const content = extractContentText(msg.content as string | import('../process/types').ContentBlock[] | undefined);
+            const contentBlocks = msg.content as string | import('../process/types').ContentBlock[] | undefined;
+            const content = extractContentText(contentBlocks);
             if (content) {
                 receivedAnyContent = true;
                 receivedAnyActivity = true;
                 buffer += content;
                 if (debounceTimer) clearTimeout(debounceTimer);
                 debounceTimer = setTimeout(() => flush(), 1500);
+            }
+
+            // Send any image content blocks as file attachments
+            const imageUrls = extractContentImageUrls(contentBlocks);
+            for (const imageUrl of imageUrls) {
+                receivedAnyContent = true;
+                receivedAnyActivity = true;
+                sendImageUrl(imageUrl);
             }
         }
 
@@ -808,16 +874,48 @@ export function subscribeForInlineProgressResponse(
         }
     };
 
+    /** Download an image URL and send as a Discord file attachment. */
+    const sendProgressImageUrl = async (imageUrl: string) => {
+        try {
+            const resp = await fetch(imageUrl);
+            if (!resp.ok) {
+                log.warn('Failed to fetch image for Discord (progress)', { imageUrl, status: resp.status });
+                return;
+            }
+            const data = new Uint8Array(await resp.arrayBuffer());
+            const ct = resp.headers.get('content-type') ?? 'image/png';
+            const ext = ct.includes('jpeg') || ct.includes('jpg') ? 'jpg' : ct.includes('gif') ? 'gif' : ct.includes('webp') ? 'webp' : 'png';
+            const filename = `image.${ext}`;
+            const attachment: DiscordFileAttachment = { name: filename, data, contentType: ct };
+            await sendEmbedWithFiles(delivery, botToken, channelId, {
+                image: { url: `attachment://${filename}` },
+                color,
+                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
+            }, [attachment]);
+        } catch (err) {
+            log.warn('Failed to send image to Discord (progress)', { imageUrl, error: err instanceof Error ? err.message : String(err) });
+        }
+    };
+
     const progressCallback: EventCallback = (_sid, event) => {
         if (event.type === 'assistant' && event.message) {
             const msg = event.message as { content?: unknown };
-            const content = extractContentText(msg.content as string | import('../process/types').ContentBlock[] | undefined);
+            const contentBlocks = msg.content as string | import('../process/types').ContentBlock[] | undefined;
+            const content = extractContentText(contentBlocks);
             if (content) {
                 receivedAnyContent = true;
                 receivedAnyActivity = true;
                 buffer += content;
                 if (debounceTimer) clearTimeout(debounceTimer);
                 debounceTimer = setTimeout(() => flush(), 1500);
+            }
+
+            // Send any image content blocks as file attachments
+            const imageUrls = extractContentImageUrls(contentBlocks);
+            for (const imageUrl of imageUrls) {
+                receivedAnyContent = true;
+                receivedAnyActivity = true;
+                sendProgressImageUrl(imageUrl);
             }
         }
 

--- a/server/process/types.ts
+++ b/server/process/types.ts
@@ -272,6 +272,18 @@ export function extractContentText(content: string | ContentBlock[] | undefined)
         .join('');
 }
 
+/** Extract image URLs from content blocks (e.g. `{ type: 'image', source: { type: 'url', url: '...' } }`). */
+export function extractContentImageUrls(content: string | ContentBlock[] | undefined): string[] {
+    if (!content || typeof content === 'string') return [];
+    return content
+        .filter((block) => block.type === 'image' && (block as unknown as { source?: unknown }).source)
+        .map((block) => {
+            const source = (block as unknown as { source?: { url?: string } }).source;
+            return source?.url;
+        })
+        .filter((url): url is string => Boolean(url));
+}
+
 export interface ProcessInfo {
     sessionId: string;
     pid: number;

--- a/server/routes/discord-image.ts
+++ b/server/routes/discord-image.ts
@@ -1,0 +1,143 @@
+/**
+ * Discord image sending route.
+ *
+ *   POST /api/discord/send-image — Send an image to a Discord channel.
+ *
+ * Accepts JSON body with:
+ *   - channelId: Discord channel ID
+ *   - imageBase64: Base64-encoded image data
+ *   - filename?: Filename for the attachment (default: "image.png")
+ *   - contentType?: MIME type (default: "image/png")
+ *   - message?: Optional text message to include
+ *   - replyToMessageId?: Message ID to reply to
+ *
+ * Or multipart/form-data with:
+ *   - channelId (form field)
+ *   - image (file)
+ *   - message (optional form field)
+ *   - replyToMessageId (optional form field)
+ */
+
+import { json, handleRouteError } from '../lib/response';
+import { getDeliveryTracker } from '../lib/delivery-tracker';
+import { sendMessageWithFiles, sendEmbedWithFiles, type DiscordFileAttachment } from '../discord/embeds';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('DiscordImageRoute');
+
+export function handleDiscordImageRoutes(
+    req: Request,
+    url: URL,
+): Response | Promise<Response> | null {
+    if (url.pathname !== '/api/discord/send-image') return null;
+    if (req.method !== 'POST') return null;
+
+    return handleSendImage(req);
+}
+
+async function handleSendImage(req: Request): Promise<Response> {
+    const botToken = process.env.DISCORD_BOT_TOKEN;
+    if (!botToken) {
+        return json({ error: 'Discord bot token not configured' }, 503);
+    }
+
+    try {
+        let channelId: string;
+        let imageData: Uint8Array;
+        let filename: string;
+        let contentType: string;
+        let message: string | undefined;
+        let replyToMessageId: string | undefined;
+
+        const ct = req.headers.get('content-type') ?? '';
+
+        if (ct.includes('multipart/form-data')) {
+            const form = await req.formData();
+            channelId = form.get('channelId') as string;
+            message = (form.get('message') as string) || undefined;
+            replyToMessageId = (form.get('replyToMessageId') as string) || undefined;
+
+            const file = form.get('image') as File | null;
+            if (!file) {
+                return json({ error: 'Missing "image" file in form data' }, 400);
+            }
+            imageData = new Uint8Array(await file.arrayBuffer());
+            filename = file.name || 'image.png';
+            contentType = file.type || 'image/png';
+        } else {
+            const body = await req.json() as {
+                channelId?: string;
+                imageBase64?: string;
+                imagePath?: string;
+                filename?: string;
+                contentType?: string;
+                message?: string;
+                replyToMessageId?: string;
+            };
+
+            if (!body.channelId) {
+                return json({ error: 'Missing required field: channelId' }, 400);
+            }
+            channelId = body.channelId;
+            message = body.message;
+            replyToMessageId = body.replyToMessageId;
+            filename = body.filename ?? 'image.png';
+            contentType = body.contentType ?? 'image/png';
+
+            if (body.imageBase64) {
+                imageData = Buffer.from(body.imageBase64, 'base64');
+            } else if (body.imagePath) {
+                // Read from local filesystem
+                const file = Bun.file(body.imagePath);
+                if (!await file.exists()) {
+                    return json({ error: `File not found: ${body.imagePath}` }, 400);
+                }
+                imageData = new Uint8Array(await file.arrayBuffer());
+                // Infer content type from extension if not specified
+                if (!body.contentType) {
+                    const ext = body.imagePath.split('.').pop()?.toLowerCase();
+                    if (ext === 'jpg' || ext === 'jpeg') contentType = 'image/jpeg';
+                    else if (ext === 'gif') contentType = 'image/gif';
+                    else if (ext === 'webp') contentType = 'image/webp';
+                }
+            } else {
+                return json({ error: 'Must provide either imageBase64 or imagePath' }, 400);
+            }
+        }
+
+        if (!channelId) {
+            return json({ error: 'Missing required field: channelId' }, 400);
+        }
+
+        const delivery = getDeliveryTracker();
+        const attachment: DiscordFileAttachment = {
+            name: filename,
+            data: imageData,
+            contentType,
+        };
+
+        let messageId: string | null;
+
+        if (replyToMessageId) {
+            // Send as embed with image + reply reference
+            messageId = await sendEmbedWithFiles(delivery, botToken, channelId, {
+                description: message || undefined,
+                image: { url: `attachment://${filename}` },
+            }, [attachment]);
+        } else if (message) {
+            messageId = await sendMessageWithFiles(delivery, botToken, channelId, message, [attachment]);
+        } else {
+            // Just the image, no text
+            messageId = await sendMessageWithFiles(delivery, botToken, channelId, '', [attachment]);
+        }
+
+        if (!messageId) {
+            return json({ error: 'Failed to send image to Discord' }, 502);
+        }
+
+        log.info('Sent image to Discord', { channelId, filename, messageId });
+        return json({ success: true, messageId });
+    } catch (err) {
+        return handleRouteError(err);
+    }
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -38,6 +38,7 @@ import { handleFeedbackRoutes } from './feedback';
 import { handleOnboardingRoutes } from './onboarding';
 import { handleSecurityOverviewRoutes } from './security-overview';
 import { handleBridgeDeliveryRoutes } from './bridge-delivery';
+import { handleDiscordImageRoutes } from './discord-image';
 import { handleFlockDirectoryRoutes } from './flock-directory';
 import { handleContactRoutes } from './contacts';
 import type { ProcessManager } from '../process/manager';
@@ -338,6 +339,9 @@ async function handleRoutes(
 
     const bridgeDeliveryResponse = handleBridgeDeliveryRoutes(req, url);
     if (bridgeDeliveryResponse) return bridgeDeliveryResponse;
+
+    const discordImageResponse = handleDiscordImageRoutes(req, url);
+    if (discordImageResponse) return discordImageResponse instanceof Promise ? await discordImageResponse : discordImageResponse;
 
     const dashboardResponse = handleDashboardRoutes(req, url, db, context);
     if (dashboardResponse) return dashboardResponse;


### PR DESCRIPTION
## Summary
- Add `POST /api/discord/send-image` endpoint for sending images to Discord channels (supports base64, file path, and multipart form data)
- Update all three response streaming callbacks in thread-manager to detect image content blocks and send them as Discord file attachments
- Add `extractContentImageUrls()` helper to extract image URLs from Claude content blocks

This enables the full screenshot-to-Discord flow: agents can take screenshots with the browser tool and have them automatically appear in Discord conversations.

## Test plan
- [x] TypeScript compiles cleanly (`bun x tsc --noEmit`)
- [x] All 29 image attachment tests pass
- [x] Spec check passes (161/161)
- [x] Manual test: took screenshot of remix.corvidlabs.xyz/login and sent to Discord via direct API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)