### PR TITLE
fix: allow image-only messages in Discord mention-reply handlers

### DIFF
--- a/server/discord/message-handler.ts
+++ b/server/discord/message-handler.ts
@@ -409,7 +409,8 @@ async function handleMentionReply(ctx: MessageHandlerContext, channelId: string,
     }
 
     const cleanText = resolveMentions(text, mentions, ctx.botUserId);
-    if (!cleanText) return;
+    const hasAttachments = (attachments?.length ?? 0) > 0;
+    if (!cleanText && !hasAttachments) return;
 
     // Create an isolated git worktree so this chat session doesn't pollute
     // the main working tree (prevents branch collisions across sessions).
@@ -474,7 +475,8 @@ async function handleMentionReplyResume(
     attachments?: DiscordAttachment[],
 ): Promise<void> {
     const cleanText = resolveMentions(text, mentions, ctx.botUserId);
-    if (!cleanText) return;
+    const hasAttachments = (attachments?.length ?? 0) > 0;
+    if (!cleanText && !hasAttachments) return;
 
     const { sessionId, agentName, agentModel, projectName, displayColor } = sessionInfo;
     const session = getSession(ctx.db, sessionId);


### PR DESCRIPTION
## Summary
- When a user replies to the bot with just an image (no text), `resolveMentions` returns an empty string, causing `handleMentionReply` and `handleMentionReplyResume` to silently bail out
- Both functions now check for attachments before returning on empty text, so image-only reply messages are properly processed

## Test plan
- [x] All 8213 tests pass
- [x] Type check clean
- [ ] Send an image-only reply to the bot in Discord and verify it responds
- [ ] Send a text+image reply and verify it still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)