### PR TITLE
debug: add logging for Discord image attachment flow

### DIFF
--- a/server/discord/gateway.ts
+++ b/server/discord/gateway.ts
@@ -216,6 +216,8 @@ export class DiscordGateway {
                     isBot: data.author?.bot,
                     mentionCount: data.mentions?.length ?? 0,
                     mentionRoleCount: data.mention_roles?.length ?? 0,
+                    attachmentCount: data.attachments?.length ?? 0,
+                    attachments: data.attachments?.map(a => ({ filename: a.filename, content_type: a.content_type, size: a.size, hasUrl: !!a.url, hasProxyUrl: !!a.proxy_url })),
                 });
                 this.handlers.onMessage(data);
                 break;

--- a/server/discord/message-handler.ts
+++ b/server/discord/message-handler.ts
@@ -489,6 +489,14 @@ async function handleMentionReplyResume(
 
     // Build multimodal content if images are attached
     const contextualContent = buildMultimodalContent(withAuthorContext(cleanText, authorId, authorUsername), attachments);
+    log.info('Mention-reply resume: sending content to session', {
+        sessionId,
+        hasAttachments: (attachments?.length ?? 0) > 0,
+        attachmentCount: attachments?.length ?? 0,
+        contentType: typeof contextualContent === 'string' ? 'string' : 'multimodal',
+        blockCount: Array.isArray(contextualContent) ? contextualContent.length : 0,
+        contentPreview: typeof contextualContent === 'string' ? contextualContent.slice(0, 200) : JSON.stringify(contextualContent).slice(0, 300),
+    });
     const sent = ctx.processManager.sendMessage(sessionId, contextualContent);
     if (!sent) {
         // resumeProcess only accepts strings — include attachment URLs so images aren't lost

--- a/server/process/sdk-process.ts
+++ b/server/process/sdk-process.ts
@@ -405,7 +405,18 @@ export function startSdkProcess(options: SdkProcessOptions): SdkProcess {
     })();
 
     function sendMessage(content: string | import('@anthropic-ai/sdk/resources/messages/messages').ContentBlockParam[]): boolean {
-        if (inputDone || abortController.signal.aborted) return false;
+        if (inputDone || abortController.signal.aborted) {
+            log.info(`sendMessage rejected for session ${session.id}: inputDone=${inputDone}, aborted=${abortController.signal.aborted}`);
+            return false;
+        }
+
+        const isMultimodal = Array.isArray(content);
+        log.info(`sendMessage: streaming ${isMultimodal ? 'multimodal' : 'text'} content to session ${session.id}`, {
+            isMultimodal,
+            blockCount: isMultimodal ? content.length : 0,
+            blockTypes: isMultimodal ? content.map(b => b.type) : [],
+            contentPreview: isMultimodal ? JSON.stringify(content).slice(0, 300) : (content as string).slice(0, 200),
+        });
 
         // Stream input to the running query
         q.streamInput((async function* () {
@@ -418,6 +429,7 @@ export function startSdkProcess(options: SdkProcessOptions): SdkProcess {
         })()).catch((err) => {
             log.warn(`streamInput failed for session ${session.id}`, {
                 error: err instanceof Error ? err.message : String(err),
+                stack: err instanceof Error ? err.stack : undefined,
             });
         });
 


### PR DESCRIPTION
## Summary
- Add info-level logging at three points in the image attachment pipeline to diagnose why images aren't reaching the AI agent
- Gateway: log attachment count and metadata on MESSAGE_CREATE
- Message handler: log content type and block details in mention-reply resume  
- SDK process: log multimodal vs text content in sendMessage, including rejection reasons

## Context
Images sent in Discord (both image-only and text+image) aren't being seen by the agent. This logging will reveal where in the pipeline attachments are being lost.