### PR TITLE
feat: Simple/Developer view mode toggle for dashboard

### DIFF
--- a/client/src/app/core/services/widget-layout.service.ts
+++ b/client/src/app/core/services/widget-layout.service.ts
@@ -12,6 +12,8 @@ export type WidgetId =
     | 'flock'
     | 'comparison';
 
+export type ViewMode = 'simple' | 'developer';
+
 export interface WidgetConfig {
     id: WidgetId;
     label: string;
@@ -19,6 +21,14 @@ export interface WidgetConfig {
 }
 
 const STORAGE_KEY = 'corvid_widget_layout';
+const VIEW_MODE_KEY = 'corvid_view_mode';
+
+/** Widgets visible in simple mode — focused on what non-technical users need */
+const SIMPLE_WIDGETS: Set<WidgetId> = new Set([
+    'agents',
+    'activity',
+    'quick-actions',
+]);
 
 const DEFAULT_WIDGETS: WidgetConfig[] = [
     { id: 'metrics', label: 'Metrics', visible: true },
@@ -35,16 +45,35 @@ const DEFAULT_WIDGETS: WidgetConfig[] = [
 
 @Injectable({ providedIn: 'root' })
 export class WidgetLayoutService {
+    /** Current view mode */
+    readonly viewMode = signal<ViewMode>(this.loadViewMode());
+
     /** Current widget layout — order + visibility */
     readonly widgets = signal<WidgetConfig[]>(this.load());
 
-    /** Only visible widgets, in order */
-    readonly visibleWidgets = computed(() =>
-        this.widgets().filter((w) => w.visible),
-    );
+    /** Only visible widgets, in order (respects view mode) */
+    readonly visibleWidgets = computed(() => {
+        const mode = this.viewMode();
+        return this.widgets().filter((w) => {
+            if (!w.visible) return false;
+            if (mode === 'simple') return SIMPLE_WIDGETS.has(w.id);
+            return true;
+        });
+    });
 
     /** Whether the customize panel is open */
     readonly customizing = signal(false);
+
+    /** Switch between simple and developer modes */
+    setViewMode(mode: ViewMode): void {
+        this.viewMode.set(mode);
+        this.saveViewMode(mode);
+    }
+
+    /** Toggle between modes */
+    toggleViewMode(): void {
+        this.setViewMode(this.viewMode() === 'simple' ? 'developer' : 'simple');
+    }
 
     /** Move a widget from one index to another */
     moveWidget(fromIndex: number, toIndex: number): void {
@@ -69,6 +98,7 @@ export class WidgetLayoutService {
         const defaults = DEFAULT_WIDGETS.map((w) => ({ ...w }));
         this.widgets.set(defaults);
         this.save(defaults);
+        this.setViewMode('developer');
     }
 
     private load(): WidgetConfig[] {
@@ -96,5 +126,17 @@ export class WidgetLayoutService {
     private save(widgets: WidgetConfig[]): void {
         if (typeof localStorage === 'undefined') return;
         localStorage.setItem(STORAGE_KEY, JSON.stringify(widgets));
+    }
+
+    private loadViewMode(): ViewMode {
+        if (typeof localStorage === 'undefined') return 'developer';
+        const stored = localStorage.getItem(VIEW_MODE_KEY);
+        if (stored === 'simple' || stored === 'developer') return stored;
+        return 'developer';
+    }
+
+    private saveViewMode(mode: ViewMode): void {
+        if (typeof localStorage === 'undefined') return;
+        localStorage.setItem(VIEW_MODE_KEY, mode);
     }
 }

--- a/client/src/app/features/dashboard/dashboard.component.ts
+++ b/client/src/app/features/dashboard/dashboard.component.ts
@@ -75,12 +75,22 @@ interface SessionStats { byAgent: AgentSessionStat[]; bySource: { source: string
             </div>
         } @else {
         <div class="dashboard">
-            <!-- Top bar: customize toggle -->
+            <!-- Top bar: view mode + customize toggle -->
             <div class="dash-toolbar">
                 <span class="dash-toolbar__title">Dashboard</span>
-                <button class="customize-btn" (click)="layoutService.customizing.set(!layoutService.customizing())">
-                    {{ layoutService.customizing() ? 'Done' : 'Customize' }}
-                </button>
+                <div class="dash-toolbar__right">
+                    <div class="view-toggle">
+                        <button class="view-toggle__btn"
+                                [class.view-toggle__btn--active]="layoutService.viewMode() === 'simple'"
+                                (click)="layoutService.setViewMode('simple')">Simple</button>
+                        <button class="view-toggle__btn"
+                                [class.view-toggle__btn--active]="layoutService.viewMode() === 'developer'"
+                                (click)="layoutService.setViewMode('developer')">Developer</button>
+                    </div>
+                    <button class="customize-btn" (click)="layoutService.customizing.set(!layoutService.customizing())">
+                        {{ layoutService.customizing() ? 'Done' : 'Customize' }}
+                    </button>
+                </div>
             </div>
 
             <!-- Customize panel (slide-down) -->
@@ -554,6 +564,7 @@ interface SessionStats { byAgent: AgentSessionStat[]; bySource: { source: string
         /* Toolbar */
         .dash-toolbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; gap: .5rem; flex-wrap: wrap; }
         .dash-toolbar__title { font-size: 1.1rem; font-weight: 700; color: var(--text-primary); margin: 0; }
+        .dash-toolbar__right { display: flex; gap: .5rem; align-items: center; }
         .view-toggle {
             display: flex; gap: .25rem;
             background: var(--bg-surface); border: 1px solid var(--border);
@@ -565,11 +576,11 @@ interface SessionStats { byAgent: AgentSessionStat[]; bySource: { source: string
             background: transparent; color: var(--text-tertiary); cursor: pointer;
             text-transform: uppercase; letter-spacing: .06em; transition: all .15s;
         }
-        .view-toggle__btn[data-active="true"] {
+        .view-toggle__btn--active {
             background: rgba(0,229,255,.1); color: var(--accent-cyan);
             border: 1px solid rgba(0,229,255,.2);
         }
-        .view-toggle__btn:hover:not([data-active="true"]) { color: var(--text-secondary); }
+        .view-toggle__btn:hover:not(.view-toggle__btn--active) { color: var(--text-secondary); }
 
         .customize-btn {
             padding: .35rem .85rem; border-radius: var(--radius); font-size: .7rem;


### PR DESCRIPTION
## Summary
- Adds a Simple/Developer toggle to the dashboard toolbar for progressive disclosure
- **Simple mode**: Shows only Agent Activity, Recent Activity, and Quick Actions — clean and focused for non-technical users
- **Developer mode**: Shows all widgets (metrics, charts, flock, comparison, etc.)
- View mode preference persists in localStorage across sessions
- Builds on the existing widget layout system — simple mode filters `visibleWidgets` without changing individual toggle states

Partial progress on #1248

## Test plan
- [ ] Dashboard toolbar shows Simple/Developer toggle buttons
- [ ] Clicking "Simple" hides metrics, charts, flock, comparison, system status
- [ ] Clicking "Developer" shows all enabled widgets
- [ ] View mode persists after page refresh
- [ ] Customize panel still works independently of view mode
- [ ] Reset to defaults switches back to developer mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)