### PR TITLE
feat: progressive disclosure — sidebar and top nav respect view mode

### DIFF
--- a/client/src/app/shared/components/sidebar.component.ts
+++ b/client/src/app/shared/components/sidebar.component.ts
@@ -12,6 +12,7 @@ import {
 import { Router, RouterLink, RouterLinkActive, NavigationEnd } from '@angular/router';
 import { filter, Subscription } from 'rxjs';
 import { KeyboardShortcutsService } from '../../core/services/keyboard-shortcuts.service';
+import { WidgetLayoutService } from '../../core/services/widget-layout.service';
 
 /** Section definition with routes for auto-expand */
 interface SidebarSection {
@@ -79,35 +80,39 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
                         <span class="sidebar__label">Agents</span>
                         <span class="sidebar__abbr">A</span>
                     </a>
-                    <a class="sidebar__link" routerLink="/flock-directory" routerLinkActive="sidebar__link--active" title="Flock Directory">
-                        <span class="sidebar__label">Flock Directory</span>
-                        <span class="sidebar__abbr">FD</span>
-                    </a>
+                    @if (isDeveloperMode()) {
+                        <a class="sidebar__link" routerLink="/flock-directory" routerLinkActive="sidebar__link--active" title="Flock Directory">
+                            <span class="sidebar__label">Flock Directory</span>
+                            <span class="sidebar__abbr">FD</span>
+                        </a>
+                    }
                 </li>
-                <li>
-                    <a class="sidebar__link" routerLink="/projects" routerLinkActive="sidebar__link--active" title="Projects">
-                        <span class="sidebar__label">Projects</span>
-                        <span class="sidebar__abbr">P</span>
-                    </a>
-                </li>
-                <li>
-                    <a class="sidebar__link" routerLink="/models" routerLinkActive="sidebar__link--active" title="Models">
-                        <span class="sidebar__label">Models</span>
-                        <span class="sidebar__abbr">M</span>
-                    </a>
-                </li>
-                <li>
-                    <a class="sidebar__link" routerLink="/personas" routerLinkActive="sidebar__link--active" title="Personas">
-                        <span class="sidebar__label">Personas</span>
-                        <span class="sidebar__abbr">Ps</span>
-                    </a>
-                </li>
-                <li>
-                    <a class="sidebar__link" routerLink="/skill-bundles" routerLinkActive="sidebar__link--active" title="Skill Bundles">
-                        <span class="sidebar__label">Skill Bundles</span>
-                        <span class="sidebar__abbr">Sk</span>
-                    </a>
-                </li>
+                @if (isDeveloperMode()) {
+                    <li>
+                        <a class="sidebar__link" routerLink="/projects" routerLinkActive="sidebar__link--active" title="Projects">
+                            <span class="sidebar__label">Projects</span>
+                            <span class="sidebar__abbr">P</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a class="sidebar__link" routerLink="/models" routerLinkActive="sidebar__link--active" title="Models">
+                            <span class="sidebar__label">Models</span>
+                            <span class="sidebar__abbr">M</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a class="sidebar__link" routerLink="/personas" routerLinkActive="sidebar__link--active" title="Personas">
+                            <span class="sidebar__label">Personas</span>
+                            <span class="sidebar__abbr">Ps</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a class="sidebar__link" routerLink="/skill-bundles" routerLinkActive="sidebar__link--active" title="Skill Bundles">
+                            <span class="sidebar__label">Skill Bundles</span>
+                            <span class="sidebar__abbr">Sk</span>
+                        </a>
+                    </li>
+                }
 
                 <!-- Sessions (collapsible) -->
                 <li class="sidebar__section sidebar__section--collapsible">
@@ -150,6 +155,7 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
                 </li>
 
                 <!-- Observe (collapsible) -->
+                @if (isDeveloperMode()) {
                 <li class="sidebar__section sidebar__section--collapsible">
                     <button
                         class="sidebar__section-toggle"
@@ -322,6 +328,7 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
                         </li>
                     </ul>
                 </li>
+                }
             </ul>
             <button
                 class="sidebar__help-btn"
@@ -623,6 +630,7 @@ export class SidebarComponent implements AfterViewInit, OnDestroy {
 
     private readonly router = inject(Router);
     private readonly shortcutsService = inject(KeyboardShortcutsService);
+    private readonly widgetLayout = inject(WidgetLayoutService);
     private readonly firstLink = viewChild<ElementRef<HTMLAnchorElement>>('firstLink');
     private readonly sidebarEl = viewChild<ElementRef<HTMLElement>>('sidebarEl');
     private routerSub: Subscription | null = null;
@@ -683,6 +691,10 @@ export class SidebarComponent implements AfterViewInit, OnDestroy {
     /** Check if a section is collapsed */
     isSectionCollapsed(sectionKey: string): boolean {
         return this.sectionStates()[sectionKey] ?? false;
+    }
+
+    isDeveloperMode(): boolean {
+        return this.widgetLayout.viewMode() === 'developer';
     }
 
     openHelp(): void {

--- a/client/src/app/shared/components/top-nav.component.ts
+++ b/client/src/app/shared/components/top-nav.component.ts
@@ -3,6 +3,7 @@ import {
     ChangeDetectionStrategy,
     inject,
     signal,
+    computed,
     OnInit,
     OnDestroy,
     HostListener,
@@ -15,6 +16,7 @@ import { SessionService } from '../../core/services/session.service';
 import { ApiService } from '../../core/services/api.service';
 import { StatusBadgeComponent } from './status-badge.component';
 import { KeyboardShortcutsService } from '../../core/services/keyboard-shortcuts.service';
+import { WidgetLayoutService } from '../../core/services/widget-layout.service';
 import { firstValueFrom } from 'rxjs';
 import type { AlgoChatNetwork } from '../../core/models/session.model';
 
@@ -112,7 +114,7 @@ const TABS: NavTab[] = [
                     <span class="topnav__logo-text">CorvidAgent</span>
                 </a>
                 <div class="topnav__tabs">
-                    @for (tab of tabs; track tab.key) {
+                    @for (tab of tabs(); track tab.key) {
                         <div class="topnav__tab-wrapper">
                             <button
                                 class="topnav__tab"
@@ -196,7 +198,7 @@ const TABS: NavTab[] = [
         @if (mobileOpen()) {
             <div class="topnav-mobile-backdrop" (click)="mobileOpen.set(false)"></div>
             <div class="topnav-mobile">
-                @for (tab of tabs; track tab.key) {
+                @for (tab of tabs(); track tab.key) {
                     <div class="topnav-mobile__section">
                         <span class="topnav-mobile__section-label">{{ tab.label }}</span>
                         @for (child of tab.children; track child.route) {
@@ -525,9 +527,25 @@ export class TopNavComponent implements OnInit, OnDestroy {
     private readonly apiService = inject(ApiService);
     private readonly router = inject(Router);
     private readonly shortcutsService = inject(KeyboardShortcutsService);
+    private readonly widgetLayout = inject(WidgetLayoutService);
     private readonly elRef = inject(ElementRef);
 
-    protected readonly tabs = TABS;
+    /** Simple mode: Chat + Agents only; Developer: all tabs */
+    private static readonly SIMPLE_TABS = new Set(['chat', 'agents']);
+    /** In simple mode, hide advanced children from Agents tab */
+    private static readonly SIMPLE_AGENT_CHILDREN = new Set(['All Agents']);
+
+    protected readonly tabs = computed<NavTab[]>(() => {
+        if (this.widgetLayout.viewMode() === 'developer') return TABS;
+        return TABS
+            .filter((t) => TopNavComponent.SIMPLE_TABS.has(t.key))
+            .map((t) => {
+                if (t.key === 'agents') {
+                    return { ...t, children: t.children.filter((c) => TopNavComponent.SIMPLE_AGENT_CHILDREN.has(c.label)) };
+                }
+                return t;
+            });
+    });
     protected readonly openDropdown = signal<string | null>(null);
     protected readonly mobileOpen = signal(false);
     protected readonly currentNetwork = signal<AlgoChatNetwork>('testnet');


### PR DESCRIPTION
## Summary
- Sidebar hides Observe, Automate, and Settings sections in Simple mode
- Sidebar hides advanced Core items (Flock Directory, Projects, Models, Personas, Skill Bundles) in Simple mode
- Top nav shows only Chat and Agents tabs in Simple mode (Agents tab shows only "All Agents")
- Both components read from the shared `WidgetLayoutService.viewMode` signal
- Toggling Simple/Developer on the dashboard now controls the entire UI consistently

Builds on #1307. Partial progress on #1248.

## Test plan
- [ ] Switch to Simple mode on dashboard — sidebar collapses to Chat, Dashboard, Agents, Sessions
- [ ] Top nav shows only Chat and Agents tabs
- [ ] Switch to Developer mode — all sidebar sections and top nav tabs return
- [ ] Navigation still works in Simple mode (routes remain accessible via URL)
- [ ] View mode persists across page refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)