### PR TITLE
fix: fall back to non-reply embed when message reference fails

### DIFF
--- a/server/discord/thread-manager.ts
+++ b/server/discord/thread-manager.ts
@@ -511,18 +511,20 @@ export function subscribeForInlineResponse(
         const parts = splitEmbedDescription(text);
         for (let i = 0; i < parts.length; i++) {
             let sentId: string | null = null;
+            const embedPayload = {
+                description: parts[i],
+                color,
+                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
+            };
             if (i === 0) {
-                sentId = await sendReplyEmbed(delivery, botToken, channelId, replyToMessageId, {
-                    description: parts[i],
-                    color,
-                    footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
-                });
+                sentId = await sendReplyEmbed(delivery, botToken, channelId, replyToMessageId, embedPayload);
+                // Fall back to non-reply if the referenced message no longer exists
+                if (!sentId) {
+                    log.debug('Reply embed failed, falling back to non-reply send', { channelId, replyToMessageId });
+                    sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
+                }
             } else {
-                sentId = await sendEmbed(delivery, botToken, channelId, {
-                    description: parts[i],
-                    color,
-                    footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
-                });
+                sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
             }
             if (sentId && onBotMessage) {
                 onBotMessage(sentId);
@@ -643,18 +645,20 @@ export function subscribeForAdaptiveInlineResponse(
         const parts = splitEmbedDescription(text);
         for (let i = 0; i < parts.length; i++) {
             let sentId: string | null = null;
+            const embedPayload = {
+                description: parts[i],
+                color,
+                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
+            };
             if (i === 0) {
-                sentId = await sendReplyEmbed(delivery, botToken, channelId, replyToMessageId, {
-                    description: parts[i],
-                    color,
-                    footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
-                });
+                sentId = await sendReplyEmbed(delivery, botToken, channelId, replyToMessageId, embedPayload);
+                // Fall back to non-reply if the referenced message no longer exists
+                if (!sentId) {
+                    log.debug('Reply embed failed, falling back to non-reply send', { channelId, replyToMessageId });
+                    sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
+                }
             } else {
-                sentId = await sendEmbed(delivery, botToken, channelId, {
-                    description: parts[i],
-                    color,
-                    footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
-                });
+                sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
             }
             if (sentId && onBotMessage) {
                 onBotMessage(sentId);
@@ -916,18 +920,20 @@ export function subscribeForInlineProgressResponse(
         const parts = splitEmbedDescription(text);
         for (let i = 0; i < parts.length; i++) {
             let sentId: string | null = null;
+            const embedPayload = {
+                description: parts[i],
+                color,
+                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
+            };
             if (i === 0) {
-                sentId = await sendReplyEmbed(delivery, botToken, channelId, replyToMessageId, {
-                    description: parts[i],
-                    color,
-                    footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
-                });
+                sentId = await sendReplyEmbed(delivery, botToken, channelId, replyToMessageId, embedPayload);
+                // Fall back to non-reply if the referenced message no longer exists
+                if (!sentId) {
+                    log.debug('Reply embed failed, falling back to non-reply send', { channelId, replyToMessageId });
+                    sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
+                }
             } else {
-                sentId = await sendEmbed(delivery, botToken, channelId, {
-                    description: parts[i],
-                    color,
-                    footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
-                });
+                sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
             }
             if (sentId && onBotMessage) {
                 onBotMessage(sentId);


### PR DESCRIPTION
## Summary
- When `sendReplyEmbed` fails (e.g. `MESSAGE_REFERENCE_UNKNOWN_MESSAGE` because the original message was deleted), the agent's response was silently lost and the progress embed got stuck showing "thinking..."
- All three inline `flush()` functions now fall back to `sendEmbed` (non-reply) when the reply delivery fails, ensuring the response always reaches the channel
- This is a different bug from #1317 — that fix handled session errors/crashes, this handles delivery failures after a successful session

## Test plan
- [ ] Delete a message that an agent is replying to mid-session — verify the response still appears (without the reply arrow)
- [ ] Normal reply flow still works as before (reply arrow present)
- [ ] Progress embed transitions to "Done" after successful delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)