### PR TITLE
fix: always show full navigation tab set regardless of view mode

### DIFF
--- a/client/src/app/shared/components/top-nav.component.ts
+++ b/client/src/app/shared/components/top-nav.component.ts
@@ -16,7 +16,6 @@ import { SessionService } from '../../core/services/session.service';
 import { ApiService } from '../../core/services/api.service';
 import { StatusBadgeComponent } from './status-badge.component';
 import { KeyboardShortcutsService } from '../../core/services/keyboard-shortcuts.service';
-import { WidgetLayoutService } from '../../core/services/widget-layout.service';
 import { firstValueFrom } from 'rxjs';
 import type { AlgoChatNetwork } from '../../core/models/session.model';
 
@@ -527,25 +526,10 @@ export class TopNavComponent implements OnInit, OnDestroy {
     private readonly apiService = inject(ApiService);
     private readonly router = inject(Router);
     private readonly shortcutsService = inject(KeyboardShortcutsService);
-    private readonly widgetLayout = inject(WidgetLayoutService);
     private readonly elRef = inject(ElementRef);
 
-    /** Simple mode: Chat + Agents only; Developer: all tabs */
-    private static readonly SIMPLE_TABS = new Set(['chat', 'agents']);
-    /** In simple mode, hide advanced children from Agents tab */
-    private static readonly SIMPLE_AGENT_CHILDREN = new Set(['All Agents']);
-
-    protected readonly tabs = computed<NavTab[]>(() => {
-        if (this.widgetLayout.viewMode() === 'developer') return TABS;
-        return TABS
-            .filter((t) => TopNavComponent.SIMPLE_TABS.has(t.key))
-            .map((t) => {
-                if (t.key === 'agents') {
-                    return { ...t, children: t.children.filter((c) => TopNavComponent.SIMPLE_AGENT_CHILDREN.has(c.label)) };
-                }
-                return t;
-            });
-    });
+    /** All tabs are always visible regardless of view mode — simple mode only affects dashboard widgets */
+    protected readonly tabs = computed<NavTab[]>(() => TABS);
     protected readonly openDropdown = signal<string | null>(null);
     protected readonly mobileOpen = signal(false);
     protected readonly currentNetwork = signal<AlgoChatNetwork>('testnet');


### PR DESCRIPTION
## Summary

- **Root cause**: Simple mode was filtering the top-nav to show only Chat and Agents tabs, hiding Observe, Automate, and Settings. The default was briefly set to `'simple'` in #1320 before being reverted, so users who visited during that window had `'simple'` stored in localStorage and permanently lost access to 3 navigation sections.
- **Fix**: Navigation tabs are now always fully rendered regardless of view mode. Simple mode only affects which dashboard widgets are visible, not the top-level navigation.
- Removes unused `WidgetLayoutService` injection from `TopNavComponent`.

## Test plan

- [ ] Visit dashboard — all 5 tabs (Chat, Agents, Observe, Automate, Settings) visible in both simple and developer mode
- [ ] Toggle view mode on dashboard — tabs stay the same, only widget layout changes
- [ ] Users who previously had `corvid_view_mode=simple` in localStorage now see the full tab set

🤖 Generated with [Claude Code](https://claude.com/claude-code)