### PR TITLE
fix: show Settings sidebar section in all view modes

### DIFF
--- a/client/src/app/shared/components/sidebar.component.ts
+++ b/client/src/app/shared/components/sidebar.component.ts
@@ -28,7 +28,7 @@ const SECTIONS: SidebarSection[] = [
     { key: 'sessions', label: 'Sessions', collapsible: true, defaultCollapsed: false, routes: ['/sessions', '/work-tasks', '/councils'] },
     { key: 'observe', label: 'Observe', collapsible: true, defaultCollapsed: false, routes: ['/feed', '/analytics', '/logs', '/brain-viewer', '/reputation'] },
     { key: 'automate', label: 'Automate', collapsible: true, defaultCollapsed: true, routes: ['/schedules', '/workflows', '/webhooks', '/mention-polling', '/mcp-servers'] },
-    { key: 'config', label: 'Settings', collapsible: true, defaultCollapsed: true, routes: ['/settings', '/security', '/allowlist', '/github-allowlist', '/repo-blocklist', '/wallets', '/spending', '/marketplace'] },
+    { key: 'config', label: 'Settings', collapsible: true, defaultCollapsed: false, routes: ['/settings', '/security', '/allowlist', '/github-allowlist', '/repo-blocklist', '/wallets', '/spending', '/marketplace'] },
 ];
 
 const STORAGE_KEY = 'sidebar_sections_collapsed';
@@ -259,7 +259,9 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
                     </ul>
                 </li>
 
-                <!-- Settings (collapsible, collapsed by default) -->
+                }
+
+                <!-- Settings (collapsible, expanded by default for easy access) -->
                 <li class="sidebar__section sidebar__section--collapsible">
                     <button
                         class="sidebar__section-toggle"
@@ -328,7 +330,6 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
                         </li>
                     </ul>
                 </li>
-                }
             </ul>
             <button
                 class="sidebar__help-btn"


### PR DESCRIPTION
## Summary
- The sidebar's Settings section (General, Security, Wallets, Spending, Allowlist, etc.) was wrapped inside `@if (isDeveloperMode())`, making it completely hidden for users in simple/default mode
- Moved the Settings section outside the developer-mode guard so it's always visible
- Changed Settings `defaultCollapsed` from `true` → `false` so it's expanded on first visit, making Discord configuration and other critical settings immediately discoverable
- Observe and Automate sections remain developer-mode-only as intended

## Test plan
- [ ] Open dashboard in simple mode — Settings section should appear in sidebar
- [ ] Open dashboard in developer mode — Settings, Observe, and Automate all visible
- [ ] Navigate to `/settings` — section auto-expands, Discord Config / Credit Config / Operational Mode / AlgoChat Status / PSK Contacts / Database backup all render
- [ ] Navigate to `/security` — resolves from Settings section link

🤖 Generated with [Claude Code](https://claude.com/claude-code)