### PR TITLE
fix: improve work task recovery after server restarts

### DIFF
--- a/server/db/work-tasks.ts
+++ b/server/db/work-tasks.ts
@@ -212,7 +212,13 @@ export function updateWorkTaskStatus(
         fields.push('iteration_count = ?');
         values.push(extra.iterationCount);
     }
-    if (status === 'completed' || status === 'failed') {
+    if (status === 'completed') {
+        fields.push("completed_at = datetime('now')");
+        // Clear any stale error from a previous failed attempt
+        if (extra?.error === undefined) {
+            fields.push('error = NULL');
+        }
+    } else if (status === 'failed') {
         fields.push("completed_at = datetime('now')");
     }
 

--- a/server/work/service.ts
+++ b/server/work/service.ts
@@ -259,6 +259,18 @@ export class WorkTaskService {
             try {
                 const worktreeExists = task.worktreeDir ? existsSync(task.worktreeDir) : false;
                 const canRetry = (task.iterationCount ?? 0) < WORK_MAX_ITERATIONS;
+                const neverStarted = !task.worktreeDir && (task.iterationCount ?? 0) === 0;
+
+                // Tasks that never actually started (no worktree, iteration 0) should
+                // always be requeued — they were just in 'branching' when the restart hit.
+                if (neverStarted && canRetry) {
+                    resetWorkTaskForRetry(this.db, task.id);
+                    log.info('Requeuing task that never started', {
+                        taskId: task.id,
+                        description: task.description.slice(0, 80),
+                    });
+                    continue;
+                }
 
                 if (!worktreeExists || !canRetry) {
                     log.info('Skipping recovery for task (worktree missing or max iterations reached)', {


### PR DESCRIPTION
## Summary
- Tasks interrupted during `branching` phase (before worktree exists) are now requeued to `pending` instead of permanently stuck as `failed`
- When a task completes successfully, any stale error message from a previous failed attempt is automatically cleared

## Context
Multiple work tasks were showing "Interrupted by server restart" — even tasks that never actually started running (they died in 3 seconds during the branching phase). The recovery logic required a worktree to exist for requeue, but tasks killed before worktree creation had no worktree, so they stayed permanently failed.

## Test plan
- [ ] Verify `bun x tsc` passes
- [ ] Restart server with a task in 'branching' state → should requeue to pending
- [ ] Complete a previously-failed task → error field should be cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)