### PR TITLE
fix: prevent localnet memory sync from falling back to plain transactions

### DIFF
--- a/server/db/memory-sync.ts
+++ b/server/db/memory-sync.ts
@@ -97,20 +97,35 @@ export class MemorySyncService {
                         await this.walletService.checkAndRefill(memory.agentId);
                     }
 
-                    // On localnet: try ARC-69 ASA path first
+                    // On localnet: ARC-69 ASA path only — never fall back to plain transactions.
+                    // Plain transactions are immutable and can't be updated/deleted, so we'd rather
+                    // retry later than create a permanent, unmodifiable memory record.
                     if (isLocalnet && this.walletService) {
                         try {
-                            const synced = await this.syncViaArc69(memory);
-                            if (synced) continue;
+                            const arc69Synced = await this.syncViaArc69(memory);
+                            if (arc69Synced) {
+                                synced++;
+                                continue;
+                            }
+                            // syncViaArc69 returned false — ARC-69 infra unavailable (no indexer, no chat account)
+                            log.warn('ARC-69 unavailable on localnet, memory stays pending', {
+                                key: memory.key,
+                                agentId: memory.agentId,
+                            });
+                            skipped++;
+                            continue;
                         } catch (err) {
-                            log.debug('ARC-69 sync failed, falling back to plain txn', {
+                            log.warn('ARC-69 sync failed on localnet, marking failed for retry', {
                                 key: memory.key,
                                 error: err instanceof Error ? err.message : String(err),
                             });
+                            updateMemoryStatus(this.db, memory.id, 'failed');
+                            failed++;
+                            continue;
                         }
                     }
 
-                    // Fallback: plain transaction path
+                    // Non-localnet: plain transaction path (fire-and-forget, immutable)
                     const encrypted = await encryptMemoryContent(
                         memory.content,
                         this.serverMnemonic,

--- a/specs/db/memory-sync.spec.md
+++ b/specs/db/memory-sync.spec.md
@@ -48,6 +48,7 @@ Background service that periodically syncs pending agent memories to **long-term
 3. **Batch size**: Each tick processes at most 10 pending memories (`BATCH_SIZE = 10`)
 4. **Failed backoff**: Memories with status `failed` are skipped if their `updatedAt` is less than 5 minutes ago (`FAILED_BACKOFF_MS`)
 5. **Wallet refill before send**: If a `walletService` is set, `checkAndRefill()` is called before each on-chain send to ensure the agent wallet has sufficient balance
+6. **Localnet ARC-69 only**: On localnet, memories are **never** synced via plain transactions. If ARC-69 is unavailable (no indexer/chat account), the memory stays `pending`. If ARC-69 throws, the memory is marked `failed` for retry after backoff. This prevents creating immutable, unmodifiable memory records on localnet
 6. **Null txid handling**: If `sendOnChainToSelf` returns null (no wallet configured), the memory stays pending (not marked failed)
 7. **Error isolation**: A failure on one memory does not abort the batch; it marks that memory as `failed` and continues
 8. **Idempotent start**: Calling `start()` when already running logs a warning and does nothing
@@ -55,11 +56,29 @@ Background service that periodically syncs pending agent memories to **long-term
 
 ## Behavioral Examples
 
-### Scenario: Successful memory sync
+### Scenario: Successful memory sync (non-localnet)
 
-- **Given** 3 memories with status `pending` in the database and `agentMessenger` is configured
+- **Given** 3 memories with status `pending` in the database, `agentMessenger` is configured, and network is `testnet`
 - **When** `tick()` runs
 - **Then** each memory is encrypted via `encryptMemoryContent`, sent on-chain via `sendOnChainToSelf`, and its txid is stored via `updateMemoryTxid`
+
+### Scenario: Successful memory sync (localnet)
+
+- **Given** a pending memory, network is `localnet`, and `walletService` is configured with indexer and chat account available
+- **When** `tick()` runs
+- **Then** the memory is synced via `syncViaArc69()` (creating or updating an ASA), and its txid and asaId are stored
+
+### Scenario: ARC-69 unavailable on localnet
+
+- **Given** a pending memory, network is `localnet`, and `walletService` is configured but indexer is unavailable
+- **When** `tick()` runs
+- **Then** `syncViaArc69()` returns false, the memory stays `pending` (not sent as a plain transaction), and it is retried on the next tick
+
+### Scenario: ARC-69 error on localnet
+
+- **Given** a pending memory, network is `localnet`, and `syncViaArc69()` throws an error
+- **When** `tick()` runs
+- **Then** the memory is marked `failed` (retried after 5-minute backoff) and is **not** sent as a plain transaction
 
 ### Scenario: Failed memory with backoff
 
@@ -95,6 +114,8 @@ Background service that periodically syncs pending agent memories to **long-term
 | `walletService.checkAndRefill` throws | Memory status is set to `failed`; error is logged |
 | `start()` called when already running | Logs a warning and returns without creating a second timer |
 | `tick()` called while already syncing | Returns immediately (reentrancy guard) |
+| `syncViaArc69` returns false on localnet | Memory stays `pending`, skipped for this tick (ARC-69 infra unavailable) |
+| `syncViaArc69` throws on localnet | Memory marked `failed` with 5-minute backoff; **never** falls back to plain transaction |
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- On localnet, if ARC-69 ASA creation failed during background memory sync, the code silently fell back to plain payment transactions at `debug` log level. These are immutable and can't be updated or deleted, defeating the purpose of ARC-69 memories.
- Now on localnet: ARC-69 succeeds or the memory stays `pending`/`failed` for retry. Plain transaction fallback only applies to testnet/mainnet where ASA costs real ALGO.
- Logging upgraded from `debug` to `warn` so ARC-69 failures are visible in logs.

## Changes

- `server/db/memory-sync.ts`: On localnet, if `syncViaArc69()` returns false (infra unavailable), memory stays `pending` and is skipped. If it throws, memory is marked `failed` with 5-minute backoff. Never falls back to plain transactions.
- `specs/db/memory-sync.spec.md`: Documents the localnet ARC-69-only invariant and adds error case coverage.

## Test plan

- [x] `bun run spec:check` passes (168/168 specs)
- [x] `bun x tsc` clean compile
- [x] Verify localnet memory save creates ARC-69 ASA, not plain transaction
- [x] Verify that if ARC-69 fails on localnet, memory stays pending/failed (no plain txn created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)