### PR TITLE
fix(docker): remove COPY patches/ — directory does not exist

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /app
 
 # Install server dependencies only
 COPY package.json bun.lock* ./
-COPY patches/ patches/
 RUN bun install --frozen-lockfile --production
 
 # Copy server source


### PR DESCRIPTION
## Summary
- Removes `COPY patches/ patches/` from the Dockerfile — the `patchedDependencies` field in package.json is empty, so no patches directory exists
- This was causing the Docker Publish CD to fail on the v0.42.0 release

## Test plan
- [ ] Docker Publish workflow passes on this branch / after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)