### PR TITLE
chore: bump version to v0.42.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.42.1] - 2026-03-21
+
+### Fixed
+- **Docker build** — remove `COPY patches/` from Dockerfile; directory does not exist (#1344)
+
 ## [0.42.0] - 2026-03-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version to v0.42.1 (patch release for Docker build fix)
- Add changelog entry for #1344

🤖 Generated with [Claude Code](https://claude.com/claude-code)