### PR TITLE
feat(ui): default to simple mode for new users

### DIFF
--- a/client/src/app/core/services/widget-layout.service.ts
+++ b/client/src/app/core/services/widget-layout.service.ts
@@ -30,6 +30,7 @@ const SIMPLE_WIDGETS: Set<WidgetId> = new Set([
     'active-sessions',
     'activity',
     'quick-actions',
+    'system-status',
 ]);
 
 const DEFAULT_WIDGETS: WidgetConfig[] = [
@@ -71,6 +72,7 @@ export class WidgetLayoutService {
     setViewMode(mode: ViewMode): void {
         this.viewMode.set(mode);
         this.saveViewMode(mode);
+        if (mode === 'simple') this.customizing.set(false);
     }
 
     /** Toggle between modes */
@@ -132,10 +134,10 @@ export class WidgetLayoutService {
     }
 
     private loadViewMode(): ViewMode {
-        if (typeof localStorage === 'undefined') return 'developer';
+        if (typeof localStorage === 'undefined') return 'simple';
         const stored = localStorage.getItem(VIEW_MODE_KEY);
         if (stored === 'simple' || stored === 'developer') return stored;
-        return 'developer';
+        return 'simple';
     }
 
     private saveViewMode(mode: ViewMode): void {

--- a/client/src/app/features/dashboard/dashboard.component.css
+++ b/client/src/app/features/dashboard/dashboard.component.css
@@ -145,6 +145,36 @@
 }
 .simple-hero__btn:hover { background: rgba(0,229,255,.14); box-shadow: 0 0 16px rgba(0,229,255,.15); }
 
+/* Simple mode prompt — top-level hero for first-time/simple users */
+.simple-prompt {
+    text-align: center; padding: 2.5rem 1.5rem;
+    background: linear-gradient(135deg, rgba(0,229,255,.04) 0%, rgba(0,229,255,.01) 100%);
+    border: 1px solid var(--border); border-radius: var(--radius-lg);
+    margin-bottom: 1rem;
+}
+.simple-prompt__title {
+    margin: 0 0 .5rem; font-size: 1.4rem; font-weight: 700;
+    color: var(--text-primary);
+}
+.simple-prompt__desc {
+    margin: 0 0 1.5rem; font-size: .85rem; color: var(--text-secondary);
+    max-width: 500px; margin-left: auto; margin-right: auto; line-height: 1.5;
+}
+.simple-prompt__actions { display: flex; gap: .75rem; justify-content: center; flex-wrap: wrap; }
+.simple-prompt__btn {
+    padding: .65rem 1.5rem; border-radius: var(--radius); font-size: .8rem; font-weight: 600;
+    font-family: inherit; border: 1px solid var(--border); color: var(--text-secondary);
+    background: var(--bg-surface); cursor: pointer; transition: all .15s;
+}
+.simple-prompt__btn:hover { border-color: var(--accent-cyan); color: var(--accent-cyan); }
+.simple-prompt__btn--primary {
+    border-color: var(--accent-cyan); color: var(--accent-cyan);
+    background: rgba(0,229,255,.08);
+}
+.simple-prompt__btn--primary:hover {
+    background: rgba(0,229,255,.16); box-shadow: 0 0 20px rgba(0,229,255,.12);
+}
+
 /* Agent grid */
 .agent-grid { display: grid; grid-template-columns: repeat(auto-fill,minmax(260px,1fr)); gap: .75rem; }
 .agent-card {

--- a/client/src/app/features/dashboard/dashboard.component.ts
+++ b/client/src/app/features/dashboard/dashboard.component.ts
@@ -89,18 +89,22 @@ interface SessionStats { byAgent: AgentSessionStat[]; bySource: { source: string
                     <div class="view-toggle">
                         <button class="view-toggle__btn"
                                 [class.view-toggle__btn--active]="layoutService.viewMode() === 'simple'"
-                                (click)="layoutService.setViewMode('simple')">Simple</button>
+                                (click)="layoutService.setViewMode('simple')"
+                                title="Simplified view for everyday use">Simple</button>
                         <button class="view-toggle__btn"
                                 [class.view-toggle__btn--active]="layoutService.viewMode() === 'developer'"
-                                (click)="layoutService.setViewMode('developer')">Developer</button>
+                                (click)="layoutService.setViewMode('developer')"
+                                title="Full dashboard with metrics, charts, and developer tools">Developer</button>
                     </div>
-                    <button class="customize-btn" (click)="layoutService.customizing.set(!layoutService.customizing())">
-                        {{ layoutService.customizing() ? 'Done' : 'Customize' }}
-                    </button>
+                    @if (layoutService.viewMode() === 'developer') {
+                        <button class="customize-btn" (click)="layoutService.customizing.set(!layoutService.customizing())">
+                            {{ layoutService.customizing() ? 'Done' : 'Customize' }}
+                        </button>
+                    }
                 </div>
             </div>
 
-            <!-- Customize panel (slide-down) -->
+            <!-- Customize panel (developer mode only) -->
             @if (layoutService.customizing()) {
                 <div class="customize-panel">
                     <div class="customize-panel__header">
@@ -127,6 +131,18 @@ interface SessionStats { byAgent: AgentSessionStat[]; bySource: { source: string
                                 </button>
                             </div>
                         }
+                    </div>
+                </div>
+            }
+
+            <!-- Simple mode hero prompt -->
+            @if (layoutService.viewMode() === 'simple') {
+                <div class="simple-prompt">
+                    <h2 class="simple-prompt__title">What would you like to build?</h2>
+                    <p class="simple-prompt__desc">Start a conversation with your agent to build something new, or check on active sessions below.</p>
+                    <div class="simple-prompt__actions">
+                        <button class="simple-prompt__btn simple-prompt__btn--primary" (click)="navigateTo('/sessions/new')">Start a Conversation</button>
+                        <button class="simple-prompt__btn" (click)="navigateTo('/chat')">Open Chat</button>
                     </div>
                 </div>
             }


### PR DESCRIPTION
## Summary
- **Default view mode changed from `developer` to `simple`** for new users — reduces cognitive load for non-technical audiences
- **Hero prompt section** added to simple mode dashboard: "What would you like to build?" with quick-start CTAs (Start a Conversation, Open Chat)
- **Customize button hidden** in simple mode — widget customization is a developer-only feature
- **System status widget** added to simple mode — users need to see connection health
- **Tooltips** added to view mode toggle buttons explaining each mode
- Switching to simple mode auto-closes the customize panel if open

Existing users who previously selected developer mode are **unaffected** — their localStorage preference is respected.

Closes #1248 (Phase 1: progressive disclosure)

## Test plan
- [x] New browser/incognito: dashboard loads in simple mode with hero prompt
- [x] Toggle to developer: all widgets appear, Customize button visible
- [x] Toggle back to simple: customize panel closes, button hidden
- [x] Refresh: preference persists in localStorage
- [x] Verify system-status widget visible in simple mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)