### PR TITLE
chore: bump version to v0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.43.0] - 2026-03-21
+
+### Added
+- **Schedule output destinations** — deliver schedule results to Discord channels, webhooks, or other agents (#1347)
+- **Simple mode default** — new users now start in simple mode for a cleaner first experience (#1349)
+- **Dashboard polish** — animations, theming improvements, and responsive layout refinements (#1348)
+
+### Fixed
+- **CSP for GitHub avatars** — allow GitHub avatar URLs in Content-Security-Policy and unblock score/cooldown endpoints (#1346)
+
 ## [0.42.1] - 2026-03-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.42.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.43.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.42.1",
+  "version": "0.43.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version to v0.43.0
- Update CHANGELOG with all changes since v0.42.1
- Update README version badge

## What's in v0.43.0

### Added
- **Schedule output destinations** — deliver schedule results to Discord channels, webhooks, or other agents (#1347)
- **Simple mode default** — new users now start in simple mode (#1349)
- **Dashboard polish** — animations, theming, and responsive layout (#1348)

### Fixed
- **CSP for GitHub avatars** — allow GitHub avatar URLs in CSP and unblock score/cooldown endpoints (#1346)

🤖 Generated with [Claude Code](https://claude.com/claude-code)