### PR TITLE
chore: update drifted stats in deep-dive.md

### DIFF
--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -37,10 +37,10 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | TypeScript LOC | 182,301 |
 | Server modules | 47 |
 | API routes | 47 modules (~300 endpoints) |
-| Database tables | 94 |
-| Database migrations | 21 (squashed baseline) |
+| Database tables | 95 |
+| Database migrations | 22 (squashed baseline) |
 | MCP tools | 48 corvid_* handlers |
-| Unit tests | 8,344 across 347 files |
+| Unit tests | 8,397 across 349 files |
 | E2E tests | 360 across 31 Playwright specs |
 | Security tests | 232 dedicated |
 | Module specs | 169 .spec.md files |


### PR DESCRIPTION
## Summary
- Sync documented stats that drifted: unit_tests 8344→8397, db_tables 94→95, migration_files 21→22

## Test plan
- [x] `bun run stats:check` passes after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)