### PR TITLE
fix(security): path traversal in Discord image route

### DIFF
--- a/server/routes/discord-image.ts
+++ b/server/routes/discord-image.ts
@@ -18,10 +18,17 @@
  *   - replyToMessageId (optional form field)
  */
 
+import { resolve, sep } from 'node:path';
 import { json, handleRouteError } from '../lib/response';
 import { getDeliveryTracker } from '../lib/delivery-tracker';
 import { sendMessageWithFiles, sendEmbedWithFiles, type DiscordFileAttachment } from '../discord/embeds';
 import { createLogger } from '../lib/logger';
+
+/** Allowed roots for imagePath — restrict filesystem reads to safe directories. */
+const ALLOWED_IMAGE_ROOTS = [
+    resolve(process.cwd()),  // project directory
+    '/tmp',
+];
 
 const log = createLogger('DiscordImageRoute');
 
@@ -87,10 +94,22 @@ async function handleSendImage(req: Request): Promise<Response> {
             if (body.imageBase64) {
                 imageData = Buffer.from(body.imageBase64, 'base64');
             } else if (body.imagePath) {
-                // Read from local filesystem
-                const file = Bun.file(body.imagePath);
+                // Resolve and validate path to prevent path traversal (CWE-22)
+                const resolvedPath = resolve(body.imagePath);
+                const isAllowed = ALLOWED_IMAGE_ROOTS.some(root => {
+                    const normalizedRoot = resolve(root);
+                    if (resolvedPath === normalizedRoot) return true;
+                    const rootWithSep = normalizedRoot.endsWith(sep) ? normalizedRoot : normalizedRoot + sep;
+                    return resolvedPath.startsWith(rootWithSep);
+                });
+                if (!isAllowed) {
+                    log.warn('Blocked path traversal attempt', { imagePath: body.imagePath });
+                    return json({ error: 'imagePath is outside allowed directories' }, 403);
+                }
+
+                const file = Bun.file(resolvedPath);
                 if (!await file.exists()) {
-                    return json({ error: `File not found: ${body.imagePath}` }, 400);
+                    return json({ error: 'File not found' }, 400);
                 }
                 imageData = new Uint8Array(await file.arrayBuffer());
                 // Infer content type from extension if not specified


### PR DESCRIPTION
## Summary
- **CWE-22 Path Traversal**: The `/api/discord/send-image` endpoint accepted a user-supplied `imagePath` and read directly from the filesystem without validation, allowing arbitrary file reads via `../` traversal sequences.
- **Fix**: Added allowlist-based path validation restricting `imagePath` to the project directory and `/tmp`, using the same boundary-aware prefix matching pattern as `isPathAllowed` in `projects.ts`.
- **Also fixed**: Error messages no longer leak the user-supplied path back in the response.

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` — passes
- [x] `bun test` — 8397 pass, 0 fail
- [x] `bun run spec:check` — 168 specs pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)