### PR TITLE
feat(ui): dashboard polish for public readiness

### DIFF
--- a/client/src/app/features/agents/agent-list.component.ts
+++ b/client/src/app/features/agents/agent-list.component.ts
@@ -117,6 +117,7 @@ const INACTIVE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
                            [style.--agent-accent]="card.agent.displayColor || ''">
                             <div class="agent-card__top">
                                 <div class="agent-card__title-row">
+                                    <span class="agent-card__health-dot" [attr.data-health]="getHealthLevel(card)" aria-hidden="true"></span>
                                     @if (card.agent.avatarUrl) {
                                         <img class="agent-card__avatar" [src]="card.agent.avatarUrl"
                                              [alt]="card.agent.name + ' avatar'" (error)="onAvatarError($event)" />
@@ -274,6 +275,12 @@ const INACTIVE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
         .agent-card__icon { font-size: 1.2rem; line-height: 1; flex-shrink: 0; }
         .agent-card__top { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 0.35rem; }
         .agent-card__title-row { display: flex; align-items: center; gap: 0.4rem; }
+        .agent-card__health-dot {
+            width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+        }
+        .agent-card__health-dot[data-health="green"] { background: var(--accent-green); box-shadow: 0 0 6px rgba(0,255,136,.4); }
+        .agent-card__health-dot[data-health="yellow"] { background: var(--accent-amber); box-shadow: 0 0 6px rgba(255,170,0,.4); }
+        .agent-card__health-dot[data-health="red"] { background: var(--accent-red); box-shadow: 0 0 6px rgba(255,51,85,.3); opacity: .6; }
         .agent-card__name { font-weight: 700; font-size: 0.9rem; color: var(--text-primary); }
         .status-indicator { display: flex; align-items: center; gap: 0.25rem; }
         .status-indicator__label { font-size: 0.55rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; }
@@ -395,6 +402,15 @@ export class AgentListComponent implements OnInit {
 
     protected onAvatarError(event: Event): void {
         (event.target as HTMLImageElement).style.display = 'none';
+    }
+
+    /** Health level based on activity recency */
+    protected getHealthLevel(card: AgentCard): string {
+        if (card.runningSessions > 0) return 'green';
+        if (!card.lastActive) return 'red';
+        const hoursAgo = (Date.now() - new Date(card.lastActive).getTime()) / (1000 * 60 * 60);
+        if (hoursAgo < 24) return 'yellow';
+        return 'red';
     }
 
     protected startSession(agentId: string, event: Event): void {

--- a/client/src/app/features/analytics/analytics.component.ts
+++ b/client/src/app/features/analytics/analytics.component.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy, inject, OnInit, signal, computed } 
 import { DecimalPipe } from '@angular/common';
 import { ApiService } from '../../core/services/api.service';
 import { firstValueFrom } from 'rxjs';
+import { SkeletonComponent } from '../../shared/components/skeleton.component';
 
 interface OverviewData {
     totalSessions: number;
@@ -54,13 +55,13 @@ interface SessionStats {
 @Component({
     selector: 'app-analytics',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [DecimalPipe],
+    imports: [DecimalPipe, SkeletonComponent],
     template: `
         <div class="analytics">
             <h2>Analytics</h2>
 
             @if (loading()) {
-                <p class="loading">Loading analytics data...</p>
+                <app-skeleton variant="card" [count]="6" />
             } @else if (overview()) {
                 <!-- Overview Cards -->
                 <div class="analytics__cards stagger-scale">

--- a/client/src/app/features/dashboard/dashboard.component.css
+++ b/client/src/app/features/dashboard/dashboard.component.css
@@ -201,6 +201,13 @@
 .agent-card:hover { border-color: var(--accent-cyan); box-shadow: 0 0 12px rgba(0,229,255,.08); }
 .agent-card__top { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: .5rem; }
 .agent-card__info, .agent-card__stat { display: flex; flex-direction: column; gap: .1rem; }
+.agent-card__name-row { display: flex; align-items: center; gap: .35rem; }
+.agent-card__health-dot {
+    width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+}
+.agent-card__health-dot[data-health="green"] { background: var(--accent-green); box-shadow: 0 0 6px rgba(0,255,136,.4); }
+.agent-card__health-dot[data-health="yellow"] { background: var(--accent-amber); box-shadow: 0 0 6px rgba(255,170,0,.4); }
+.agent-card__health-dot[data-health="red"] { background: var(--accent-red); box-shadow: 0 0 6px rgba(255,51,85,.3); opacity: .6; }
 .agent-card__name { font-weight: 700; font-size: .85rem; color: var(--text-primary); }
 .agent-card__provider-badge {
     font-size: .55rem; font-family: var(--font-mono,monospace); font-weight: 600;

--- a/client/src/app/features/dashboard/dashboard.component.ts
+++ b/client/src/app/features/dashboard/dashboard.component.ts
@@ -229,7 +229,10 @@ interface SessionStats { byAgent: AgentSessionStat[]; bySource: { source: string
                                             <a class="agent-card" [routerLink]="['/agents', summary.agent.id]">
                                                 <div class="agent-card__top">
                                                     <div class="agent-card__info">
-                                                        <span class="agent-card__name">{{ summary.agent.name }}</span>
+                                                        <div class="agent-card__name-row">
+                                                            <span class="agent-card__health-dot" [attr.data-health]="getAgentHealth(summary)"></span>
+                                                            <span class="agent-card__name">{{ summary.agent.name }}</span>
+                                                        </div>
                                                         <span class="agent-card__provider-badge" [attr.data-provider]="summary.agent.provider || 'anthropic'">
                                                             {{ summary.agent.provider || 'anthropic' }}{{ summary.agent.model ? ' / ' + summary.agent.model : '' }}
                                                         </span>
@@ -911,6 +914,15 @@ export class DashboardComponent implements OnInit, OnDestroy {
     /** Which widgets should span full width */
     protected isFullWidth(id: WidgetId): boolean {
         return id === 'metrics' || id === 'agents' || id === 'active-sessions' || id === 'flock' || id === 'comparison';
+    }
+
+    /** Returns 'green' (active now), 'yellow' (active within 24h), 'red' (inactive >24h) */
+    protected getAgentHealth(summary: AgentSummary): string {
+        if (summary.runningSessions > 0) return 'green';
+        if (!summary.lastActive) return 'red';
+        const hoursAgo = (Date.now() - new Date(summary.lastActive).getTime()) / (1000 * 60 * 60);
+        if (hoursAgo < 24) return 'yellow';
+        return 'red';
     }
 
     protected sourceBarPct(count: number): number {

--- a/client/src/app/features/logs/system-logs.component.ts
+++ b/client/src/app/features/logs/system-logs.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../core/services/api.service';
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 import { EmptyStateComponent } from '../../shared/components/empty-state.component';
+import { SkeletonComponent } from '../../shared/components/skeleton.component';
 import { firstValueFrom } from 'rxjs';
 
 interface LogEntry {
@@ -30,7 +31,7 @@ interface CreditTransaction {
 @Component({
     selector: 'app-system-logs',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [RouterLink, RelativeTimePipe, FormsModule, EmptyStateComponent],
+    imports: [RouterLink, RelativeTimePipe, FormsModule, EmptyStateComponent, SkeletonComponent],
     template: `
         <div class="logs">
             <h2>System Logs</h2>
@@ -87,7 +88,7 @@ interface CreditTransaction {
                 </div>
 
                 @if (loadingLogs()) {
-                    <p class="loading">Loading logs...</p>
+                    <app-skeleton variant="table" [count]="5" />
                 } @else if (logs().length === 0) {
                     <app-empty-state
                         icon="  [___]\n  |   |\n  |...|"
@@ -117,7 +118,7 @@ interface CreditTransaction {
 
             @if (activeTab() === 'credits') {
                 @if (loadingCredits()) {
-                    <p class="loading">Loading credit transactions...</p>
+                    <app-skeleton variant="table" [count]="4" />
                 } @else if (creditTxns().length === 0) {
                     <app-empty-state
                         icon="  [___]\n  | 0 |\n  |...|"

--- a/client/src/app/features/marketplace/marketplace.component.ts
+++ b/client/src/app/features/marketplace/marketplace.component.ts
@@ -7,13 +7,14 @@ import { AgentService } from '../../core/services/agent.service';
 import { NotificationService } from '../../core/services/notification.service';
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 import { EmptyStateComponent } from '../../shared/components/empty-state.component';
+import { SkeletonComponent } from '../../shared/components/skeleton.component';
 import type { MarketplaceListing, MarketplaceReview, ListingCategory } from '../../core/models/marketplace.model';
 import type { TrustLevel } from '../../core/models/reputation.model';
 
 @Component({
     selector: 'app-marketplace',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FormsModule, DecimalPipe, RelativeTimePipe, EmptyStateComponent],
+    imports: [FormsModule, DecimalPipe, RelativeTimePipe, EmptyStateComponent, SkeletonComponent],
     template: `
         <div class="page">
             <div class="page__header">
@@ -101,7 +102,7 @@ import type { TrustLevel } from '../../core/models/reputation.model';
             }
 
             @if (marketplaceService.loading()) {
-                <p class="loading">Loading listings...</p>
+                <app-skeleton variant="card" [count]="4" />
             } @else if (loadError()) {
                 <div class="error-banner">
                     <p>Marketplace service unavailable (503). The service may not be initialized yet.</p>

--- a/client/src/app/features/mcp-servers/mcp-server-list.component.ts
+++ b/client/src/app/features/mcp-servers/mcp-server-list.component.ts
@@ -3,6 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { McpServerService } from '../../core/services/mcp-server.service';
 import { AgentService } from '../../core/services/agent.service';
 import { NotificationService } from '../../core/services/notification.service';
+import { SkeletonComponent } from '../../shared/components/skeleton.component';
 import type { McpServerConfig, CreateMcpServerConfigInput } from '../../core/models/mcp-server.model';
 
 interface OfficialMcpServer {
@@ -132,7 +133,7 @@ const OFFICIAL_SERVERS: OfficialMcpServer[] = [
 @Component({
     selector: 'app-mcp-server-list',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FormsModule],
+    imports: [FormsModule, SkeletonComponent],
     template: `
         <div class="page">
             <div class="page__header">
@@ -248,7 +249,7 @@ const OFFICIAL_SERVERS: OfficialMcpServer[] = [
 
             <!-- Configured Servers -->
             @if (mcpService.loading()) {
-                <p class="loading">Loading servers...</p>
+                <app-skeleton variant="table" [count]="4" />
             } @else if (mcpService.servers().length === 0) {
                 <p class="empty">No custom MCP servers configured.</p>
             } @else {

--- a/client/src/app/features/mention-polling/mention-polling-list.component.ts
+++ b/client/src/app/features/mention-polling/mention-polling-list.component.ts
@@ -7,12 +7,13 @@ import { ProjectService } from '../../core/services/project.service';
 import { NotificationService } from '../../core/services/notification.service';
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 import { EmptyStateComponent } from '../../shared/components/empty-state.component';
+import { SkeletonComponent } from '../../shared/components/skeleton.component';
 import type { MentionPollingConfig, MentionPollingStatus, PollingActivity } from '../../core/models/mention-polling.model';
 
 @Component({
     selector: 'app-mention-polling-list',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FormsModule, RelativeTimePipe, EmptyStateComponent],
+    imports: [FormsModule, RelativeTimePipe, EmptyStateComponent, SkeletonComponent],
     template: `
         <div class="polling">
             <div class="polling__header">
@@ -147,7 +148,7 @@ import type { MentionPollingConfig, MentionPollingStatus, PollingActivity } from
             </div>
 
             @if (pollingService.loading()) {
-                <p class="loading">Loading polling configs...</p>
+                <app-skeleton variant="table" [count]="4" />
             } @else if (filteredConfigs().length === 0) {
                 <app-empty-state
                     icon="  [@_@]\n   /|\\\n   / \\"

--- a/client/src/app/features/personas/persona-manager.component.ts
+++ b/client/src/app/features/personas/persona-manager.component.ts
@@ -5,11 +5,12 @@ import { PersonaService } from '../../core/services/persona.service';
 import { NotificationService } from '../../core/services/notification.service';
 import type { Agent } from '../../core/models/agent.model';
 import type { AgentPersona, PersonaArchetype } from '../../core/models/persona.model';
+import { SkeletonComponent } from '../../shared/components/skeleton.component';
 
 @Component({
     selector: 'app-persona-manager',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FormsModule],
+    imports: [FormsModule, SkeletonComponent],
     template: `
         <div class="page">
             <div class="page__header">
@@ -17,7 +18,7 @@ import type { AgentPersona, PersonaArchetype } from '../../core/models/persona.m
             </div>
 
             @if (agentService.loading()) {
-                <p class="loading">Loading agents...</p>
+                <app-skeleton variant="line" [count]="4" />
             } @else if (agentService.agents().length === 0) {
                 <p class="empty">No agents found. Create an agent first.</p>
             } @else {
@@ -41,7 +42,7 @@ import type { AgentPersona, PersonaArchetype } from '../../core/models/persona.m
                             <p>Select an agent above to configure its persona</p>
                         </div>
                     } @else if (personaService.loading()) {
-                        <p class="loading">Loading persona...</p>
+                        <app-skeleton variant="line" [count]="4" />
                     } @else {
                         <div class="detail-header">
                             <h3>{{ selectedAgentName() }}</h3>

--- a/client/src/app/features/reputation/reputation.component.ts
+++ b/client/src/app/features/reputation/reputation.component.ts
@@ -6,12 +6,13 @@ import { AgentService } from '../../core/services/agent.service';
 import { NotificationService } from '../../core/services/notification.service';
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 import { EmptyStateComponent } from '../../shared/components/empty-state.component';
+import { SkeletonComponent } from '../../shared/components/skeleton.component';
 import type { ReputationScore, ReputationEvent, ScoreExplanation, ComponentExplanation, AgentReputationStats } from '../../core/models/reputation.model';
 
 @Component({
     selector: 'app-reputation',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FormsModule, DecimalPipe, RelativeTimePipe, EmptyStateComponent],
+    imports: [FormsModule, DecimalPipe, RelativeTimePipe, EmptyStateComponent, SkeletonComponent],
     template: `
         <div class="page">
             <div class="page__header">
@@ -25,7 +26,7 @@ import type { ReputationScore, ReputationEvent, ScoreExplanation, ComponentExpla
             </div>
 
             @if (reputationService.loading()) {
-                <p class="loading">Loading reputation scores...</p>
+                <app-skeleton variant="table" [count]="4" />
             } @else if (loadError()) {
                 <div class="error-banner">
                     <p>Reputation service unavailable (503). Scores may not be computed yet.</p>

--- a/client/src/app/features/settings/settings.component.ts
+++ b/client/src/app/features/settings/settings.component.ts
@@ -3,6 +3,7 @@ import { DecimalPipe, TitleCasePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ApiService } from '../../core/services/api.service';
+import { SkeletonComponent } from '../../shared/components/skeleton.component';
 import { NotificationService } from '../../core/services/notification.service';
 import { SessionService } from '../../core/services/session.service';
 import { GuidedTourService } from '../../core/services/guided-tour.service';
@@ -49,13 +50,13 @@ interface PSKContact {
 @Component({
     selector: 'app-settings',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FormsModule, DecimalPipe, TitleCasePipe],
+    imports: [FormsModule, DecimalPipe, TitleCasePipe, SkeletonComponent],
     template: `
         <div class="settings">
             <h2>Settings</h2>
 
             @if (loading()) {
-                <p class="loading">Loading settings...</p>
+                <app-skeleton variant="line" [count]="6" />
             } @else {
                 <!-- System Info -->
                 <div class="settings__section">

--- a/client/src/app/features/skill-bundles/skill-bundle-list.component.ts
+++ b/client/src/app/features/skill-bundles/skill-bundle-list.component.ts
@@ -3,12 +3,13 @@ import { FormsModule } from '@angular/forms';
 import { SkillBundleService } from '../../core/services/skill-bundle.service';
 import { NotificationService } from '../../core/services/notification.service';
 import { EmptyStateComponent } from '../../shared/components/empty-state.component';
+import { SkeletonComponent } from '../../shared/components/skeleton.component';
 import type { SkillBundle } from '../../core/models/skill-bundle.model';
 
 @Component({
     selector: 'app-skill-bundle-list',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FormsModule, EmptyStateComponent],
+    imports: [FormsModule, EmptyStateComponent, SkeletonComponent],
     template: `
         <div class="page">
             <div class="page__header">
@@ -81,7 +82,7 @@ import type { SkillBundle } from '../../core/models/skill-bundle.model';
             }
 
             @if (bundleService.loading()) {
-                <p class="loading">Loading bundles...</p>
+                <app-skeleton variant="card" [count]="3" />
             } @else if (filteredBundles().length === 0) {
                 <app-empty-state
                     icon="  [###]\n  [###]\n  [###]"

--- a/client/src/app/features/spending/spending.component.ts
+++ b/client/src/app/features/spending/spending.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../core/services/api.service';
 import { NotificationService } from '../../core/services/notification.service';
 import { firstValueFrom } from 'rxjs';
+import { SkeletonComponent } from '../../shared/components/skeleton.component';
 
 interface AgentSpendingInfo {
     agentId: string;
@@ -39,13 +40,13 @@ interface CreditTransaction {
 @Component({
     selector: 'app-spending',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FormsModule, DecimalPipe],
+    imports: [FormsModule, DecimalPipe, SkeletonComponent],
     template: `
         <div class="spending">
             <h2>Spending Controls</h2>
 
             @if (loading()) {
-                <p class="loading">Loading spending data...</p>
+                <app-skeleton variant="card" [count]="4" />
             } @else {
                 <!-- Per-Agent Spending Caps -->
                 <div class="spending__section">

--- a/client/src/app/features/wallets/wallet-viewer.component.ts
+++ b/client/src/app/features/wallets/wallet-viewer.component.ts
@@ -13,6 +13,7 @@ import { NotificationService } from '../../core/services/notification.service';
 import { WebSocketService } from '../../core/services/websocket.service';
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 import { EmptyStateComponent } from '../../shared/components/empty-state.component';
+import { SkeletonComponent } from '../../shared/components/skeleton.component';
 import { firstValueFrom } from 'rxjs';
 
 interface WalletSummary {
@@ -39,7 +40,7 @@ interface WalletMessage {
 @Component({
     selector: 'app-wallet-viewer',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [RelativeTimePipe, EmptyStateComponent],
+    imports: [RelativeTimePipe, EmptyStateComponent, SkeletonComponent],
     template: `
         <div class="page">
             <div class="page__header">
@@ -61,7 +62,7 @@ interface WalletMessage {
             </div>
 
             @if (loading()) {
-                <p class="loading">Loading wallets...</p>
+                <app-skeleton variant="card" [count]="3" />
             } @else if (filteredWallets().length === 0) {
                 <app-empty-state
                     icon="  [===]\n  | $ |\n  [===]"
@@ -127,7 +128,7 @@ interface WalletMessage {
                             @if (expandedWallet() === wallet.address) {
                                 <div class="wallet-card__messages">
                                     @if (messagesLoading()) {
-                                        <p class="loading">Loading messages...</p>
+                                        <app-skeleton variant="line" [count]="3" />
                                     } @else if (messages().length === 0) {
                                         <p class="empty">No messages found.</p>
                                     } @else {

--- a/client/src/app/features/webhooks/webhook-list.component.ts
+++ b/client/src/app/features/webhooks/webhook-list.component.ts
@@ -8,12 +8,13 @@ import { ProjectService } from '../../core/services/project.service';
 import { NotificationService } from '../../core/services/notification.service';
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 import { EmptyStateComponent } from '../../shared/components/empty-state.component';
+import { SkeletonComponent } from '../../shared/components/skeleton.component';
 import type { WebhookRegistration, WebhookDelivery, WebhookEventType, WebhookRegistrationStatus } from '../../core/models/webhook.model';
 
 @Component({
     selector: 'app-webhook-list',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [RouterLink, FormsModule, SlicePipe, RelativeTimePipe, EmptyStateComponent],
+    imports: [RouterLink, FormsModule, SlicePipe, RelativeTimePipe, EmptyStateComponent, SkeletonComponent],
     template: `
         <div class="webhooks">
             <div class="webhooks__header">
@@ -120,7 +121,7 @@ import type { WebhookRegistration, WebhookDelivery, WebhookEventType, WebhookReg
             </div>
 
             @if (webhookService.loading()) {
-                <p class="loading">Loading webhooks...</p>
+                <app-skeleton variant="table" [count]="4" />
             } @else if (filteredRegistrations().length === 0) {
                 <app-empty-state
                     icon="  {->}\n  |  |\n  {<-}"

--- a/client/src/app/features/work-tasks/work-task-list.component.ts
+++ b/client/src/app/features/work-tasks/work-task-list.component.ts
@@ -440,6 +440,19 @@ import { WorkTask } from '../../core/models/work-task.model';
             max-height: 120px;
             overflow-y: auto;
         }
+
+        @media (max-width: 768px) {
+            .tasks { padding: 1rem; }
+            .tasks__header { flex-direction: column; align-items: flex-start; gap: 0.5rem; }
+            .create-form__row { flex-direction: column; }
+            .form-select { min-width: 100%; }
+            .task-card__header { flex-wrap: wrap; gap: 0.35rem; }
+            .task-meta { flex-direction: column; gap: 0.25rem; }
+            .tasks__filters { flex-wrap: wrap; }
+        }
+        @media (max-width: 480px) {
+            .tasks { padding: 0.75rem; }
+        }
     `,
 })
 export class WorkTaskListComponent implements OnInit, OnDestroy {

--- a/client/src/app/features/workflows/workflow-list.component.ts
+++ b/client/src/app/features/workflows/workflow-list.component.ts
@@ -6,12 +6,13 @@ import { AgentService } from '../../core/services/agent.service';
 import { NotificationService } from '../../core/services/notification.service';
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 import { EmptyStateComponent } from '../../shared/components/empty-state.component';
+import { SkeletonComponent } from '../../shared/components/skeleton.component';
 import type { Workflow, WorkflowNode, WorkflowEdge, WorkflowNodeType, WorkflowRun } from '../../core/models/workflow.model';
 
 @Component({
     selector: 'app-workflow-list',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FormsModule, SlicePipe, RelativeTimePipe, EmptyStateComponent],
+    imports: [FormsModule, SlicePipe, RelativeTimePipe, EmptyStateComponent, SkeletonComponent],
     template: `
         <div class="page">
             <div class="page-header">
@@ -52,7 +53,7 @@ import type { Workflow, WorkflowNode, WorkflowEdge, WorkflowNodeType, WorkflowRu
             }
 
             @if (workflowService.loading()) {
-                <div class="loading">Loading workflows...</div>
+                <app-skeleton variant="table" [count]="4" />
             }
 
             <div class="filter-bar">

--- a/client/src/app/shared/components/sidebar.component.ts
+++ b/client/src/app/shared/components/sidebar.component.ts
@@ -140,12 +140,17 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
             border-right: 1px solid rgba(255, 255, 255, 0.04);
             display: flex;
             flex-direction: column;
-            overflow-y: auto;
+            overflow: hidden;
         }
         .sidebar__list {
             list-style: none;
             margin: 0;
             padding: 0;
+            flex: 1;
+            min-height: 0;
+            overflow-y: auto;
+            scrollbar-width: thin;
+            scrollbar-color: var(--border-bright) transparent;
         }
         .sidebar__link {
             display: block;

--- a/client/src/app/shared/components/status-badge.component.ts
+++ b/client/src/app/shared/components/status-badge.component.ts
@@ -33,6 +33,13 @@ import { Component, ChangeDetectionStrategy, input } from '@angular/core';
         .status-badge--stopped { background: var(--bg-raised); color: var(--text-tertiary); border-color: var(--border); }
         .status-badge--error { background: var(--accent-red-dim); color: var(--accent-red); border-color: rgba(255, 51, 85, 0.3); }
         .status-badge--queued { background: rgba(251, 191, 36, 0.1); color: var(--accent-yellow, #fbbf24); border-color: rgba(251, 191, 36, 0.3); }
+        .status-badge--completed { background: var(--accent-green-dim); color: var(--accent-green); border-color: rgba(0, 255, 136, 0.3); }
+        .status-badge--failed { background: var(--accent-red-dim); color: var(--accent-red); border-color: rgba(255, 51, 85, 0.3); }
+        .status-badge--pending { background: var(--accent-amber-dim); color: var(--accent-amber); border-color: rgba(255, 170, 0, 0.3); }
+        .status-badge--branching,
+        .status-badge--validating { background: var(--accent-cyan-dim, rgba(0, 200, 255, 0.1)); color: var(--accent-cyan, #00c8ff); border-color: rgba(0, 200, 255, 0.3); animation: statusPulse 1.5s ease-in-out infinite; }
+        .status-badge--cancelled { background: var(--bg-raised); color: var(--text-tertiary); border-color: var(--border); }
+        .status-badge--active { background: var(--accent-green-dim); color: var(--accent-green); border-color: rgba(0, 255, 136, 0.3); }
         .status-badge--connected { background: var(--accent-green-dim); color: var(--accent-green); border-color: rgba(0, 255, 136, 0.3); }
         .status-badge--disconnected { background: var(--accent-red-dim); color: var(--accent-red); border-color: rgba(255, 51, 85, 0.3); }
     `,

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -34,6 +34,7 @@
 :root {
     /* Backgrounds */
     --bg-deep: #0a0a12;
+    --bg-base: #0a0a12;
     --bg-surface: #0f1018;
     --bg-raised: #161822;
     --bg-input: #0c0d14;


### PR DESCRIPTION
## Summary
- **Sidebar scrolling**: Fixed overflow so nav items scroll independently while help/collapse buttons stay pinned at bottom
- **Agent health indicators**: Added green/yellow/red health dots to agent cards on dashboard and agent list based on activity recency (green = running, yellow = active <24h, red = inactive >24h)
- **Dark mode consistency**: Added missing `--bg-base` CSS variable; expanded `StatusBadgeComponent` with 7 additional status variants (completed, failed, pending, branching, validating, cancelled, active)
- **Loading states**: Replaced plain "Loading..." text with animated skeleton screens across 13 feature components (webhooks, workflows, analytics, spending, settings, MCP servers, mention-polling, skill-bundles, marketplace, reputation, wallets, personas, system-logs)
- **Mobile responsiveness**: Added responsive breakpoints to work task list (header, create form, filters, card layout stack on small screens)
- **Stats update**: Corrected drifted db_tables and migration_files counts in deep-dive.md

## Test plan
- [x] `bun x tsc` passes with no errors
- [x] `bun test` passes (1 pre-existing failure in tree-sitter wasm, unrelated)
- [x] `bun run spec:check` passes (168/168 specs, 0 failures)
- [x] Visual check: sidebar scrolls properly when many nav items overflow
- [x] Visual check: agent health dots appear correctly on dashboard and agent list
- [x] Visual check: skeleton loaders appear during data fetch on all updated views
- [x] Visual check: work task list is usable on mobile widths

Closes #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)