### PR TITLE
feat(scheduler): composable pipeline execution with shared context

### DIFF
--- a/server/__tests__/schedule-output-destinations.test.ts
+++ b/server/__tests__/schedule-output-destinations.test.ts
@@ -99,6 +99,8 @@ function makeSchedule(outputDestinations: ScheduleOutputDestination[] | null): A
         notifyAddress: null,
         triggerEvents: null,
         outputDestinations,
+        executionMode: 'independent',
+        pipelineSteps: null,
         lastRunAt: null,
         nextRunAt: null,
         createdAt: new Date().toISOString(),

--- a/server/__tests__/scheduler-flock-testing.test.ts
+++ b/server/__tests__/scheduler-flock-testing.test.ts
@@ -45,6 +45,8 @@ function createMockSchedule(overrides: Partial<AgentSchedule> = {}): AgentSchedu
         notifyAddress: null,
         triggerEvents: null,
         outputDestinations: null,
+        executionMode: 'independent',
+        pipelineSteps: null,
         lastRunAt: null,
         nextRunAt: null,
         createdAt: new Date().toISOString(),

--- a/server/__tests__/scheduler-pipeline.test.ts
+++ b/server/__tests__/scheduler-pipeline.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for composable schedule pipelines — sequential multi-action execution
+ * with shared context, conditional steps, and template resolution.
+ */
+import { describe, it, expect } from 'bun:test';
+import type {
+    PipelineContext,
+    PipelineStep,
+} from '../../shared/types';
+import {
+    shouldStepRun,
+    buildPipelineSummary,
+    listPipelineTemplates,
+    getPipelineTemplate,
+} from '../scheduler/pipeline';
+
+// ─── shouldStepRun ────────────────────────────────────────────────────────────
+
+describe('shouldStepRun', () => {
+    function makeCtx(overrides?: Partial<PipelineContext>): PipelineContext {
+        return {
+            stepResults: {},
+            summary: '',
+            hasFailure: false,
+            ...overrides,
+        };
+    }
+
+    it('always runs the first step regardless of condition', () => {
+        expect(shouldStepRun('on_success', makeCtx({ hasFailure: true }), 0)).toBe(true);
+        expect(shouldStepRun('on_failure', makeCtx({ hasFailure: false }), 0)).toBe(true);
+        expect(shouldStepRun('always', makeCtx(), 0)).toBe(true);
+    });
+
+    it('on_success runs when no prior failures', () => {
+        expect(shouldStepRun('on_success', makeCtx({ hasFailure: false }), 1)).toBe(true);
+    });
+
+    it('on_success skips when there is a prior failure', () => {
+        expect(shouldStepRun('on_success', makeCtx({ hasFailure: true }), 1)).toBe(false);
+    });
+
+    it('on_failure runs when there is a prior failure', () => {
+        expect(shouldStepRun('on_failure', makeCtx({ hasFailure: true }), 1)).toBe(true);
+    });
+
+    it('on_failure skips when no prior failures', () => {
+        expect(shouldStepRun('on_failure', makeCtx({ hasFailure: false }), 1)).toBe(false);
+    });
+
+    it('always runs regardless of failure state', () => {
+        expect(shouldStepRun('always', makeCtx({ hasFailure: true }), 2)).toBe(true);
+        expect(shouldStepRun('always', makeCtx({ hasFailure: false }), 2)).toBe(true);
+    });
+});
+
+// ─── buildPipelineSummary ────────────────────────────────────────────────────
+
+describe('buildPipelineSummary', () => {
+    it('builds summary from step results', () => {
+        const ctx: PipelineContext = {
+            stepResults: {
+                audit: {
+                    label: 'audit',
+                    actionType: 'dependency_audit',
+                    status: 'completed',
+                    result: 'Found 3 outdated dependencies',
+                    executionId: 'exec-1',
+                    durationMs: 1200,
+                },
+                fix: {
+                    label: 'fix',
+                    actionType: 'improvement_loop',
+                    status: 'failed',
+                    result: 'Timeout while processing',
+                    executionId: 'exec-2',
+                    durationMs: 5000,
+                },
+            },
+            summary: '',
+            hasFailure: true,
+        };
+
+        const summary = buildPipelineSummary(ctx);
+        expect(summary).toContain('[OK] audit');
+        expect(summary).toContain('dependency_audit');
+        expect(summary).toContain('1200ms');
+        expect(summary).toContain('[FAIL] fix');
+        expect(summary).toContain('improvement_loop');
+        expect(summary).toContain('5000ms');
+    });
+
+    it('marks skipped steps', () => {
+        const ctx: PipelineContext = {
+            stepResults: {
+                step1: {
+                    label: 'step1',
+                    actionType: 'review_prs',
+                    status: 'skipped',
+                    result: null,
+                    executionId: '',
+                    durationMs: 0,
+                },
+            },
+            summary: '',
+            hasFailure: false,
+        };
+        const summary = buildPipelineSummary(ctx);
+        expect(summary).toContain('[SKIP] step1');
+    });
+
+    it('returns empty string for empty context', () => {
+        const ctx: PipelineContext = { stepResults: {}, summary: '', hasFailure: false };
+        expect(buildPipelineSummary(ctx)).toBe('');
+    });
+});
+
+// ─── Pipeline Templates ──────────────────────────────────────────────────────
+
+describe('Pipeline Templates', () => {
+    it('listPipelineTemplates returns all built-in templates', () => {
+        const templates = listPipelineTemplates();
+        expect(templates.length).toBeGreaterThanOrEqual(3);
+        expect(templates.map((t) => t.id)).toContain('github-digest-discord');
+        expect(templates.map((t) => t.id)).toContain('audit-and-improve');
+        expect(templates.map((t) => t.id)).toContain('review-and-report');
+    });
+
+    it('getPipelineTemplate returns template by ID', () => {
+        const template = getPipelineTemplate('github-digest-discord');
+        expect(template).toBeDefined();
+        expect(template!.name).toBe('GitHub Digest + Discord Post');
+        expect(template!.steps.length).toBe(2);
+        expect(template!.steps[0].label).toBe('review');
+        expect(template!.steps[1].label).toBe('notify');
+    });
+
+    it('getPipelineTemplate returns undefined for unknown ID', () => {
+        expect(getPipelineTemplate('nonexistent')).toBeUndefined();
+    });
+
+    it('all templates have at least 2 steps with unique labels', () => {
+        const templates = listPipelineTemplates();
+        for (const tmpl of templates) {
+            expect(tmpl.steps.length).toBeGreaterThanOrEqual(2);
+            const labels = tmpl.steps.map((s) => s.label);
+            expect(new Set(labels).size).toBe(labels.length);
+        }
+    });
+
+    it('template steps have valid action types', () => {
+        const validTypes = [
+            'star_repo', 'fork_repo', 'review_prs', 'work_task', 'council_launch',
+            'send_message', 'github_suggest', 'codebase_review', 'dependency_audit',
+            'improvement_loop', 'memory_maintenance', 'reputation_attestation',
+            'outcome_analysis', 'daily_review', 'status_checkin', 'marketplace_billing',
+            'flock_testing', 'custom',
+        ];
+        const templates = listPipelineTemplates();
+        for (const tmpl of templates) {
+            for (const step of tmpl.steps) {
+                expect(validTypes).toContain(step.action.type);
+            }
+        }
+    });
+});
+
+// ─── PipelineStep Type Validation ────────────────────────────────────────────
+
+describe('PipelineStep structure', () => {
+    it('step with all optional fields', () => {
+        const step: PipelineStep = {
+            label: 'test-step',
+            action: { type: 'review_prs', repos: ['owner/repo'] },
+            condition: 'on_success',
+        };
+        expect(step.label).toBe('test-step');
+        expect(step.action.type).toBe('review_prs');
+        expect(step.condition).toBe('on_success');
+    });
+
+    it('step with minimal fields', () => {
+        const step: PipelineStep = {
+            label: 'minimal',
+            action: { type: 'status_checkin' },
+        };
+        expect(step.condition).toBeUndefined();
+    });
+});
+
+// ─── Context interpolation (tested indirectly through template patterns) ────
+
+describe('Template variable patterns', () => {
+    it('github-digest-discord template uses pipeline step reference', () => {
+        const template = getPipelineTemplate('github-digest-discord')!;
+        const notifyStep = template.steps.find((s) => s.label === 'notify');
+        expect(notifyStep).toBeDefined();
+        expect(notifyStep!.action.message).toContain('{{pipeline.steps.review.result}}');
+    });
+
+    it('audit-and-improve template uses pipeline step reference in prompt', () => {
+        const template = getPipelineTemplate('audit-and-improve')!;
+        const improveStep = template.steps.find((s) => s.label === 'improve');
+        expect(improveStep).toBeDefined();
+        expect(improveStep!.action.prompt).toContain('{{pipeline.steps.audit.result}}');
+    });
+});

--- a/server/db/migrations/078_baseline.ts
+++ b/server/db/migrations/078_baseline.ts
@@ -117,6 +117,8 @@ const TABLES = [
         notify_address     TEXT DEFAULT NULL,
         trigger_events     TEXT DEFAULT NULL,
         output_destinations TEXT DEFAULT NULL,
+        execution_mode     TEXT DEFAULT 'independent',
+        pipeline_steps     TEXT DEFAULT NULL,
         tenant_id          TEXT NOT NULL DEFAULT 'default',
         created_at         TEXT DEFAULT (datetime('now')),
         updated_at         TEXT DEFAULT (datetime('now'))

--- a/server/db/migrations/100_pipeline_schedules.ts
+++ b/server/db/migrations/100_pipeline_schedules.ts
@@ -1,0 +1,27 @@
+import { Database } from 'bun:sqlite';
+
+/**
+ * Migration 100: Add pipeline execution support to agent_schedules.
+ *
+ * Adds execution_mode ('independent' | 'pipeline') and pipeline_steps (JSON)
+ * columns for composable multi-action pipelines with shared context.
+ */
+
+function columnExists(db: Database, table: string, column: string): boolean {
+    const cols = db.query(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+    return cols.some((c) => c.name === column);
+}
+
+export function up(db: Database): void {
+    if (!columnExists(db, 'agent_schedules', 'execution_mode')) {
+        db.exec(`ALTER TABLE agent_schedules ADD COLUMN execution_mode TEXT DEFAULT 'independent'`);
+    }
+    if (!columnExists(db, 'agent_schedules', 'pipeline_steps')) {
+        db.exec(`ALTER TABLE agent_schedules ADD COLUMN pipeline_steps TEXT DEFAULT NULL`);
+    }
+}
+
+export function down(db: Database): void {
+    db.exec(`ALTER TABLE agent_schedules DROP COLUMN execution_mode`);
+    db.exec(`ALTER TABLE agent_schedules DROP COLUMN pipeline_steps`);
+}

--- a/server/db/schedules.ts
+++ b/server/db/schedules.ts
@@ -10,8 +10,10 @@ import type {
     ScheduleStatus,
     ScheduleExecutionStatus,
     ScheduleActionType,
+    ScheduleExecutionMode,
     ScheduleTriggerEvent,
     ScheduleOutputDestination,
+    PipelineStep,
 } from '../../shared/types';
 import { DEFAULT_TENANT_ID } from '../tenant/types';
 import { withTenantFilter, validateTenantOwnership } from '../tenant/db-filter';
@@ -35,6 +37,8 @@ function rowToSchedule(row: Record<string, unknown>): AgentSchedule {
         notifyAddress: row.notify_address as string | null,
         triggerEvents: row.trigger_events ? JSON.parse(row.trigger_events as string) as ScheduleTriggerEvent[] : null,
         outputDestinations: row.output_destinations ? JSON.parse(row.output_destinations as string) as ScheduleOutputDestination[] : null,
+        executionMode: (row.execution_mode as ScheduleExecutionMode) ?? 'independent',
+        pipelineSteps: row.pipeline_steps ? JSON.parse(row.pipeline_steps as string) as PipelineStep[] : null,
         lastRunAt: row.last_run_at as string | null,
         nextRunAt: row.next_run_at as string | null,
         createdAt: row.created_at as string,
@@ -70,8 +74,8 @@ export function createSchedule(db: Database, input: CreateScheduleInput, tenantI
     db.query(`
         INSERT INTO agent_schedules (id, agent_id, name, description, cron_expression, interval_ms,
             actions, approval_policy, max_executions, max_budget_per_run, notify_address, trigger_events,
-            output_destinations, tenant_id, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            output_destinations, execution_mode, pipeline_steps, tenant_id, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
         id,
         input.agentId,
@@ -86,6 +90,8 @@ export function createSchedule(db: Database, input: CreateScheduleInput, tenantI
         input.notifyAddress ?? null,
         input.triggerEvents ? JSON.stringify(input.triggerEvents) : null,
         input.outputDestinations ? JSON.stringify(input.outputDestinations) : null,
+        input.executionMode ?? 'independent',
+        input.pipelineSteps ? JSON.stringify(input.pipelineSteps) : null,
         tenantId,
         now,
         now,
@@ -151,6 +157,8 @@ export function updateSchedule(db: Database, id: string, input: UpdateScheduleIn
     if (input.notifyAddress !== undefined) { fields.push('notify_address = ?'); values.push(input.notifyAddress); }
     if (input.triggerEvents !== undefined) { fields.push('trigger_events = ?'); values.push(input.triggerEvents ? JSON.stringify(input.triggerEvents) : null); }
     if (input.outputDestinations !== undefined) { fields.push('output_destinations = ?'); values.push(input.outputDestinations ? JSON.stringify(input.outputDestinations) : null); }
+    if (input.executionMode !== undefined) { fields.push('execution_mode = ?'); values.push(input.executionMode); }
+    if (input.pipelineSteps !== undefined) { fields.push('pipeline_steps = ?'); values.push(input.pipelineSteps ? JSON.stringify(input.pipelineSteps) : null); }
 
     if (fields.length === 0) return existing;
 

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -46,7 +46,7 @@ type Domain = {
 
 // ── Schema version (bump when adding new migrations) ────────────────
 
-const SCHEMA_VERSION = 99;
+const SCHEMA_VERSION = 100;
 
 // ── Build MIGRATIONS dict ───────────────────────────────────────────
 

--- a/server/db/schema/schedules.ts
+++ b/server/db/schema/schedules.ts
@@ -19,6 +19,8 @@ export const tables: string[] = [
         notify_address     TEXT DEFAULT NULL,
         trigger_events     TEXT DEFAULT NULL,
         output_destinations TEXT DEFAULT NULL,
+        execution_mode     TEXT DEFAULT 'independent',
+        pipeline_steps     TEXT DEFAULT NULL,
         tenant_id          TEXT NOT NULL DEFAULT 'default',
         created_at         TEXT DEFAULT (datetime('now')),
         updated_at         TEXT DEFAULT (datetime('now'))

--- a/server/lib/validation.ts
+++ b/server/lib/validation.ts
@@ -502,6 +502,12 @@ const ScheduleOutputDestinationSchema = z.object({
     format: z.enum(['summary', 'full', 'on_error_only']).optional(),
 });
 
+const PipelineStepSchema = z.object({
+    label: z.string().min(1).max(64).regex(/^[a-zA-Z0-9_-]+$/, 'Label must be alphanumeric with dashes/underscores'),
+    action: ScheduleActionSchema,
+    condition: z.enum(['always', 'on_success', 'on_failure']).optional(),
+});
+
 export const CreateScheduleSchema = z.object({
     agentId: z.string().min(1, 'agentId is required'),
     name: z.string().min(1, 'name is required'),
@@ -515,9 +521,14 @@ export const CreateScheduleSchema = z.object({
     notifyAddress: z.string().min(1).optional(),
     triggerEvents: z.array(ScheduleTriggerEventSchema).optional(),
     outputDestinations: z.array(ScheduleOutputDestinationSchema).optional(),
+    executionMode: z.enum(['independent', 'pipeline']).optional(),
+    pipelineSteps: z.array(PipelineStepSchema).min(2, 'Pipeline requires at least 2 steps').max(10).optional(),
 }).refine(
     (d) => d.cronExpression || d.intervalMs || (d.triggerEvents && d.triggerEvents.length > 0),
     { message: 'Either cronExpression, intervalMs, or triggerEvents must be provided' },
+).refine(
+    (d) => d.executionMode !== 'pipeline' || (d.pipelineSteps && d.pipelineSteps.length >= 2),
+    { message: 'Pipeline mode requires pipelineSteps with at least 2 steps' },
 );
 
 export const UpdateScheduleSchema = z.object({
@@ -533,6 +544,8 @@ export const UpdateScheduleSchema = z.object({
     notifyAddress: z.string().min(1).nullable().optional(),
     triggerEvents: z.array(ScheduleTriggerEventSchema).nullable().optional(),
     outputDestinations: z.array(ScheduleOutputDestinationSchema).nullable().optional(),
+    executionMode: z.enum(['independent', 'pipeline']).optional(),
+    pipelineSteps: z.array(PipelineStepSchema).min(2).max(10).nullable().optional(),
 });
 
 export const ScheduleApprovalSchema = z.object({

--- a/server/routes/schedules.ts
+++ b/server/routes/schedules.ts
@@ -15,6 +15,7 @@ import {
     updateScheduleNextRun,
 } from '../db/schedules';
 import { getNextCronDate } from '../scheduler/cron-parser';
+import { listPipelineTemplates, getPipelineTemplate } from '../scheduler/pipeline';
 import { parseBodyOrThrow, ValidationError, CreateScheduleSchema, UpdateScheduleSchema, ScheduleApprovalSchema, BulkScheduleActionSchema } from '../lib/validation';
 import { isGitHubConfigured } from '../github/operations';
 import { json, handleRouteError, badRequest, safeNumParam } from '../lib/response';
@@ -175,6 +176,19 @@ export function handleScheduleRoutes(
         return json({ configured: isGitHubConfigured() });
     }
 
+    // List pipeline templates
+    if (url.pathname === '/api/schedules/pipeline-templates' && req.method === 'GET') {
+        return json(listPipelineTemplates());
+    }
+
+    // Get single pipeline template
+    const templateMatch = url.pathname.match(/^\/api\/schedules\/pipeline-templates\/([^/]+)$/);
+    if (templateMatch && req.method === 'GET') {
+        const template = getPipelineTemplate(templateMatch[1]);
+        if (!template) return json({ error: 'Template not found' }, 404);
+        return json(template);
+    }
+
     return null;
 }
 
@@ -215,6 +229,12 @@ async function handleCreateSchedule(req: Request, db: Database, tenantId: string
 
         const injectionError = scanScheduleActions(data.actions);
         if (injectionError) return badRequest(injectionError);
+
+        // Also scan pipeline step actions if present
+        if (data.pipelineSteps?.length) {
+            const pipelineInjectionError = scanScheduleActions(data.pipelineSteps.map((s: { action: { prompt?: string; description?: string; message?: string } }) => s.action));
+            if (pipelineInjectionError) return badRequest(pipelineInjectionError);
+        }
 
         const schedule = createSchedule(db, data, tenantId);
 

--- a/server/scheduler/pipeline.ts
+++ b/server/scheduler/pipeline.ts
@@ -1,0 +1,230 @@
+/**
+ * Pipeline execution engine — runs schedule actions sequentially with shared context.
+ *
+ * Each pipeline step executes one action, captures its result, and passes context
+ * to subsequent steps. Steps can be conditional on prior step outcomes.
+ */
+import type {
+    AgentSchedule,
+    PipelineStep,
+    PipelineContext,
+    PipelineStepCondition,
+    SchedulePipelineTemplate,
+} from '../../shared/types';
+import {
+    createExecution,
+    getExecution,
+} from '../db/schedules';
+import { createLogger } from '../lib/logger';
+import { recordAudit } from '../db/audit';
+import type { HandlerContext } from './handlers/types';
+import { runAction, type RunActionDeps } from './execution';
+
+const log = createLogger('Pipeline');
+
+/** Check whether a step should execute based on its condition and prior context. */
+export function shouldStepRun(
+    condition: PipelineStepCondition,
+    ctx: PipelineContext,
+    stepIndex: number,
+): boolean {
+    // First step always runs regardless of condition.
+    if (stepIndex === 0) return true;
+    switch (condition) {
+        case 'always': return true;
+        case 'on_success': return !ctx.hasFailure;
+        case 'on_failure': return ctx.hasFailure;
+        default: return true;
+    }
+}
+
+/** Build a summary string from pipeline step results. */
+export function buildPipelineSummary(ctx: PipelineContext): string {
+    const lines: string[] = [];
+    for (const [label, step] of Object.entries(ctx.stepResults)) {
+        const icon = step.status === 'completed' ? '[OK]' : step.status === 'failed' ? '[FAIL]' : '[SKIP]';
+        const duration = `${step.durationMs}ms`;
+        const snippet = step.result ? step.result.slice(0, 120) : '';
+        lines.push(`${icon} ${label} (${step.actionType}, ${duration}): ${snippet}`);
+    }
+    return lines.join('\n');
+}
+
+/**
+ * Execute a pipeline: run steps sequentially with shared context.
+ *
+ * Returns a PipelineContext with all step results and an aggregated summary.
+ * Each step creates its own execution record, and results are passed forward.
+ */
+export async function executePipeline(
+    deps: RunActionDeps,
+    hctx: HandlerContext,
+    schedule: AgentSchedule,
+    steps: PipelineStep[],
+    emitFn: (event: { type: string; data: unknown }) => void,
+): Promise<PipelineContext> {
+    const ctx: PipelineContext = {
+        stepResults: {},
+        summary: '',
+        hasFailure: false,
+    };
+
+    for (let i = 0; i < steps.length; i++) {
+        const step = steps[i];
+        const condition = step.condition ?? 'on_success';
+
+        if (!shouldStepRun(condition, ctx, i)) {
+            log.debug('Pipeline step skipped by condition', {
+                scheduleId: schedule.id, label: step.label, condition, hasFailure: ctx.hasFailure,
+            });
+            ctx.stepResults[step.label] = {
+                label: step.label,
+                actionType: step.action.type,
+                status: 'skipped',
+                result: null,
+                executionId: '',
+                durationMs: 0,
+            };
+            continue;
+        }
+
+        // Inject prior context into the action's message/prompt if it references {{pipeline.summary}}
+        const action = { ...step.action };
+        if (action.message) {
+            action.message = interpolatePipelineVars(action.message, ctx);
+        }
+        if (action.prompt) {
+            action.prompt = interpolatePipelineVars(action.prompt, ctx);
+        }
+
+        const execution = createExecution(
+            deps.db, schedule.id, schedule.agentId,
+            action.type, action as unknown as Record<string, unknown>,
+            { pipelineStep: step.label, stepIndex: i, totalSteps: steps.length },
+        );
+        emitFn({ type: 'schedule_execution_update', data: execution });
+        recordAudit(deps.db, 'schedule_execute', schedule.agentId,
+            'schedule_execution', execution.id,
+            `Pipeline step ${i + 1}/${steps.length} (${step.label}): ${action.type} for "${schedule.name}"`);
+
+        const startTime = Date.now();
+
+        // runAction handles dispatch, error handling, lock cleanup, and notifications.
+        await runAction(deps, hctx, execution.id, schedule, action);
+
+        const durationMs = Date.now() - startTime;
+        const updated = getExecution(deps.db, execution.id);
+        const status = updated?.status === 'completed' ? 'completed' : 'failed';
+        const result = updated?.result ?? null;
+
+        if (status === 'failed') {
+            ctx.hasFailure = true;
+        }
+
+        ctx.stepResults[step.label] = {
+            label: step.label,
+            actionType: action.type,
+            status,
+            result,
+            executionId: execution.id,
+            durationMs,
+        };
+    }
+
+    ctx.summary = buildPipelineSummary(ctx);
+    return ctx;
+}
+
+/** Replace pipeline template variables in a string. */
+function interpolatePipelineVars(template: string, ctx: PipelineContext): string {
+    let result = template;
+    result = result.replace(/\{\{pipeline\.summary\}\}/g, ctx.summary || '(no prior results)');
+    result = result.replace(/\{\{pipeline\.hasFailure\}\}/g, String(ctx.hasFailure));
+
+    // Replace step-specific references: {{pipeline.steps.<label>.result}}
+    const stepRefPattern = /\{\{pipeline\.steps\.(\w+)\.result\}\}/g;
+    result = result.replace(stepRefPattern, (_match, label) => {
+        const stepResult = ctx.stepResults[label];
+        return stepResult?.result ?? `(no result for ${label})`;
+    });
+
+    return result;
+}
+
+// ─── Pipeline Templates ─────────────────────────────────────────────────────
+
+export const PIPELINE_TEMPLATES: SchedulePipelineTemplate[] = [
+    {
+        id: 'github-digest-discord',
+        name: 'GitHub Digest + Discord Post',
+        description: 'Review open PRs across repos, then post a summary to Discord.',
+        steps: [
+            {
+                label: 'review',
+                action: { type: 'review_prs', description: 'Review open PRs' },
+                condition: 'always',
+            },
+            {
+                label: 'notify',
+                action: {
+                    type: 'send_message',
+                    message: 'PR Review Summary:\n{{pipeline.steps.review.result}}',
+                    description: 'Post review summary to Discord',
+                },
+                condition: 'on_success',
+            },
+        ],
+    },
+    {
+        id: 'audit-and-improve',
+        name: 'Dependency Audit + Improvement Loop',
+        description: 'Run a dependency audit, then trigger improvement tasks for any issues found.',
+        steps: [
+            {
+                label: 'audit',
+                action: { type: 'dependency_audit', description: 'Scan dependencies for issues' },
+                condition: 'always',
+            },
+            {
+                label: 'improve',
+                action: {
+                    type: 'improvement_loop',
+                    prompt: 'Address findings from dependency audit:\n{{pipeline.steps.audit.result}}',
+                    maxImprovementTasks: 3,
+                    description: 'Fix audit findings',
+                },
+                condition: 'on_success',
+            },
+        ],
+    },
+    {
+        id: 'review-and-report',
+        name: 'Codebase Review + Status Report',
+        description: 'Review codebase health, then send a status checkin with findings.',
+        steps: [
+            {
+                label: 'review',
+                action: { type: 'codebase_review', description: 'Review codebase health' },
+                condition: 'always',
+            },
+            {
+                label: 'status',
+                action: {
+                    type: 'status_checkin',
+                    description: 'Post status with review findings',
+                },
+                condition: 'always',
+            },
+        ],
+    },
+];
+
+/** Look up a pipeline template by ID. */
+export function getPipelineTemplate(templateId: string): SchedulePipelineTemplate | undefined {
+    return PIPELINE_TEMPLATES.find((t) => t.id === templateId);
+}
+
+/** List all available pipeline templates. */
+export function listPipelineTemplates(): SchedulePipelineTemplate[] {
+    return [...PIPELINE_TEMPLATES];
+}

--- a/server/scheduler/service.ts
+++ b/server/scheduler/service.ts
@@ -43,6 +43,7 @@ import { SystemStateDetector, type SystemStateResult, type SystemStateConfig } f
 import { getAllRules } from './priority-rules';
 import type { HandlerContext } from './handlers/types';
 import { runAction, type RunActionDeps } from './execution';
+import { executePipeline } from './pipeline';
 import {
     shouldSkipByHealthGate,
     handleApprovalIfNeeded,
@@ -262,6 +263,19 @@ export class SchedulerService {
             const updatedSchedule = getSchedule(this.db, schedule.id);
             if (updatedSchedule) this.emit({ type: 'schedule_update', data: updatedSchedule });
 
+            // Pipeline mode: run steps sequentially with shared context.
+            if (schedule.executionMode === 'pipeline' && schedule.pipelineSteps?.length) {
+                this.notifyScheduleEvent(schedule, 'started',
+                    `Pipeline "${schedule.name}" started (${schedule.pipelineSteps.length} steps)`);
+                const emitFn = (e: { type: string; data: unknown }) => this.emit(e);
+                executePipeline(
+                    this.buildRunActionDeps(), this.buildHandlerContext(),
+                    schedule, schedule.pipelineSteps, emitFn,
+                );
+                return;
+            }
+
+            // Independent mode (default): run actions independently.
             for (const action of schedule.actions) {
                 if (this.runningExecutions.size >= MAX_CONCURRENT_EXECUTIONS) break;
 

--- a/shared/types/schedules.ts
+++ b/shared/types/schedules.ts
@@ -43,6 +43,52 @@ export interface ScheduleAction {
     focusArea?: string;
 }
 
+// ─── Pipeline Types ─────────────────────────────────────────────────────────
+
+/** Execution mode for schedule actions: independent (default) or pipeline. */
+export type ScheduleExecutionMode = 'independent' | 'pipeline';
+
+/** Condition for whether a pipeline step should run based on previous step outcome. */
+export type PipelineStepCondition = 'always' | 'on_success' | 'on_failure';
+
+/** A single step in a pipeline, wrapping an action with pipeline-specific metadata. */
+export interface PipelineStep {
+    /** Unique label for this step (used as key in pipeline context). */
+    label: string;
+    /** The action to execute. */
+    action: ScheduleAction;
+    /** When this step should run relative to the previous step. Defaults to 'on_success'. */
+    condition?: PipelineStepCondition;
+}
+
+/** Shared context passed between pipeline steps during sequential execution. */
+export interface PipelineContext {
+    /** Results keyed by step label. */
+    stepResults: Record<string, PipelineStepResult>;
+    /** Accumulated summary across all steps. */
+    summary: string;
+    /** Whether any step has failed. */
+    hasFailure: boolean;
+}
+
+export interface PipelineStepResult {
+    label: string;
+    actionType: ScheduleActionType;
+    status: 'completed' | 'failed' | 'skipped';
+    result: string | null;
+    executionId: string;
+    durationMs: number;
+}
+
+/** Pre-defined pipeline template for common automation patterns. */
+export interface SchedulePipelineTemplate {
+    id: string;
+    name: string;
+    description: string;
+    steps: PipelineStep[];
+    outputDestinations?: ScheduleOutputDestination[];
+}
+
 export type ScheduleOutputDestinationType = 'discord_channel' | 'algochat_agent' | 'algochat_address';
 export type ScheduleOutputFormat = 'summary' | 'full' | 'on_error_only';
 
@@ -68,6 +114,10 @@ export interface AgentSchedule {
     notifyAddress: string | null;
     triggerEvents: ScheduleTriggerEvent[] | null;
     outputDestinations: ScheduleOutputDestination[] | null;
+    /** Execution mode: 'independent' runs actions in parallel, 'pipeline' runs steps sequentially with shared context. */
+    executionMode: ScheduleExecutionMode;
+    /** Pipeline steps — used when executionMode is 'pipeline'. */
+    pipelineSteps: PipelineStep[] | null;
     lastRunAt: string | null;
     nextRunAt: string | null;
     createdAt: string;
@@ -105,6 +155,8 @@ export interface CreateScheduleInput {
     notifyAddress?: string;
     triggerEvents?: ScheduleTriggerEvent[];
     outputDestinations?: ScheduleOutputDestination[];
+    executionMode?: ScheduleExecutionMode;
+    pipelineSteps?: PipelineStep[];
 }
 
 export interface UpdateScheduleInput {
@@ -120,4 +172,6 @@ export interface UpdateScheduleInput {
     notifyAddress?: string | null;
     triggerEvents?: ScheduleTriggerEvent[] | null;
     outputDestinations?: ScheduleOutputDestination[] | null;
+    executionMode?: ScheduleExecutionMode;
+    pipelineSteps?: PipelineStep[] | null;
 }


### PR DESCRIPTION
## Summary
- Adds multi-action **pipeline execution mode** to the scheduler, where actions run sequentially with shared context between steps
- Each pipeline step can be conditional (`on_success`, `on_failure`, `always`) and reference prior step results via template variables (`{{pipeline.steps.<label>.result}}`)
- Includes 3 built-in pipeline templates (GitHub digest + Discord post, dependency audit + improvement loop, codebase review + status report)
- New API endpoints: `GET /api/schedules/pipeline-templates` and `GET /api/schedules/pipeline-templates/:id`
- Full Zod validation, DB migration (100), schema updates, and 18 new unit tests

## Key files
- `shared/types/schedules.ts` — pipeline type definitions (PipelineStep, PipelineContext, etc.)
- `server/scheduler/pipeline.ts` — pipeline execution engine and templates
- `server/scheduler/service.ts` — schedule execution mode branching
- `server/db/migrations/100_pipeline_schedules.ts` — migration for new columns
- `server/__tests__/scheduler-pipeline.test.ts` — pipeline unit tests

## Test plan
- [x] `bun x tsc` passes with zero errors
- [x] `bun run spec:check` passes (168 specs, 0 failures)
- [x] 18 new pipeline tests all pass
- [x] Full test suite: 8395+ pass, no new failures (1 pre-existing AstParser failure)
- [ ] Manual test: create a pipeline schedule via API and verify sequential execution
- [ ] Verify pipeline template variable interpolation with live actions

Closes #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)