### PR TITLE
spec: document exports for discord rate-limit helpers

### DIFF
--- a/specs/discord/bridge.spec.md
+++ b/specs/discord/bridge.spec.md
@@ -1,6 +1,6 @@
 ---
 module: discord-bridge
-version: 18
+version: 19
 status: active
 files:
   - server/discord/bridge.ts
@@ -165,6 +165,8 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | `extractMentionsFromEmbed` | `(embed)` | `string \| undefined` | Extract Discord mentions from embed description for top-level content field notifications |
 | `sendEmbedWithFiles` | `(delivery, botToken, channelId, embed, files)` | `Promise<string \| null>` | Send an embed with file attachments via multipart/form-data |
 | `sendMessageWithFiles` | `(delivery, botToken, channelId, content, files)` | `Promise<string \| null>` | Send a text message with file attachments via multipart/form-data |
+| `getRateLimitWaitMs` | `()` | `number` | Check if globally rate-limited; returns remaining wait ms or 0 |
+| `discordFetch` | `(url: string, init: RequestInit)` | `Promise<Response>` | Wrapper for Discord API fetch that handles 429 rate limits globally, preventing Cloudflare IP bans |
 
 ### Exported Functions (from message-handler.ts)
 


### PR DESCRIPTION
## Summary
- Add `getRateLimitWaitMs` and `discordFetch` to the Discord bridge spec's embeds.ts exports table
- These were introduced in #1373 (Cloudflare IP ban prevention) but not added to the spec
- Reduces `spec:check` warnings from 3 → 0

Ref #591

## Validation
- `bun run spec:check` → 173 passed, 0 warnings, 0 failed
- `bun x tsc --noEmit --skipLibCheck` → clean

## Test plan
- [x] `bun run spec:check` passes with 0 warnings
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)