### PR TITLE
fix(e2e): add E2E_ prefix to all test data and clean up afterAll hooks

### DIFF
--- a/e2e/agents.spec.ts
+++ b/e2e/agents.spec.ts
@@ -171,7 +171,7 @@ test.describe('Agents', () => {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-                name: `CRUD Agent ${Date.now()}`,
+                name: `E2E_CRUD Agent ${Date.now()}`,
                 model: 'claude-sonnet-4-20250514',
             }),
         });
@@ -186,7 +186,7 @@ test.describe('Agents', () => {
         const updateRes = await authedFetch(`${BASE_URL}/api/agents/${agent.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'Updated CRUD Agent' }),
+            body: JSON.stringify({ name: 'E2E_Updated CRUD Agent' }),
         });
         expect(updateRes.ok).toBe(true);
 

--- a/e2e/api-coverage.spec.ts
+++ b/e2e/api-coverage.spec.ts
@@ -52,7 +52,7 @@ test.describe('API Coverage — Previously Untested Endpoints', () => {
         const project = await api.seedProject('Update Session Project');
         const agent = await api.seedAgent('Update Session Agent');
         const session = await api.seedSession(project.id, agent.id);
-        const newName = `Updated ${Date.now()}`;
+        const newName = `E2E_Updated ${Date.now()}`;
 
         const res = await authedFetch(`${BASE_URL}/api/sessions/${session.id}`, {
             method: 'PUT',

--- a/e2e/approval.spec.ts
+++ b/e2e/approval.spec.ts
@@ -28,7 +28,7 @@ test.describe.serial('Approval Dialog Critical Path', () => {
         const projectRes = await authedFetch(`${BASE_URL}/api/projects`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'Approval E2E Project', workingDir: '/tmp' }),
+            body: JSON.stringify({ name: 'E2E_Approval Project', workingDir: '/tmp' }),
         });
         expect(projectRes.ok).toBe(true);
         const project = await projectRes.json();
@@ -38,7 +38,7 @@ test.describe.serial('Approval Dialog Critical Path', () => {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-                name: 'Approval E2E Agent',
+                name: 'E2E_Approval Agent',
                 model: 'claude-sonnet-4-20250514',
             }),
         });
@@ -52,13 +52,26 @@ test.describe.serial('Approval Dialog Critical Path', () => {
             body: JSON.stringify({
                 projectId,
                 agentId,
-                name: 'Approval E2E Session',
+                name: 'E2E_Approval Session',
                 initialPrompt: 'Test prompt for approval flow',
             }),
         });
         expect(sessionRes.ok).toBe(true);
         const session = await sessionRes.json();
         sessionId = session.id;
+    });
+
+    test.afterAll(async () => {
+        // Clean up all data created in beforeAll (reverse dependency order)
+        const del = (path: string) =>
+            fetch(`${BASE_URL}${path}`, {
+                method: 'DELETE',
+                headers: { Authorization: `Bearer ${process.env.API_KEY || 'e2e-test-key'}` },
+            }).catch(() => {});
+
+        if (sessionId) await del(`/api/sessions/${sessionId}`);
+        if (agentId) await del(`/api/agents/${agentId}`);
+        if (projectId) await del(`/api/projects/${projectId}`);
     });
 
     /**

--- a/e2e/council-flow.spec.ts
+++ b/e2e/council-flow.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, gotoWithRetry , authedFetch } from './fixtures';
+import { test, expect, gotoWithRetry , authedFetch, e2eName } from './fixtures';
 
 const BASE_URL = `http://localhost:${process.env.E2E_PORT || '3001'}`;
 
@@ -31,7 +31,7 @@ test.describe.serial('Council Deliberation Flow', () => {
         const projectRes = await authedFetch(`${BASE_URL}/api/projects`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'Council Flow Project', workingDir: '/tmp' }),
+            body: JSON.stringify({ name: e2eName('Council Flow Project'), workingDir: '/tmp' }),
         });
         if (!projectRes.ok) throw new Error(`seedProject failed: ${projectRes.status} ${await projectRes.text()}`);
         const project = await projectRes.json();
@@ -40,7 +40,7 @@ test.describe.serial('Council Deliberation Flow', () => {
         const agent1Res = await authedFetch(`${BASE_URL}/api/agents`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'Flow Agent Alpha', model: 'claude-sonnet-4-20250514' }),
+            body: JSON.stringify({ name: e2eName('Flow Agent Alpha'), model: 'claude-sonnet-4-20250514' }),
         });
         if (!agent1Res.ok) throw new Error(`seedAgent1 failed: ${agent1Res.status} ${await agent1Res.text()}`);
         const agent1 = await agent1Res.json();
@@ -49,7 +49,7 @@ test.describe.serial('Council Deliberation Flow', () => {
         const agent2Res = await authedFetch(`${BASE_URL}/api/agents`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'Flow Agent Beta', model: 'claude-sonnet-4-20250514' }),
+            body: JSON.stringify({ name: e2eName('Flow Agent Beta'), model: 'claude-sonnet-4-20250514' }),
         });
         if (!agent2Res.ok) throw new Error(`seedAgent2 failed: ${agent2Res.status} ${await agent2Res.text()}`);
         const agent2 = await agent2Res.json();
@@ -60,7 +60,7 @@ test.describe.serial('Council Deliberation Flow', () => {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-                name: 'Flow Council With Chairman',
+                name: e2eName('Flow Council With Chairman'),
                 agentIds: [agent1Id, agent2Id],
                 chairmanAgentId: agent1Id,
             }),
@@ -74,7 +74,7 @@ test.describe.serial('Council Deliberation Flow', () => {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-                name: 'Flow Council No Chairman',
+                name: e2eName('Flow Council No Chairman'),
                 agentIds: [agent1Id, agent2Id],
             }),
         });
@@ -84,6 +84,21 @@ test.describe.serial('Council Deliberation Flow', () => {
 
         await page.close();
         await ctx.close();
+    });
+
+    test.afterAll(async () => {
+        // Clean up all data created in beforeAll (reverse dependency order)
+        const del = (path: string) =>
+            fetch(`${BASE_URL}${path}`, {
+                method: 'DELETE',
+                headers: { Authorization: `Bearer ${process.env.API_KEY || 'e2e-test-key'}` },
+            }).catch(() => {});
+
+        if (councilWithChairmanId) await del(`/api/councils/${councilWithChairmanId}`);
+        if (councilNoChairmanId) await del(`/api/councils/${councilNoChairmanId}`);
+        if (agent1Id) await del(`/api/agents/${agent1Id}`);
+        if (agent2Id) await del(`/api/agents/${agent2Id}`);
+        if (projectId) await del(`/api/projects/${projectId}`);
     });
 
     test('launch council and verify responding stage', async ({ page, api }) => {

--- a/e2e/councils.spec.ts
+++ b/e2e/councils.spec.ts
@@ -31,7 +31,7 @@ test.describe('Councils', () => {
         await expect(page.locator('h2')).toHaveText('New Council');
 
         // Fill form
-        await page.locator('#name').fill('Integration Council');
+        await page.locator('#name').fill('E2E_E2E_Integration Council');
         await page.locator('#description').fill('A council for testing');
 
         // Select agents via checkboxes
@@ -43,11 +43,11 @@ test.describe('Councils', () => {
 
         // Should redirect to council detail
         await page.waitForURL(/\/sessions\/councils\//);
-        await expect(page.locator('h2')).toHaveText('Integration Council');
+        await expect(page.locator('h2')).toHaveText('E2E_Integration Council');
 
         // Navigate to list and verify
         await gotoWithRetry(page, '/sessions/councils');
-        await expect(page.locator('text=Integration Council').first()).toBeVisible();
+        await expect(page.locator('text=E2E_Integration Council').first()).toBeVisible();
     });
 
     test('council detail shows members and launch form', async ({ page, api }) => {
@@ -58,7 +58,7 @@ test.describe('Councils', () => {
         await gotoWithRetry(page, `/sessions/councils/${council.id}`);
 
         // Verify council info
-        await expect(page.locator('h2')).toHaveText('Detail Council');
+        await expect(page.locator('h2')).toHaveText('E2E_Detail Council');
         await expect(page.locator('text=2 agents')).toBeVisible();
         await expect(page.locator('text=Detail Agent 1').first()).toBeVisible();
 
@@ -79,18 +79,18 @@ test.describe('Councils', () => {
         await page.waitForURL(/\/sessions\/councils\/.*\/edit/);
 
         // Wait for form to load existing data (name input should have existing value)
-        await expect(page.locator('#name')).toHaveValue('Before Edit');
+        await expect(page.locator('#name')).toHaveValue('E2E_Before Edit');
 
         // Wait for agent checkboxes to appear and be checked
         await expect(page.locator('input[type="checkbox"]:checked')).toHaveCount(1);
 
         // Change name
-        await page.locator('#name').fill('After Edit');
+        await page.locator('#name').fill('E2E_After Edit');
         await page.locator('form button[type="submit"]').click();
 
         // Should redirect back to detail
         await page.waitForURL(/\/sessions\/councils\/[^/]+$/);
-        await expect(page.locator('h2')).toHaveText('After Edit');
+        await expect(page.locator('h2')).toHaveText('E2E_After Edit');
     });
 
     test('delete council removes it from list', async ({ page, api }) => {
@@ -123,7 +123,7 @@ test.describe('Councils', () => {
 
         // Create
         const council = await api.seedCouncil([agent1.id, agent2.id], 'API Council', agent1.id);
-        expect(council.name).toBe('API Council');
+        expect(council.name).toBe('E2E_API Council');
         expect(council.agentIds).toHaveLength(2);
         expect(council.chairmanAgentId).toBe(agent1.id);
 
@@ -131,17 +131,17 @@ test.describe('Councils', () => {
         const getRes = await authedFetch(`${BASE_URL}/api/councils/${council.id}`);
         expect(getRes.ok).toBe(true);
         const fetched = await getRes.json();
-        expect(fetched.name).toBe('API Council');
+        expect(fetched.name).toBe('E2E_API Council');
 
         // Update
         const updateRes = await authedFetch(`${BASE_URL}/api/councils/${council.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'Updated Council', agentIds: [agent1.id] }),
+            body: JSON.stringify({ name: 'E2E_Updated Council', agentIds: [agent1.id] }),
         });
         expect(updateRes.ok).toBe(true);
         const updated = await updateRes.json();
-        expect(updated.name).toBe('Updated Council');
+        expect(updated.name).toBe('E2E_Updated Council');
         expect(updated.agentIds).toHaveLength(1);
 
         // Delete
@@ -221,7 +221,7 @@ test.describe('Councils', () => {
         const res = await authedFetch(`${BASE_URL}/api/councils`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'Bad Council', agentIds: [] }),
+            body: JSON.stringify({ name: 'E2E_Bad Council', agentIds: [] }),
         });
         expect(res.status).toBe(400);
         const data = await res.json();

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -5,6 +5,9 @@ import { randomBytes } from 'node:crypto';
 const BASE_URL = `http://localhost:${process.env.E2E_PORT || '3001'}`;
 const E2E_API_KEY = process.env.API_KEY || 'e2e-test-key';
 
+/** Prefix all test entity names so they're easily identifiable and cleanable. */
+const e2eName = (name: string) => name.startsWith('E2E_') ? name : `E2E_${name}`;
+
 /**
  * Navigate to a page, retrying on 429 rate-limit responses or empty lazy-load.
  * Pass an optional `isRendered` callback to customise the content check;
@@ -101,13 +104,14 @@ export const test = base.extend<{ api: ApiHelpers }>({
         const createdSkillBundleIds: string[] = [];
         const createdMcpServerIds: string[] = [];
         const createdListingIds: string[] = [];
+        const createdPersonaIds: string[] = [];
 
         const helpers: ApiHelpers = {
-            async seedProject(name = 'E2E Test Project') {
+            async seedProject(name = 'Test Project') {
                 const res = await fetchWithRetry(`${BASE_URL}/api/projects`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ name, workingDir: '/tmp' }),
+                    body: JSON.stringify({ name: e2eName(name), workingDir: '/tmp' }),
                 });
                 if (!res.ok) {
                     const body = await res.text().catch(() => '');
@@ -118,12 +122,12 @@ export const test = base.extend<{ api: ApiHelpers }>({
                 return project;
             },
 
-            async seedAgent(name = 'E2E Test Agent') {
+            async seedAgent(name = 'Test Agent') {
                 const res = await fetchWithRetry(`${BASE_URL}/api/agents`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        name,
+                        name: e2eName(name),
                         model: 'claude-sonnet-4-20250514',
                         algochatEnabled: true,
                     }),
@@ -137,11 +141,11 @@ export const test = base.extend<{ api: ApiHelpers }>({
                 return agent;
             },
 
-            async seedCouncil(agentIds: string[], name = 'E2E Test Council', chairmanAgentId?: string) {
+            async seedCouncil(agentIds: string[], name = 'Test Council', chairmanAgentId?: string) {
                 const res = await fetchWithRetry(`${BASE_URL}/api/councils`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ name, agentIds, chairmanAgentId }),
+                    body: JSON.stringify({ name: e2eName(name), agentIds, chairmanAgentId }),
                 });
                 if (!res.ok) {
                     const body = await res.text().catch(() => '');
@@ -152,13 +156,14 @@ export const test = base.extend<{ api: ApiHelpers }>({
                 return council;
             },
 
-            async seedPersona(agentId: string, data: Record<string, unknown> = {}) {
+            async seedPersona(agentId: string, _data: Record<string, unknown> = {}) {
+                const data = _data.name ? { ..._data, name: e2eName(_data.name as string) } : _data;
                 // Create a standalone persona
                 const createRes = await fetchWithRetry(`${BASE_URL}/api/personas`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        name: `e2e-persona-${Date.now()}`,
+                        name: e2eName(`persona-${Date.now()}`),
                         archetype: 'professional',
                         traits: ['helpful', 'concise'],
                         voiceGuidelines: 'Be direct and clear.',
@@ -172,6 +177,7 @@ export const test = base.extend<{ api: ApiHelpers }>({
                     throw new Error(`seedPersona create failed: ${createRes.status} ${createRes.statusText} — ${body}`);
                 }
                 const persona = await createRes.json();
+                createdPersonaIds.push(persona.id);
 
                 // Assign it to the agent
                 const assignRes = await fetchWithRetry(`${BASE_URL}/api/agents/${agentId}/personas`, {
@@ -187,15 +193,16 @@ export const test = base.extend<{ api: ApiHelpers }>({
             },
 
             async seedSkillBundle(data: Record<string, unknown> = {}) {
+                const prefixed = data.name ? { ...data, name: e2eName(data.name as string) } : data;
                 const res = await fetchWithRetry(`${BASE_URL}/api/skill-bundles`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        name: `E2E Test Bundle ${Date.now()}-${randomBytes(3).toString('hex').slice(0, 4)}`,
+                        name: e2eName(`Test Bundle ${Date.now()}-${randomBytes(3).toString('hex').slice(0, 4)}`),
                         description: 'Bundle for e2e testing',
                         tools: ['Read', 'Write'],
                         promptAdditions: 'Test prompt addition',
-                        ...data,
+                        ...prefixed,
                     }),
                 });
                 if (!res.ok) {
@@ -207,7 +214,8 @@ export const test = base.extend<{ api: ApiHelpers }>({
                 return bundle;
             },
 
-            async seedMarketplaceListing(agentId: string, data: Record<string, unknown> = {}) {
+            async seedMarketplaceListing(agentId: string, _data: Record<string, unknown> = {}) {
+                const data = _data.name ? { ..._data, name: e2eName(_data.name as string) } : _data;
                 // Ensure the agent meets the verification gate for publishing
                 await fetchWithRetry(`${BASE_URL}/api/reputation/identity/${agentId}`, {
                     method: 'PUT',
@@ -220,7 +228,7 @@ export const test = base.extend<{ api: ApiHelpers }>({
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         agentId,
-                        name: 'E2E Test Listing Agent',
+                        name: e2eName('Test Listing Agent'),
                         description: 'Test marketplace listing for E2E',
                         category: 'general',
                         pricingModel: 'free',
@@ -250,12 +258,13 @@ export const test = base.extend<{ api: ApiHelpers }>({
                 return published;
             },
 
-            async seedMcpServer(data: Record<string, unknown> = {}) {
+            async seedMcpServer(_data: Record<string, unknown> = {}) {
+                const data = _data.name ? { ..._data, name: e2eName(_data.name as string) } : _data;
                 const res = await fetchWithRetry(`${BASE_URL}/api/mcp-servers`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        name: 'E2E Test MCP Server',
+                        name: e2eName('Test MCP Server'),
                         command: 'echo',
                         args: ['hello'],
                         enabled: true,
@@ -291,7 +300,7 @@ export const test = base.extend<{ api: ApiHelpers }>({
                     const projRes = await fetchWithRetry(`${BASE_URL}/api/projects`, {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ name: `WT Project ${Date.now()}`, workingDir: '/tmp' }),
+                        body: JSON.stringify({ name: e2eName(`WT Project ${Date.now()}`), workingDir: '/tmp' }),
                     });
                     if (projRes.ok) {
                         const proj = await projRes.json();
@@ -311,13 +320,14 @@ export const test = base.extend<{ api: ApiHelpers }>({
                 return res.json();
             },
 
-            async seedSchedule(agentId: string, data: Record<string, unknown> = {}) {
+            async seedSchedule(agentId: string, _data: Record<string, unknown> = {}) {
+                const data = _data.name ? { ..._data, name: e2eName(_data.name as string) } : _data;
                 const res = await fetchWithRetry(`${BASE_URL}/api/schedules`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         agentId,
-                        name: `E2E Schedule ${Date.now()}-${randomBytes(3).toString('hex').slice(0, 4)}`,
+                        name: e2eName(`Schedule ${Date.now()}-${randomBytes(3).toString('hex').slice(0, 4)}`),
                         intervalMs: 3600000,
                         actions: [{ type: 'review_prs', repos: ['test/repo'] }],
                         approvalPolicy: 'auto',
@@ -333,13 +343,14 @@ export const test = base.extend<{ api: ApiHelpers }>({
                 return schedule;
             },
 
-            async seedWorkflow(agentId: string, data: Record<string, unknown> = {}) {
+            async seedWorkflow(agentId: string, _data: Record<string, unknown> = {}) {
+                const data = _data.name ? { ..._data, name: e2eName(_data.name as string) } : _data;
                 const res = await fetchWithRetry(`${BASE_URL}/api/workflows`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         agentId,
-                        name: `E2E Workflow ${Date.now()}-${randomBytes(3).toString('hex').slice(0, 4)}`,
+                        name: e2eName(`Workflow ${Date.now()}-${randomBytes(3).toString('hex').slice(0, 4)}`),
                         nodes: [
                             { id: 'start', type: 'start', label: 'Start' },
                             { id: 'agent', type: 'agent_session', label: 'Agent Session', config: { prompt: 'test' } },
@@ -362,14 +373,15 @@ export const test = base.extend<{ api: ApiHelpers }>({
                 return workflow;
             },
 
-            async seedWebhook(agentId: string, data: Record<string, unknown> = {}) {
+            async seedWebhook(agentId: string, _data: Record<string, unknown> = {}) {
+                const data = _data.name ? { ..._data, name: e2eName(_data.name as string) } : _data;
                 // Webhook registrations require a projectId
                 let projectId = data.projectId as string | undefined;
                 if (!projectId) {
                     const projRes = await fetchWithRetry(`${BASE_URL}/api/projects`, {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ name: `WH Project ${Date.now()}`, workingDir: '/tmp' }),
+                        body: JSON.stringify({ name: e2eName(`WH Project ${Date.now()}`), workingDir: '/tmp' }),
                     });
                     if (projRes.ok) {
                         const proj = await projRes.json();
@@ -382,8 +394,8 @@ export const test = base.extend<{ api: ApiHelpers }>({
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         agentId,
-                        repo: `e2e-org/repo-${Date.now()}`,
-                        mentionUsername: `e2e-bot-${randomBytes(3).toString('hex').slice(0, 4)}`,
+                        repo: `E2E_org/repo-${Date.now()}`,
+                        mentionUsername: `E2E_bot-${randomBytes(3).toString('hex').slice(0, 4)}`,
                         events: ['issue_comment', 'pull_request_review_comment'],
                         projectId,
                         ...data,
@@ -398,14 +410,15 @@ export const test = base.extend<{ api: ApiHelpers }>({
                 return webhook;
             },
 
-            async seedMentionPolling(agentId: string, data: Record<string, unknown> = {}) {
+            async seedMentionPolling(agentId: string, _data: Record<string, unknown> = {}) {
+                const data = _data.name ? { ..._data, name: e2eName(_data.name as string) } : _data;
                 // Mention polling requires a projectId
                 let projectId = data.projectId as string | undefined;
                 if (!projectId) {
                     const projRes = await fetchWithRetry(`${BASE_URL}/api/projects`, {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ name: `MP Project ${Date.now()}`, workingDir: '/tmp' }),
+                        body: JSON.stringify({ name: e2eName(`MP Project ${Date.now()}`), workingDir: '/tmp' }),
                     });
                     if (projRes.ok) {
                         const proj = await projRes.json();
@@ -419,8 +432,8 @@ export const test = base.extend<{ api: ApiHelpers }>({
                     body: JSON.stringify({
                         agentId,
                         projectId,
-                        repo: `e2e-org/poll-${Date.now()}`,
-                        mentionUsername: `e2e-poll-${randomBytes(3).toString('hex').slice(0, 4)}`,
+                        repo: `E2E_org/poll-${Date.now()}`,
+                        mentionUsername: `E2E_poll-${randomBytes(3).toString('hex').slice(0, 4)}`,
                         intervalSeconds: 300,
                         eventFilter: ['issue_comment', 'pull_request_review_comment'],
                         ...data,
@@ -435,14 +448,15 @@ export const test = base.extend<{ api: ApiHelpers }>({
                 return polling;
             },
 
-            async seedSession(projectId: string, agentId?: string, data: Record<string, unknown> = {}) {
+            async seedSession(projectId: string, agentId?: string, _data: Record<string, unknown> = {}) {
+                const data = _data.name ? { ..._data, name: e2eName(_data.name as string) } : _data;
                 const res = await fetchWithRetry(`${BASE_URL}/api/sessions`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         projectId,
                         agentId,
-                        name: `E2E Session ${Date.now()}-${randomBytes(3).toString('hex').slice(0, 4)}`,
+                        name: e2eName(`Session ${Date.now()}-${randomBytes(3).toString('hex').slice(0, 4)}`),
                         ...data,
                     }),
                 });
@@ -550,6 +564,7 @@ export const test = base.extend<{ api: ApiHelpers }>({
         for (const id of createdSkillBundleIds) await del(`/api/skill-bundles/${id}`);
         for (const id of createdMcpServerIds) await del(`/api/mcp-servers/${id}`);
         for (const id of createdListingIds) await del(`/api/marketplace/listings/${id}`);
+        for (const id of createdPersonaIds) await del(`/api/personas/${id}`);
         for (const id of createdAgentIds) await del(`/api/agents/${id}`);
         for (const id of createdProjectIds) await del(`/api/projects/${id}`);
     },
@@ -568,3 +583,6 @@ export function authedFetch(url: string, init: RequestInit = {}): Promise<Respon
 
 /** The API key used for E2E auth, for tests that need to construct URLs. */
 export { E2E_API_KEY };
+
+/** Re-export the E2E name prefix helper for spec files that create data outside seed functions. */
+export { e2eName };

--- a/e2e/marketplace.spec.ts
+++ b/e2e/marketplace.spec.ts
@@ -54,14 +54,14 @@ test.describe('Marketplace', () => {
 
         // Fill form — use .form-select to avoid matching the filter-select
         await page.locator('.form-select').first().selectOption(agent.id);
-        await page.locator('input[placeholder="Listing name"]').fill('E2E Marketplace Listing');
+        await page.locator('input[placeholder="Listing name"]').fill('E2E_Marketplace Listing');
         await page.locator('textarea[placeholder*="description"]').fill('Test listing description');
         await page.locator('input[placeholder*="typescript"]').fill('test, e2e');
 
         // Submit
         await page.locator('button.btn--primary:text("Create Listing")').click();
         await expect(page.locator('text=Listing created').first()).toBeVisible({ timeout: 10000 });
-        await expect(page.locator('text=E2E Marketplace Listing').first()).toBeVisible();
+        await expect(page.locator('text=E2E_Marketplace Listing').first()).toBeVisible();
     });
 
     test('leave review and verify it appears', async ({ page, api }) => {
@@ -414,7 +414,7 @@ test.describe('Marketplace', () => {
         const registerRes = await authedFetch(`${BASE_URL}/api/marketplace/federation/instances`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ url: 'https://e2e-test-instance.example.com', name: 'E2E Test Instance' }),
+            body: JSON.stringify({ url: 'https://e2e-test-instance.example.com', name: 'E2E_Test Instance' }),
         });
         expect([201, 503]).toContain(registerRes.status);
 

--- a/e2e/mcp-servers.spec.ts
+++ b/e2e/mcp-servers.spec.ts
@@ -16,14 +16,14 @@ test.describe('MCP Servers', () => {
         await expect(page.locator('h3:text("Add MCP Server")')).toBeVisible();
 
         // Fill form
-        await page.locator('input[placeholder*="GitHub MCP"]').fill('E2E Test Server');
+        await page.locator('input[placeholder*="GitHub MCP"]').fill('E2E_Test Server');
         await page.locator('input[placeholder*="npx"]').fill('echo');
         await page.locator('textarea[placeholder*="--port"]').fill('hello\nworld');
 
         // Submit
         await page.locator('button:text("Create Server")').click();
         await expect(page.locator('text=MCP server created').first()).toBeVisible({ timeout: 5000 });
-        await expect(page.locator('text=E2E Test Server').first()).toBeVisible();
+        await expect(page.locator('text=E2E_Test Server').first()).toBeVisible();
     });
 
     test('test connection and verify error handling', async ({ page, api }) => {
@@ -93,7 +93,7 @@ test.describe('MCP Servers', () => {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-                name: `API MCP ${Date.now()}`,
+                name: `E2E_API MCP ${Date.now()}`,
                 command: 'echo',
                 args: ['test'],
                 enabled: true,
@@ -110,7 +110,7 @@ test.describe('MCP Servers', () => {
         const updateRes = await authedFetch(`${BASE_URL}/api/mcp-servers/${server.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'Updated MCP Server' }),
+            body: JSON.stringify({ name: 'E2E_Updated MCP Server' }),
         });
         expect(updateRes.ok).toBe(true);
 

--- a/e2e/perf.spec.ts
+++ b/e2e/perf.spec.ts
@@ -50,8 +50,8 @@ test.describe('Optimistic Updates & Render Performance', () => {
 
     test.describe('Agent optimistic updates', () => {
         test('create agent via API and verify it appears in list without reload', async ({ page }) => {
-            const uniqueName = `Opt Agent ${Date.now()}`;
-            const renamedName = `Renamed ${Date.now()}`;
+            const uniqueName = `E2E_Opt Agent ${Date.now()}`;
+            const renamedName = `E2E_Renamed ${Date.now()}`;
 
             await gotoWithRetry(page, '/agents');
 

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -11,7 +11,7 @@ test.describe('Projects', () => {
     });
 
     test('create project via form', async ({ page }) => {
-        const projectName = `PW Project ${Date.now()}`;
+        const projectName = `E2E_PW Project ${Date.now()}`;
         await gotoWithRetry(page, '/projects/new', { isRendered: async (p) => (await p.locator('h2').count()) > 0 || (await p.locator('.list').count()) > 0 });
 
         await page.locator('#name').fill(projectName);
@@ -39,7 +39,7 @@ test.describe('Projects', () => {
 
     test('edit project updates name', async ({ page, api }) => {
         const project = await api.seedProject('Edit Me Project');
-        const newName = `Edited Project ${Date.now()}`;
+        const newName = `E2E_Edited Project ${Date.now()}`;
 
         await gotoWithRetry(page, `/projects/${project.id}`, { isRendered: async (p) => (await p.locator('h2').count()) > 0 || (await p.locator('.list').count()) > 0 });
         await page.locator('a:text("Edit"), button:text("Edit")').first().click();
@@ -73,7 +73,7 @@ test.describe('Projects', () => {
         const createRes = await authedFetch(`${BASE_URL}/api/projects`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: `API CRUD ${Date.now()}`, workingDir: '/tmp' }),
+            body: JSON.stringify({ name: `E2E_API CRUD ${Date.now()}`, workingDir: '/tmp' }),
         });
         expect(createRes.status).toBe(201);
         const project = await createRes.json();
@@ -89,7 +89,7 @@ test.describe('Projects', () => {
         const updateRes = await authedFetch(`${BASE_URL}/api/projects/${project.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'Updated Name' }),
+            body: JSON.stringify({ name: 'E2E_Updated Name' }),
         });
         expect(updateRes.ok).toBe(true);
 
@@ -120,7 +120,7 @@ test.describe('Projects', () => {
         const res1 = await authedFetch(`${BASE_URL}/api/projects`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'No Dir' }),
+            body: JSON.stringify({ name: 'E2E_No Dir' }),
         });
         expect(res1.status).toBe(400);
 

--- a/e2e/prompt-injection.spec.ts
+++ b/e2e/prompt-injection.spec.ts
@@ -37,14 +37,14 @@ test.describe('Prompt Injection Detection', () => {
             body: JSON.stringify({
                 projectId,
                 agentId,
-                name: 'Normal Session',
+                name: 'E2E_Normal Session',
                 initialPrompt: 'Hello, can you help me with a coding question?',
             }),
         });
         expect(res.ok).toBe(true);
         const session = await res.json();
         expect(session.id).toBeDefined();
-        expect(session.name).toBe('Normal Session');
+        expect(session.name).toBe('E2E_Normal Session');
     });
 
     test('session creation with legitimate technical content succeeds', async () => {
@@ -54,7 +54,7 @@ test.describe('Prompt Injection Detection', () => {
             body: JSON.stringify({
                 projectId,
                 agentId,
-                name: 'Technical Session',
+                name: 'E2E_Technical Session',
                 initialPrompt: 'How do I write a SELECT query to join two tables in PostgreSQL?',
             }),
         });
@@ -68,7 +68,7 @@ test.describe('Prompt Injection Detection', () => {
             body: JSON.stringify({
                 projectId,
                 agentId,
-                name: 'Security Discussion',
+                name: 'E2E_Security Discussion',
                 initialPrompt: 'What are best practices for preventing prompt injection attacks?',
             }),
         });

--- a/e2e/schedules.spec.ts
+++ b/e2e/schedules.spec.ts
@@ -108,7 +108,7 @@ test.describe('Schedules', () => {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 agentId: agent.id,
-                name: `CRUD Schedule ${Date.now()}`,
+                name: `E2E_CRUD Schedule ${Date.now()}`,
                 intervalMs: 3600000,
                 actions: [{ type: 'review_prs', repos: ['test/repo'] }],
                 approvalPolicy: 'auto',
@@ -125,7 +125,7 @@ test.describe('Schedules', () => {
         const updateRes = await authedFetch(`${BASE_URL}/api/schedules/${schedule.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'Updated Schedule' }),
+            body: JSON.stringify({ name: 'E2E_Updated Schedule' }),
         });
         expect(updateRes.ok).toBe(true);
 

--- a/e2e/session-launcher.spec.ts
+++ b/e2e/session-launcher.spec.ts
@@ -81,7 +81,7 @@ test.describe('Session Launcher', () => {
         const res = await authedFetch(`${BASE_URL}/api/sessions`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'No Project' }),
+            body: JSON.stringify({ name: 'E2E_No Project' }),
         });
         expect(res.status).toBe(400);
     });

--- a/e2e/sessions.spec.ts
+++ b/e2e/sessions.spec.ts
@@ -133,7 +133,7 @@ test.describe('Sessions', () => {
             body: JSON.stringify({
                 projectId: project.id,
                 agentId: agent.id,
-                name: `CRUD Session ${Date.now()}`,
+                name: `E2E_CRUD Session ${Date.now()}`,
             }),
         });
         expect(createRes.status).toBe(201);
@@ -151,7 +151,7 @@ test.describe('Sessions', () => {
         const updateRes = await authedFetch(`${BASE_URL}/api/sessions/${session.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'Updated Session' }),
+            body: JSON.stringify({ name: 'E2E_Updated Session' }),
         });
         expect(updateRes.ok).toBe(true);
 

--- a/e2e/skill-bundles.spec.ts
+++ b/e2e/skill-bundles.spec.ts
@@ -151,7 +151,7 @@ test.describe('Skill Bundles', () => {
 
     test('API CRUD for skill bundles', async ({}) => {
         const BASE_URL = `http://localhost:${process.env.E2E_PORT || '3001'}`;
-        const name = `API Bundle ${Date.now()}`;
+        const name = `E2E_API Bundle ${Date.now()}`;
 
         // Create
         const createRes = await authedFetch(`${BASE_URL}/api/skill-bundles`, {

--- a/e2e/webhooks.spec.ts
+++ b/e2e/webhooks.spec.ts
@@ -115,8 +115,8 @@ test.describe('Webhooks', () => {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 agentId: agent.id,
-                repo: `crud-org/repo-${Date.now()}`,
-                mentionUsername: 'crud-bot',
+                repo: `E2E_crud-org/repo-${Date.now()}`,
+                mentionUsername: 'E2E_crud-bot',
                 events: ['issue_comment'],
                 projectId: project.id,
             }),

--- a/e2e/workflows.spec.ts
+++ b/e2e/workflows.spec.ts
@@ -34,7 +34,7 @@ test.describe('Workflows', () => {
     test('edit name via API, verify update', async ({ page, api }) => {
         const agent = await api.seedAgent('EditName Agent');
         const workflow = await api.seedWorkflow(agent.id);
-        const newName = `Updated Workflow ${Date.now()}`;
+        const newName = `E2E_Updated Workflow ${Date.now()}`;
 
         // Update via API
         const res = await authedFetch(`${BASE_URL}/api/workflows/${workflow.id}`, {
@@ -124,7 +124,7 @@ test.describe('Workflows', () => {
         const updateRes = await authedFetch(`${BASE_URL}/api/workflows/${workflow.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'Updated' }),
+            body: JSON.stringify({ name: 'E2E_Updated' }),
         });
         expect(updateRes.ok).toBe(true);
 


### PR DESCRIPTION
## Summary
- All seed functions and direct API calls now auto-prefix entity names with `E2E_`, making test artifacts trivially identifiable for cleanup (`WHERE name LIKE 'E2E_%'`)
- Added missing `afterAll` cleanup in `council-flow.spec.ts` and `approval.spec.ts` to prevent leaked test data
- 17 files changed across the full e2e suite

## Test plan
- [ ] Run full e2e suite (`bun test:e2e`) — all tests should pass with prefixed names
- [ ] Verify DB shows `E2E_` prefixed entities during test runs
- [ ] Confirm no leftover test data after suite completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)