### PR TITLE
fix(ui): set active tab immediately on click

### DIFF
--- a/client/src/app/features/sessions/session-view.component.ts
+++ b/client/src/app/features/sessions/session-view.component.ts
@@ -177,6 +177,7 @@ export class SessionViewComponent implements OnInit, OnDestroy {
             if (!newId || newId === this.sessionId) return;
             this.cleanupCurrentSession();
             this.sessionId = newId;
+            this.chatTabs.activeSessionId.set(newId);
             this.loadSession(newId);
         });
     }


### PR DESCRIPTION
## Summary
- Set `activeSessionId` immediately when route param changes, before the async session load completes
- Fixes the issue where the cyan active tab indicator only appeared after double-clicking or waiting for the HTTP fetch

## Test plan
- [ ] Click a chat tab — active indicator should appear instantly on single click
- [ ] Verify session content still loads correctly after tab switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)