### PR TITLE
fix(ui): remove duplicate chat tab bar in session view

### DIFF
--- a/client/src/app/features/sessions/session-view.component.ts
+++ b/client/src/app/features/sessions/session-view.component.ts
@@ -14,14 +14,12 @@ import type { Session, SessionMessage } from '../../core/models/session.model';
 import type { StreamEvent, ApprovalRequestWire, OwnerQuestionWire } from '@shared/ws-protocol';
 import { NotificationService } from '../../core/services/notification.service';
 import { ChatTabsService } from '../../core/services/chat-tabs.service';
-import { ChatTabBarComponent } from '../../shared/components/chat-tab-bar.component';
 
 @Component({
     selector: 'app-session-view',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [StatusBadgeComponent, SessionOutputComponent, SessionInputComponent, ApprovalDialogComponent, ChatTabBarComponent, DecimalPipe, RelativeTimePipe],
+    imports: [StatusBadgeComponent, SessionOutputComponent, SessionInputComponent, ApprovalDialogComponent, DecimalPipe, RelativeTimePipe],
     template: `
-        <app-chat-tab-bar />
         @if (session(); as s) {
             <div class="session-view">
                 <div class="session-view__header">


### PR DESCRIPTION
## Summary
- Removed the `<app-chat-tab-bar />` from `session-view.component.ts` — it was already rendered globally in `app.ts`
- Clicking a chat tab navigated to the session view, which rendered a second tab bar underneath the global one

## Test plan
- [ ] Click on a chat tab — only one tab bar should be visible
- [ ] Navigate between sessions via tabs — no duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)