### PR TITLE
chore: release v0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,29 @@ All notable changes to this project will be documented in this file.
 ## [0.45.0] - 2026-03-22
 
 ### Added
-- **UX overhaul (phases 1–3)** — security hardening and spec-sync v2.0.0 (#1389)
+- **UX overhaul (phases 1–5)** — chat-first layout, security hardening, spec-sync v2.0.0, icons, CSS vars, skeleton loaders (#1389, #1399)
+- **Security: injection guard + RBAC hardening** — input sanitization across all user-input routes (#1387)
+- **Discord: /agent-skill and /agent-persona commands** — manage skills and personas from Discord (#1386)
+- **CLI: provision command** — multi-agent deployment provisioning (#1392)
 - **Reputation score history** — tracking, trend chart, and agent comparison (#1385)
 - **Dashboard: log & diff viewers** — agent health badges (#1382)
 - **Dashboard: pipeline stages** — reputation trend chart (#1381)
 
 ### Fixed
+- **UI: remove duplicate chat tab bar** — fix duplicate tab bar in session view (#1400)
 - **UI: active tab on click** — set active tab immediately, no double-click needed (#1395, #1396)
+- **Consolidate duplicate isCloudModel** — single source of truth for cloud model detection (#1391)
 - **Security: RBAC guards** — add guards to discord-image and openrouter routes (#1380)
+
+### Removed
+- **Flock-directory contract** — remove dead contract code (#1390)
 
 ### Tests
 - Add unit tests for onboarding components — 49 tests (#1384)
 - A2A invocation guard coverage expansion (#1383)
 
 ### Docs
+- **API docs** — add request/response examples for ~150 endpoints (#1394)
 - Update version and stats for v0.44.0 release (#1379)
 
 ## [0.44.0] - 2026-03-22

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.44.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.45.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>


### PR DESCRIPTION
## Summary
- Complete v0.45.0 changelog covering all 18 commits since v0.44.0
- Includes the 6 PRs merged today: injection guard + RBAC (#1387), isCloudModel consolidation (#1391), flock-directory removal (#1390), CLI provision (#1392), Discord commands (#1386), API docs (#1394)
- Plus UX overhaul phases 1-5 (#1389, #1399), UI fixes (#1395, #1396, #1400), dashboard features (#1381, #1382, #1385), security RBAC (#1380), tests (#1383, #1384)
- README version badge bumped 0.44.0 → 0.45.0

## Release checklist
- [x] Changelog updated with all 18 commits
- [x] README badge updated
- [ ] Merge PR
- [ ] Delete stale v0.45.0 tag and re-tag on merged commit
- [ ] Create GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)