### PR TITLE
docs: fix stale stats in CONTRIBUTING.md and README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ That's it. We review PRs quickly and give constructive feedback. No contribution
 
 ### About this project
 
-This is a real, production AI agent platform — not a toy. The codebase has 6,600+ tests, 85 database migrations, and ships code autonomously. You'll be working alongside AI agents (including me, corvid-agent, who helps maintain this repo). It's a unique experience.
+This is a real, production AI agent platform — not a toy. The codebase has 8,500+ tests, 26 database migrations, and ships code autonomously. You'll be working alongside AI agents (including me, corvid-agent, who helps maintain this repo). It's a unique experience.
 
 ## Quick Setup
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ skills/
 
 ## Tech stack
 
-Bun + Angular 21 + SQLite + Claude Agent SDK + Algorand (on-chain identity). 48 MCP tools, ~380 API endpoints, 8,500+ unit tests, 360 E2E tests.
+Bun + Angular 21 + SQLite + Claude Agent SDK + Algorand (on-chain identity). 48 MCP tools, ~380 API endpoints, 8,500+ unit tests, 362 E2E test files.
 
 **[Architecture →](docs/how-it-works.md)** | **[Security →](SECURITY.md)** | **[Deployment →](docs/self-hosting.md)**
 


### PR DESCRIPTION
## Summary
- **CONTRIBUTING.md**: Fixed "6,600+ tests" → "8,500+ tests" and "85 database migrations" → "26 database migrations" to match actual counts from `bun run stats:check`
- **README.md**: Updated E2E test count from 360 → 362 to match test runner output

## Audit context
Full documentation & API sync audit performed 2026-03-23:
- **180/180 specs pass** (`bun run spec:check`)
- **All documented API endpoints verified in code** — no stale or missing endpoints in api-reference.md
- **All README links valid** — every relative link resolves to an existing file
- **Tech stack versions accurate** — Angular ^21.1.0, algosdk ^3.5.2, Claude Agent SDK ^0.2.80
- **docs/deep-dive.md stats verified** — all pass stats:check

## Test plan
- [x] `bun run stats:check` passes
- [x] `bun run spec:check` passes (180/180)
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)