### PR TITLE
fix(ui): remove sidebar, use top-nav as single navigation pattern

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -5,10 +5,8 @@ import {
     OnInit,
     OnDestroy,
     signal,
-    computed,
     viewChild,
     ElementRef,
-    AfterViewInit,
 } from '@angular/core';
 import { RouterOutlet, Router, NavigationEnd } from '@angular/router';
 import { filter } from 'rxjs/operators';
@@ -21,7 +19,6 @@ import { ToastContainerComponent } from './shared/components/toast-container.com
 import { KeyboardShortcutsOverlayComponent } from './shared/components/keyboard-shortcuts-overlay.component';
 import { GuidedTourComponent } from './shared/components/guided-tour.component';
 import { MobileBottomNavComponent } from './shared/components/mobile-bottom-nav.component';
-import { SidebarComponent } from './shared/components/sidebar.component';
 import { WebSocketService } from './core/services/websocket.service';
 import { SessionService } from './core/services/session.service';
 import { ChatTabsService } from './core/services/chat-tabs.service';
@@ -30,7 +27,7 @@ import { KeyboardShortcutsService } from './core/services/keyboard-shortcuts.ser
 @Component({
     selector: 'app-root',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [RouterOutlet, TopNavComponent, ChatTabBarComponent, ActivityRailComponent, CommandPaletteComponent, ToastContainerComponent, KeyboardShortcutsOverlayComponent, GuidedTourComponent, MobileBottomNavComponent, SidebarComponent],
+    imports: [RouterOutlet, TopNavComponent, ChatTabBarComponent, ActivityRailComponent, CommandPaletteComponent, ToastContainerComponent, KeyboardShortcutsOverlayComponent, GuidedTourComponent, MobileBottomNavComponent],
     template: `
         <div class="app-layout" [class.app-layout--session]="isSessionView()">
             <app-top-nav />
@@ -47,7 +44,6 @@ import { KeyboardShortcutsService } from './core/services/keyboard-shortcuts.ser
                 </div>
             }
             <div class="app-layout__body">
-                <app-sidebar class="app-layout__sidebar" [(sidebarOpen)]="sidebarOpen" />
                 <main class="app-layout__content" role="main" id="main-content" #mainContent (scroll)="onScroll($event)">
                     <router-outlet />
                 </main>
@@ -107,16 +103,6 @@ import { KeyboardShortcutsService } from './core/services/keyboard-shortcuts.ser
             color: var(--accent-yellow, #fc0);
         }
 
-        /* Sidebar: hidden on mobile (top-nav handles mobile nav) */
-        .app-layout__sidebar {
-            display: none;
-        }
-        @media (min-width: 768px) {
-            .app-layout__sidebar {
-                display: flex;
-            }
-        }
-
         /* Mobile: reserve space for bottom nav (not in session view) */
         @media (max-width: 767px) {
             .app-layout__content {
@@ -142,7 +128,6 @@ export class App implements OnInit, OnDestroy {
     private readonly _shortcuts = inject(KeyboardShortcutsService);
     private readonly router = inject(Router);
 
-    protected readonly sidebarOpen = signal(false);
     protected readonly showScrollTop = signal(false);
     protected readonly isSessionView = signal(false);
     private readonly mainContent = viewChild<ElementRef<HTMLElement>>('mainContent');


### PR DESCRIPTION
## Summary

Removes the left sidebar from the app layout. It was duplicating every route already present in the top navigation bar.

## The Layout (definitive — do not add competing nav)

```
┌──────────────────────────────────────────────┐
│  Top Nav (desktop: dropdowns, mobile: ☰)     │  ← ONLY navigation
├──────────────────────────────────────────────┤
│  Chat Tab Bar (when tabs open, hidden mobile)│
├─────────────────────────────────┬────────────┤
│                                 │  Activity  │
│         Main Content            │   Rail     │
│         <router-outlet>         │  (right)   │
│                                 │            │
├─────────────────────────────────┴────────────┤
│  Mobile Bottom Nav (≤767px, not in sessions) │
└──────────────────────────────────────────────┘
```

**Desktop**: Top nav bar with dropdown menus → all routes  
**Mobile**: Top nav hamburger menu + bottom nav bar  
**Activity rail** (right): Shows active sessions — NOT navigation, stays  

There is ONE navigation component: `TopNavComponent`. No sidebar. No second nav. If new routes are added, they go in the top nav.

## Changes

- Removed `SidebarComponent` import and usage from `app.ts`
- Removed `sidebarOpen` signal and sidebar toggle logic
- Removed sidebar-related CSS (grid layout that accommodated sidebar)
- Layout is now a simple flex column: top-nav → body (content + activity rail)

## Test plan

- [x] Build succeeds (`bun run build`)
- [x] No sidebar visible on desktop or mobile
- [x] Top nav still has all routes and works
- [x] Mobile hamburger menu works
- [x] Activity rail still visible on desktop
- [x] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)