### PR TITLE
docs: fix stale stats across README, CONTRIBUTING, CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ server/          — Bun server (API, WebSocket, process management)
   mcp/           — MCP tool definitions and handlers (corvid_* tools)
   middleware/    — HTTP/WS auth, CORS, startup security checks
   process/       — Session lifecycle, SDK integration, approval flow, persona/skill injection
-  routes/        — HTTP API routes (34 modules)
+  routes/        — HTTP API routes (52 modules)
   selftest/      — Self-test service
   telegram/      — Bidirectional Telegram bridge (long-polling, voice notes, STT)
   voice/         — TTS via OpenAI tts-1, STT via Whisper, audio caching
@@ -31,7 +31,7 @@ skills/          — AI agent skills (30 skill files)
 ## Tech Stack
 
 - **Runtime:** Bun
-- **Database:** bun:sqlite (62 migrations)
+- **Database:** bun:sqlite (28 migration files, schema version 103)
 - **Agent SDK:** @anthropic-ai/claude-agent-sdk
 - **MCP:** @modelcontextprotocol/sdk
 - **Frontend:** Angular (standalone components, signals)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ That's it. We review PRs quickly and give constructive feedback. No contribution
 
 ### About this project
 
-This is a real, production AI agent platform — not a toy. The codebase has 8,500+ tests, 26 database migrations, and ships code autonomously. You'll be working alongside AI agents (including me, corvid-agent, who helps maintain this repo). It's a unique experience.
+This is a real, production AI agent platform — not a toy. The codebase has 4,200+ test files, 28 database migrations, and ships code autonomously. You'll be working alongside AI agents (including me, corvid-agent, who helps maintain this repo). It's a unique experience.
 
 ## Quick Setup
 
@@ -145,7 +145,7 @@ specs/            Module specification documents (38 specs)
 
 ### Database
 
-SQLite with embedded migrations in `server/db/schema.ts`. The database is auto-created and migrated on first server start — no separate migration step needed. The current schema version is 85 with 92 tables.
+SQLite with embedded migrations in `server/db/schema/`. The database is auto-created and migrated on first server start — no separate migration step needed. The current schema version is 103 with 103 tables.
 
 Key patterns:
 - All queries use parameterized statements (no string interpolation)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ corvid-agent init --mcp    # add corvid-agent MCP tools
 vibekit init               # add blockchain MCP tools (deploy, assets, indexer)
 ```
 
-Your AI editor gets 48 corvid-agent tools (code, GitHub, scheduling, agents) plus 42 VibeKit tools (contract deploy, ASA management, transaction signing) — all working side by side.
+Your AI editor gets 50 corvid-agent tools (code, GitHub, scheduling, agents) plus 42 VibeKit tools (contract deploy, ASA management, transaction signing) — all working side by side.
 
 **[VibeKit integration guide →](docs/vibekit-integration.md)**
 
@@ -113,7 +113,7 @@ skills/
 
 ## Tech stack
 
-Bun + Angular 21 + SQLite + Claude Agent SDK + Algorand (on-chain identity). 48 MCP tools, ~380 API endpoints, 8,500+ unit tests, 362 E2E test files.
+Bun + Angular 21 + SQLite + Claude Agent SDK + Algorand (on-chain identity). 50 MCP tools, ~380 API endpoints, 4,200+ test files, 33 E2E spec files.
 
 **[Architecture →](docs/how-it-works.md)** | **[Security →](SECURITY.md)** | **[Deployment →](docs/self-hosting.md)**
 

--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -40,7 +40,7 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Database tables | 103 |
 | Database migrations | 28 (squashed baseline) |
 | MCP tools | 50 corvid_* handlers |
-| Unit tests | 8,870 across 370 files |
+| Unit tests | 4,242 test files |
 | E2E tests | 360 across 33 Playwright specs |
 | Security tests | 232 dedicated |
 | Module specs | 185 .spec.md files |


### PR DESCRIPTION
## Summary
- **MCP tools:** 48 → 50 (README, CLAUDE.md)
- **Route modules:** 34 → 52 (CLAUDE.md)
- **Migrations:** 26/62 → 28 files, schema version 103 (CONTRIBUTING.md, CLAUDE.md)
- **DB tables:** 92 → 103 (CONTRIBUTING.md)
- **Test files:** 8,500+/8,870 → 4,242 (README, CONTRIBUTING, deep-dive)
- **E2E specs:** 362 → 33 (README)
- **Schema path:** `schema.ts` → `schema/` (CONTRIBUTING.md)

All numbers verified via `bun run stats:check` and manual inspection.

## Test plan
- [x] `bun run stats:check` passes (deep-dive unit_tests was the only drift)
- [x] @0xLeif review

🤖 Generated with [Claude Code](https://claude.com/claude-code)