### PR TITLE
Fix TypeScript compilation errors in discord-schedule-commands.test.ts

### DIFF
--- a/server/__tests__/discord-schedule-commands.test.ts
+++ b/server/__tests__/discord-schedule-commands.test.ts
@@ -38,13 +38,22 @@ function makeCtx(): InteractionContext {
     return {
         db,
         config: {} as any,
-        threadSessions: new Map(),
-        mentionSessions: new Map(),
-        threadCallbacks: new Map(),
+        processManager: null as any,
+        workTaskService: null,
+        delivery: null as any,
         mutedUsers: new Set(),
+        threadSessions: new Map(),
+        threadCallbacks: new Map(),
+        threadLastActivity: new Map(),
+        createStandaloneThread: async () => null,
+        subscribeForResponseWithEmbed: () => {},
+        sendTaskResult: async () => {},
+        muteUser: () => {},
+        unmuteUser: () => {},
+        mentionSessions: new Map(),
+        subscribeForInlineResponse: () => {},
         guildCache: null as any,
-        syncGuildData: async () => {},
-        deliveryTracker: null as any,
+        syncGuildData: () => {},
     };
 }
 
@@ -71,7 +80,7 @@ function seedAgent() {
     db.query(`INSERT INTO agents (id, name, wallet_address) VALUES ('agent-1', 'TestAgent', 'addr1')`).run();
 }
 
-function seedSchedule(name: string = 'Test Schedule', status: string = 'active') {
+function seedSchedule(name: string = 'Test Schedule', _status: string = 'active') {
     return createSchedule(db, {
         agentId: 'agent-1',
         name,


### PR DESCRIPTION
## Summary
Resolved 2 TypeScript compilation errors in `server/__tests__/discord-schedule-commands.test.ts`:

1. **TS2353 (Line 47)**: Fixed property name mismatch in `makeCtx()`. The `InteractionContext` interface defines `delivery` but the test was using `deliveryTracker`. Also added all missing required properties from the interface.

2. **TS6133 (Line 74)**: Fixed unused variable in `seedSchedule()` function by prefixing the unused `status` parameter with an underscore (`_status`).

## Test Plan
- ✅ TypeScript compilation passes with `bun x tsc --noEmit --skipLibCheck`
- ✅ All 19 tests in the file pass with `bun test`