### PR TITLE
fix(frontend): enhance connection banner and add live feed loading skeleton

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -36,11 +36,14 @@ import { KeyboardShortcutsService } from './core/services/keyboard-shortcuts.ser
             }
             @if (wsService.serverRestarting()) {
                 <div class="app-layout__banner app-layout__banner--restart" role="alert">
+                    <span class="app-layout__banner-dot"></span>
                     Server is restarting — reconnecting automatically...
                 </div>
             } @else if (!wsService.connected()) {
                 <div class="app-layout__banner" role="alert">
+                    <span class="app-layout__banner-dot"></span>
                     Connection lost — reconnecting...
+                    <button class="app-layout__banner-retry" (click)="retryConnection()" type="button">Retry now</button>
                 </div>
             }
             <div class="app-layout__body">
@@ -96,6 +99,38 @@ import { KeyboardShortcutsService } from './core/services/keyboard-shortcuts.ser
             font-weight: 600;
             text-align: center;
             letter-spacing: 0.03em;
+        }
+        .app-layout__banner-dot {
+            display: inline-block;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: currentColor;
+            margin-right: 0.5rem;
+            animation: bannerPulse 1.5s ease-in-out infinite;
+        }
+        @keyframes bannerPulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.3; }
+        }
+        .app-layout__banner-retry {
+            margin-left: 0.75rem;
+            padding: 0.15rem 0.6rem;
+            background: transparent;
+            border: 1px solid currentColor;
+            border-radius: var(--radius-sm, 4px);
+            color: inherit;
+            font-family: inherit;
+            font-size: 0.65rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            cursor: pointer;
+            transition: background 0.15s, color 0.15s;
+        }
+        .app-layout__banner-retry:hover {
+            background: currentColor;
+            color: var(--bg-deep, #0a0a12);
         }
         .app-layout__banner--restart {
             background: var(--accent-yellow-dim, rgba(255, 204, 0, 0.1));
@@ -157,5 +192,10 @@ export class App implements OnInit, OnDestroy {
 
     protected scrollToTop(): void {
         this.mainContent()?.nativeElement.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+
+    protected retryConnection(): void {
+        this.wsService.disconnect();
+        this.wsService.connect();
     }
 }

--- a/client/src/app/features/feed/live-feed.component.ts
+++ b/client/src/app/features/feed/live-feed.component.ts
@@ -1,6 +1,7 @@
 import { Component, ChangeDetectionStrategy, inject, signal, computed, OnInit, OnDestroy, ElementRef, viewChild } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { EmptyStateComponent } from '../../shared/components/empty-state.component';
+import { SkeletonComponent } from '../../shared/components/skeleton.component';
 import { WebSocketService } from '../../core/services/websocket.service';
 import { AgentService } from '../../core/services/agent.service';
 import { ApiService } from '../../core/services/api.service';
@@ -27,7 +28,7 @@ interface FeedEntry {
 @Component({
     selector: 'app-live-feed',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [DatePipe, EmptyStateComponent],
+    imports: [DatePipe, EmptyStateComponent, SkeletonComponent],
     template: `
         <div class="page">
             <div class="page__header">
@@ -81,7 +82,9 @@ interface FeedEntry {
                 </div>
             }
 
-            @if (entries().length === 0) {
+            @if (loading()) {
+                <app-skeleton variant="table" [count]="6" />
+            } @else if (entries().length === 0) {
                 <app-empty-state
                     icon="[ ]"
                     [title]="isFiltered() ? 'No matches' : 'No messages yet'"
@@ -293,6 +296,7 @@ export class LiveFeedComponent implements OnInit, OnDestroy {
     private walletToAgent: Record<string, Agent> = {};
     private agentColorMap: Record<string, number> = {};
     private nextColorIndex = 0;
+    protected readonly loading = signal(true);
     private seenMessageKeys = new Set<string>();
     private searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -306,7 +310,11 @@ export class LiveFeedComponent implements OnInit, OnDestroy {
         }
 
         // Load message history from DB
-        await this.loadHistory();
+        try {
+            await this.loadHistory();
+        } finally {
+            this.loading.set(false);
+        }
 
         this.unsubscribeWs = this.wsService.onMessage((msg: ServerWsMessage) => {
             if (this.isFiltered()) return;


### PR DESCRIPTION
## Summary

Frontend stability improvements for external users (part of #1450):

- **Connection banner enhancement** — added pulsing indicator dot and "Retry now" button to the global disconnection banner so users can immediately see connection issues and take action
- **Live feed loading skeleton** — added `loading` state with skeleton placeholder during initial data fetch, preventing a brief blank screen on the Observe > Feed page

## What changed

- `app.ts` — Enhanced the existing `@if (!wsService.connected())` banner with a pulsing dot animation and retry button; same treatment for server restart banner
- `live-feed.component.ts` — Added `loading` signal, `SkeletonComponent` import, and loading guard around feed content

## Validation

- TypeScript: clean (`bun x tsc --noEmit`)
- Tests: 20/20 pass
- Specs: 184/184 pass, 100% coverage
- Stats: up to date

Closes #1450 (partial — tracking issue for broader frontend stability work)