### PR TITLE
fix(frontend): form validation errors, avatar fallback, input error styles

### DIFF
--- a/client/src/app/features/agents/agent-form.component.ts
+++ b/client/src/app/features/agents/agent-form.component.ts
@@ -20,7 +20,11 @@ import { firstValueFrom } from 'rxjs';
             <form [formGroup]="form" (ngSubmit)="onSubmit()" class="form">
                 <div class="form__field">
                     <label for="name" class="form__label">Name</label>
-                    <input id="name" formControlName="name" class="form__input" />
+                    <input id="name" formControlName="name" class="form__input"
+                           [attr.aria-describedby]="form.get('name')?.invalid && form.get('name')?.touched ? 'name-error' : null" />
+                    @if (form.get('name')?.hasError('required') && form.get('name')?.touched) {
+                        <span id="name-error" class="form__error" role="alert">Agent name is required.</span>
+                    }
                 </div>
 
                 <div class="form__field">

--- a/client/src/app/features/agents/agent-list.component.ts
+++ b/client/src/app/features/agents/agent-list.component.ts
@@ -119,11 +119,13 @@ const INACTIVE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
                             <div class="agent-card__top">
                                 <div class="agent-card__title-row">
                                     <span class="agent-card__health-dot" [attr.data-health]="getHealthLevel(card)" aria-hidden="true"></span>
-                                    @if (card.agent.avatarUrl) {
+                                    @if (card.agent.avatarUrl && !avatarErrors().has(card.agent.id)) {
                                         <img class="agent-card__avatar" [src]="card.agent.avatarUrl"
-                                             [alt]="card.agent.name + ' avatar'" (error)="onAvatarError($event)" />
+                                             [alt]="card.agent.name + ' avatar'" (error)="onAvatarError(card.agent.id)" />
                                     } @else if (card.agent.displayIcon) {
                                         <span class="agent-card__icon">{{ card.agent.displayIcon }}</span>
+                                    } @else {
+                                        <span class="agent-card__icon agent-card__icon--fallback" aria-hidden="true">[&gt;_]</span>
                                     }
                                     <span class="agent-card__name"
                                           [style.color]="card.agent.displayColor || ''">{{ card.agent.name }}</span>
@@ -271,6 +273,7 @@ const INACTIVE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
         .agent-card:hover::before { opacity: 1; }
         .agent-card__avatar { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid var(--border-bright); flex-shrink: 0; }
         .agent-card__icon { font-size: 1.2rem; line-height: 1; flex-shrink: 0; }
+        .agent-card__icon--fallback { font-size: 0.65rem; font-family: var(--font-mono, monospace); color: var(--text-tertiary); background: var(--bg-input); border: 1px solid var(--border); border-radius: 50%; width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; }
         .agent-card__top { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 0.35rem; }
         .agent-card__title-row { display: flex; align-items: center; gap: 0.4rem; }
         .agent-card__health-dot {
@@ -334,6 +337,7 @@ export class AgentListComponent implements OnInit {
     protected readonly filterPermission = signal<string | null>(null);
     protected readonly hideInactive = signal(true);
     protected readonly agentCards = signal<AgentCard[]>([]);
+    protected readonly avatarErrors = signal<Set<string>>(new Set());
     protected readonly permissionModes = ['default', 'plan', 'auto-edit', 'full-auto'];
 
     protected readonly filteredAgents = computed(() => {
@@ -398,8 +402,10 @@ export class AgentListComponent implements OnInit {
         return PROVIDER_COLORS[provider ?? 'anthropic'] ?? DEFAULT_PROVIDER_COLOR;
     }
 
-    protected onAvatarError(event: Event): void {
-        (event.target as HTMLImageElement).style.display = 'none';
+    protected onAvatarError(agentId: string): void {
+        const errors = new Set(this.avatarErrors());
+        errors.add(agentId);
+        this.avatarErrors.set(errors);
     }
 
     /** Health level based on activity recency */

--- a/client/src/app/features/councils/council-form.component.ts
+++ b/client/src/app/features/councils/council-form.component.ts
@@ -16,7 +16,11 @@ import type { Agent } from '../../core/models/agent.model';
             <form [formGroup]="form" (ngSubmit)="onSubmit()" class="form">
                 <div class="form__field">
                     <label for="name" class="form__label">Name</label>
-                    <input id="name" formControlName="name" class="form__input" />
+                    <input id="name" formControlName="name" class="form__input"
+                           [attr.aria-describedby]="form.get('name')?.invalid && form.get('name')?.touched ? 'name-error' : null" />
+                    @if (form.get('name')?.hasError('required') && form.get('name')?.touched) {
+                        <span id="name-error" class="form__error" role="alert">Council name is required.</span>
+                    }
                 </div>
 
                 <div class="form__field">

--- a/client/src/app/features/projects/project-form.component.ts
+++ b/client/src/app/features/projects/project-form.component.ts
@@ -15,16 +15,24 @@ import { DirBrowserComponent } from '../../shared/components/dir-browser.compone
             <form [formGroup]="form" (ngSubmit)="onSubmit()" class="form">
                 <div class="form__field">
                     <label for="name" class="form__label">Name</label>
-                    <input id="name" formControlName="name" class="form__input" />
+                    <input id="name" formControlName="name" class="form__input"
+                           [attr.aria-describedby]="form.get('name')?.invalid && form.get('name')?.touched ? 'name-error' : null" />
+                    @if (form.get('name')?.hasError('required') && form.get('name')?.touched) {
+                        <span id="name-error" class="form__error" role="alert">Project name is required.</span>
+                    }
                 </div>
 
                 <div class="form__field">
                     <label for="workingDir" class="form__label">Working Directory</label>
                     <div class="form__row">
                         <input id="workingDir" formControlName="workingDir" class="form__input"
-                               placeholder="/path/to/project" />
+                               placeholder="/path/to/project"
+                               [attr.aria-describedby]="form.get('workingDir')?.invalid && form.get('workingDir')?.touched ? 'workingDir-error' : null" />
                         <button type="button" class="btn btn--secondary" (click)="showBrowser.set(true)">Browse</button>
                     </div>
+                    @if (form.get('workingDir')?.hasError('required') && form.get('workingDir')?.touched) {
+                        <span id="workingDir-error" class="form__error" role="alert">Working directory is required.</span>
+                    }
                 </div>
 
                 @if (showBrowser()) {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -321,6 +321,17 @@ select:focus-visible {
     font-size: var(--text-xs);
     color: var(--text-tertiary);
 }
+.form__error {
+    font-size: var(--text-xs);
+    color: var(--accent-red);
+    margin-top: 0.15rem;
+}
+.form__input.ng-invalid.ng-touched {
+    border-color: var(--accent-red);
+}
+.form__input.ng-invalid.ng-touched:focus {
+    box-shadow: 0 0 0 1px rgba(255, 51, 85, 0.2), 0 0 12px rgba(255, 51, 85, 0.08);
+}
 .form__row { display: flex; gap: 0.5rem; align-items: stretch; }
 .form__row .form__input { flex: 1; }
 .form__fieldset {


### PR DESCRIPTION
## Summary
- Add inline validation error messages with `role="alert"` and `aria-describedby` on all form required fields (agent, project, council forms)
- Add global `.form__error` CSS class and `.ng-invalid.ng-touched` red border styling for invalid inputs
- Replace silent avatar-error hiding with a fallback placeholder icon `[>_]` on agent cards
- Use signal-based avatar error tracking for proper Angular change detection

## Test plan
- [ ] Navigate to agent/project/council create forms, submit without filling required fields — error messages should appear
- [ ] Tab through form fields — invalid fields should show red border after blur
- [ ] Set an agent's avatar URL to an invalid URL — fallback icon should appear instead of blank space
- [ ] Verify all 8882 tests still pass
- [ ] Verify spec:check and stats:check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)