### PR TITLE
fix(frontend): add confirmation dialogs to destructive actions

### DIFF
--- a/client/src/app/features/contacts/contact-list.component.ts
+++ b/client/src/app/features/contacts/contact-list.component.ts
@@ -501,6 +501,7 @@ export class ContactListComponent implements OnInit {
     async removeLink(link: PlatformLink): Promise<void> {
         const c = this.selectedContact();
         if (!c) return;
+        if (!confirm(`Remove ${link.platform} link? This cannot be undone.`)) return;
         await this.contactService.removeLink(c.id, link.id);
         this.selectedContact.set(this.contactService.findById(c.id) ?? c);
     }

--- a/client/src/app/features/feed/live-feed.component.ts
+++ b/client/src/app/features/feed/live-feed.component.ts
@@ -515,6 +515,7 @@ export class LiveFeedComponent implements OnInit, OnDestroy {
     }
 
     protected onClear(): void {
+        if (!confirm('Clear all feed messages? This cannot be undone.')) return;
         this.rawEntries.set([]);
         this.expandedIds.set(new Set());
         this.seenMessageKeys.clear();

--- a/client/src/app/features/models/models.component.ts
+++ b/client/src/app/features/models/models.component.ts
@@ -526,6 +526,7 @@ export class ModelsComponent implements OnInit, OnDestroy {
     }
 
     async deleteModel(model: string): Promise<void> {
+        if (!confirm(`Delete model "${model}"? This cannot be undone.`)) return;
         this.deletingModel.set(model);
         try {
             await firstValueFrom(

--- a/client/src/app/features/skill-bundles/skill-bundle-list.component.ts
+++ b/client/src/app/features/skill-bundles/skill-bundle-list.component.ts
@@ -323,6 +323,7 @@ export class SkillBundleListComponent implements OnInit {
             this.notify.error('Cannot delete preset bundles');
             return;
         }
+        if (!confirm(`Delete skill bundle "${bundle.name}"?`)) return;
         try {
             await this.bundleService.deleteBundle(bundle.id);
             this.expandedId.set(null);

--- a/client/src/app/features/spending/spending.component.ts
+++ b/client/src/app/features/spending/spending.component.ts
@@ -293,6 +293,7 @@ export class SpendingComponent implements OnInit {
     }
 
     async removeCap(agentId: string): Promise<void> {
+        if (!confirm('Remove spending cap? The agent will revert to default limits.')) return;
         try {
             await firstValueFrom(this.api.delete(`/agents/${agentId}/spending-cap`));
             this.notify.success('Spending cap removed');


### PR DESCRIPTION
## Summary
- Add `confirm()` guards before 5 irreversible destructive actions that were missing them
- Live feed clear, Ollama model delete, skill bundle delete, contact link remove, spending cap remove
- Follows the existing pattern already used in mention-polling, repo-blocklist, and wallet-viewer

## Test plan
- [ ] Click "Clear" on live feed — confirmation dialog should appear
- [ ] Delete an Ollama model — confirmation with model name should appear
- [ ] Delete a skill bundle — confirmation with bundle name should appear
- [ ] Remove a contact platform link — confirmation should appear
- [ ] Remove a spending cap — confirmation should appear
- [ ] Clicking "Cancel" on any dialog should abort the action

🤖 Generated with [Claude Code](https://claude.com/claude-code)