### PR TITLE
test: expand coverage for buddy mode and auth middleware

### DIFF
--- a/server/__tests__/auth-middleware.test.ts
+++ b/server/__tests__/auth-middleware.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Tests for authentication middleware — HTTP auth, WS auth, CORS, key rotation, expiry.
+ */
+import { describe, test, expect, beforeEach } from 'bun:test';
+import {
+    loadAuthConfig,
+    checkHttpAuth,
+    checkWsAuth,
+    rotateApiKey,
+    getApiKeyRotationStatus,
+    setApiKeyExpiry,
+    isApiKeyExpired,
+    getApiKeyExpiryWarning,
+    buildCorsHeaders,
+    timingSafeEqual,
+    type AuthConfig,
+} from '../middleware/auth';
+
+function makeConfig(overrides: Partial<AuthConfig> = {}): AuthConfig {
+    return {
+        apiKey: 'test-api-key-secure-enough',
+        allowedOrigins: [],
+        bindHost: '127.0.0.1',
+        ...overrides,
+    };
+}
+
+function makeRequest(path: string, opts: { method?: string; headers?: Record<string, string> } = {}): { req: Request; url: URL } {
+    const url = new URL(`http://localhost:3000${path}`);
+    const req = new Request(url.toString(), {
+        method: opts.method ?? 'GET',
+        headers: opts.headers ?? {},
+    });
+    return { req, url };
+}
+
+// ── timingSafeEqual ──────────────────────────────────────────────────
+
+describe('timingSafeEqual', () => {
+    test('returns true for equal strings', () => {
+        expect(timingSafeEqual('hello', 'hello')).toBe(true);
+    });
+
+    test('returns false for different strings', () => {
+        expect(timingSafeEqual('hello', 'world')).toBe(false);
+    });
+
+    test('returns false for different lengths', () => {
+        expect(timingSafeEqual('short', 'much-longer-string')).toBe(false);
+    });
+
+    test('returns true for empty strings', () => {
+        expect(timingSafeEqual('', '')).toBe(true);
+    });
+
+    test('returns false for one empty one not', () => {
+        expect(timingSafeEqual('', 'x')).toBe(false);
+    });
+});
+
+// ── checkHttpAuth ────────────────────────────────────────────────────
+
+describe('checkHttpAuth', () => {
+    test('allows all requests when no API key configured', () => {
+        const config = makeConfig({ apiKey: null });
+        const { req, url } = makeRequest('/api/agents');
+        expect(checkHttpAuth(req, url, config)).toBeNull();
+    });
+
+    test('allows OPTIONS preflight', () => {
+        const config = makeConfig();
+        const { req, url } = makeRequest('/api/agents', { method: 'OPTIONS' });
+        expect(checkHttpAuth(req, url, config)).toBeNull();
+    });
+
+    test('allows /api/health without auth', () => {
+        const config = makeConfig();
+        const { req, url } = makeRequest('/api/health');
+        expect(checkHttpAuth(req, url, config)).toBeNull();
+    });
+
+    test('allows /.well-known/agent-card.json without auth', () => {
+        const config = makeConfig();
+        const { req, url } = makeRequest('/.well-known/agent-card.json');
+        expect(checkHttpAuth(req, url, config)).toBeNull();
+    });
+
+    test('allows /api/tenants/register without auth', () => {
+        const config = makeConfig();
+        const { req, url } = makeRequest('/api/tenants/register');
+        expect(checkHttpAuth(req, url, config)).toBeNull();
+    });
+
+    test('rejects request without Authorization header', () => {
+        const config = makeConfig();
+        const { req, url } = makeRequest('/api/agents');
+        const resp = checkHttpAuth(req, url, config);
+        expect(resp).not.toBeNull();
+        expect(resp!.status).toBe(401);
+    });
+
+    test('rejects malformed Authorization header', () => {
+        const config = makeConfig();
+        const { req, url } = makeRequest('/api/agents', {
+            headers: { Authorization: 'Basic dXNlcjpwYXNz' },
+        });
+        const resp = checkHttpAuth(req, url, config);
+        expect(resp).not.toBeNull();
+        expect(resp!.status).toBe(401);
+    });
+
+    test('rejects invalid API key', () => {
+        const config = makeConfig();
+        const { req, url } = makeRequest('/api/agents', {
+            headers: { Authorization: 'Bearer wrong-key' },
+        });
+        const resp = checkHttpAuth(req, url, config);
+        expect(resp).not.toBeNull();
+        expect(resp!.status).toBe(403);
+    });
+
+    test('accepts valid API key', () => {
+        const config = makeConfig();
+        const { req, url } = makeRequest('/api/agents', {
+            headers: { Authorization: `Bearer ${config.apiKey}` },
+        });
+        expect(checkHttpAuth(req, url, config)).toBeNull();
+    });
+
+    test('rejects expired but valid key', () => {
+        const config = makeConfig({
+            apiKeyExpiresAt: Date.now() - 1000, // expired
+        });
+        const { req, url } = makeRequest('/api/agents', {
+            headers: { Authorization: `Bearer ${config.apiKey}` },
+        });
+        const resp = checkHttpAuth(req, url, config);
+        expect(resp).not.toBeNull();
+        expect(resp!.status).toBe(401);
+    });
+});
+
+// ── checkWsAuth ──────────────────────────────────────────────────────
+
+describe('checkWsAuth', () => {
+    test('allows when no API key configured', () => {
+        const config = makeConfig({ apiKey: null });
+        const { req, url } = makeRequest('/ws');
+        expect(checkWsAuth(req, url, config)).toBe(true);
+    });
+
+    test('accepts valid Bearer header', () => {
+        const config = makeConfig();
+        const { req, url } = makeRequest('/ws', {
+            headers: { Authorization: `Bearer ${config.apiKey}` },
+        });
+        expect(checkWsAuth(req, url, config)).toBe(true);
+    });
+
+    test('accepts valid query param (deprecated)', () => {
+        const config = makeConfig();
+        const url = new URL(`http://localhost:3000/ws?key=${config.apiKey}`);
+        const req = new Request(url.toString());
+        expect(checkWsAuth(req, url, config)).toBe(true);
+    });
+
+    test('rejects invalid auth', () => {
+        const config = makeConfig();
+        const { req, url } = makeRequest('/ws');
+        expect(checkWsAuth(req, url, config)).toBe(false);
+    });
+
+    test('rejects wrong key', () => {
+        const config = makeConfig();
+        const { req, url } = makeRequest('/ws', {
+            headers: { Authorization: 'Bearer wrong' },
+        });
+        expect(checkWsAuth(req, url, config)).toBe(false);
+    });
+});
+
+// ── API Key Rotation ─────────────────────────────────────────────────
+
+describe('rotateApiKey', () => {
+    test('generates new key and retains previous', () => {
+        const config = makeConfig();
+        const originalKey = config.apiKey!;
+        const newKey = rotateApiKey(config, 60_000);
+
+        expect(newKey).not.toBe(originalKey);
+        expect(config.apiKey).toBe(newKey);
+        expect(config.previousApiKey).toBe(originalKey);
+        expect(config.previousKeyExpiry).toBeGreaterThan(Date.now());
+    });
+
+    test('previous key accepted during grace period', () => {
+        const config = makeConfig();
+        const originalKey = config.apiKey!;
+        rotateApiKey(config, 60_000);
+
+        // Original key should still work during grace period
+        const { req, url } = makeRequest('/api/agents', {
+            headers: { Authorization: `Bearer ${originalKey}` },
+        });
+        expect(checkHttpAuth(req, url, config)).toBeNull();
+    });
+
+    test('previous key rejected after grace period', () => {
+        const config = makeConfig();
+        const originalKey = config.apiKey!;
+        rotateApiKey(config, 1); // 1ms grace
+
+        // Manually expire
+        config.previousKeyExpiry = Date.now() - 1000;
+
+        const { req, url } = makeRequest('/api/agents', {
+            headers: { Authorization: `Bearer ${originalKey}` },
+        });
+        const resp = checkHttpAuth(req, url, config);
+        expect(resp).not.toBeNull();
+        expect(resp!.status).toBe(403);
+    });
+});
+
+describe('getApiKeyRotationStatus', () => {
+    test('no active key', () => {
+        const config = makeConfig({ apiKey: null });
+        const status = getApiKeyRotationStatus(config);
+        expect(status.hasActiveKey).toBe(false);
+        expect(status.isInGracePeriod).toBe(false);
+    });
+
+    test('active key, no rotation', () => {
+        const config = makeConfig();
+        const status = getApiKeyRotationStatus(config);
+        expect(status.hasActiveKey).toBe(true);
+        expect(status.isInGracePeriod).toBe(false);
+        expect(status.gracePeriodExpiry).toBeNull();
+    });
+
+    test('during grace period', () => {
+        const config = makeConfig();
+        rotateApiKey(config, 60_000);
+        const status = getApiKeyRotationStatus(config);
+        expect(status.isInGracePeriod).toBe(true);
+        expect(status.gracePeriodExpiry).toBeTruthy();
+    });
+});
+
+// ── API Key Expiration ───────────────────────────────────────────────
+
+describe('isApiKeyExpired', () => {
+    test('not expired when no expiry set', () => {
+        const config = makeConfig();
+        expect(isApiKeyExpired(config)).toBe(false);
+    });
+
+    test('not expired when expiry is in future', () => {
+        const config = makeConfig({ apiKeyExpiresAt: Date.now() + 86_400_000 });
+        expect(isApiKeyExpired(config)).toBe(false);
+    });
+
+    test('expired when expiry is in past', () => {
+        const config = makeConfig({ apiKeyExpiresAt: Date.now() - 1000 });
+        expect(isApiKeyExpired(config)).toBe(true);
+    });
+});
+
+describe('setApiKeyExpiry', () => {
+    test('sets createdAt and expiresAt', () => {
+        const config = makeConfig();
+        setApiKeyExpiry(config, 3600_000);
+        expect(config.apiKeyCreatedAt).toBeGreaterThan(0);
+        expect(config.apiKeyExpiresAt).toBeGreaterThan(Date.now());
+    });
+});
+
+describe('getApiKeyExpiryWarning', () => {
+    test('null when no expiry', () => {
+        const config = makeConfig();
+        expect(getApiKeyExpiryWarning(config)).toBeNull();
+    });
+
+    test('null when expiry is far in future', () => {
+        const config = makeConfig({ apiKeyExpiresAt: Date.now() + 30 * 86_400_000 });
+        expect(getApiKeyExpiryWarning(config)).toBeNull();
+    });
+
+    test('warns when expiry is within 7 days', () => {
+        const config = makeConfig({ apiKeyExpiresAt: Date.now() + 3 * 86_400_000 });
+        const warning = getApiKeyExpiryWarning(config);
+        expect(warning).toContain('3 days');
+    });
+
+    test('null when already expired', () => {
+        const config = makeConfig({ apiKeyExpiresAt: Date.now() - 1000 });
+        expect(getApiKeyExpiryWarning(config)).toBeNull();
+    });
+});
+
+// ── CORS ─────────────────────────────────────────────────────────────
+
+describe('buildCorsHeaders', () => {
+    test('returns wildcard when no origins configured', () => {
+        const config = makeConfig();
+        const { req } = makeRequest('/api/agents', {
+            headers: { Origin: 'http://example.com' },
+        });
+        const headers = buildCorsHeaders(req, config);
+        expect(headers['Access-Control-Allow-Origin']).toBe('*');
+    });
+
+    test('reflects allowed origin', () => {
+        const config = makeConfig({ allowedOrigins: ['http://example.com'] });
+        const { req } = makeRequest('/api/agents', {
+            headers: { Origin: 'http://example.com' },
+        });
+        const headers = buildCorsHeaders(req, config);
+        expect(headers['Access-Control-Allow-Origin']).toBe('http://example.com');
+        expect(headers['Vary']).toBe('Origin');
+    });
+
+    test('blocks disallowed origin', () => {
+        const config = makeConfig({ allowedOrigins: ['http://example.com'] });
+        const { req } = makeRequest('/api/agents', {
+            headers: { Origin: 'http://evil.com' },
+        });
+        const headers = buildCorsHeaders(req, config);
+        expect(headers['Access-Control-Allow-Origin']).toBe('');
+    });
+
+    test('allows same-origin (no Origin header)', () => {
+        const config = makeConfig({ allowedOrigins: ['http://example.com'] });
+        const { req } = makeRequest('/api/agents');
+        const headers = buildCorsHeaders(req, config);
+        expect(headers['Access-Control-Allow-Origin']).toBe('*');
+    });
+});
+
+// ── loadAuthConfig ───────────────────────────────────────────────────
+
+describe('loadAuthConfig', () => {
+    let origEnv: Record<string, string | undefined>;
+
+    beforeEach(() => {
+        origEnv = {
+            API_KEY: process.env.API_KEY,
+            BIND_HOST: process.env.BIND_HOST,
+            ALLOWED_ORIGINS: process.env.ALLOWED_ORIGINS,
+            API_KEY_TTL_DAYS: process.env.API_KEY_TTL_DAYS,
+        };
+    });
+
+    // Restore env after each test
+    function restoreEnv() {
+        for (const [k, v] of Object.entries(origEnv)) {
+            if (v === undefined) delete process.env[k];
+            else process.env[k] = v;
+        }
+    }
+
+    test('loads with no env vars set', () => {
+        delete process.env.API_KEY;
+        delete process.env.BIND_HOST;
+        delete process.env.ALLOWED_ORIGINS;
+        delete process.env.API_KEY_TTL_DAYS;
+        const config = loadAuthConfig();
+        expect(config.apiKey).toBeNull();
+        expect(config.bindHost).toBe('127.0.0.1');
+        expect(config.allowedOrigins).toEqual([]);
+        restoreEnv();
+    });
+
+    test('parses comma-separated origins', () => {
+        process.env.ALLOWED_ORIGINS = 'http://a.com, http://b.com';
+        delete process.env.API_KEY;
+        delete process.env.BIND_HOST;
+        delete process.env.API_KEY_TTL_DAYS;
+        const config = loadAuthConfig();
+        expect(config.allowedOrigins).toEqual(['http://a.com', 'http://b.com']);
+        restoreEnv();
+    });
+
+    test('sets expiry when API_KEY_TTL_DAYS is set', () => {
+        process.env.API_KEY = 'test-key-for-ttl';
+        process.env.API_KEY_TTL_DAYS = '30';
+        delete process.env.BIND_HOST;
+        delete process.env.ALLOWED_ORIGINS;
+        const config = loadAuthConfig();
+        expect(config.apiKeyExpiresAt).toBeGreaterThan(Date.now());
+        restoreEnv();
+    });
+});

--- a/server/__tests__/buddy-db.test.ts
+++ b/server/__tests__/buddy-db.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Tests for buddy mode DB helpers (pairings, sessions, messages CRUD).
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import { createAgent } from '../db/agents';
+import {
+    createBuddyPairing,
+    getBuddyPairing,
+    listBuddyPairings,
+    getDefaultBuddyForAgent,
+    updateBuddyPairing,
+    deleteBuddyPairing,
+    createBuddySession,
+    getBuddySession,
+    listBuddySessions,
+    updateBuddySessionStatus,
+    addBuddyMessage,
+    listBuddyMessages,
+} from '../db/buddy';
+
+let db: Database;
+let leadId: string;
+let buddyId: string;
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+
+    const lead = createAgent(db, { name: 'LeadAgent', model: 'test-model' });
+    const buddy = createAgent(db, { name: 'BuddyAgent', model: 'test-model' });
+    leadId = lead.id;
+    buddyId = buddy.id;
+});
+
+afterEach(() => {
+    db.close();
+});
+
+// ── Pairings ─────────────────────────────────────────────────────────
+
+describe('createBuddyPairing', () => {
+    test('creates with defaults', () => {
+        const pairing = createBuddyPairing(db, leadId, buddyId);
+        expect(pairing.id).toBeTruthy();
+        expect(pairing.agentId).toBe(leadId);
+        expect(pairing.buddyAgentId).toBe(buddyId);
+        expect(pairing.enabled).toBe(true);
+        expect(pairing.maxRounds).toBe(5);
+        expect(pairing.buddyRole).toBe('reviewer');
+        expect(pairing.createdAt).toBeTruthy();
+        expect(pairing.updatedAt).toBeTruthy();
+    });
+
+    test('creates with custom options', () => {
+        const pairing = createBuddyPairing(db, leadId, buddyId, {
+            maxRounds: 8,
+            buddyRole: 'validator',
+        });
+        expect(pairing.maxRounds).toBe(8);
+        expect(pairing.buddyRole).toBe('validator');
+    });
+
+    test('rejects duplicate agent-buddy pair', () => {
+        createBuddyPairing(db, leadId, buddyId);
+        expect(() => createBuddyPairing(db, leadId, buddyId)).toThrow();
+    });
+});
+
+describe('getBuddyPairing', () => {
+    test('returns null for nonexistent id', () => {
+        expect(getBuddyPairing(db, 'nonexistent')).toBeNull();
+    });
+
+    test('returns pairing by id', () => {
+        const created = createBuddyPairing(db, leadId, buddyId);
+        const fetched = getBuddyPairing(db, created.id);
+        expect(fetched).not.toBeNull();
+        expect(fetched!.id).toBe(created.id);
+    });
+});
+
+describe('listBuddyPairings', () => {
+    test('returns empty for agent with no pairings', () => {
+        expect(listBuddyPairings(db, leadId)).toEqual([]);
+    });
+
+    test('returns pairings for agent', () => {
+        const extra = createAgent(db, { name: 'ExtraBuddy', model: 'test-model' });
+        createBuddyPairing(db, leadId, buddyId);
+        createBuddyPairing(db, leadId, extra.id);
+        const pairings = listBuddyPairings(db, leadId);
+        expect(pairings).toHaveLength(2);
+    });
+});
+
+describe('getDefaultBuddyForAgent', () => {
+    test('returns null when no enabled pairing', () => {
+        expect(getDefaultBuddyForAgent(db, leadId)).toBeNull();
+    });
+
+    test('returns earliest enabled pairing', () => {
+        const pairing = createBuddyPairing(db, leadId, buddyId);
+        const result = getDefaultBuddyForAgent(db, leadId);
+        expect(result).not.toBeNull();
+        expect(result!.id).toBe(pairing.id);
+    });
+
+    test('skips disabled pairings', () => {
+        const pairing = createBuddyPairing(db, leadId, buddyId);
+        updateBuddyPairing(db, pairing.id, { enabled: false });
+        expect(getDefaultBuddyForAgent(db, leadId)).toBeNull();
+    });
+});
+
+describe('updateBuddyPairing', () => {
+    test('updates enabled flag', () => {
+        const pairing = createBuddyPairing(db, leadId, buddyId);
+        updateBuddyPairing(db, pairing.id, { enabled: false });
+        const updated = getBuddyPairing(db, pairing.id)!;
+        expect(updated.enabled).toBe(false);
+    });
+
+    test('updates maxRounds', () => {
+        const pairing = createBuddyPairing(db, leadId, buddyId);
+        updateBuddyPairing(db, pairing.id, { maxRounds: 10 });
+        const updated = getBuddyPairing(db, pairing.id)!;
+        expect(updated.maxRounds).toBe(10);
+    });
+
+    test('updates buddyRole', () => {
+        const pairing = createBuddyPairing(db, leadId, buddyId);
+        updateBuddyPairing(db, pairing.id, { buddyRole: 'collaborator' });
+        const updated = getBuddyPairing(db, pairing.id)!;
+        expect(updated.buddyRole).toBe('collaborator');
+    });
+
+    test('no-op when no updates provided', () => {
+        const pairing = createBuddyPairing(db, leadId, buddyId);
+        updateBuddyPairing(db, pairing.id, {});
+        const unchanged = getBuddyPairing(db, pairing.id)!;
+        expect(unchanged.maxRounds).toBe(pairing.maxRounds);
+    });
+});
+
+describe('deleteBuddyPairing', () => {
+    test('deletes a pairing', () => {
+        const pairing = createBuddyPairing(db, leadId, buddyId);
+        deleteBuddyPairing(db, pairing.id);
+        expect(getBuddyPairing(db, pairing.id)).toBeNull();
+    });
+
+    test('no-op for nonexistent id', () => {
+        expect(() => deleteBuddyPairing(db, 'nonexistent')).not.toThrow();
+    });
+});
+
+// ── Sessions ─────────────────────────────────────────────────────────
+
+describe('createBuddySession', () => {
+    test('creates with defaults', () => {
+        const session = createBuddySession(db, {
+            leadAgentId: leadId,
+            buddyAgentId: buddyId,
+            prompt: 'Review this code',
+            source: 'web',
+        });
+        expect(session.id).toBeTruthy();
+        expect(session.leadAgentId).toBe(leadId);
+        expect(session.buddyAgentId).toBe(buddyId);
+        expect(session.prompt).toBe('Review this code');
+        expect(session.source).toBe('web');
+        expect(session.status).toBe('active');
+        expect(session.currentRound).toBe(0);
+        expect(session.maxRounds).toBe(5);
+        expect(session.completedAt).toBeNull();
+    });
+
+    test('creates with custom maxRounds and source', () => {
+        const session = createBuddySession(db, {
+            leadAgentId: leadId,
+            buddyAgentId: buddyId,
+            prompt: 'Test',
+            source: 'discord',
+            sourceId: 'channel-123',
+            maxRounds: 3,
+        });
+        expect(session.maxRounds).toBe(3);
+        expect(session.source).toBe('discord');
+        expect(session.sourceId).toBe('channel-123');
+    });
+});
+
+describe('getBuddySession', () => {
+    test('returns null for nonexistent id', () => {
+        expect(getBuddySession(db, 'nope')).toBeNull();
+    });
+});
+
+describe('listBuddySessions', () => {
+    test('returns empty when none exist', () => {
+        expect(listBuddySessions(db)).toEqual([]);
+    });
+
+    test('filters by leadAgentId', () => {
+        createBuddySession(db, { leadAgentId: leadId, buddyAgentId: buddyId, prompt: 'A', source: 'web' });
+        createBuddySession(db, { leadAgentId: buddyId, buddyAgentId: leadId, prompt: 'B', source: 'web' });
+        const sessions = listBuddySessions(db, { leadAgentId: leadId });
+        expect(sessions).toHaveLength(1);
+        expect(sessions[0].prompt).toBe('A');
+    });
+
+    test('filters by status', () => {
+        const s = createBuddySession(db, { leadAgentId: leadId, buddyAgentId: buddyId, prompt: 'A', source: 'web' });
+        updateBuddySessionStatus(db, s.id, 'completed');
+        const active = listBuddySessions(db, { status: 'active' });
+        const completed = listBuddySessions(db, { status: 'completed' });
+        expect(active).toHaveLength(0);
+        expect(completed).toHaveLength(1);
+    });
+
+    test('respects limit', () => {
+        for (let i = 0; i < 5; i++) {
+            createBuddySession(db, { leadAgentId: leadId, buddyAgentId: buddyId, prompt: `P${i}`, source: 'web' });
+        }
+        const limited = listBuddySessions(db, { limit: 2 });
+        expect(limited).toHaveLength(2);
+    });
+});
+
+describe('updateBuddySessionStatus', () => {
+    test('marks completed with timestamp', () => {
+        const session = createBuddySession(db, { leadAgentId: leadId, buddyAgentId: buddyId, prompt: 'T', source: 'web' });
+        updateBuddySessionStatus(db, session.id, 'completed', 3);
+        const updated = getBuddySession(db, session.id)!;
+        expect(updated.status).toBe('completed');
+        expect(updated.completedAt).toBeTruthy();
+        expect(updated.currentRound).toBe(3);
+    });
+
+    test('marks failed with timestamp', () => {
+        const session = createBuddySession(db, { leadAgentId: leadId, buddyAgentId: buddyId, prompt: 'T', source: 'web' });
+        updateBuddySessionStatus(db, session.id, 'failed');
+        const updated = getBuddySession(db, session.id)!;
+        expect(updated.status).toBe('failed');
+        expect(updated.completedAt).toBeTruthy();
+    });
+
+    test('updates active status without completed_at', () => {
+        const session = createBuddySession(db, { leadAgentId: leadId, buddyAgentId: buddyId, prompt: 'T', source: 'web' });
+        updateBuddySessionStatus(db, session.id, 'active', 2);
+        const updated = getBuddySession(db, session.id)!;
+        expect(updated.status).toBe('active');
+        expect(updated.completedAt).toBeNull();
+        expect(updated.currentRound).toBe(2);
+    });
+});
+
+// ── Messages ─────────────────────────────────────────────────────────
+
+describe('addBuddyMessage', () => {
+    test('creates a message', () => {
+        const session = createBuddySession(db, { leadAgentId: leadId, buddyAgentId: buddyId, prompt: 'T', source: 'web' });
+        const msg = addBuddyMessage(db, session.id, leadId, 1, 'lead', 'Here is my output');
+        expect(msg.id).toBeTruthy();
+        expect(msg.buddySessionId).toBe(session.id);
+        expect(msg.agentId).toBe(leadId);
+        expect(msg.round).toBe(1);
+        expect(msg.role).toBe('lead');
+        expect(msg.content).toBe('Here is my output');
+    });
+});
+
+describe('listBuddyMessages', () => {
+    test('returns messages ordered by round', () => {
+        const session = createBuddySession(db, { leadAgentId: leadId, buddyAgentId: buddyId, prompt: 'T', source: 'web' });
+        addBuddyMessage(db, session.id, leadId, 1, 'lead', 'Round 1 lead');
+        addBuddyMessage(db, session.id, buddyId, 1, 'buddy', 'Round 1 review');
+        addBuddyMessage(db, session.id, leadId, 2, 'lead', 'Round 2 lead');
+
+        const messages = listBuddyMessages(db, session.id);
+        expect(messages).toHaveLength(3);
+        expect(messages[0].round).toBe(1);
+        expect(messages[0].role).toBe('lead');
+        expect(messages[1].round).toBe(1);
+        expect(messages[1].role).toBe('buddy');
+        expect(messages[2].round).toBe(2);
+    });
+
+    test('returns empty for unknown session', () => {
+        expect(listBuddyMessages(db, 'nonexistent')).toEqual([]);
+    });
+});
+
+// ── Cascade ──────────────────────────────────────────────────────────
+
+describe('cascade deletes', () => {
+    test('deleting agent cascades buddy pairings', () => {
+        createBuddyPairing(db, leadId, buddyId);
+        db.prepare('DELETE FROM agents WHERE id = ?').run(leadId);
+        expect(listBuddyPairings(db, leadId)).toEqual([]);
+    });
+
+    test('deleting session cascades buddy messages', () => {
+        const session = createBuddySession(db, { leadAgentId: leadId, buddyAgentId: buddyId, prompt: 'T', source: 'web' });
+        addBuddyMessage(db, session.id, leadId, 1, 'lead', 'msg');
+        db.prepare('DELETE FROM buddy_sessions WHERE id = ?').run(session.id);
+        expect(listBuddyMessages(db, session.id)).toEqual([]);
+    });
+});

--- a/server/__tests__/buddy-service-approval.test.ts
+++ b/server/__tests__/buddy-service-approval.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for BuddyService.isApproval — the approval detection logic.
+ *
+ * Since isApproval is private, we test it via a thin wrapper that
+ * instantiates BuddyService with a minimal mock and exposes the method.
+ */
+import { describe, test, expect } from 'bun:test';
+import { BuddyService } from '../buddy/service';
+
+// BuddyService needs db + processManager, but isApproval is pure logic.
+// We create a minimal instance and access the private method via bracket notation.
+const service = new BuddyService({
+    db: {} as any,
+    processManager: {} as any,
+});
+
+function isApproval(output: string): boolean {
+    return (service as any).isApproval(output);
+}
+
+describe('isApproval', () => {
+    // ── Positive cases ───────────────────────────────────────────────
+    describe('detects approval', () => {
+        test('plain LGTM', () => {
+            expect(isApproval('LGTM')).toBe(true);
+        });
+
+        test('lowercase lgtm', () => {
+            expect(isApproval('lgtm')).toBe(true);
+        });
+
+        test('looks good to me', () => {
+            expect(isApproval('Looks good to me!')).toBe(true);
+        });
+
+        test('approved', () => {
+            expect(isApproval('Approved.')).toBe(true);
+        });
+
+        test('no issues found is rejected by negative pattern (known edge case)', () => {
+            // The negative pattern /issues?\s+(found|...)/ fires before the
+            // approval phrase check, so "no issues found" is treated as
+            // qualified feedback. This tests current behavior.
+            expect(isApproval('No issues found.')).toBe(false);
+        });
+
+        test('no issues (without "found")', () => {
+            expect(isApproval('No issues.')).toBe(true);
+        });
+
+        test('ship it', () => {
+            expect(isApproval('Ship it!')).toBe(true);
+        });
+
+        test('lgtm with minor context', () => {
+            expect(isApproval('Everything checks out. LGTM.')).toBe(true);
+        });
+    });
+
+    // ── Negative qualifier rejection ─────────────────────────────────
+    describe('rejects qualified approvals', () => {
+        test('not approved', () => {
+            expect(isApproval('Not approved yet.')).toBe(false);
+        });
+
+        test('approved but with issues', () => {
+            expect(isApproval('Approved, but there are two issues remaining.')).toBe(false);
+        });
+
+        test('lgtm however', () => {
+            expect(isApproval('LGTM, however the tests are missing.')).toBe(false);
+        });
+
+        test('with reservations', () => {
+            expect(isApproval('Approved with reservations about the error handling.')).toBe(false);
+        });
+
+        test("don't approve yet", () => {
+            expect(isApproval("I don't think this is ready. Not approved.")).toBe(false);
+        });
+
+        test('issues remain', () => {
+            expect(isApproval('LGTM overall, but issues still remain with the tests.')).toBe(false);
+        });
+
+        test('do not merge', () => {
+            expect(isApproval('Do not merge this yet. Approved in principle only.')).toBe(false);
+        });
+    });
+
+    // ── Length threshold ─────────────────────────────────────────────
+    describe('rejects long responses', () => {
+        test('approval buried in long text is not detected', () => {
+            const longText = 'x'.repeat(250) + ' LGTM ' + 'y'.repeat(100);
+            expect(isApproval(longText)).toBe(false);
+        });
+
+        test('short approval within limit is detected', () => {
+            const text = 'Code review complete. LGTM.';
+            expect(isApproval(text)).toBe(true);
+        });
+    });
+
+    // ── Non-approval responses ───────────────────────────────────────
+    describe('rejects non-approval', () => {
+        test('feedback with suggestions', () => {
+            expect(isApproval('Please fix the error handling in processQueue.')).toBe(false);
+        });
+
+        test('empty string', () => {
+            expect(isApproval('')).toBe(false);
+        });
+
+        test('generic praise without approval phrase', () => {
+            expect(isApproval('Great work on this feature!')).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- **92 new test cases** across 3 new test files covering previously untested modules
- `buddy-db.test.ts`: Full CRUD coverage for buddy pairings, sessions, and messages including cascade deletes and edge cases
- `buddy-service-approval.test.ts`: Approval detection logic covering positive matches, negative qualifier rejection, length thresholds, and edge cases (also documents a known edge case where "no issues found" is rejected by the negative pattern)
- `auth-middleware.test.ts`: HTTP/WS auth checks, public path bypass, CORS header building, API key rotation with grace period, key expiry/warnings, timing-safe comparison, and loadAuthConfig env parsing

## Validation
- `bun x tsc --noEmit --skipLibCheck` — clean
- `bun test` — 8,974 tests pass (92 new), 0 failures
- `bun run spec:check` — 187/187 specs pass, 100% coverage

## Test plan
- [x] All 92 new tests pass
- [x] Full test suite passes with no regressions
- [x] TypeScript compiles cleanly
- [x] Spec check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)