### PR TITLE
feat(try-mode): auto-detect AI provider for zero-config sandbox

### DIFF
--- a/cli/commands/demo.ts
+++ b/cli/commands/demo.ts
@@ -31,6 +31,36 @@ async function waitForServer(baseUrl: string, maxWaitMs = 30_000): Promise<boole
     return false;
 }
 
+// ─── Provider Detection ─────────────────────────────────────────────────────
+
+interface ProviderInfo {
+    model: string;
+    provider?: string;
+}
+
+async function detectDemoProvider(baseUrl: string): Promise<ProviderInfo> {
+    // Query the server's health endpoint to check which providers are available
+    try {
+        const res = await fetch(`${baseUrl}/api/health`, { signal: AbortSignal.timeout(5_000) });
+        if (res.ok) {
+            const health = (await res.json()) as {
+                dependencies?: { llm?: { anthropic?: string; ollama?: string } };
+            };
+            const llm = health.dependencies?.llm;
+            if (llm?.anthropic === 'healthy') {
+                return { model: 'claude-sonnet-4-20250514' };
+            }
+            if (llm?.ollama === 'healthy') {
+                return { model: 'llama3.1', provider: 'ollama' };
+            }
+        }
+    } catch {
+        // Fall through to defaults
+    }
+    // Default to Claude — the SDK process will handle missing-provider errors
+    return { model: 'claude-sonnet-4-20250514' };
+}
+
 // ─── Seed Demo Agent ────────────────────────────────────────────────────────
 
 interface DemoData {
@@ -40,6 +70,8 @@ interface DemoData {
 }
 
 async function seedDemo(baseUrl: string, projectRoot: string): Promise<DemoData> {
+    const providerInfo = await detectDemoProvider(baseUrl);
+
     const projectRes = await fetch(`${baseUrl}/api/projects`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -52,13 +84,10 @@ async function seedDemo(baseUrl: string, projectRoot: string): Promise<DemoData>
     if (!projectRes.ok) throw new Error(`Project creation failed: ${await projectRes.text()}`);
     const project = (await projectRes.json()) as { id: string };
 
-    const agentRes = await fetch(`${baseUrl}/api/agents`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            name: 'Demo Agent',
-            description: 'A demo agent that introduces corvid-agent capabilities',
-            systemPrompt: `You are running inside corvid-agent, an AI agent orchestration platform. You are in demo mode — introduce yourself briefly and show what you can do.
+    const agentBody: Record<string, unknown> = {
+        name: 'Demo Agent',
+        description: 'A demo agent that introduces corvid-agent capabilities',
+        systemPrompt: `You are running inside corvid-agent, an AI agent orchestration platform. You are in demo mode — introduce yourself briefly and show what you can do.
 
 Demonstrate these capabilities concisely (1-2 lines each):
 1. You can analyze code — show by examining a file in the current project
@@ -68,8 +97,16 @@ Demonstrate these capabilities concisely (1-2 lines each):
 
 Keep your response under 15 lines. Be friendly and enthusiastic but concise.
 End by suggesting what the user can try next (e.g., ask you to review a file, explain the architecture, or check for bugs).`,
-            model: 'claude-sonnet-4-20250514',
-        }),
+        model: providerInfo.model,
+    };
+    if (providerInfo.provider) {
+        agentBody.provider = providerInfo.provider;
+    }
+
+    const agentRes = await fetch(`${baseUrl}/api/agents`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(agentBody),
     });
     if (!agentRes.ok) throw new Error(`Agent creation failed: ${await agentRes.text()}`);
     const agent = (await agentRes.json()) as { id: string };

--- a/scripts/try.ts
+++ b/scripts/try.ts
@@ -7,6 +7,10 @@
  * session with welcome messages, and opens the dashboard in the browser.
  * No .env or API keys required — works out of the box.
  *
+ * Auto-detects available AI providers (Claude CLI, API key, Ollama) and
+ * configures the demo agent accordingly. If no provider is found, the
+ * dashboard still works for exploration with actionable setup hints.
+ *
  * Part of #595 (onboarding epic), closes #596.
  */
 
@@ -17,6 +21,70 @@ import { join } from 'node:path';
 const PORT = process.env.PORT ?? '3000';
 const HOST = '127.0.0.1';
 const BASE_URL = `http://${HOST}:${PORT}`;
+
+// ── Provider detection ──────────────────────────────────────────────────────
+
+interface DetectedProvider {
+    name: string;
+    type: 'anthropic' | 'ollama' | 'openrouter' | 'none';
+    model: string;
+    /** Extra env vars to pass to the server for this provider. */
+    env: Record<string, string>;
+}
+
+async function detectProvider(): Promise<DetectedProvider> {
+    // 1. Check for ANTHROPIC_API_KEY
+    if (process.env.ANTHROPIC_API_KEY) {
+        console.log('  ✓ Anthropic API key detected');
+        return { name: 'Anthropic (API key)', type: 'anthropic', model: 'claude-sonnet-4-20250514', env: {} };
+    }
+
+    // 2. Check for Claude CLI
+    if (Bun.which('claude')) {
+        console.log('  ✓ Claude CLI detected');
+        return { name: 'Claude (CLI)', type: 'anthropic', model: 'claude-sonnet-4-20250514', env: {} };
+    }
+
+    // 3. Check for OpenRouter API key
+    if (process.env.OPENROUTER_API_KEY) {
+        console.log('  ✓ OpenRouter API key detected');
+        return { name: 'OpenRouter', type: 'openrouter', model: 'anthropic/claude-sonnet-4-20250514', env: {} };
+    }
+
+    // 4. Check for Ollama
+    const ollamaHost = process.env.OLLAMA_HOST ?? 'http://localhost:11434';
+    try {
+        const res = await fetch(`${ollamaHost}/api/tags`, { signal: AbortSignal.timeout(3_000) });
+        if (res.ok) {
+            const data = (await res.json()) as { models?: Array<{ name: string }> };
+            const models = data.models ?? [];
+            // Pick a reasonable default model from what's available
+            const preferred = ['llama3.1', 'llama3', 'qwen2.5', 'mistral', 'gemma2'];
+            const match = preferred.find((p) => models.some((m) => m.name.startsWith(p)));
+            const model = match
+                ? models.find((m) => m.name.startsWith(match))!.name
+                : models[0]?.name ?? 'llama3.1';
+            console.log(`  ✓ Ollama detected (${models.length} model${models.length !== 1 ? 's' : ''} available)`);
+            return {
+                name: 'Ollama (local)',
+                type: 'ollama',
+                model,
+                env: { OLLAMA_LOCAL_EXPERIMENTAL: 'true' },
+            };
+        }
+    } catch {
+        // Ollama not running
+    }
+
+    // 5. No provider found
+    console.log('  ⚠ No AI provider detected');
+    console.log('    The dashboard will work, but chat requires an AI provider.');
+    console.log('    Options:');
+    console.log('      • Set ANTHROPIC_API_KEY in your environment');
+    console.log('      • Install Claude CLI: npm i -g @anthropic-ai/claude-code');
+    console.log('      • Start Ollama: ollama serve');
+    return { name: 'none', type: 'none', model: 'none', env: {} };
+}
 
 // ── Banner ──────────────────────────────────────────────────────────────────
 function printBanner(): void {
@@ -47,7 +115,7 @@ async function waitForServer(maxWaitMs = 30_000): Promise<boolean> {
 }
 
 // ── Demo data seeding ───────────────────────────────────────────────────────
-async function seedDemoData(): Promise<{ agentId: string; sessionId: string; projectId: string }> {
+async function seedDemoData(provider: DetectedProvider): Promise<{ agentId: string; sessionId: string; projectId: string }> {
     // Create a project
     const projectRes = await fetch(`${BASE_URL}/api/projects`, {
         method: 'POST',
@@ -61,14 +129,11 @@ async function seedDemoData(): Promise<{ agentId: string; sessionId: string; pro
     if (!projectRes.ok) throw new Error(`Failed to create project: ${await projectRes.text()}`);
     const project = (await projectRes.json()) as { id: string };
 
-    // Create a demo agent
-    const agentRes = await fetch(`${BASE_URL}/api/agents`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            name: 'Corvid',
-            description: 'A friendly demo agent that shows what corvid-agent can do',
-            systemPrompt: `You are Corvid, a helpful AI assistant running inside corvid-agent. You are friendly, concise, and technically capable. When users ask what you can do, explain that corvid-agent is an AI agent framework that can:
+    // Create a demo agent configured for the detected provider
+    const agentBody: Record<string, unknown> = {
+        name: 'Corvid',
+        description: 'A friendly demo agent that shows what corvid-agent can do',
+        systemPrompt: `You are Corvid, a helpful AI assistant running inside corvid-agent. You are friendly, concise, and technically capable. When users ask what you can do, explain that corvid-agent is an AI agent framework that can:
 - Run AI sessions with Claude or local models via Ollama
 - Review PRs and triage GitHub issues automatically
 - Execute scheduled tasks (daily reviews, test runs)
@@ -76,8 +141,21 @@ async function seedDemoData(): Promise<{ agentId: string; sessionId: string; pro
 - Coordinate multiple agents via councils
 
 You're currently running in try mode — an in-memory sandbox so users can explore the dashboard and chat with you without any configuration.`,
-            model: 'claude-sonnet-4-20250514',
-        }),
+        model: provider.model,
+    };
+
+    // Set the provider field for non-anthropic providers so the process manager
+    // routes to the correct execution engine
+    if (provider.type === 'ollama') {
+        agentBody.provider = 'ollama';
+    } else if (provider.type === 'openrouter') {
+        agentBody.provider = 'openrouter';
+    }
+
+    const agentRes = await fetch(`${BASE_URL}/api/agents`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(agentBody),
     });
     if (!agentRes.ok) throw new Error(`Failed to create agent: ${await agentRes.text()}`);
     const agent = (await agentRes.json()) as { id: string };
@@ -97,9 +175,27 @@ You're currently running in try mode — an in-memory sandbox so users can explo
     const session = (await sessionRes.json()) as { id: string };
 
     // Seed a welcome message so users see a live conversation immediately
-    const welcomeContent = `👋 Welcome to **corvid-agent** try mode!
+    const providerLine = provider.type !== 'none'
+        ? `**AI Provider:** ${provider.name} (model: \`${provider.model}\`) — ready to chat!`
+        : `**AI Provider:** None detected — you can explore the dashboard, but chat requires a provider.\n> Set \`ANTHROPIC_API_KEY\` in your environment, install the [Claude CLI](https://docs.anthropic.com/en/docs/claude-code), or start [Ollama](https://ollama.com) and re-run \`bun run try\`.`;
+
+    const chatSuggestions = provider.type !== 'none'
+        ? `Try asking me something like:
+- *"What can you do?"*
+- *"Explain the corvid-agent architecture"*
+- *"How do I set up a real agent?"*`
+        : `Once you have an AI provider configured, restart \`bun run try\` and you'll be able to chat here.
+
+In the meantime, explore the dashboard:
+- Browse the **Agents** and **Sessions** pages
+- Check **Settings** to see configuration options
+- Visit the **API docs** at ${BASE_URL}/api-docs`;
+
+    const welcomeContent = `Welcome to **corvid-agent** try mode!
 
 You're running in a sandboxed environment — no data is persisted and no API keys are required.
+
+${providerLine}
 
 Here's what you can explore:
 - **Chat** with me right here — ask questions, give me tasks, or just say hello
@@ -108,10 +204,7 @@ Here's what you can explore:
 - **Work Tasks** — schedule autonomous background tasks for agents to run
 - **Councils** — coordinate multiple agents to collaborate on complex problems
 
-Try asking me something like:
-- *"What can you do?"*
-- *"Explain the corvid-agent architecture"*
-- *"How do I set up a real agent?"*
+${chatSuggestions}
 
 > **Sandbox mode** — nothing you do here is saved. Restart \`bun run try\` to reset.`;
 
@@ -145,9 +238,13 @@ function checkClientBuild(): boolean {
 async function main(): Promise<void> {
     printBanner();
 
+    // Detect available AI provider before starting the server
+    console.log('  Detecting AI providers...');
+    const provider = await detectProvider();
+
     // Check if client is built
     if (!checkClientBuild()) {
-        console.log('  Dashboard not built yet. Building...');
+        console.log('\n  Dashboard not built yet. Building...');
         const buildResult = spawn(['bun', 'run', 'build:client'], {
             cwd: join(import.meta.dir, '..'),
             stdio: ['ignore', 'inherit', 'inherit'],
@@ -160,7 +257,7 @@ async function main(): Promise<void> {
     }
 
     // Start the server with TRY_MODE
-    console.log('  Starting server...');
+    console.log('\n  Starting server...');
     const serverProcess: Subprocess = spawn(['bun', 'server/index.ts'], {
         cwd: join(import.meta.dir, '..'),
         env: {
@@ -173,6 +270,8 @@ async function main(): Promise<void> {
             ALGOCHAT_MNEMONIC: '',
             SANDBOX_ENABLED: 'false',
             MULTI_TENANT: 'false',
+            // Pass through provider-specific env vars
+            ...provider.env,
         },
         stdio: ['ignore', 'inherit', 'inherit'],
     });
@@ -197,10 +296,10 @@ async function main(): Promise<void> {
         process.exit(1);
     }
 
-    // Seed demo data
+    // Seed demo data with the detected provider
     console.log('  Seeding demo data...');
     try {
-        const { agentId, sessionId } = await seedDemoData();
+        const { agentId, sessionId } = await seedDemoData(provider);
         console.log(`  Demo agent created: ${agentId.slice(0, 8)}...`);
         console.log(`  Welcome session created: ${sessionId.slice(0, 8)}...`);
     } catch (err) {
@@ -212,6 +311,7 @@ async function main(): Promise<void> {
   Dashboard:  ${BASE_URL}
   API docs:   ${BASE_URL}/api-docs
   Health:     ${BASE_URL}/api/health
+  Provider:   ${provider.name}${provider.type !== 'none' ? ` (${provider.model})` : ''}
   ────────────────────────────────────────────────────
 
   Press Ctrl+C to stop.


### PR DESCRIPTION
## Summary
- **Auto-detect available AI providers** in `bun run try` (Anthropic API key → Claude CLI → OpenRouter → Ollama → none) and configure the demo agent with the right provider/model
- **Show provider status** in the welcome message and terminal output — when no provider is available, display actionable setup instructions instead of failing silently
- **Update `corvid-agent demo`** CLI command to query the server health endpoint for provider info instead of hardcoding `claude-sonnet-4-20250514`

Closes the gap where `bun run try` appeared to work but chat was broken without an API key. New users now get clear feedback about what's configured and what to do next.

Refs #1460

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` passes
- [x] `bun test` — 8882 tests pass
- [x] `bun run spec:check` — 187 specs pass, 100% coverage
- [x] Manual: `bun run try` with ANTHROPIC_API_KEY set → detects Anthropic, seeds correct model
- [x] Manual: `bun run try` with only Claude CLI → detects CLI, uses claude-sonnet
- [x] Manual: `bun run try` with only Ollama running → detects Ollama, picks best local model
- [x] Manual: `bun run try` with no providers → shows setup hints in terminal + welcome message

🤖 Generated with [Claude Code](https://claude.com/claude-code)