### PR TITLE
chore: bump version to v0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.49.0] - 2026-03-24
+
+### Added
+- **Try-mode: auto-detect AI provider** — zero-config sandbox auto-detects Claude, OpenAI, Gemini, Ollama, and OpenRouter from environment; no manual provider selection needed (#1463)
+
+### Fixed
+- **Discord: image attachments** — download and base64-encode image attachments at receive time instead of passing expiring CDN URLs to Claude, fixing image analysis loops (#1464)
+- **Flock: test reliability** — increase test timeouts and add multi-turn thread continuity for flock tests (#1456)
+
+### Tests
+- **Buddy mode + auth middleware coverage** — add 823 lines of tests covering buddy DB operations, buddy approval logic, and auth middleware edge cases (#1462)
+
 ## [0.48.0] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.48.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.49.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>

--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -46,7 +46,7 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Module specs | 188 .spec.md files |
 | Test:code ratio | 1.14x (more test than production) |
 | Dependencies | 17 direct |
-| Version | 0.48.0 |
+| Version | 0.49.0 |
 | Git commits | 934 |
 
 ### Tech Stack

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version from 0.48.0 → 0.49.0 in package.json, README badge, and deep-dive docs
- Add CHANGELOG entry for v0.49.0 covering:
  - **feat**: try-mode auto-detect AI provider for zero-config sandbox (#1463)
  - **fix**: Discord image attachments downloaded as base64 at receive time (#1464)
  - **fix**: Flock test timeouts and multi-turn thread continuity (#1456)
  - **test**: Buddy mode DB, approval logic, and auth middleware coverage (#1462)

## Test plan
- [x] `bun run spec:check` passes (187/187)
- [x] `bun run stats:check` passes (all stats current)

🤖 Generated with [Claude Code](https://claude.com/claude-code)