### PR TITLE
chore: bump version to v0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.50.0] - 2026-03-24
+
+### Added
+- **Discord: tiered /message tool access** — restrict /message tool availability based on Discord role tiers (admin/mod/trusted/default) with configurable allow-lists per tier (#1466)
+- **Discord: buddy review support** — buddy agents can now review /message tool usage and approve or flag messages before sending (#1466)
+
+### Fixed
+- **Tests: resumeProcess scan window** — widen test scan window from 8000 to 10000 chars to accommodate tiered access code in process manager (#1466)
+- **Tests: fetch mock casts** — fix pre-existing TypeScript errors in discord-image-attachments tests by casting fetch mocks through `unknown` (#1466)
+
 ## [0.49.0] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.49.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.50.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: corvid-agent
 description: Agent orchestration platform with MCP tools, AlgoChat messaging, and on-chain wallet integration
 type: application
-version: 0.44.0
-appVersion: "0.44.0"
+version: 0.50.0
+appVersion: "0.50.0"
 keywords:
   - ai
   - agent

--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -46,8 +46,8 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Module specs | 188 .spec.md files |
 | Test:code ratio | 1.14x (more test than production) |
 | Dependencies | 17 direct |
-| Version | 0.49.0 |
-| Git commits | 934 |
+| Version | 0.50.0 |
+| Git commits | 941 |
 
 ### Tech Stack
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version from 0.49.0 to 0.50.0 across all version files
- Update CHANGELOG with tiered /message access, buddy review support, and test fixes from #1466
- Catch up Helm chart version (was at 0.44.0)

## Test plan
- [x] `bun run spec:check` — 187/187 passed
- [x] `bun run stats:check` — all up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)