### PR TITLE
fix(contacts): add partial name match and memory fallback to lookup tool

### DIFF
--- a/server/__tests__/contacts-tool-handler.test.ts
+++ b/server/__tests__/contacts-tool-handler.test.ts
@@ -3,6 +3,7 @@ import { Database } from 'bun:sqlite';
 import { runMigrations } from '../db/schema';
 import { handleLookupContact } from '../mcp/tool-handlers/contacts';
 import { createContact, addPlatformLink } from '../db/contacts';
+import { saveMemory } from '../db/agent-memories';
 import type { McpToolContext } from '../mcp/tool-handlers/types';
 
 let db: Database;
@@ -11,7 +12,9 @@ function createMockContext(overrides?: Partial<McpToolContext>): McpToolContext 
     return {
         agentId: 'test-agent',
         db,
-        agentMessenger: {} as McpToolContext['agentMessenger'],
+        agentMessenger: {
+            readOnChainMemories: async () => [],
+        } as unknown as McpToolContext['agentMessenger'],
         agentDirectory: {} as McpToolContext['agentDirectory'],
         agentWalletService: {} as McpToolContext['agentWalletService'],
         ...overrides,
@@ -22,6 +25,8 @@ beforeEach(() => {
     db = new Database(':memory:');
     db.exec('PRAGMA foreign_keys = ON');
     runMigrations(db);
+    // Insert a test agent so agent_memories FK is satisfied
+    db.query("INSERT INTO agents (id, name) VALUES ('test-agent', 'Test Agent')").run();
 });
 
 afterEach(() => db.close());
@@ -115,5 +120,51 @@ describe('handleLookupContact', () => {
         const result = await handleLookupContact(ctx, { name: 'Alice' });
         const text = (result.content[0] as { type: 'text'; text: string }).text;
         expect(text).toContain('Created:');
+    });
+
+    it('finds contact by partial name match', async () => {
+        createContact(db, '', 'Alice Wonderland');
+        const ctx = createMockContext();
+        const result = await handleLookupContact(ctx, { name: 'Alice' });
+        const text = (result.content[0] as { type: 'text'; text: string }).text;
+        expect(text).toContain('Alice Wonderland');
+    });
+
+    it('returns multiple matches when partial name is ambiguous', async () => {
+        createContact(db, '', 'Alice Smith');
+        createContact(db, '', 'Alice Jones');
+        const ctx = createMockContext();
+        const result = await handleLookupContact(ctx, { name: 'Alice' });
+        const text = (result.content[0] as { type: 'text'; text: string }).text;
+        expect(text).toContain('Multiple contacts');
+        expect(text).toContain('Alice Smith');
+        expect(text).toContain('Alice Jones');
+    });
+
+    it('falls back to memory when no contact in DB', async () => {
+        saveMemory(db, { agentId: 'test-agent', key: 'user-leif', content: 'Leif — Discord: leif.algo, ID: 181969874455756800' });
+        const ctx = createMockContext();
+        const result = await handleLookupContact(ctx, { name: 'Leif' });
+        const text = (result.content[0] as { type: 'text'; text: string }).text;
+        expect(text).toContain('found info in memory');
+        expect(text).toContain('user-leif');
+        expect(text).toContain('leif.algo');
+    });
+
+    it('does not trigger memory fallback when contact exists in DB', async () => {
+        createContact(db, '', 'Leif');
+        saveMemory(db, { agentId: 'test-agent', key: 'user-leif', content: 'Leif — Discord: leif.algo' });
+        const ctx = createMockContext();
+        const result = await handleLookupContact(ctx, { name: 'Leif' });
+        const text = (result.content[0] as { type: 'text'; text: string }).text;
+        expect(text).toContain('Contact: Leif');
+        expect(text).not.toContain('found info in memory');
+    });
+
+    it('returns no-contact when neither DB nor memory has results', async () => {
+        const ctx = createMockContext();
+        const result = await handleLookupContact(ctx, { name: 'Nobody' });
+        const text = (result.content[0] as { type: 'text'; text: string }).text;
+        expect(text).toContain('No contact found');
     });
 });

--- a/server/mcp/tool-handlers/contacts.ts
+++ b/server/mcp/tool-handlers/contacts.ts
@@ -1,5 +1,10 @@
 /**
  * MCP tool handler for cross-platform contact identity lookup.
+ *
+ * Lookup order:
+ *   1. Exact name match (case-insensitive) or platform ID match in contacts DB
+ *   2. Partial (LIKE) name match in contacts DB
+ *   3. Memory search (local SQLite + on-chain fallback) for `user-*` keys
  */
 
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
@@ -8,14 +13,56 @@ import { textResult, errorResult } from './types';
 import {
     findContactByName,
     findContactByPlatformId,
+    listContacts,
     type ContactPlatform,
     type Contact,
 } from '../../db/contacts';
+import { searchMemories } from '../../db/agent-memories';
 import { createLogger } from '../../lib/logger';
 
 const log = createLogger('McpToolHandlers');
 
 const VALID_PLATFORMS = new Set(['discord', 'algochat', 'github']);
+
+/**
+ * Search agent memories for contact-like info matching a name.
+ * Returns formatted memory results or null if nothing found.
+ */
+async function searchMemoryForContact(
+    ctx: McpToolContext,
+    name: string,
+): Promise<string | null> {
+    // Search local SQLite memories
+    const memories = searchMemories(ctx.db, ctx.agentId, name);
+    const contactMemories = memories.filter((m) => m.key.startsWith('user-'));
+
+    if (contactMemories.length > 0) {
+        const lines = contactMemories.map((m) => `[memory: ${m.key}] ${m.content}`);
+        return lines.join('\n\n');
+    }
+
+    // Fallback: search on-chain memories
+    try {
+        const onChainResults = await ctx.agentMessenger.readOnChainMemories(
+            ctx.agentId,
+            ctx.serverMnemonic,
+            ctx.network,
+            { limit: 10, search: name },
+        );
+        const contactResults = onChainResults.filter((m) => m.key.startsWith('user-'));
+        if (contactResults.length > 0) {
+            const lines = contactResults.map((m) => `[on-chain memory: ${m.key}] ${m.content}`);
+            return lines.join('\n\n');
+        }
+    } catch (err) {
+        log.debug('Memory fallback search failed during contact lookup', {
+            name,
+            error: err instanceof Error ? err.message : String(err),
+        });
+    }
+
+    return null;
+}
 
 export async function handleLookupContact(
     ctx: McpToolContext,
@@ -25,7 +72,20 @@ export async function handleLookupContact(
         let contact: Contact | null = null;
 
         if (args.name) {
+            // Step 1: Exact name match
             contact = findContactByName(ctx.db, '', args.name);
+
+            // Step 2: Partial (LIKE) match
+            if (!contact) {
+                const { contacts } = listContacts(ctx.db, '', { search: args.name, limit: 5 });
+                if (contacts.length === 1) {
+                    // Unique partial match — treat as found
+                    contact = findContactByName(ctx.db, '', contacts[0].displayName);
+                } else if (contacts.length > 1) {
+                    const names = contacts.map((c) => c.displayName).join(', ');
+                    return textResult(`Multiple contacts match "${args.name}": ${names}. Please be more specific.`);
+                }
+            }
         } else if (args.platform && args.platform_id) {
             if (!VALID_PLATFORMS.has(args.platform)) {
                 return errorResult(`Invalid platform "${args.platform}". Must be discord, algochat, or github.`);
@@ -35,11 +95,22 @@ export async function handleLookupContact(
             return errorResult('Provide either name or platform+platform_id.');
         }
 
-        if (!contact) {
-            return textResult('No contact found matching the query.');
+        if (contact) {
+            return textResult(formatContact(contact));
         }
 
-        return textResult(formatContact(contact));
+        // Step 3: Memory fallback — search for contact info in agent memories
+        if (args.name) {
+            const memoryResult = await searchMemoryForContact(ctx, args.name);
+            if (memoryResult) {
+                return textResult(
+                    `No contact in database, but found info in memory:\n\n${memoryResult}\n\n` +
+                    '(Tip: use corvid_save_contact to add this person to the contacts database for faster lookup next time.)',
+                );
+            }
+        }
+
+        return textResult('No contact found matching the query.');
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         log.error('MCP lookup_contact failed', { error: message });


### PR DESCRIPTION
## Summary

Closes #1468

- **Partial name matching**: When exact `findContactByName` returns nothing, tries `listContacts` with LIKE search. If one unique match, returns it; if multiple, lists them for disambiguation.
- **Memory fallback**: When neither exact nor partial DB match exists, searches agent memories (local SQLite + on-chain) for `user-*` keys matching the name. Returns memory content with a tip to save the contact for future lookups.
- **No false positives**: Memory fallback only triggers when the DB has zero results, so existing contacts are always preferred.

## Test plan

- [x] 15 tests pass (5 new covering partial match, ambiguous match, memory fallback, no-fallback-when-DB-has-result, and no-result scenarios)
- [x] All 43 existing contact tests still pass
- [x] Manual: `corvid_lookup_contact({ name: "Leif" })` finds contact via memory when not in contacts DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)