### PR TITLE
fix(types): replace `as any` with ScheduleActionType in schedule commands

### DIFF
--- a/server/discord/command-handlers/schedule-commands.ts
+++ b/server/discord/command-handlers/schedule-commands.ts
@@ -16,6 +16,7 @@ import {
     updateSchedule,
     deleteSchedule,
 } from '../../db/schedules';
+import type { ScheduleAction, ScheduleActionType } from '../../../shared/types';
 import { respondToInteraction, respondToInteractionEmbed } from '../embeds';
 import { listPipelineTemplates, getPipelineTemplate } from '../../scheduler/pipeline';
 import { createLogger } from '../../lib/logger';
@@ -189,8 +190,8 @@ async function handleScheduleCreate(
         return;
     }
 
-    const actions = [{
-        type: actionType as any,
+    const actions: ScheduleAction[] = [{
+        type: actionType as ScheduleActionType,
         ...(channelId ? { channelId } : {}),
         ...(actionType === 'discord_post' ? { message: `Scheduled post from "${name}"` } : {}),
     }];


### PR DESCRIPTION
## Summary
- Replace `as any` cast with proper `ScheduleActionType` in `handleScheduleCreate`
- Add `ScheduleAction[]` type annotation to the actions array
- Import `ScheduleAction` and `ScheduleActionType` from shared types

## Motivation
The `actionType as any` cast bypassed all type checking on the schedule action object. Using proper types ensures the action structure matches the `ScheduleAction` interface at compile time.

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 8982 pass, 1 pre-existing failure (unrelated `/work` command)
- [x] `bun run spec:check` — 189/189 pass, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)