### PR TITLE
feat(scheduler): add on-chain daily activity attestation

### DIFF
--- a/server/__tests__/daily-review-attestation.test.ts
+++ b/server/__tests__/daily-review-attestation.test.ts
@@ -1,0 +1,143 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from '../db/schema';
+import { execDailyReview } from '../scheduler/handlers/maintenance';
+import { getExecution } from '../db/schedules';
+import type { HandlerContext } from '../scheduler/handlers/types';
+import type { AgentSchedule } from '../../shared/types';
+import { DailyReviewService } from '../improvement/daily-review';
+import { MemoryManager } from '../memory/index';
+
+let db: Database;
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+
+    db.query(`INSERT INTO agents (id, name, model, system_prompt) VALUES ('agent-1', 'Test Agent', 'test', 'test')`).run();
+    db.query(`INSERT INTO agent_schedules (id, agent_id, name, description, cron_expression, actions, approval_policy, status)
+        VALUES ('sched-1', 'agent-1', 'Daily Review', 'Test', '0 0 * * *', '[]', 'auto', 'active')`).run();
+});
+
+afterEach(() => {
+    db.close();
+});
+
+function createExecution(): string {
+    const id = crypto.randomUUID();
+    db.query(`INSERT INTO schedule_executions (id, schedule_id, agent_id, status, action_type, started_at)
+        VALUES (?, 'sched-1', 'agent-1', 'running', 'daily_review', ?)`).run(id, new Date().toISOString());
+    return id;
+}
+
+const schedule: AgentSchedule = {
+    id: 'sched-1',
+    agentId: 'agent-1',
+    name: 'Daily Review',
+    description: 'Test',
+    cronExpression: '0 0 * * *',
+    intervalMs: null,
+    actions: [],
+    approvalPolicy: 'auto',
+    status: 'active',
+    maxExecutions: null,
+    executionCount: 0,
+    maxBudgetPerRun: null,
+    notifyAddress: null,
+    triggerEvents: null,
+    outputDestinations: null,
+    executionMode: 'independent',
+    pipelineSteps: null,
+    lastRunAt: null,
+    nextRunAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+};
+
+describe('execDailyReview attestation', () => {
+    test('publishes on-chain attestation when agentMessenger is available', async () => {
+        const memoryManager = new MemoryManager(db);
+        const dailyReviewService = new DailyReviewService(db, memoryManager);
+        const executionId = createExecution();
+
+        let sentNote = '';
+        const mockMessenger = {
+            sendOnChainToSelf: mock(async (_agentId: string, note: string) => {
+                sentNote = note;
+                return 'mock-txid-123';
+            }),
+        };
+
+        const ctx = {
+            db,
+            dailyReviewService,
+            agentMessenger: mockMessenger as any,
+        } as unknown as HandlerContext;
+
+        await execDailyReview(ctx, executionId, schedule);
+
+        const execution = getExecution(db, executionId);
+        expect(execution?.status).toBe('completed');
+        expect(execution?.result).toContain('attestation=');
+        expect(execution?.result).toContain('txid=mock-txid-123');
+        expect(sentNote).toMatch(/^corvid-daily-review:agent-1:\d{4}-\d{2}-\d{2}:[a-f0-9]{64}$/);
+    });
+
+    test('completes without attestation when agentMessenger is null', async () => {
+        const memoryManager = new MemoryManager(db);
+        const dailyReviewService = new DailyReviewService(db, memoryManager);
+        const executionId = createExecution();
+
+        const ctx = {
+            db,
+            dailyReviewService,
+            agentMessenger: null,
+        } as unknown as HandlerContext;
+
+        await execDailyReview(ctx, executionId, schedule);
+
+        const execution = getExecution(db, executionId);
+        expect(execution?.status).toBe('completed');
+        expect(execution?.result).not.toContain('attestation=');
+    });
+
+    test('completes even if on-chain publish fails', async () => {
+        const memoryManager = new MemoryManager(db);
+        const dailyReviewService = new DailyReviewService(db, memoryManager);
+        const executionId = createExecution();
+
+        const mockMessenger = {
+            sendOnChainToSelf: mock(async () => { throw new Error('network error'); }),
+        };
+
+        const ctx = {
+            db,
+            dailyReviewService,
+            agentMessenger: mockMessenger as any,
+        } as unknown as HandlerContext;
+
+        await execDailyReview(ctx, executionId, schedule);
+
+        const execution = getExecution(db, executionId);
+        expect(execution?.status).toBe('completed');
+        // Should still complete, just without attestation info
+        expect(execution?.result).not.toContain('attestation=');
+    });
+
+    test('fails when dailyReviewService is not configured', async () => {
+        const executionId = createExecution();
+
+        const ctx = {
+            db,
+            dailyReviewService: null,
+            agentMessenger: null,
+        } as unknown as HandlerContext;
+
+        await execDailyReview(ctx, executionId, schedule);
+
+        const execution = getExecution(db, executionId);
+        expect(execution?.status).toBe('failed');
+        expect(execution?.result).toContain('not configured');
+    });
+});

--- a/server/scheduler/execution.ts
+++ b/server/scheduler/execution.ts
@@ -74,7 +74,7 @@ async function dispatchAction(
         case 'memory_maintenance':     await execMemoryMaintenance(hctx, executionId, schedule); break;
         case 'reputation_attestation': await execReputationAttestation(hctx, executionId, schedule); break;
         case 'outcome_analysis':       await execOutcomeAnalysis(hctx, executionId, schedule); break;
-        case 'daily_review':           execDailyReview(hctx, executionId, schedule); break;
+        case 'daily_review':           await execDailyReview(hctx, executionId, schedule); break;
         case 'status_checkin':         await execStatusCheckin(hctx, executionId, schedule); break;
         case 'marketplace_billing':    execMarketplaceBilling(hctx, executionId); break;
         case 'flock_testing':          await execFlockTesting(hctx, executionId, schedule); break;

--- a/server/scheduler/handlers/maintenance.ts
+++ b/server/scheduler/handlers/maintenance.ts
@@ -9,6 +9,13 @@ import { createSession } from '../../db/sessions';
 import { summarizeOldMemories } from '../../memory/summarizer';
 import type { HandlerContext } from './types';
 
+/** SHA-256 hash of the daily review summary for on-chain attestation. */
+async function hashSummary(text: string): Promise<string> {
+    const data = new TextEncoder().encode(text);
+    const buf = await crypto.subtle.digest('SHA-256', data);
+    return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
 export async function execMemoryMaintenance(
     ctx: HandlerContext,
     executionId: string,
@@ -99,11 +106,11 @@ export async function execOutcomeAnalysis(
     }
 }
 
-export function execDailyReview(
+export async function execDailyReview(
     ctx: HandlerContext,
     executionId: string,
     schedule: AgentSchedule,
-): void {
+): Promise<void> {
     if (!ctx.dailyReviewService) {
         updateExecutionStatus(ctx.db, executionId, 'failed', {
             result: 'Daily review service not configured',
@@ -113,12 +120,26 @@ export function execDailyReview(
 
     try {
         const result = ctx.dailyReviewService.run(schedule.agentId);
+
+        // Publish daily activity attestation on-chain
+        let attestationNote = '';
+        if (ctx.agentMessenger) {
+            try {
+                const hash = await hashSummary(result.summary);
+                const note = `corvid-daily-review:${schedule.agentId}:${result.date}:${hash}`;
+                const txid = await ctx.agentMessenger.sendOnChainToSelf(schedule.agentId, note);
+                attestationNote = txid ? ` attestation=${hash.slice(0, 16)}... txid=${txid}` : ` attestation=${hash.slice(0, 16)}... (off-chain)`;
+            } catch {
+                // On-chain attestation is best-effort
+            }
+        }
+
         const summary = [
             `Executions: ${result.executions.completed} completed, ${result.executions.failed} failed (${result.executions.total} total).`,
             `PRs: ${result.prs.opened} opened, ${result.prs.merged} merged, ${result.prs.closed} closed.`,
             `Health: ${result.health.uptimePercent}% uptime (${result.health.snapshotCount} snapshots).`,
             result.observations.length > 0 ? `Observations: ${result.observations.join('; ')}` : '',
-        ].filter(Boolean).join(' ');
+        ].filter(Boolean).join(' ') + attestationNote;
 
         updateExecutionStatus(ctx.db, executionId, 'completed', { result: summary });
     } catch (err) {


### PR DESCRIPTION
## Summary
- Publishes a SHA-256 hash of the daily review summary as an on-chain attestation via AlgoChat after each daily review runs
- Attestation format: `corvid-daily-review:{agentId}:{date}:{sha256hash}` — anyone can verify the review content matches the hash
- Best-effort: if on-chain publish fails, the daily review still completes normally

Addresses the "Build a public-facing 'what I did today' summary (daily status attestations)" checklist item in #1457.

## Changes
- `server/scheduler/handlers/maintenance.ts` — make `execDailyReview` async, add `hashSummary` helper, publish attestation on-chain after review
- `server/scheduler/execution.ts` — `await` the now-async `execDailyReview`
- `server/__tests__/daily-review-attestation.test.ts` — 4 tests covering attestation success, no messenger, publish failure, and missing service

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` passes
- [x] All 4 new attestation tests pass
- [x] Existing daily-review tests still pass
- [x] `bun run spec:check` — 189/189 specs pass

Closes #1457 (partial — addresses one checklist item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)