### PR TITLE
feat(flock): replace AlgoChat with A2A HTTP transport for testing

### DIFF
--- a/server/flock-directory/testing/a2a-transport.ts
+++ b/server/flock-directory/testing/a2a-transport.ts
@@ -1,0 +1,112 @@
+/**
+ * A2A HTTP transport for Flock Directory agent testing.
+ *
+ * Sends test challenges to agents via the A2A protocol (HTTP POST to /a2a/tasks/send)
+ * instead of AlgoChat. This avoids self-test deadlocks and keeps test conversations
+ * off-chain while still recording scores to the contract.
+ *
+ * Agent instance URLs come from the Flock Directory registry.
+ */
+import type { Database } from 'bun:sqlite';
+import type { TestTransport } from './runner';
+import { FlockDirectoryService } from '../service';
+import { createLogger } from '../../lib/logger';
+
+const log = createLogger('FlockA2ATransport');
+
+/**
+ * Create an A2A HTTP transport that sends test challenges via /a2a/tasks/send.
+ *
+ * Looks up the agent's instance_url from the Flock Directory, then submits an
+ * A2A task and polls for completion.
+ */
+export function createA2ATransport(db: Database): TestTransport {
+    const flockService = new FlockDirectoryService(db);
+
+    return {
+        async sendAndWait(agentAddress: string, message: string, timeoutMs: number, _threadId?: string): Promise<string | null> {
+            // Resolve Algorand address → instance URL
+            const agent = flockService.getByAddress(agentAddress);
+            if (!agent) {
+                log.warn('No agent found for wallet address', { agentAddress });
+                return null;
+            }
+
+            if (!agent.instanceUrl) {
+                log.warn('Agent has no instance URL configured', { agentId: agent.id, name: agent.name });
+                return null;
+            }
+
+            const baseUrl = agent.instanceUrl.replace(/\/+$/, '');
+
+            try {
+                // Step 1: Submit A2A task
+                const submitResponse = await fetch(`${baseUrl}/a2a/tasks/send`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'User-Agent': 'CorvidAgent/FlockTester',
+                    },
+                    body: JSON.stringify({
+                        params: {
+                            message: `[FLOCK-TEST] ${message}`,
+                            timeoutMs,
+                        },
+                    }),
+                    signal: AbortSignal.timeout(Math.min(timeoutMs, 30_000)),
+                });
+
+                if (!submitResponse.ok) {
+                    log.warn('A2A task submit failed', {
+                        agentId: agent.id,
+                        status: submitResponse.status,
+                    });
+                    return null;
+                }
+
+                const task = await submitResponse.json() as { id: string; state: string };
+                const taskId = task.id;
+
+                // Step 2: Poll until completed/failed/timeout
+                const deadline = Date.now() + timeoutMs;
+                const pollIntervalMs = 2000;
+
+                while (Date.now() < deadline) {
+                    try {
+                        const pollResponse = await fetch(`${baseUrl}/a2a/tasks/${taskId}`, {
+                            headers: { 'User-Agent': 'CorvidAgent/FlockTester' },
+                            signal: AbortSignal.timeout(10_000),
+                        });
+
+                        if (pollResponse.ok) {
+                            const pollResult = await pollResponse.json() as {
+                                id: string;
+                                state: string;
+                                messages?: Array<{ role: string; parts: Array<{ text: string }> }>;
+                            };
+
+                            if (pollResult.state === 'completed' || pollResult.state === 'failed') {
+                                const agentMessages = (pollResult.messages ?? []).filter((m) => m.role === 'agent');
+                                const lastMessage = agentMessages[agentMessages.length - 1];
+                                return lastMessage?.parts?.[0]?.text ?? null;
+                            }
+                        }
+                    } catch {
+                        // Poll failure — retry
+                    }
+
+                    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+                }
+
+                log.warn('A2A test timed out', { agentId: agent.id, taskId, timeoutMs });
+                return null;
+            } catch (err) {
+                log.warn('A2A transport error', {
+                    agentId: agent.id,
+                    error: err instanceof Error ? err.message : String(err),
+                });
+                return null;
+            }
+        },
+    };
+}

--- a/server/routes/flock-testing.ts
+++ b/server/routes/flock-testing.ts
@@ -2,10 +2,9 @@
  * Flock Directory testing routes — Agent test results, stats, and on-demand test trigger.
  */
 import type { Database } from 'bun:sqlite';
-import { FlockTestRunner, type TestTransport } from '../flock-directory/testing/runner';
+import { FlockTestRunner } from '../flock-directory/testing/runner';
+import { createA2ATransport } from '../flock-directory/testing/a2a-transport';
 import type { FlockDirectoryService } from '../flock-directory/service';
-import type { AgentMessenger } from '../algochat/agent-messenger';
-import { getAgentByWalletAddress } from '../db/agents';
 import type { RequestContext } from '../middleware/guards';
 import { json, notFound, safeNumParam, handleRouteError } from '../lib/response';
 
@@ -15,7 +14,6 @@ const testCooldowns = new Map<string, number>();
 
 export interface FlockTestingDeps {
     flockDirectory?: FlockDirectoryService | null;
-    agentMessenger?: AgentMessenger | null;
 }
 
 export function handleFlockTestingRoutes(
@@ -37,13 +35,9 @@ export function handleFlockTestingRoutes(
     if (runMatch && method === 'POST') {
         const agentId = runMatch[1];
         const flockDirectory = deps?.flockDirectory;
-        const agentMessenger = deps?.agentMessenger;
 
         if (!flockDirectory) {
             return json({ error: 'Flock Directory not available' }, 503);
-        }
-        if (!agentMessenger) {
-            return json({ error: 'Agent messenger not configured — cannot send test challenges' }, 503);
         }
 
         // Enforce cooldown
@@ -73,29 +67,7 @@ export function handleFlockTestingRoutes(
 
         return (async () => {
             try {
-                const transport: TestTransport = {
-                    async sendAndWait(agentAddress: string, message: string, timeoutMs: number, threadId?: string): Promise<string | null> {
-                        // agentAddress is an Algorand wallet address — resolve to agent UUID
-                        const targetAgent = getAgentByWalletAddress(db, agentAddress);
-                        if (!targetAgent) return null;
-
-                        try {
-                            const result = await agentMessenger.invokeAndWait(
-                                {
-                                    fromAgentId: 'flock-tester',
-                                    toAgentId: targetAgent.id,
-                                    content: `[FLOCK-TEST] ${message}`,
-                                    threadId,
-                                },
-                                timeoutMs,
-                            );
-                            return result.response;
-                        } catch {
-                            return null;
-                        }
-                    },
-                };
-
+                const transport = createA2ATransport(db);
                 const runner = new FlockTestRunner(db, transport);
                 const result = await runner.runTest(agent.id, agent.address, { mode: 'full', decayPerDay: 0.02 });
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -444,7 +444,6 @@ async function handleRoutes(
     // Flock Testing routes (test results, stats, on-demand test trigger)
     const flockTestResponse = await handleFlockTestingRoutes(req, url, db, null, context, {
         flockDirectory,
-        agentMessenger,
     });
     if (flockTestResponse) return flockTestResponse;
 

--- a/server/scheduler/handlers/flock-testing.ts
+++ b/server/scheduler/handlers/flock-testing.ts
@@ -3,51 +3,19 @@
  *
  * Runs the test suite against all active agents in the Flock Directory,
  * scoring them on responsiveness, accuracy, context, efficiency, safety,
- * and bot verification. Updates reputation scores based on test results.
+ * and bot verification. Uses A2A HTTP transport to avoid self-test deadlocks
+ * and keep test conversations off-chain.
  */
 import type { AgentSchedule } from '../../../shared/types';
 import { updateExecutionStatus } from '../../db/schedules';
 import { getAgentByWalletAddress } from '../../db/agents';
 import { FlockDirectoryService } from '../../flock-directory/service';
-import { FlockTestRunner, type TestTransport, type TestRunConfig } from '../../flock-directory/testing/runner';
+import { FlockTestRunner, type TestRunConfig } from '../../flock-directory/testing/runner';
+import { createA2ATransport } from '../../flock-directory/testing/a2a-transport';
 import { createLogger } from '../../lib/logger';
 import type { HandlerContext } from './types';
 
 const log = createLogger('FlockTestingHandler');
-
-/**
- * AlgoChat-based test transport.
- * Sends a message to an agent via AlgoChat and waits for a response.
- */
-function createAlgoChatTransport(ctx: HandlerContext, senderAgentId: string): TestTransport {
-    return {
-        async sendAndWait(agentAddress: string, message: string, timeoutMs: number, threadId?: string): Promise<string | null> {
-            if (!ctx.agentMessenger) return null;
-
-            // agentAddress is an Algorand wallet address — resolve to agent UUID
-            const targetAgent = getAgentByWalletAddress(ctx.db, agentAddress);
-            if (!targetAgent) {
-                log.warn('No agent found for wallet address', { agentAddress });
-                return null;
-            }
-
-            try {
-                const result = await ctx.agentMessenger.invokeAndWait(
-                    {
-                        fromAgentId: senderAgentId,
-                        toAgentId: targetAgent.id,
-                        content: `[FLOCK-TEST] ${message}`,
-                        threadId,
-                    },
-                    timeoutMs,
-                );
-                return result.response;
-            } catch {
-                return null;
-            }
-        },
-    };
-}
 
 /**
  * Run automated tests against all active Flock Directory agents.
@@ -56,19 +24,15 @@ function createAlgoChatTransport(ctx: HandlerContext, senderAgentId: string): Te
  * 1. Runs the full test suite (or random subset based on schedule config)
  * 2. Records results to the database
  * 3. Updates the agent's reputation score with the test-derived score
+ *
+ * Uses A2A HTTP transport so test challenges go over standard HTTP,
+ * keeping test conversations off-chain while results are recorded on-chain.
  */
 export async function execFlockTesting(
     ctx: HandlerContext,
     executionId: string,
     schedule: AgentSchedule,
 ): Promise<void> {
-    if (!ctx.agentMessenger) {
-        updateExecutionStatus(ctx.db, executionId, 'failed', {
-            result: 'Agent messenger not configured — cannot send test challenges',
-        });
-        return;
-    }
-
     try {
         const flockService = new FlockDirectoryService(ctx.db);
         const activeAgents = flockService.listActive();
@@ -80,7 +44,7 @@ export async function execFlockTesting(
             return;
         }
 
-        const transport = createAlgoChatTransport(ctx, schedule.agentId);
+        const transport = createA2ATransport(ctx.db);
         const runner = new FlockTestRunner(ctx.db, transport);
 
         const config: TestRunConfig = {


### PR DESCRIPTION
## Summary
- Adds `server/flock-directory/testing/a2a-transport.ts` — A2A HTTP transport that resolves agent `instance_url` from the flock directory and sends test challenges via `/a2a/tasks/send` with polling
- Replaces inline AlgoChat transport in both the scheduler handler and on-demand route with the new A2A transport
- Removes unused `agentMessenger` dependency from flock testing routes/deps
- No conversation content or PII hits the blockchain — only numeric scores are written to the contract

## Test plan
- [x] Build passes (`bun x tsc`)
- [x] All 25 flock testing tests pass
- [x] Spec check clean (`bun run spec:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)