### PR TITLE
fix(security): add Zod input validation to permission API endpoints

### DIFF
--- a/server/lib/validation.ts
+++ b/server/lib/validation.ts
@@ -925,3 +925,56 @@ export const CreditGrantSchema = z.object({
     amount: z.number().positive().finite(),
     reference: z.string().optional(),
 });
+
+// ─── Permissions ────────────────────────────────────────────────────────────
+
+export const PermissionGrantSchema = z.object({
+	agent_id: z.string().min(1),
+	action: z.string().min(1),
+	granted_by: z.string().optional(),
+	reason: z.string().optional(),
+	expires_at: z.string().nullable().optional(),
+	tenant_id: z.string().optional(),
+});
+
+export const PermissionRevokeSchema = z.object({
+	grant_id: z.number().optional(),
+	agent_id: z.string().optional(),
+	action: z.string().optional(),
+	revoked_by: z.string().optional(),
+	reason: z.string().optional(),
+	tenant_id: z.string().optional(),
+}).refine(
+	(d) => d.grant_id !== undefined || d.agent_id !== undefined,
+	{ message: 'grant_id or agent_id is required' },
+);
+
+export const PermissionEmergencyRevokeSchema = z.object({
+	agent_id: z.string().min(1),
+	revoked_by: z.string().optional(),
+	reason: z.string().optional(),
+});
+
+export const PermissionCheckSchema = z.object({
+	agent_id: z.string().min(1),
+	tool_name: z.string().min(1),
+	session_id: z.string().optional(),
+	tenant_id: z.string().optional(),
+});
+
+export const PermissionApplyRoleSchema = z.object({
+	agent_id: z.string().min(1),
+	role: z.string().min(1),
+	granted_by: z.string().optional(),
+	tenant_id: z.string().optional(),
+	expires_at: z.string().nullable().optional(),
+	reason: z.string().optional(),
+});
+
+export const PermissionRevokeRoleSchema = z.object({
+	agent_id: z.string().min(1),
+	role: z.string().min(1),
+	revoked_by: z.string().optional(),
+	tenant_id: z.string().optional(),
+	reason: z.string().optional(),
+});

--- a/server/routes/permissions.ts
+++ b/server/routes/permissions.ts
@@ -17,204 +17,220 @@
 import type { Database } from 'bun:sqlite';
 import { PermissionBroker } from '../permissions/broker';
 import { TOOL_ACTION_MAP } from '../permissions/types';
-import { listRoleTemplates, getRoleTemplate, applyRoleTemplate, revokeRoleTemplate } from '../permissions/role-templates';
+import {
+	listRoleTemplates,
+	getRoleTemplate,
+	applyRoleTemplate,
+	revokeRoleTemplate,
+} from '../permissions/role-templates';
 import { json, badRequest, notFound } from '../lib/response';
+import {
+	parseBodyOrThrow,
+	ValidationError,
+	PermissionGrantSchema,
+	PermissionRevokeSchema,
+	PermissionEmergencyRevokeSchema,
+	PermissionCheckSchema,
+	PermissionApplyRoleSchema,
+	PermissionRevokeRoleSchema,
+} from '../lib/validation';
 
 export function handlePermissionRoutes(
-    req: Request,
-    url: URL,
-    db: Database,
+	req: Request,
+	url: URL,
+	db: Database,
 ): Response | Promise<Response> | null {
-    if (!url.pathname.startsWith('/api/permissions')) return null;
+	if (!url.pathname.startsWith('/api/permissions')) return null;
 
-    const broker = new PermissionBroker(db);
-    const method = req.method;
+	const broker = new PermissionBroker(db);
+	const method = req.method;
 
-    // POST /api/permissions/grant
-    if (url.pathname === '/api/permissions/grant' && method === 'POST') {
-        return handleGrant(req, broker);
-    }
+	// POST /api/permissions/grant
+	if (url.pathname === '/api/permissions/grant' && method === 'POST') {
+		return handleGrant(req, broker);
+	}
 
-    // POST /api/permissions/revoke
-    if (url.pathname === '/api/permissions/revoke' && method === 'POST') {
-        return handleRevoke(req, broker);
-    }
+	// POST /api/permissions/revoke
+	if (url.pathname === '/api/permissions/revoke' && method === 'POST') {
+		return handleRevoke(req, broker);
+	}
 
-    // POST /api/permissions/emergency-revoke
-    if (url.pathname === '/api/permissions/emergency-revoke' && method === 'POST') {
-        return handleEmergencyRevoke(req, broker);
-    }
+	// POST /api/permissions/emergency-revoke
+	if (url.pathname === '/api/permissions/emergency-revoke' && method === 'POST') {
+		return handleEmergencyRevoke(req, broker);
+	}
 
-    // POST /api/permissions/check
-    if (url.pathname === '/api/permissions/check' && method === 'POST') {
-        return handleCheck(req, broker);
-    }
+	// POST /api/permissions/check
+	if (url.pathname === '/api/permissions/check' && method === 'POST') {
+		return handleCheck(req, broker);
+	}
 
-    // GET /api/permissions/actions — list the action taxonomy
-    if (url.pathname === '/api/permissions/actions' && method === 'GET') {
-        return json({ actions: TOOL_ACTION_MAP });
-    }
+	// GET /api/permissions/actions — list the action taxonomy
+	if (url.pathname === '/api/permissions/actions' && method === 'GET') {
+		return json({ actions: TOOL_ACTION_MAP });
+	}
 
-    // GET /api/permissions/roles — list available role templates
-    if (url.pathname === '/api/permissions/roles' && method === 'GET') {
-        return json({ templates: listRoleTemplates() });
-    }
+	// GET /api/permissions/roles — list available role templates
+	if (url.pathname === '/api/permissions/roles' && method === 'GET') {
+		return json({ templates: listRoleTemplates() });
+	}
 
-    // GET /api/permissions/roles/:name — get a specific role template
-    const roleMatch = url.pathname.match(/^\/api\/permissions\/roles\/([^/]+)$/);
-    if (roleMatch && method === 'GET') {
-        const template = getRoleTemplate(roleMatch[1]);
-        if (!template) return notFound(`Role template "${roleMatch[1]}" not found`);
-        return json({ template });
-    }
+	// GET /api/permissions/roles/:name — get a specific role template
+	const roleMatch = url.pathname.match(/^\/api\/permissions\/roles\/([^/]+)$/);
+	if (roleMatch && method === 'GET') {
+		const template = getRoleTemplate(roleMatch[1]);
+		if (!template) return notFound(`Role template "${roleMatch[1]}" not found`);
+		return json({ template });
+	}
 
-    // POST /api/permissions/roles/apply — apply a role template to an agent
-    if (url.pathname === '/api/permissions/roles/apply' && method === 'POST') {
-        return handleApplyRole(req, db);
-    }
+	// POST /api/permissions/roles/apply — apply a role template to an agent
+	if (url.pathname === '/api/permissions/roles/apply' && method === 'POST') {
+		return handleApplyRole(req, db);
+	}
 
-    // POST /api/permissions/roles/revoke — revoke a role template from an agent
-    if (url.pathname === '/api/permissions/roles/revoke' && method === 'POST') {
-        return handleRevokeRole(req, db);
-    }
+	// POST /api/permissions/roles/revoke — revoke a role template from an agent
+	if (url.pathname === '/api/permissions/roles/revoke' && method === 'POST') {
+		return handleRevokeRole(req, db);
+	}
 
-    // GET /api/permissions/:agentId — list active grants
-    const agentMatch = url.pathname.match(/^\/api\/permissions\/([^/]+)$/);
-    if (agentMatch && method === 'GET') {
-        const agentId = agentMatch[1];
-        const tenantId = url.searchParams.get('tenant_id') ?? 'default';
-        const includeHistory = url.searchParams.get('history') === 'true';
+	// GET /api/permissions/:agentId — list active grants
+	const agentMatch = url.pathname.match(/^\/api\/permissions\/([^/]+)$/);
+	if (agentMatch && method === 'GET') {
+		const agentId = agentMatch[1];
+		const tenantId = url.searchParams.get('tenant_id') ?? 'default';
+		const includeHistory = url.searchParams.get('history') === 'true';
 
-        const grants = includeHistory
-            ? broker.getGrantHistory(agentId, tenantId)
-            : broker.getGrants(agentId, tenantId);
+		const grants = includeHistory
+			? broker.getGrantHistory(agentId, tenantId)
+			: broker.getGrants(agentId, tenantId);
 
-        return json({ agentId, grants, count: grants.length });
-    }
+		return json({ agentId, grants, count: grants.length });
+	}
 
-    return notFound('Permission endpoint not found');
+	return notFound('Permission endpoint not found');
 }
 
 async function handleGrant(req: Request, broker: PermissionBroker): Promise<Response> {
-    const body = await req.json().catch(() => null);
-    if (!body) return badRequest('Invalid JSON body');
+	try {
+		const body = await parseBodyOrThrow(req, PermissionGrantSchema);
 
-    const { agent_id, action, granted_by, reason, expires_at, tenant_id } = body;
-    if (!agent_id || !action) return badRequest('agent_id and action are required');
+		const grant = await broker.grant({
+			agentId: body.agent_id,
+			action: body.action,
+			grantedBy: body.granted_by ?? 'api',
+			reason: body.reason ?? '',
+			expiresAt: body.expires_at ?? null,
+			tenantId: body.tenant_id ?? 'default',
+		});
 
-    const grant = await broker.grant({
-        agentId: agent_id,
-        action,
-        grantedBy: granted_by ?? 'api',
-        reason: reason ?? '',
-        expiresAt: expires_at ?? null,
-        tenantId: tenant_id ?? 'default',
-    });
-
-    return json({ grant }, 201);
+		return json({ grant }, 201);
+	} catch (err) {
+		if (err instanceof ValidationError) return badRequest(err.message);
+		throw err;
+	}
 }
 
 async function handleRevoke(req: Request, broker: PermissionBroker): Promise<Response> {
-    const body = await req.json().catch(() => null);
-    if (!body) return badRequest('Invalid JSON body');
+	try {
+		const body = await parseBodyOrThrow(req, PermissionRevokeSchema);
 
-    const { grant_id, agent_id, action, revoked_by, reason, tenant_id } = body;
-    if (!grant_id && !agent_id) return badRequest('grant_id or agent_id is required');
+		const affected = broker.revoke({
+			grantId: body.grant_id,
+			agentId: body.agent_id,
+			action: body.action,
+			revokedBy: body.revoked_by ?? 'api',
+			reason: body.reason,
+			tenantId: body.tenant_id ?? 'default',
+		});
 
-    const affected = broker.revoke({
-        grantId: grant_id,
-        agentId: agent_id,
-        action,
-        revokedBy: revoked_by ?? 'api',
-        reason,
-        tenantId: tenant_id ?? 'default',
-    });
-
-    return json({ affected });
+		return json({ affected });
+	} catch (err) {
+		if (err instanceof ValidationError) return badRequest(err.message);
+		throw err;
+	}
 }
 
 async function handleEmergencyRevoke(req: Request, broker: PermissionBroker): Promise<Response> {
-    const body = await req.json().catch(() => null);
-    if (!body) return badRequest('Invalid JSON body');
+	try {
+		const body = await parseBodyOrThrow(req, PermissionEmergencyRevokeSchema);
 
-    const { agent_id, revoked_by, reason } = body;
-    if (!agent_id) return badRequest('agent_id is required');
+		const affected = broker.emergencyRevoke(
+			body.agent_id,
+			body.revoked_by ?? 'api',
+			body.reason ?? 'Emergency revocation via API',
+		);
 
-    const affected = broker.emergencyRevoke(
-        agent_id,
-        revoked_by ?? 'api',
-        reason ?? 'Emergency revocation via API',
-    );
-
-    return json({ affected, emergency: true });
+		return json({ affected, emergency: true });
+	} catch (err) {
+		if (err instanceof ValidationError) return badRequest(err.message);
+		throw err;
+	}
 }
 
 async function handleCheck(req: Request, broker: PermissionBroker): Promise<Response> {
-    const body = await req.json().catch(() => null);
-    if (!body) return badRequest('Invalid JSON body');
+	try {
+		const body = await parseBodyOrThrow(req, PermissionCheckSchema);
 
-    const { agent_id, tool_name, session_id, tenant_id } = body;
-    if (!agent_id || !tool_name) return badRequest('agent_id and tool_name are required');
+		const result = await broker.checkTool(body.agent_id, body.tool_name, {
+			sessionId: body.session_id,
+			tenantId: body.tenant_id ?? 'default',
+		});
 
-    const result = await broker.checkTool(agent_id, tool_name, {
-        sessionId: session_id,
-        tenantId: tenant_id ?? 'default',
-    });
-
-    return json({ ...result });
+		return json({ ...result });
+	} catch (err) {
+		if (err instanceof ValidationError) return badRequest(err.message);
+		throw err;
+	}
 }
 
 async function handleApplyRole(req: Request, db: Database): Promise<Response> {
-    const body = await req.json().catch(() => null);
-    if (!body) return badRequest('Invalid JSON body');
+	try {
+		const body = await parseBodyOrThrow(req, PermissionApplyRoleSchema);
 
-    const { agent_id, role, granted_by, tenant_id, expires_at, reason } = body;
-    if (!agent_id || !role) return badRequest('agent_id and role are required');
+		const result = await applyRoleTemplate(db, body.agent_id, body.role, body.granted_by ?? 'api', {
+			tenantId: body.tenant_id ?? 'default',
+			expiresAt: body.expires_at ?? null,
+			reason: body.reason,
+		});
 
-    try {
-        const result = await applyRoleTemplate(db, agent_id, role, granted_by ?? 'api', {
-            tenantId: tenant_id ?? 'default',
-            expiresAt: expires_at ?? null,
-            reason,
-        });
-
-        return json({
-            template: result.template.name,
-            agent_id,
-            granted: result.grants.length,
-            skipped: result.skipped,
-            grants: result.grants,
-        }, 201);
-    } catch (err) {
-        if (err instanceof Error && err.message.startsWith('Unknown role template')) {
-            return notFound(err.message);
-        }
-        throw err;
-    }
+		return json(
+			{
+				template: result.template.name,
+				agent_id: body.agent_id,
+				granted: result.grants.length,
+				skipped: result.skipped,
+				grants: result.grants,
+			},
+			201,
+		);
+	} catch (err) {
+		if (err instanceof ValidationError) return badRequest(err.message);
+		if (err instanceof Error && err.message.startsWith('Unknown role template')) {
+			return notFound(err.message);
+		}
+		throw err;
+	}
 }
 
 async function handleRevokeRole(req: Request, db: Database): Promise<Response> {
-    const body = await req.json().catch(() => null);
-    if (!body) return badRequest('Invalid JSON body');
+	try {
+		const body = await parseBodyOrThrow(req, PermissionRevokeRoleSchema);
 
-    const { agent_id, role, revoked_by, tenant_id, reason } = body;
-    if (!agent_id || !role) return badRequest('agent_id and role are required');
+		const result = revokeRoleTemplate(db, body.agent_id, body.role, body.revoked_by ?? 'api', {
+			tenantId: body.tenant_id ?? 'default',
+			reason: body.reason,
+		});
 
-    try {
-        const result = revokeRoleTemplate(db, agent_id, role, revoked_by ?? 'api', {
-            tenantId: tenant_id ?? 'default',
-            reason,
-        });
-
-        return json({
-            template: result.template.name,
-            agent_id,
-            revoked: result.revoked,
-        });
-    } catch (err) {
-        if (err instanceof Error && err.message.startsWith('Unknown role template')) {
-            return notFound(err.message);
-        }
-        throw err;
-    }
+		return json({
+			template: result.template.name,
+			agent_id: body.agent_id,
+			revoked: result.revoked,
+		});
+	} catch (err) {
+		if (err instanceof ValidationError) return badRequest(err.message);
+		if (err instanceof Error && err.message.startsWith('Unknown role template')) {
+			return notFound(err.message);
+		}
+		throw err;
+	}
 }

--- a/specs/lib/infra.spec.md
+++ b/specs/lib/infra.spec.md
@@ -176,6 +176,12 @@ Core infrastructure utilities providing structured logging, environment safety, 
 | `DeviceAuthorizeSchema` | Auth Flow | Validates device authorization: `userCode`, `tenantId`, `email`, `approve` (all required). |
 | `PSKContactNicknameSchema` | PSK Contacts | Validates PSK contact: `nickname` (required). |
 | `CreditGrantSchema` | Wallet Credits | Validates credit grant: `amount` (positive finite number), optional `reference`. |
+| `PermissionGrantSchema` | Permissions | Validates permission grant: `agent_id`, `action` (required), optional `granted_by`, `reason`, `expires_at`, `tenant_id`. |
+| `PermissionRevokeSchema` | Permissions | Validates permission revoke: requires `grant_id` or `agent_id`, optional `action`, `revoked_by`, `reason`, `tenant_id`. |
+| `PermissionEmergencyRevokeSchema` | Permissions | Validates emergency revoke: `agent_id` (required), optional `revoked_by`, `reason`. |
+| `PermissionCheckSchema` | Permissions | Validates permission check: `agent_id`, `tool_name` (required), optional `session_id`, `tenant_id`. |
+| `PermissionApplyRoleSchema` | Permissions | Validates role apply: `agent_id`, `role` (required), optional `granted_by`, `tenant_id`, `expires_at`, `reason`. |
+| `PermissionRevokeRoleSchema` | Permissions | Validates role revoke: `agent_id`, `role` (required), optional `revoked_by`, `tenant_id`, `reason`. |
 | `CastVoteSchema` | Councils | Validates council vote: `agentId` (required), `vote` (approve/reject/abstain), optional `reason`. |
 | `HumanApprovalSchema` | Councils | Validates human approval: `approvedBy` (required). |
 | `CreateProposalSchema` | Governance Proposals | Validates proposal creation: `councilId`, `title`, `authorId` (required), optional `description`, `governanceTier` (0-2), `affectedPaths`, `quorumThreshold`, `minimumVoters`. |


### PR DESCRIPTION
## Summary
- All 6 POST endpoints in the permission broker routes (`/api/permissions/grant`, `/revoke`, `/emergency-revoke`, `/check`, `/roles/apply`, `/roles/revoke`) were using unsafe `req.json().catch(() => null)` with manual field checks instead of the codebase-standard `parseBodyOrThrow` with Zod schemas
- Added 6 Zod schemas (`PermissionGrantSchema`, `PermissionRevokeSchema`, `PermissionEmergencyRevokeSchema`, `PermissionCheckSchema`, `PermissionApplyRoleSchema`, `PermissionRevokeRoleSchema`) to `server/lib/validation.ts`
- Updated all permission route handlers to use `parseBodyOrThrow` with proper `ValidationError` handling
- These are security-critical endpoints (grant/revoke agent capabilities) — type confusion or malformed input could lead to unintended permission grants

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` — passes
- [x] `bun test` — 9004 pass (2 pre-existing failures, unchanged)
- [x] `bun run spec:check` — 192 specs, 0 failures, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)