### PR TITLE
fix(health-collector): eliminate false-positive FIXME/HACK/TODO counts

### DIFF
--- a/server/improvement/health-collector.ts
+++ b/server/improvement/health-collector.ts
@@ -127,9 +127,10 @@ export function parseTodoOutput(output: string): { todoCount: number; fixmeCount
     const samples: string[] = [];
 
     for (const line of lines) {
-        if (/TODO/i.test(line)) todoCount++;
-        if (/FIXME/i.test(line)) fixmeCount++;
-        if (/HACK/i.test(line)) hackCount++;
+        // Only count markers that appear after // or /* (actual code comments)
+        if (/(\/\/|\/\*)\s*TODO/i.test(line)) todoCount++;
+        if (/(\/\/|\/\*)\s*FIXME/i.test(line)) fixmeCount++;
+        if (/(\/\/|\/\*)\s*HACK/i.test(line)) hackCount++;
         if (samples.length < 10) {
             samples.push(line.trim().slice(0, 200));
         }
@@ -253,7 +254,7 @@ export class CodebaseHealthCollector {
 
     private async countTodos(cwd: string): Promise<{ todoCount: number; fixmeCount: number; hackCount: number; samples: string[] }> {
         const { stdout } = await spawnAndCapture(
-            ['grep', '-rn', '--exclude-dir=node_modules', 'TODO\\|FIXME\\|HACK', '--include=*.ts', 'server/', 'client/', 'shared/'],
+            ['grep', '-rn', '--exclude-dir=node_modules', '// TODO\\|// FIXME\\|// HACK\\|/\\* TODO\\|/\\* FIXME\\|/\\* HACK', '--include=*.ts', 'server/', 'client/', 'shared/'],
             cwd,
         );
         return parseTodoOutput(stdout);


### PR DESCRIPTION
## Summary

Fixes false-positive FIXME/HACK/TODO counting in `server/improvement/health-collector.ts`. The previous grep pattern matched these keywords anywhere in a line, including string literals and regex patterns.

**Changes:**
- Modified `countTodos()` grep pattern to only match comment-style markers (`// TODO`, `/* FIXME`, etc.)
- Updated `parseTodoOutput()` to verify markers appear after `//` or `/*` using regex `/(\/\/|\/\*)\s*(TODO|FIXME|HACK)/i`

**Test Results:**
- All 9017 unit and integration tests pass
- Unit tests for parsing functions pass (23 tests)
- Integration test for real directory collection passes (1 test)
- TypeScript compilation passes with no errors

**Expected Impact:**
- FIXME count drops from 15 to ≤4 (only real comment markers)
- HACK count drops similarly
- Eliminates false positives from patterns like `if (/FIXME/i.test(line))`

🤖 Generated with [Claude Code](https://claude.com/claude-code)