### PR TITLE
chore: prep v0.52.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.52.0] - 2026-03-25
+
+### Added
+- **Buddy mode: visible review rounds** — buddy review rounds now visible in Discord with sandbox `/message` support (#1477)
+- **Buddy mode: default pairings** — seed default buddy pairings on startup for zero-config buddy reviews (#1476)
+- **Buddy mode: improved review quality** — memory tools and tighter approval detection for more accurate buddy reviews (#1480)
+- **Scheduler: on-chain attestation** — daily activity attestation published on-chain via scheduler (#1474)
+- **Flock: A2A HTTP transport** — replace AlgoChat transport with A2A HTTP for flock agent communication (#1475)
+- **Security: Zod validation** — add Zod input validation to all permission API endpoints (#1479)
+
+### Fixed
+- **Sessions: auto-resume** — automatically resume sessions interrupted by server restarts
+- **Health collector: false positives** — eliminate false-positive FIXME/HACK/TODO counts in health reports (#1484)
+- **Types: schedule action** — replace `as any` with proper `ScheduleActionType` (#1472)
+
+### Changed
+- **Deps: SDK + types** — update @anthropic-ai/claude-agent-sdk to 0.2.83, @types/bun to 1.3.11, @types/node to 25.5.0 (#1482)
+- **Spec sync: v2.1.0** — update spec-sync tooling to v2.1.0 (#1481)
+- **Docs: sync stale counts** — refresh test, spec, and MCP tool counts in documentation (#1483)
+
 ## [0.51.0] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.51.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.52.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump `package.json` version from 0.51.0 → 0.52.0
- Update README version badge to 0.52.0
- Add full v0.52.0 changelog entry covering all 12 commits since v0.51.0

## What's in v0.52.0
- **Buddy mode** — visible review rounds in Discord, default pairings, memory-powered reviews
- **Flock** — A2A HTTP transport replacing AlgoChat
- **Security** — Zod validation on permission APIs
- **Scheduler** — on-chain daily activity attestation
- **Fixes** — session auto-resume, health collector false positives, type cleanup
- **Deps** — SDK 0.2.83, spec-sync v2.1.0, types updates

## Test plan
- [ ] CI passes
- [ ] Version badge renders correctly on README
- [ ] Changelog entry matches merged PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)