### PR TITLE
chore: prep v0.53.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.53.0] - 2026-03-25
+
+### Added
+- **DX: frictionless onboarding** — root `docker-compose.yml`, `bun run setup` wizard, improved quickstart paths (#1460)
+- **CLI: settings command** — `corvid-agent settings` for viewing/editing config, plus cookbook docs (#1488, #1490)
+- **CLI: plugin system** — `corvid-agent plugin` commands for listing, installing, and managing plugins (#1489, #1491)
+- **Discord: council selection** — `/council` now supports `council_name`, `agents`, and `project` options for picking councils, ad-hoc agent groups, and project context (#1492)
+- **Discord: responsive interface** — collapsible embeds and mobile-friendly layouts for Discord commands (#1491)
+
+### Fixed
+- **Buddy: review tool visibility** — expand buddy review tools (Read, Glob, Grep, code_symbols, find_references) for better context during reviews (#1492)
+
 ## [0.52.0] - 2026-03-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.52.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.53.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version to 0.53.0 in `package.json`
- Update version badge in `README.md`
- Add v0.53.0 changelog entry covering: frictionless onboarding, settings CLI, plugin system, council selection, responsive Discord interface, buddy review tool fixes

## Test plan
- [x] Version badge renders correctly
- [x] Changelog follows existing format
- [x] No stale 0.52.0 references outside changelog history

🤖 Generated with [Claude Code](https://claude.com/claude-code)