### PR TITLE
chore: prep v0.53.1 release — bump version, update README badge, add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.53.1] - 2026-03-25
+
+### Fixed
+- **CI: test reliability** — fix env var race condition in Discord tests, update buddy tools count assertion (#1494)
+
 ## [0.53.0] - 2026-03-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.53.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.53.1-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: corvid-agent
 description: Agent orchestration platform with MCP tools, AlgoChat messaging, and on-chain wallet integration
 type: application
-version: 0.51.0
-appVersion: "0.51.0"
+version: 0.53.1
+appVersion: "0.53.1"
 keywords:
   - ai
   - agent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.53.0",
+  "version": "0.53.1",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version to 0.53.1 across package.json, Helm Chart, and README badge
- Fix Helm Chart version drift (was stuck at 0.51.0, now aligned at 0.53.1)
- Add changelog entry for #1494 CI test fixes

## Checklist
- [x] `bun scripts/version-check.ts` — all versions aligned
- [x] `bun x tsc --noEmit` — clean
- [x] `bun run spec:check` — 192/192 passed, 100% coverage
- [x] `bun test` — 9033 tests pass, 0 fail
- [x] CHANGELOG.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)