### PR TITLE
fix(providers): enforce provider isolation in fallback chains

### DIFF
--- a/server/__tests__/model-router.test.ts
+++ b/server/__tests__/model-router.test.ts
@@ -241,11 +241,14 @@ describe('FallbackManager', () => {
     let fallback: FallbackManager;
     const savedAnthropicKey = process.env.ANTHROPIC_API_KEY;
     const savedOpenaiKey = process.env.OPENAI_API_KEY;
+    const savedEnabledProviders = process.env.ENABLED_PROVIDERS;
 
     beforeEach(() => {
         // Set dummy API keys so registry doesn't auto-restrict to ollama-only
         process.env.ANTHROPIC_API_KEY = 'sk-ant-test-dummy';
         process.env.OPENAI_API_KEY = 'sk-test-dummy';
+        // Explicitly allow all providers to avoid cross-test env pollution
+        process.env.ENABLED_PROVIDERS = 'anthropic,openai,ollama,openrouter,cursor';
         registry = new (LlmProviderRegistry as new () => LlmProviderRegistry)();
         registry.register(createMockProvider('anthropic', ['claude-sonnet-4-5-20250929']));
         registry.register(createMockProvider('openai', ['gpt-4o']));
@@ -257,6 +260,8 @@ describe('FallbackManager', () => {
         else process.env.ANTHROPIC_API_KEY = savedAnthropicKey;
         if (savedOpenaiKey === undefined) delete process.env.OPENAI_API_KEY;
         else process.env.OPENAI_API_KEY = savedOpenaiKey;
+        if (savedEnabledProviders === undefined) delete process.env.ENABLED_PROVIDERS;
+        else process.env.ENABLED_PROVIDERS = savedEnabledProviders;
     });
 
     test('DEFAULT_FALLBACK_CHAINS has expected chains', () => {

--- a/server/providers/fallback.ts
+++ b/server/providers/fallback.ts
@@ -32,44 +32,34 @@ export interface FallbackChain {
  * Default fallback chains for common scenarios.
  *
  * Council decision 2026-03-13: Claude-First dispatch.
- *   - Production chains use Claude (Anthropic) exclusively.
- *   - OpenAI is retained as a secondary fallback for resilience.
- *   - Ollama entries are removed from production paths; they only appear in the
- *     'local' and 'local-experimental' chains, which are only reachable when
- *     OLLAMA_LOCAL_EXPERIMENTAL=true.
+ * Updated 2026-03-25: Provider isolation — no cross-provider fallback.
+ *   - Each chain contains only models from a single provider.
+ *   - If a provider fails, the error surfaces — no silent switching to a
+ *     different provider (prevents surprise charges on OpenRouter/OpenAI).
+ *   - OpenRouter and OpenAI remain registered providers for explicit use,
+ *     but are NOT in default fallback chains.
+ *   - Ollama entries only appear in 'local' and 'cloud' chains.
  *   - Fallback = task queue (TaskQueueService), NOT model degradation.
  */
 export const DEFAULT_FALLBACK_CHAINS: Record<string, FallbackChain> = {
-    /** High-capability chain: council sessions, architecture decisions. */
+    /** High-capability chain: council sessions, architecture decisions. Anthropic-only. */
     'high-capability': {
         chain: [
             { provider: 'anthropic', model: 'claude-opus-4-6' },
             { provider: 'anthropic', model: 'claude-sonnet-4-6' },
-            { provider: 'openai', model: 'gpt-4.1' },
-            { provider: 'openai', model: 'o3' },
-            { provider: 'openrouter', model: 'google/gemini-2.5-pro' },
-            { provider: 'openrouter', model: 'openai/gpt-4.1' },
         ],
     },
-    /** Balanced chain: work tasks, code generation, specialist agents. */
+    /** Balanced chain: work tasks, code generation, specialist agents. Anthropic-only. */
     'balanced': {
         chain: [
             { provider: 'anthropic', model: 'claude-sonnet-4-6' },
             { provider: 'anthropic', model: 'claude-haiku-4-5-20251001' },
-            { provider: 'openai', model: 'gpt-4.1' },
-            { provider: 'openai', model: 'gpt-4.1-mini' },
-            { provider: 'openrouter', model: 'deepseek/deepseek-chat-v3' },
-            { provider: 'openrouter', model: 'mistralai/mistral-large' },
         ],
     },
-    /** Cost-optimized chain: routing, triage, lightweight classification. */
+    /** Cost-optimized chain: routing, triage, lightweight classification. Anthropic-only. */
     'cost-optimized': {
         chain: [
             { provider: 'anthropic', model: 'claude-haiku-4-5-20251001' },
-            { provider: 'openai', model: 'gpt-4.1-nano' },
-            { provider: 'openai', model: 'gpt-4o-mini' },
-            { provider: 'openrouter', model: 'google/gemini-2.5-flash' },
-            { provider: 'openrouter', model: 'qwen/qwen-2.5-coder-32b-instruct' },
         ],
     },
     /**

--- a/server/providers/ollama/provider.ts
+++ b/server/providers/ollama/provider.ts
@@ -126,12 +126,12 @@ export class OllamaProvider extends BaseLlmProvider {
     }
 
     /**
-     * Get the host for a specific model. Cloud models (suffix "-cloud") require
-     * the local Ollama instance because cloud proxying uses locally-stored auth.
+     * Get the host for a specific model. Cloud models (suffix "-cloud" or ":cloud")
+     * require the local Ollama instance because cloud proxying uses locally-stored auth.
      * If OLLAMA_HOST points to a non-local address, cloud models fall back to localhost.
      */
     private hostForModel(model: string): string {
-        if (model.includes('-cloud')) {
+        if (model.includes('-cloud') || model.endsWith(':cloud')) {
             const configuredHost = this.host;
             // If host is already localhost, use it directly
             if (configuredHost.includes('localhost') || configuredHost.includes('127.0.0.1')) {

--- a/specs/providers/provider-system.spec.md
+++ b/specs/providers/provider-system.spec.md
@@ -44,7 +44,7 @@ Core LLM provider abstraction layer that defines the provider interface, manages
 | Type | Description |
 |------|-------------|
 | `ModelTier` | Enum: `OPUS = 'opus'`, `SONNET = 'sonnet'`, `HAIKU = 'haiku'` — maps semantic task categories to Claude model families per council decision 2026-03-13 |
-| `LlmProviderType` | Union: `'anthropic' \| 'openai' \| 'ollama'` |
+| `LlmProviderType` | Union: `'anthropic' \| 'openai' \| 'ollama' \| 'openrouter' \| 'cursor'` |
 | `ExecutionMode` | Union: `'managed' \| 'direct'` |
 | `JsonSchemaProperty` | JSON Schema property descriptor with type, description, enum, items, default |
 | `JsonSchemaObject` | JSON Schema object with properties, required, and index signature for tool parameter schemas |
@@ -125,7 +125,8 @@ Core LLM provider abstraction layer that defines the provider interface, manages
 8. `FallbackManager.completeWithFallback()` throws `ExternalServiceError` only when all models in the chain fail.
 9. Cooldown-expired providers are automatically marked healthy again on the next availability check.
 10. `MODEL_PRICING` is the single source of truth for model capabilities and cost; the router and cost functions derive all decisions from it.
-11. `hasClaudeAccess()` caches CLI detection on first call and reuses the cached value thereafter.
+11. **Provider isolation**: Default fallback chains contain only models from a single provider. No cross-provider fallback — if the designated provider fails, the error surfaces rather than silently switching to a different provider. OpenRouter and OpenAI remain registered providers for explicit use but are not in default fallback chains.
+12. `hasClaudeAccess()` caches CLI detection on first call and reuses the cached value thereafter.
 
 ## Behavioral Examples
 
@@ -144,10 +145,10 @@ Core LLM provider abstraction layer that defines the provider interface, manages
 - **When** a provider is registered
 - **Then** only Ollama-type providers are accepted; cloud providers are skipped
 
-### Scenario: Fallback chain handles provider failure
-- **Given** a fallback chain with `[anthropic/claude-sonnet-4-6, openai/gpt-4.1]`
-- **When** the Anthropic provider throws a rate limit error
-- **Then** the failure is recorded, the provider enters cooldown tracking, and the request is retried with OpenAI
+### Scenario: Fallback chain handles model failure within same provider
+- **Given** a fallback chain with `[anthropic/claude-opus-4-6, anthropic/claude-sonnet-4-6]`
+- **When** claude-opus-4-6 throws a rate limit error
+- **Then** the failure is recorded, and the request is retried with claude-sonnet-4-6 (same provider)
 
 ### Scenario: All providers in chain fail
 - **Given** a fallback chain where every provider throws an error


### PR DESCRIPTION
## Summary
- **Remove OpenRouter and OpenAI from default fallback chains** — each chain now only contains models from a single provider (Anthropic). If a provider fails, the error surfaces instead of silently switching to a different provider (prevents surprise charges).
- **Fix `hostForModel()` to detect `:cloud` suffix** — models like `kimi-k2.5:cloud` now correctly route through localhost for the Ollama cloud proxy.
- **Update spec** — add `openrouter | cursor` to `LlmProviderType`, add provider isolation invariant (#11), update fallback scenario.
- **Fix flaky test** — FallbackManager test now sets `ENABLED_PROVIDERS` to prevent cross-test env pollution from parallel test files.

## Test plan
- [x] All 9041 tests pass (0 failures)
- [x] `bun run spec:check` — 192 specs, 100% coverage
- [x] `bun x tsc` — no type errors
- [x] Manual: verify Anthropic requests error through on failure (no silent OpenRouter fallback)
- [x] Manual: verify `:cloud` suffix models route to localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)