### PR TITLE
test(buddy+council): add mixed-provider smoke tests (#1497)

### DIFF
--- a/server/__tests__/buddy-mixed-provider.test.ts
+++ b/server/__tests__/buddy-mixed-provider.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Buddy mixed-provider smoke tests.
+ *
+ * These tests verify that Buddy-mode collaboration works correctly when agents
+ * use different LLM providers (Ollama, Anthropic, Cursor).  They cover the
+ * FallbackManager layer that Buddy sessions rely on, plus the isApproval
+ * detection logic that is provider-agnostic.
+ *
+ * Test naming follows: [<provider-config>] buddy: <scenario>
+ */
+import { describe, it, expect, afterEach, mock } from 'bun:test';
+import { FallbackManager } from '../providers/fallback';
+import { BuddyService } from '../buddy/service';
+import {
+    createProviderAgent,
+    createMockRegistry,
+    makeParams,
+    makeChain,
+    mockProviderResponse,
+    mockProviderFailure,
+    assertProviderUsed,
+    assertProviderNotUsed,
+} from './helpers/provider-matrix';
+
+// ─── isApproval wrapper ───────────────────────────────────────────────────────
+
+// BuddyService.isApproval is private; access via bracket notation.
+const buddyService = new BuddyService({ db: {} as any, processManager: {} as any });
+function isApproval(text: string): boolean {
+    return (buddyService as any).isApproval(text);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('buddy mixed-provider smoke tests', () => {
+    afterEach(() => {
+        mock.restore();
+    });
+
+    // ── [ollama] Ollama-only Buddy flow ──────────────────────────────────────
+
+    describe('[ollama] buddy: Ollama-only provider flow', () => {
+        it('primary Ollama provider completes successfully', async () => {
+            const ollamaPrimary = createProviderAgent(
+                'ollama',
+                'qwen3:14b',
+                mockProviderResponse('Here is the implementation.', 'qwen3:14b'),
+            );
+            const registry = createMockRegistry([ollamaPrimary]);
+            const manager = new FallbackManager(registry);
+
+            const chain = makeChain({ provider: 'ollama', model: 'qwen3:14b' });
+            const result = await manager.completeWithFallback(makeParams(), chain);
+
+            expect(result.content).toBe('Here is the implementation.');
+            expect(result.usedProvider).toBe('ollama');
+            expect(result.usedModel).toBe('qwen3:14b');
+            assertProviderUsed(ollamaPrimary);
+        });
+
+        it('buddy Ollama provider completes review', async () => {
+            const ollamaBuddy = createProviderAgent(
+                'ollama',
+                'llama3.1:8b',
+                mockProviderResponse('LGTM.', 'llama3.1:8b'),
+            );
+            const registry = createMockRegistry([ollamaBuddy]);
+            const manager = new FallbackManager(registry);
+
+            const chain = makeChain({ provider: 'ollama', model: 'llama3.1:8b' });
+            const result = await manager.completeWithFallback(
+                makeParams({ messages: [{ role: 'user', content: 'Review this: const x = 1;' }] }),
+                chain,
+            );
+
+            expect(result.content).toBe('LGTM.');
+            expect(result.usedProvider).toBe('ollama');
+            assertProviderUsed(ollamaBuddy);
+        });
+
+        it('approval detection works on Ollama-sourced review output', () => {
+            // Ollama produces a clean approval — isApproval should detect it
+            expect(isApproval('LGTM')).toBe(true);
+            expect(isApproval('Looks good to me!')).toBe(true);
+            expect(isApproval('Ship it!')).toBe(true);
+        });
+
+        it('approval detection correctly rejects Ollama feedback with caveats', () => {
+            // Ollama sometimes adds qualifiers — these must not be treated as approval
+            expect(isApproval('LGTM, however the error handling needs work.')).toBe(false);
+            expect(isApproval('Approved with reservations about the null check.')).toBe(false);
+        });
+    });
+
+    // ── [cursor] Cursor-only Buddy flow ──────────────────────────────────────
+
+    describe('[cursor] buddy: Cursor-only provider flow', () => {
+        it('primary Cursor provider completes successfully', async () => {
+            const cursorPrimary = createProviderAgent(
+                'cursor',
+                'cursor-fast',
+                mockProviderResponse('Implementation complete.', 'cursor-fast'),
+            );
+            const registry = createMockRegistry([cursorPrimary]);
+            const manager = new FallbackManager(registry);
+
+            const chain = makeChain({ provider: 'cursor', model: 'cursor-fast' });
+            const result = await manager.completeWithFallback(makeParams(), chain);
+
+            expect(result.content).toBe('Implementation complete.');
+            expect(result.usedProvider).toBe('cursor');
+            assertProviderUsed(cursorPrimary);
+        });
+
+        it('buddy Cursor provider completes review and approval is detected', async () => {
+            const cursorBuddy = createProviderAgent(
+                'cursor',
+                'cursor-fast',
+                mockProviderResponse('Approved.', 'cursor-fast'),
+            );
+            const registry = createMockRegistry([cursorBuddy]);
+            const manager = new FallbackManager(registry);
+
+            const chain = makeChain({ provider: 'cursor', model: 'cursor-fast' });
+            const result = await manager.completeWithFallback(
+                makeParams({ messages: [{ role: 'user', content: 'Review this PR' }] }),
+                chain,
+            );
+
+            expect(result.usedProvider).toBe('cursor');
+            expect(isApproval(result.content)).toBe(true);
+        });
+
+        it('no provider errors surface for a valid Cursor completion', async () => {
+            const cursorProvider = createProviderAgent(
+                'cursor',
+                'cursor-fast',
+                mockProviderResponse('No issues.', 'cursor-fast'),
+            );
+            const registry = createMockRegistry([cursorProvider]);
+            const manager = new FallbackManager(registry);
+
+            const chain = makeChain({ provider: 'cursor', model: 'cursor-fast' });
+            await expect(manager.completeWithFallback(makeParams(), chain)).resolves.toBeDefined();
+        });
+    });
+
+    // ── [mixed:ollama+anthropic] Cross-provider buddy flow ───────────────────
+
+    describe('[mixed:ollama+anthropic] buddy: cross-provider review handoff', () => {
+        it('primary Ollama produces work, Anthropic reviews — both succeed', async () => {
+            const ollamaPrimary = createProviderAgent(
+                'ollama',
+                'qwen3:14b',
+                mockProviderResponse('Here is the code change.', 'qwen3:14b'),
+            );
+            const anthropicBuddy = createProviderAgent(
+                'anthropic',
+                'claude-sonnet-4-6',
+                mockProviderResponse('LGTM', 'claude-sonnet-4-6'),
+            );
+            const registry = createMockRegistry([ollamaPrimary, anthropicBuddy]);
+            const manager = new FallbackManager(registry);
+
+            // Round 1: lead agent (Ollama) does the work
+            const leadChain = makeChain({ provider: 'ollama', model: 'qwen3:14b' });
+            const leadResult = await manager.completeWithFallback(makeParams(), leadChain);
+            expect(leadResult.usedProvider).toBe('ollama');
+            assertProviderUsed(ollamaPrimary);
+
+            // Round 2: buddy agent (Anthropic) reviews
+            const buddyChain = makeChain({ provider: 'anthropic', model: 'claude-sonnet-4-6' });
+            const reviewResult = await manager.completeWithFallback(
+                makeParams({ messages: [{ role: 'user', content: leadResult.content }] }),
+                buddyChain,
+            );
+            expect(reviewResult.usedProvider).toBe('anthropic');
+            assertProviderUsed(anthropicBuddy);
+
+            // Approval detection works on Anthropic review output
+            expect(isApproval(reviewResult.content)).toBe(true);
+        });
+
+        it('providers are isolated — Ollama primary does NOT call Anthropic', async () => {
+            const ollamaPrimary = createProviderAgent(
+                'ollama',
+                'qwen3:14b',
+                mockProviderResponse('Done.', 'qwen3:14b'),
+            );
+            const anthropicBuddy = createProviderAgent(
+                'anthropic',
+                'claude-sonnet-4-6',
+                mockProviderResponse('LGTM', 'claude-sonnet-4-6'),
+            );
+            const registry = createMockRegistry([ollamaPrimary, anthropicBuddy]);
+            const manager = new FallbackManager(registry);
+
+            // Only run the lead chain — Anthropic should NOT be called
+            const leadChain = makeChain({ provider: 'ollama', model: 'qwen3:14b' });
+            await manager.completeWithFallback(makeParams(), leadChain);
+
+            assertProviderUsed(ollamaPrimary);
+            assertProviderNotUsed(anthropicBuddy);
+        });
+
+        it('synthesis does not collapse when providers differ', async () => {
+            const ollamaLeadOutput = 'Refactored the session manager to use a pool.';
+            const anthropicReviewOutput = 'Code review complete. LGTM.';
+
+            // Both providers succeed independently
+            expect(ollamaLeadOutput.length).toBeGreaterThan(0);
+            expect(anthropicReviewOutput.length).toBeGreaterThan(0);
+
+            // isApproval works on Anthropic review regardless of lead's provider
+            expect(isApproval(anthropicReviewOutput)).toBe(true);
+
+            // Non-approval feedback from buddy should NOT be collapsed
+            const nonApproval = 'The pool size should be configurable.';
+            expect(isApproval(nonApproval)).toBe(false);
+        });
+    });
+
+    // ── [degraded:ollama-offline] Provider fallback during buddy review ───────
+
+    describe('[degraded:ollama-offline] buddy: fallback when buddy provider fails', () => {
+        it('FallbackManager routes to next provider when Ollama returns error', async () => {
+            const ollamaFailing = createProviderAgent(
+                'ollama',
+                'qwen3:14b',
+                mockProviderFailure(new Error('ECONNREFUSED: Ollama not reachable')),
+            );
+            const anthropicFallback = createProviderAgent(
+                'anthropic',
+                'claude-haiku-4-5-20251001',
+                mockProviderResponse('Review complete. Approved.', 'claude-haiku-4-5-20251001'),
+            );
+            const registry = createMockRegistry([ollamaFailing, anthropicFallback]);
+            const manager = new FallbackManager(registry);
+
+            // Chain: try Ollama first, fall back to Anthropic
+            const chain = makeChain(
+                { provider: 'ollama', model: 'qwen3:14b' },
+                { provider: 'anthropic', model: 'claude-haiku-4-5-20251001' },
+            );
+
+            const result = await manager.completeWithFallback(makeParams(), chain);
+
+            // Fallback to Anthropic should have happened
+            expect(result.usedProvider).toBe('anthropic');
+            expect(result.content).toBe('Review complete. Approved.');
+            assertProviderUsed(ollamaFailing);
+            assertProviderUsed(anthropicFallback);
+        });
+
+        it('review still completes via fallback — approval detection is unaffected', async () => {
+            const ollamaFailing = createProviderAgent(
+                'ollama',
+                'qwen3:14b',
+                mockProviderFailure('connection refused'),
+            );
+            const cursorFallback = createProviderAgent(
+                'cursor',
+                'cursor-fast',
+                mockProviderResponse('LGTM. Ship it!', 'cursor-fast'),
+            );
+            const registry = createMockRegistry([ollamaFailing, cursorFallback]);
+            const manager = new FallbackManager(registry);
+
+            const chain = makeChain(
+                { provider: 'ollama', model: 'qwen3:14b' },
+                { provider: 'cursor', model: 'cursor-fast' },
+            );
+
+            const result = await manager.completeWithFallback(makeParams(), chain);
+            expect(result.usedProvider).toBe('cursor');
+
+            // Approval detection still works on the fallback provider's output
+            expect(isApproval(result.content)).toBe(true);
+        });
+
+        it('throws ExternalServiceError when ALL providers fail', async () => {
+            const ollamaFailing = createProviderAgent(
+                'ollama',
+                'qwen3:14b',
+                mockProviderFailure('ECONNREFUSED'),
+            );
+            const anthropicFailing = createProviderAgent(
+                'anthropic',
+                'claude-haiku-4-5-20251001',
+                mockProviderFailure('503 Service Unavailable'),
+            );
+            const registry = createMockRegistry([ollamaFailing, anthropicFailing]);
+            const manager = new FallbackManager(registry);
+
+            const chain = makeChain(
+                { provider: 'ollama', model: 'qwen3:14b' },
+                { provider: 'anthropic', model: 'claude-haiku-4-5-20251001' },
+            );
+
+            await expect(manager.completeWithFallback(makeParams(), chain)).rejects.toThrow(
+                'All providers in fallback chain failed',
+            );
+        });
+
+        it('Ollama marked unhealthy after repeated ECONNREFUSED failures', async () => {
+            const ollamaFailing = createProviderAgent(
+                'ollama',
+                'qwen3:14b',
+                mockProviderFailure('ECONNREFUSED'),
+            );
+            const registry = createMockRegistry([ollamaFailing]);
+            const manager = new FallbackManager(registry);
+
+            const chain = makeChain({ provider: 'ollama', model: 'qwen3:14b' });
+
+            // Three consecutive failures are needed to trip the cooldown threshold
+            for (let i = 0; i < 3; i++) {
+                await expect(manager.completeWithFallback(makeParams(), chain)).rejects.toThrow();
+            }
+
+            // Provider should now be in cooldown after MAX_CONSECUTIVE_FAILURES=3
+            expect(manager.isProviderAvailable('ollama')).toBe(false);
+        });
+    });
+});

--- a/server/__tests__/council-mixed-provider.test.ts
+++ b/server/__tests__/council-mixed-provider.test.ts
@@ -1,0 +1,442 @@
+/**
+ * Council mixed-provider smoke tests.
+ *
+ * These tests verify that Council mode works correctly with heterogeneous
+ * provider configurations.  They exercise:
+ *   - FallbackManager with multi-provider chains (the dispatch layer councils use)
+ *   - waitForSessions with provider-tagged session IDs (the parallelism layer)
+ *   - aggregateSessionResponses with cross-provider member outputs
+ *   - Degraded and stalled provider scenarios
+ *
+ * Test naming follows: [<provider-config>] council: <scenario>
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { FallbackManager } from '../providers/fallback';
+import { waitForSessions } from '../routes/councils';
+import { aggregateSessionResponses } from '../councils/synthesis';
+import { listSessionsByCouncilLaunch } from '../db/sessions';
+import { runMigrations } from '../db/schema';
+import { createAgent } from '../db/agents';
+import { createProject } from '../db/projects';
+import { createSession } from '../db/sessions';
+import { createCouncil, createCouncilLaunch, getCouncilLaunch, updateCouncilLaunchStage } from '../db/councils';
+import type { ProcessManager, EventCallback } from '../process/manager';
+import type { ClaudeStreamEvent } from '../process/types';
+import type { CouncilStage } from '../../shared/types';
+import {
+    createProviderAgent,
+    createMockRegistry,
+    makeParams,
+    makeChain,
+    mockProviderResponse,
+    mockProviderFailure,
+    assertProviderUsed,
+} from './helpers/provider-matrix';
+
+// ─── Mock ProcessManager ─────────────────────────────────────────────────────
+
+function createMockPM() {
+    const subscribers = new Map<string, Set<EventCallback>>();
+    const running = new Set<string>();
+
+    const pm: Pick<ProcessManager, 'subscribe' | 'unsubscribe' | 'isRunning' | 'stopProcess'> = {
+        subscribe: (sessionId: string, cb: EventCallback) => {
+            if (!subscribers.has(sessionId)) subscribers.set(sessionId, new Set());
+            subscribers.get(sessionId)!.add(cb);
+        },
+        unsubscribe: (sessionId: string, cb: EventCallback) => {
+            subscribers.get(sessionId)?.delete(cb);
+        },
+        isRunning: (sessionId: string) => running.has(sessionId),
+        stopProcess: mock((sessionId: string) => { running.delete(sessionId); }),
+    };
+
+    return {
+        pm: pm as unknown as ProcessManager,
+        markRunning(sessionId: string) { running.add(sessionId); },
+        emitExit(sessionId: string) {
+            running.delete(sessionId);
+            const cbs = subscribers.get(sessionId);
+            if (cbs) {
+                for (const cb of cbs) {
+                    cb(sessionId, { type: 'session_exited', exitCode: 0, duration: 1000 } as ClaudeStreamEvent);
+                }
+            }
+        },
+        subscribers,
+        running,
+    };
+}
+
+// ─── Database helpers ─────────────────────────────────────────────────────────
+
+let db: Database;
+
+/** Seed a project + N agents + council + launch.  Returns helpers for creating sessions. */
+function seedCouncil(opts: { agentCount?: number; stage?: CouncilStage } = {}) {
+    const n = opts.agentCount ?? 3;
+    const project = createProject(db, { name: 'Test Project', workingDir: '/tmp/test' });
+    const agents = Array.from({ length: n }, (_, i) =>
+        createAgent(db, { name: `Agent ${String.fromCharCode(65 + i)}`, model: 'sonnet' }),
+    );
+    const council = createCouncil(db, {
+        name: 'Test Council',
+        agentIds: agents.map((a) => a.id),
+        chairmanAgentId: agents[0].id,
+    });
+    const launchId = crypto.randomUUID();
+    createCouncilLaunch(db, {
+        id: launchId,
+        councilId: council.id,
+        projectId: project.id,
+        prompt: 'What is the best approach?',
+    });
+    if (opts.stage) {
+        updateCouncilLaunchStage(db, launchId, opts.stage);
+    }
+    return { project, agents, council, launchId };
+}
+
+function insertAssistantMessage(sessionId: string, content: string) {
+    db.query(
+        `INSERT INTO session_messages (session_id, role, content) VALUES (?, 'assistant', ?)`,
+    ).run(sessionId, content);
+}
+
+beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+});
+
+afterEach(() => {
+    db.close();
+    mock.restore();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('council mixed-provider smoke tests', () => {
+
+    // ── [ollama] Homogeneous Ollama council ──────────────────────────────────
+
+    describe('[ollama] council: homogeneous Ollama council', () => {
+        it('all three Ollama sessions complete and waitForSessions resolves', async () => {
+            const { pm, markRunning, emitExit } = createMockPM();
+
+            markRunning('ollama-s1');
+            markRunning('ollama-s2');
+            markRunning('ollama-s3');
+
+            const promise = waitForSessions(pm, ['ollama-s1', 'ollama-s2', 'ollama-s3'], 5000);
+
+            emitExit('ollama-s1');
+            emitExit('ollama-s2');
+            emitExit('ollama-s3');
+
+            const result = await promise;
+            expect(result.completed.sort()).toEqual(['ollama-s1', 'ollama-s2', 'ollama-s3']);
+            expect(result.timedOut).toEqual([]);
+        });
+
+        it('all three Ollama providers complete the FallbackManager chain', async () => {
+            const ollamaA = createProviderAgent('ollama', 'qwen3:14b',
+                mockProviderResponse('Agent A response.', 'qwen3:14b'));
+            const ollamaB = createProviderAgent('ollama', 'llama3.1:8b',
+                mockProviderResponse('Agent B response.', 'llama3.1:8b'));
+            const ollamaC = createProviderAgent('ollama', 'mistral:7b',
+                mockProviderResponse('Agent C response.', 'mistral:7b'));
+
+            // Each agent gets its own registry (isolated by session)
+            const [rA, rB, rC] = await Promise.all([
+                new FallbackManager(createMockRegistry([ollamaA])).completeWithFallback(
+                    makeParams(),
+                    makeChain({ provider: 'ollama', model: 'qwen3:14b' }),
+                ),
+                new FallbackManager(createMockRegistry([ollamaB])).completeWithFallback(
+                    makeParams(),
+                    makeChain({ provider: 'ollama', model: 'llama3.1:8b' }),
+                ),
+                new FallbackManager(createMockRegistry([ollamaC])).completeWithFallback(
+                    makeParams(),
+                    makeChain({ provider: 'ollama', model: 'mistral:7b' }),
+                ),
+            ]);
+
+            expect(rA.usedProvider).toBe('ollama');
+            expect(rB.usedProvider).toBe('ollama');
+            expect(rC.usedProvider).toBe('ollama');
+            assertProviderUsed(ollamaA);
+            assertProviderUsed(ollamaB);
+            assertProviderUsed(ollamaC);
+        });
+
+        it('synthesis aggregation works when all members are Ollama', () => {
+            const { agents, launchId } = seedCouncil({ stage: 'responding', agentCount: 3 });
+            const launch = getCouncilLaunch(db, launchId)!;
+
+            for (const agent of agents) {
+                const s = createSession(db, {
+                    projectId: launch.projectId,
+                    agentId: agent.id,
+                    name: `Member: ${agent.name}`,
+                    councilLaunchId: launchId,
+                    councilRole: 'member',
+                });
+                insertAssistantMessage(s.id, `[ollama] ${agent.name}: use caching.`);
+            }
+
+            const sessions = listSessionsByCouncilLaunch(db, launchId);
+            const parts = aggregateSessionResponses(db, sessions);
+
+            expect(parts).toHaveLength(3);
+            expect(parts.every((p) => p.length > 0)).toBe(true);
+            expect(parts.every((p) => p.includes('[ollama]'))).toBe(true);
+        });
+    });
+
+    // ── [mixed:ollama+anthropic+cursor] Diverse provider council ─────────────
+
+    describe('[mixed:ollama+anthropic+cursor] council: diverse provider deliberation', () => {
+        it('three providers each complete their dispatch chain independently', async () => {
+            const ollamaAgent = createProviderAgent('ollama', 'qwen3:14b',
+                mockProviderResponse('Ollama perspective: use caching.', 'qwen3:14b'));
+            const anthropicAgent = createProviderAgent('anthropic', 'claude-sonnet-4-6',
+                mockProviderResponse('Anthropic perspective: use indexing.', 'claude-sonnet-4-6'));
+            const cursorAgent = createProviderAgent('cursor', 'cursor-fast',
+                mockProviderResponse('Cursor perspective: use partitioning.', 'cursor-fast'));
+
+            const results = await Promise.all([
+                new FallbackManager(createMockRegistry([ollamaAgent])).completeWithFallback(
+                    makeParams(),
+                    makeChain({ provider: 'ollama', model: 'qwen3:14b' }),
+                ),
+                new FallbackManager(createMockRegistry([anthropicAgent])).completeWithFallback(
+                    makeParams(),
+                    makeChain({ provider: 'anthropic', model: 'claude-sonnet-4-6' }),
+                ),
+                new FallbackManager(createMockRegistry([cursorAgent])).completeWithFallback(
+                    makeParams(),
+                    makeChain({ provider: 'cursor', model: 'cursor-fast' }),
+                ),
+            ]);
+
+            expect(results[0].usedProvider).toBe('ollama');
+            expect(results[1].usedProvider).toBe('anthropic');
+            expect(results[2].usedProvider).toBe('cursor');
+        });
+
+        it('synthesis correctly aggregates cross-provider responses', () => {
+            const { agents, launchId } = seedCouncil({ stage: 'responding', agentCount: 3 });
+            const launch = getCouncilLaunch(db, launchId)!;
+
+            const providerTags = ['[ollama]', '[anthropic]', '[cursor]'];
+            for (let i = 0; i < agents.length; i++) {
+                const s = createSession(db, {
+                    projectId: launch.projectId,
+                    agentId: agents[i].id,
+                    name: `Member: ${agents[i].name}`,
+                    councilLaunchId: launchId,
+                    councilRole: 'member',
+                });
+                insertAssistantMessage(s.id, `${providerTags[i]} response from ${agents[i].name}.`);
+            }
+
+            const sessions = listSessionsByCouncilLaunch(db, launchId);
+            const parts = aggregateSessionResponses(db, sessions);
+
+            expect(parts).toHaveLength(3);
+            const allContent = parts.join('\n');
+            expect(allContent).toContain('[ollama]');
+            expect(allContent).toContain('[anthropic]');
+            expect(allContent).toContain('[cursor]');
+        });
+
+        it('all sessions complete via waitForSessions regardless of provider label', async () => {
+            const { pm, markRunning, emitExit } = createMockPM();
+
+            const sessionIds = ['ollama:s1', 'anthropic:s2', 'cursor:s3'];
+            for (const id of sessionIds) markRunning(id);
+
+            const promise = waitForSessions(pm, sessionIds, 5000);
+            for (const id of sessionIds) emitExit(id);
+
+            const result = await promise;
+            expect(result.completed.sort()).toEqual(sessionIds.sort());
+            expect(result.timedOut).toEqual([]);
+        });
+    });
+
+    // ── [degraded:ollama-offline] One provider offline in council ────────────
+
+    describe('[degraded:ollama-offline] council: completes with 2/3 members', () => {
+        it('council still completes when one provider session times out', async () => {
+            const { pm, markRunning, emitExit } = createMockPM();
+
+            markRunning('s-ollama');
+            markRunning('s-anthropic');
+            markRunning('s-cursor');
+
+            const promise = waitForSessions(pm, ['s-ollama', 's-anthropic', 's-cursor'], 200);
+
+            // Anthropic and Cursor finish — Ollama stalls (provider offline)
+            emitExit('s-anthropic');
+            emitExit('s-cursor');
+
+            const result = await promise;
+            expect(result.completed.sort()).toEqual(['s-anthropic', 's-cursor']);
+            expect(result.timedOut).toEqual(['s-ollama']);
+        });
+
+        it('synthesis handles partial results when one session has no content', () => {
+            const { agents, launchId } = seedCouncil({ stage: 'responding', agentCount: 3 });
+            const launch = getCouncilLaunch(db, launchId)!;
+
+            // First agent (Ollama) session has no response — provider offline
+            createSession(db, {
+                projectId: launch.projectId,
+                agentId: agents[0].id,
+                name: 'Member: Agent A (ollama)',
+                councilLaunchId: launchId,
+                councilRole: 'member',
+            });
+            // No assistant message for agents[0]
+
+            const s1 = createSession(db, {
+                projectId: launch.projectId,
+                agentId: agents[1].id,
+                name: 'Member: Agent B (anthropic)',
+                councilLaunchId: launchId,
+                councilRole: 'member',
+            });
+            insertAssistantMessage(s1.id, 'Anthropic response: use Redis.');
+
+            const s2 = createSession(db, {
+                projectId: launch.projectId,
+                agentId: agents[2].id,
+                name: 'Member: Agent C (cursor)',
+                councilLaunchId: launchId,
+                councilRole: 'member',
+            });
+            insertAssistantMessage(s2.id, 'Cursor response: use memcached.');
+
+            const sessions = listSessionsByCouncilLaunch(db, launchId);
+            const parts = aggregateSessionResponses(db, sessions);
+
+            // Only 2 sessions have content
+            expect(parts).toHaveLength(2);
+        });
+
+        it('FallbackManager skips offline Ollama and uses Anthropic fallback', async () => {
+            const ollamaOffline = createProviderAgent('ollama', 'qwen3:14b',
+                mockProviderFailure('ECONNREFUSED: connection refused'));
+            const anthropicOnline = createProviderAgent('anthropic', 'claude-haiku-4-5-20251001',
+                mockProviderResponse('Council member response via fallback.', 'claude-haiku-4-5-20251001'));
+
+            const registry = createMockRegistry([ollamaOffline, anthropicOnline]);
+            const manager = new FallbackManager(registry);
+
+            const chain = makeChain(
+                { provider: 'ollama', model: 'qwen3:14b' },
+                { provider: 'anthropic', model: 'claude-haiku-4-5-20251001' },
+            );
+
+            const result = await manager.completeWithFallback(makeParams(), chain);
+
+            expect(result.usedProvider).toBe('anthropic');
+            assertProviderUsed(ollamaOffline);
+            assertProviderUsed(anthropicOnline);
+        });
+    });
+
+    // ── [stalled:ollama-cheerleading] Stalled provider in council ────────────
+
+    describe('[stalled:ollama-cheerleading] council: stalled provider does not block', () => {
+        it('fast agents complete before stalled Ollama agent times out', async () => {
+            const { pm, markRunning, emitExit } = createMockPM();
+
+            markRunning('fast-anthropic');
+            markRunning('fast-cursor');
+            markRunning('stalled-ollama');
+
+            const startTime = Date.now();
+            const promise = waitForSessions(
+                pm,
+                ['fast-anthropic', 'fast-cursor', 'stalled-ollama'],
+                200, // short timeout
+            );
+
+            emitExit('fast-anthropic');
+            emitExit('fast-cursor');
+            // stalled-ollama never exits
+
+            const result = await promise;
+            const elapsed = Date.now() - startTime;
+
+            expect(result.completed.sort()).toEqual(['fast-anthropic', 'fast-cursor']);
+            expect(result.timedOut).toEqual(['stalled-ollama']);
+            expect(elapsed).toBeLessThan(2000);
+        });
+
+        it('synthesis still aggregates responses from non-stalled members', () => {
+            const { agents, launchId } = seedCouncil({ stage: 'responding', agentCount: 3 });
+            const launch = getCouncilLaunch(db, launchId)!;
+
+            // agents[0] is the stalled Ollama — produces only a cheerleading response
+            const s0 = createSession(db, {
+                projectId: launch.projectId,
+                agentId: agents[0].id,
+                name: 'Member: Agent A (stalled-ollama)',
+                councilLaunchId: launchId,
+                councilRole: 'member',
+            });
+            insertAssistantMessage(s0.id, 'Great question!');
+
+            const s1 = createSession(db, {
+                projectId: launch.projectId,
+                agentId: agents[1].id,
+                name: 'Member: Agent B',
+                councilLaunchId: launchId,
+                councilRole: 'member',
+            });
+            insertAssistantMessage(s1.id, 'Use event sourcing for this.');
+
+            const s2 = createSession(db, {
+                projectId: launch.projectId,
+                agentId: agents[2].id,
+                name: 'Member: Agent C',
+                councilLaunchId: launchId,
+                councilRole: 'member',
+            });
+            insertAssistantMessage(s2.id, 'CQRS would solve the read/write split.');
+
+            const sessions = listSessionsByCouncilLaunch(db, launchId);
+            const parts = aggregateSessionResponses(db, sessions);
+
+            // All 3 sessions have content; stall detection is a higher-level concern
+            expect(parts).toHaveLength(3);
+            const allContent = parts.join('\n');
+            expect(allContent).toContain('event sourcing');
+            expect(allContent).toContain('CQRS');
+        });
+
+        it('council times out gracefully with partial responses when one agent stalls', async () => {
+            const { pm, markRunning, emitExit } = createMockPM();
+
+            markRunning('m1');
+            markRunning('m2-stalled-ollama');
+            markRunning('m3');
+
+            const promise = waitForSessions(pm, ['m1', 'm2-stalled-ollama', 'm3'], 100);
+
+            emitExit('m1');
+            emitExit('m3');
+            // m2-stalled-ollama never exits
+
+            const result = await promise;
+            expect(result.completed.sort()).toEqual(['m1', 'm3']);
+            expect(result.timedOut).toEqual(['m2-stalled-ollama']);
+        });
+    });
+});

--- a/server/__tests__/helpers/provider-matrix.ts
+++ b/server/__tests__/helpers/provider-matrix.ts
@@ -1,0 +1,139 @@
+/**
+ * Shared helpers for provider-matrix smoke tests.
+ *
+ * Reuses the createMockProvider / createMockRegistry patterns established in
+ * fallback-manager.test.ts and provider-registry.test.ts so that buddy and
+ * council mixed-provider tests share a single source of truth.
+ */
+import { mock } from 'bun:test';
+import type { LlmProvider, LlmProviderType, LlmCompletionParams, LlmCompletionResult } from '../../providers/types';
+import { LlmProviderRegistry } from '../../providers/registry';
+import type { FallbackChain } from '../../providers/fallback';
+
+// ─── Provider factory ─────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal mock LlmProvider for the given type.
+ *
+ * @param type     - provider type (e.g. 'ollama', 'anthropic', 'cursor')
+ * @param model    - default model string returned in getInfo
+ * @param impl     - optional override for the `complete` implementation
+ */
+export function createProviderAgent(
+    type: LlmProviderType,
+    model: string,
+    impl?: (params: LlmCompletionParams) => Promise<LlmCompletionResult>,
+): LlmProvider {
+    return {
+        type,
+        executionMode: type === 'ollama' || type === 'cursor' ? 'direct' : 'managed',
+        getInfo: () => ({
+            type,
+            name: `mock-${type}`,
+            executionMode: type === 'ollama' || type === 'cursor' ? 'direct' : 'managed',
+            models: [model],
+            defaultModel: model,
+            supportsTools: true,
+            supportsStreaming: true,
+        }),
+        complete: impl ?? mock(() => Promise.resolve(makeResult('ok', model))),
+        isAvailable: mock(() => Promise.resolve(true)),
+    };
+}
+
+// ─── Registry factory ─────────────────────────────────────────────────────────
+
+/**
+ * Build a lightweight mock registry from a list of providers.
+ * Mirrors the pattern used in fallback-manager.test.ts.
+ */
+export function createMockRegistry(providers: LlmProvider[]): LlmProviderRegistry {
+    return {
+        get(type: LlmProviderType) {
+            return providers.find((p) => p.type === type);
+        },
+        getAll() {
+            return providers;
+        },
+        getDefault() {
+            return providers[0];
+        },
+    } as unknown as LlmProviderRegistry;
+}
+
+// ─── Response factories ───────────────────────────────────────────────────────
+
+/** Build a valid LlmCompletionResult. */
+export function makeResult(content: string, model: string): LlmCompletionResult {
+    return { content, model, usage: { inputTokens: 10, outputTokens: 20 } };
+}
+
+/** Build a minimal LlmCompletionParams for tests. */
+export function makeParams(overrides?: Partial<LlmCompletionParams>): LlmCompletionParams {
+    return {
+        model: 'test-model',
+        systemPrompt: 'You are a test assistant.',
+        messages: [{ role: 'user', content: 'Hello' }],
+        ...overrides,
+    };
+}
+
+// ─── Provider response helpers ────────────────────────────────────────────────
+
+/**
+ * Return a `complete` implementation that resolves with the given content.
+ * Use this to simulate a successful provider response.
+ */
+export function mockProviderResponse(
+    response: string,
+    model: string,
+): (params: LlmCompletionParams) => Promise<LlmCompletionResult> {
+    return mock((_params: LlmCompletionParams) => Promise.resolve(makeResult(response, model)));
+}
+
+/**
+ * Return a `complete` implementation that rejects with the given error.
+ * Use this to simulate a provider failure (connection error, 503, etc.).
+ */
+export function mockProviderFailure(
+    error: Error | string,
+): (params: LlmCompletionParams) => Promise<LlmCompletionResult> {
+    const err = typeof error === 'string' ? new Error(error) : error;
+    return mock((_params: LlmCompletionParams) => Promise.reject(err));
+}
+
+// ─── Chain factory ────────────────────────────────────────────────────────────
+
+/** Build a FallbackChain from provider/model pairs. */
+export function makeChain(...entries: Array<{ provider: LlmProviderType; model: string }>): FallbackChain {
+    return { chain: entries };
+}
+
+// ─── Assertion helpers ────────────────────────────────────────────────────────
+
+/**
+ * Assert that the `complete` mock on the given provider was called at least once.
+ * Providers returned by createProviderAgent store their `complete` as a Bun mock.
+ */
+export function assertProviderUsed(provider: LlmProvider): void {
+    const completeMock = provider.complete as ReturnType<typeof mock>;
+    if (typeof completeMock.mock === 'undefined') {
+        throw new Error('assertProviderUsed: provider.complete is not a bun mock');
+    }
+    if (completeMock.mock.calls.length === 0) {
+        throw new Error(`Expected provider '${provider.type}' to be called, but it was not.`);
+    }
+}
+
+/**
+ * Assert that the `complete` mock on the given provider was NOT called.
+ */
+export function assertProviderNotUsed(provider: LlmProvider): void {
+    const completeMock = provider.complete as ReturnType<typeof mock>;
+    if (typeof completeMock.mock === 'undefined') {
+        throw new Error('assertProviderNotUsed: provider.complete is not a bun mock');
+    }
+    if (completeMock.mock.calls.length > 0) {
+        throw new Error(`Expected provider '${provider.type}' NOT to be called, but it was called ${completeMock.mock.calls.length} time(s).`);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 26 provider-matrix smoke tests verifying Buddy and Council multi-agent flows work across Ollama, Anthropic, and Cursor providers
- Creates `server/__tests__/helpers/provider-matrix.ts` with shared test helpers (`createProviderAgent`, `createMockRegistry`, `makeChain`, `mockProviderResponse/Failure`, `assertProviderUsed`) reusing patterns from existing `fallback-manager.test.ts`
- `server/__tests__/buddy-mixed-provider.test.ts` — Ollama-only, Cursor-only, mixed Ollama+Anthropic, and degraded-provider Buddy flows (14 tests)
- `server/__tests__/council-mixed-provider.test.ts` — homogeneous Ollama, diverse mixed (Ollama+Anthropic+Cursor), degraded (1 provider offline), and stalled-Ollama Council scenarios (12 tests)

Test naming convention makes provider-specific failures obvious: `[ollama] buddy: ...`, `[mixed:ollama+anthropic] buddy: ...`, `[degraded:ollama-offline] council: ...`

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 9067 pass, 0 fail
- [x] `bun run spec:check` — 192/192 passed

Closes #1497

🤖 Generated with [Claude Code](https://claude.com/claude-code)