### PR TITLE
fix(security): parameterize SQL queries in test files

### DIFF
--- a/server/__tests__/algochat-discovery-service.test.ts
+++ b/server/__tests__/algochat-discovery-service.test.ts
@@ -477,10 +477,10 @@ describe('DiscoveryService', () => {
 
         test('should include agent wallet addresses from DB', () => {
             const agent1 = createAgent(db, { name: 'Agent 1' });
-            db.exec(`UPDATE agents SET wallet_address = 'AGENT_WALLET_1' WHERE id = '${agent1.id}'`);
+            db.prepare('UPDATE agents SET wallet_address = ? WHERE id = ?').run('AGENT_WALLET_1', agent1.id);
 
             const agent2 = createAgent(db, { name: 'Agent 2' });
-            db.exec(`UPDATE agents SET wallet_address = 'AGENT_WALLET_2' WHERE id = '${agent2.id}'`);
+            db.prepare('UPDATE agents SET wallet_address = ? WHERE id = ?').run('AGENT_WALLET_2', agent2.id);
 
             const service = createMockService();
             const discovery = new DiscoveryService(db, createMockConfig(), service, () => true);
@@ -513,7 +513,7 @@ describe('DiscoveryService', () => {
 
             // Add a new agent after first call
             const lateAgent = createAgent(db, { name: 'Late Agent' });
-            db.exec(`UPDATE agents SET wallet_address = 'LATE_WALLET' WHERE id = '${lateAgent.id}'`);
+            db.prepare('UPDATE agents SET wallet_address = ? WHERE id = ?').run('LATE_WALLET', lateAgent.id);
 
             const second = discovery.getAgentWalletAddresses();
 
@@ -530,7 +530,7 @@ describe('DiscoveryService', () => {
 
             // Add a new agent
             const lateAgent = createAgent(db, { name: 'Late Agent' });
-            db.exec(`UPDATE agents SET wallet_address = 'LATE_WALLET' WHERE id = '${lateAgent.id}'`);
+            db.prepare('UPDATE agents SET wallet_address = ? WHERE id = ?').run('LATE_WALLET', lateAgent.id);
 
             // Simulate TTL expiration by manipulating internal state
             // Access the private field via any cast

--- a/server/__tests__/crypto-audit.test.ts
+++ b/server/__tests__/crypto-audit.test.ts
@@ -181,7 +181,7 @@ describe('Wallet Encryption Key Rotation', () => {
 
         // Store in DB
         db.exec(`INSERT INTO agents (id, name, model, system_prompt) VALUES ('agent-1', 'TestAgent', 'test', 'test')`);
-        db.exec(`UPDATE agents SET wallet_mnemonic_encrypted = '${encrypted}', wallet_address = 'TESTADDR' WHERE id = 'agent-1'`);
+        db.prepare('UPDATE agents SET wallet_mnemonic_encrypted = ?, wallet_address = ? WHERE id = ?').run(encrypted, 'TESTADDR', 'agent-1');
 
         // Store in keystore
         writeFileSync(TEST_KEYSTORE_PATH, JSON.stringify({
@@ -202,7 +202,7 @@ describe('Wallet Encryption Key Rotation', () => {
         const encrypted = await encryptMnemonic(mnemonic, null, 'testnet');
 
         db.exec(`INSERT INTO agents (id, name, model, system_prompt) VALUES ('agent-1', 'TestAgent', 'test', 'test')`);
-        db.exec(`UPDATE agents SET wallet_mnemonic_encrypted = '${encrypted}', wallet_address = 'TESTADDR' WHERE id = 'agent-1'`);
+        db.prepare('UPDATE agents SET wallet_mnemonic_encrypted = ?, wallet_address = ? WHERE id = ?').run(encrypted, 'TESTADDR', 'agent-1');
 
         writeFileSync(TEST_KEYSTORE_PATH, JSON.stringify({
             TestAgent: { address: 'TESTADDR', encryptedMnemonic: encrypted },
@@ -239,9 +239,9 @@ describe('Wallet Encryption Key Rotation', () => {
         }), { encoding: 'utf-8', mode: 0o600 });
 
         db.exec(`INSERT INTO agents (id, name, model, system_prompt) VALUES ('a1', 'Agent1', 'test', 'test')`);
-        db.exec(`UPDATE agents SET wallet_mnemonic_encrypted = '${encrypted}', wallet_address = 'ADDR1' WHERE id = 'a1'`);
+        db.prepare('UPDATE agents SET wallet_mnemonic_encrypted = ?, wallet_address = ? WHERE id = ?').run(encrypted, 'ADDR1', 'a1');
         db.exec(`INSERT INTO agents (id, name, model, system_prompt) VALUES ('a2', 'Agent2', 'test', 'test')`);
-        db.exec(`UPDATE agents SET wallet_mnemonic_encrypted = '${encrypted}', wallet_address = 'ADDR2' WHERE id = 'a2'`);
+        db.prepare('UPDATE agents SET wallet_mnemonic_encrypted = ?, wallet_address = ? WHERE id = ?').run(encrypted, 'ADDR2', 'a2');
 
         await rotateWalletEncryptionKey(db, OLD_PASSPHRASE, NEW_PASSPHRASE, 'testnet');
 
@@ -273,7 +273,7 @@ describe('Wallet Encryption Key Rotation', () => {
         const encrypted = await encryptMnemonic(mnemonic, null, 'testnet');
 
         db.exec(`INSERT INTO agents (id, name, model, system_prompt) VALUES ('agent-1', 'TestAgent', 'test', 'test')`);
-        db.exec(`UPDATE agents SET wallet_mnemonic_encrypted = '${encrypted}', wallet_address = 'TESTADDR' WHERE id = 'agent-1'`);
+        db.prepare('UPDATE agents SET wallet_mnemonic_encrypted = ?, wallet_address = ? WHERE id = ?').run(encrypted, 'TESTADDR', 'agent-1');
 
         // Try to rotate with wrong old passphrase — should fail
         const result = await rotateWalletEncryptionKey(db, 'wrong-passphrase-that-is-long-enough-32chars', NEW_PASSPHRASE, 'testnet');
@@ -294,7 +294,7 @@ describe('Wallet Encryption Key Rotation', () => {
         const encrypted = await encryptMnemonic(mnemonic, null, 'testnet');
 
         db.exec(`INSERT INTO agents (id, name, model, system_prompt) VALUES ('agent-1', 'TestAgent', 'test', 'test')`);
-        db.exec(`UPDATE agents SET wallet_mnemonic_encrypted = '${encrypted}', wallet_address = 'TESTADDR' WHERE id = 'agent-1'`);
+        db.prepare('UPDATE agents SET wallet_mnemonic_encrypted = ?, wallet_address = ? WHERE id = ?').run(encrypted, 'TESTADDR', 'agent-1');
 
         await rotateWalletEncryptionKey(db, OLD_PASSPHRASE, NEW_PASSPHRASE, 'testnet');
 
@@ -312,7 +312,7 @@ describe('Wallet Encryption Key Rotation', () => {
         const encrypted = await encryptMnemonic(mnemonic, null, 'testnet');
 
         db.exec(`INSERT INTO agents (id, name, model, system_prompt) VALUES ('agent-1', 'TestAgent', 'test', 'test')`);
-        db.exec(`UPDATE agents SET wallet_mnemonic_encrypted = '${encrypted}', wallet_address = 'TESTADDR' WHERE id = 'agent-1'`);
+        db.prepare('UPDATE agents SET wallet_mnemonic_encrypted = ?, wallet_address = ? WHERE id = ?').run(encrypted, 'TESTADDR', 'agent-1');
 
         await rotateWalletEncryptionKey(db, OLD_PASSPHRASE, NEW_PASSPHRASE, 'testnet');
 

--- a/server/__tests__/graduation-service.test.ts
+++ b/server/__tests__/graduation-service.test.ts
@@ -21,7 +21,7 @@ function createTestDb(): Database {
 
     // Minimal schema needed for graduation service
     db.exec(`CREATE TABLE IF NOT EXISTS agents (id TEXT PRIMARY KEY)`);
-    db.exec(`INSERT INTO agents (id) VALUES ('${AGENT_ID}')`);
+    db.prepare('INSERT INTO agents (id) VALUES (?)').run(AGENT_ID);
 
     // agent_memories table (used by saveMemory in graduation)
     db.exec(`

--- a/server/__tests__/key-access-audit.test.ts
+++ b/server/__tests__/key-access-audit.test.ts
@@ -208,9 +208,9 @@ describe('Key access audit actions', () => {
         const enc = await encryptMnemonicWithPassphrase(mnemonic, OLD);
 
         db.exec(`INSERT INTO agents (id, name, model, system_prompt) VALUES ('a1', 'Agent1', 'test', 'test')`);
-        db.exec(`UPDATE agents SET wallet_mnemonic_encrypted = '${enc}', wallet_address = 'ADDR1' WHERE id = 'a1'`);
+        db.prepare('UPDATE agents SET wallet_mnemonic_encrypted = ?, wallet_address = ? WHERE id = ?').run(enc, 'ADDR1', 'a1');
         db.exec(`INSERT INTO agents (id, name, model, system_prompt) VALUES ('a2', 'Agent2', 'test', 'test')`);
-        db.exec(`UPDATE agents SET wallet_mnemonic_encrypted = '${enc}', wallet_address = 'ADDR2' WHERE id = 'a2'`);
+        db.prepare('UPDATE agents SET wallet_mnemonic_encrypted = ?, wallet_address = ? WHERE id = ?').run(enc, 'ADDR2', 'a2');
 
         const result = await rotateWalletEncryptionKey(db, OLD, NEW, 'testnet');
         expect(result.success).toBe(true);

--- a/server/__tests__/observations.test.ts
+++ b/server/__tests__/observations.test.ts
@@ -27,7 +27,7 @@ function createTestDb(): Database {
     db.exec('PRAGMA journal_mode = WAL');
     // The observations migration references agents(id) FK, so create a stub table
     db.exec(`CREATE TABLE IF NOT EXISTS agents (id TEXT PRIMARY KEY)`);
-    db.exec(`INSERT INTO agents (id) VALUES ('${AGENT_ID}')`);
+    db.prepare('INSERT INTO agents (id) VALUES (?)').run(AGENT_ID);
     up(db);
     return db;
 }
@@ -365,7 +365,7 @@ describe('purgeOldObservations', () => {
         dismissObservation(db, obs.id);
 
         // Manually set created_at to 60 days ago
-        db.exec(`UPDATE memory_observations SET created_at = datetime('now', '-60 days') WHERE id = '${obs.id}'`);
+        db.prepare("UPDATE memory_observations SET created_at = datetime('now', '-60 days') WHERE id = ?").run(obs.id);
 
         const purged = purgeOldObservations(db, 30);
         // purge count includes FTS trigger changes, so just verify it's > 0
@@ -380,7 +380,7 @@ describe('purgeOldObservations', () => {
             source: 'session',
             content: 'still active',
         });
-        db.exec(`UPDATE memory_observations SET created_at = datetime('now', '-60 days') WHERE id = '${obs.id}'`);
+        db.prepare("UPDATE memory_observations SET created_at = datetime('now', '-60 days') WHERE id = ?").run(obs.id);
 
         const purged = purgeOldObservations(db, 30);
         expect(purged).toBe(0);

--- a/server/__tests__/security-audit.test.ts
+++ b/server/__tests__/security-audit.test.ts
@@ -834,7 +834,7 @@ describe('SSRF Prevention', () => {
 describe('Cross-Tenant Isolation', () => {
     test('resolveAgentTenant returns undefined for DEFAULT_TENANT_ID agent', () => {
         const db = createTenantTestDb();
-        db.exec(`INSERT INTO agents (id, tenant_id) VALUES ('agent-1', '${DEFAULT_TENANT_ID}')`);
+        db.prepare('INSERT INTO agents (id, tenant_id) VALUES (?, ?)').run('agent-1', DEFAULT_TENANT_ID);
         const result = resolveAgentTenant(db, 'agent-1');
         expect(result).toBeUndefined();
         db.close();
@@ -865,7 +865,7 @@ describe('Cross-Tenant Isolation', () => {
 
     test('resolveCouncilTenant returns undefined for default tenant', () => {
         const db = createTenantTestDb();
-        db.exec(`INSERT INTO agents (id, tenant_id) VALUES ('agent-c1', '${DEFAULT_TENANT_ID}')`);
+        db.prepare('INSERT INTO agents (id, tenant_id) VALUES (?, ?)').run('agent-c1', DEFAULT_TENANT_ID);
         db.exec(`INSERT INTO sessions (id, agent_id, council_launch_id) VALUES ('session-c1', 'agent-c1', 'launch-1')`);
         const result = resolveCouncilTenant(db, 'launch-1');
         expect(result).toBeUndefined();


### PR DESCRIPTION
## Summary
- Replace 19 instances of SQL string interpolation (`db.exec(`...${var}...`)`) with parameterized queries (`db.prepare('...?...').run(var)`) across 6 test files
- Prevents accidental copy-paste of SQL injection anti-patterns into production code
- No production code changes — test-only hardening

## Files changed
- `server/__tests__/observations.test.ts` (3 fixes)
- `server/__tests__/graduation-service.test.ts` (1 fix)
- `server/__tests__/key-access-audit.test.ts` (2 fixes)
- `server/__tests__/security-audit.test.ts` (2 fixes)
- `server/__tests__/crypto-audit.test.ts` (7 fixes)
- `server/__tests__/algochat-discovery-service.test.ts` (4 fixes)

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` — passes
- [x] `bun test` — 9114 pass (2 pre-existing failures unrelated)
- [x] `bun run spec:check` — 192/192, 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)