### PR TITLE
fix(ollama): add nemotron to TEXT_BASED_TOOL_FAMILIES

### DIFF
--- a/server/providers/ollama/provider.ts
+++ b/server/providers/ollama/provider.ts
@@ -235,13 +235,13 @@ export class OllamaProvider extends BaseLlmProvider {
      * extractToolCallsFromContent().
      *
      * - qwen3: 10x+ slower when `tools` is in the API request
-     * - kimi, minimax, gemini, glm, devstral: Cloud-proxied models where
+     * - kimi, minimax, gemini, glm, devstral, nemotron: Cloud-proxied models where
      *   the Ollama proxy doesn't reliably translate native tool_calls back.
      *   These models output tool call JSON in text when instructed via
      *   system prompt, which the text-based extractor handles well.
      */
     private static readonly TEXT_BASED_TOOL_FAMILIES = new Set([
-        'qwen3', 'kimi', 'minimax', 'gemini', 'glm', 'devstral',
+        'qwen3', 'kimi', 'minimax', 'gemini', 'glm', 'devstral', 'nemotron',
     ]);
 
     /**


### PR DESCRIPTION
## Summary
- Adds `nemotron` to `TEXT_BASED_TOOL_FAMILIES` in the Ollama provider
- Nemotron Cloud models go through Ollama's cloud proxy which doesn't reliably translate native `tool_calls` back in responses
- This caused Condor (`nemotron-3-super:cloud`) to narrate tool usage in text instead of actually executing tools
- Routing through the text-based tool calling path fixes the issue (same solution used for kimi, minimax, gemini, glm, devstral)

## Test plan
- [ ] Deploy and spin up a Condor session with a simple task requiring tool calls
- [ ] Verify Condor actually executes tools instead of narrating them

🤖 Generated with [Claude Code](https://claude.com/claude-code)