### PR TITLE
chore: prep v0.55.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.55.0] - 2026-03-27
+
+### Added
+- **Cursor: first-class provider** — CursorProvider promoted to production-quality LlmProvider with exit code classification, transient/permanent error detection, 120s idle timeout, and 41 tests (#1545, #1531)
+- **Agent signatures** — agent identity signatures on all GitHub write operations with model-based regex mapping and fail-open safety (#1555)
+- **Memory browser** — full CRUD UI with search, filter, pagination, and signal-based service for on-chain ARC-69 memories (#1552)
+- **Agent comms visualization** — real-time WebSocket timeline of all agent-to-agent messages with history and dedup handling (#1551)
+- **Cron editor** — extracted `CronHumanPipe`, inline validation, preset chips, and human-readable preview for schedule management (#1553)
+- **Shared agent library (CRVLIB)** — ARC-69 shared agent library for reusable on-chain agent components (#1537)
+- **Ollama: cloud intern models** — GPT-OSS, DeepSeek V3.1, Qwen3 Coder as cloud intern model options (#1524)
+- **Ollama: cloud optimizations** — compact prompts and timeout caps for cloud model families (#1522)
+- **Work: intern PR guard** — prevent intern-tier models from creating production PRs (#1546)
+
+### Fixed
+- **Flock: inner transaction fees** — fix AVM fee-pooling bug with extraFee for inner transactions, plus 45 e2e tests (#1550)
+- **Ollama: readiness probe** — check Ollama readiness before provider registration (#1544)
+- **Ollama: nemotron** — add nemotron to TEXT_BASED_TOOL_FAMILIES (#1521)
+- **Health collector** — fix grep --include flag ordering (#1543)
+- **MCP: tool permissions** — empty tool permissions no longer blocks all tools (#1523)
+- **Scheduler** — resolve project ID via tenant fallback (#1540)
+
+### Docs
+- **Provider parity plan** — Ollama + Cursor checklist and test plan (#1534)
+- **TypeScript 6.0 evaluation** — upgrade evaluation document (#1541)
+- **CRVLIB spec** — add missing exports and fix consumed-by section (#1538)
+
 ## [0.54.0] - 2026-03-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.54.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.55.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>
@@ -122,7 +122,7 @@ skills/
 
 ## Tech stack
 
-Bun + Angular 21 + SQLite + Claude Agent SDK + Algorand (on-chain identity). 50 MCP tools, ~380 API endpoints, 10,500+ test files, 193 E2E spec files.
+Bun + Angular 21 + SQLite + Claude Agent SDK + Algorand (on-chain identity). 65 MCP tools, ~380 API endpoints, 10,500+ test files, 196 module specs.
 
 **[Architecture →](docs/how-it-works.md)** | **[Security →](SECURITY.md)** | **[Deployment →](docs/self-hosting.md)**
 


### PR DESCRIPTION
## Summary
- Bump version badge in README from 0.54.0 → 0.55.0
- Update tech stack stats (65 MCP tools, 196 module specs)
- Add full v0.55.0 changelog entry covering all 6 sprint PRs + prior unreleased work

## What's in v0.55.0
**Backend:** Agent identity signatures, Cursor first-class provider, CRVLIB shared library, Ollama cloud models, intern PR guard, 45 Flock e2e tests
**Frontend:** Memory browser, Agent comms visualization, Cron editor with presets
**Fixes:** MCP tool permissions, scheduler tenant fallback, Ollama readiness probe, inner txn fees

## Site
GitHub Pages site updated separately (pushed to corvid-agent.github.io main):
- Version refs → v0.55.0
- Stats: 10,500+ tests, 196 specs, 65 MCP tools, 997 commits
- New "Scale" era added to releases page with v0.42.0–v0.55.0 entries