### PR TITLE
fix(ollama): improve Nemotron cloud proxy timeout handling

### DIFF
--- a/server/providers/ollama/provider.ts
+++ b/server/providers/ollama/provider.ts
@@ -363,6 +363,8 @@ export class OllamaProvider extends BaseLlmProvider {
         if (msg.includes('out of memory') || msg.includes('oom')) return true;
         // Stream idle timeout (model may recover)
         if (msg.includes('stream idle')) return true;
+        // NVIDIA cloud proxy timeout — their backend killed the request, retry may succeed
+        if (msg.includes('cloud proxy timeout')) return true;
         return false;
     }
 
@@ -516,12 +518,14 @@ export class OllamaProvider extends BaseLlmProvider {
         // Build Ollama options for optimal performance.
         const isCloud = OllamaProvider.isCloudModel(params.model);
         const defaultCtx = parseInt(process.env.OLLAMA_NUM_CTX ?? '8192', 10);
+        // Cloud-proxied models have tight server-side timeouts (~90s on NVIDIA).
+        // Reduce context window to speed up prompt evaluation on the remote side.
+        const effectiveCtx = isCloud ? Math.min(defaultCtx, 4096) : defaultCtx;
         const localMaxOutput = parseInt(process.env.OLLAMA_NUM_PREDICT ?? '2048', 10);
-        // Cloud-proxied models have tight server-side timeouts (~90s).
-        // Cap output tokens lower to stay within the window.
+        // Cap output tokens lower to stay within the cloud timeout window.
         const maxOutput = isCloud ? Math.min(localMaxOutput, 1024) : localMaxOutput;
         const options: Record<string, unknown> = {
-            num_ctx: defaultCtx,
+            num_ctx: effectiveCtx,
             // Cap output tokens to prevent runaway generation (14B models can get stuck)
             num_predict: maxOutput,
         };
@@ -593,7 +597,10 @@ export class OllamaProvider extends BaseLlmProvider {
         let streamedToolCalls: OllamaChatMessage['tool_calls'] = [];
         let lastActivitySignal = 0;
         const ACTIVITY_INTERVAL = 10_000; // Signal activity every 10s
-        const STREAM_IDLE_TIMEOUT_MS = 2 * 60 * 1000; // 2 min — abort if no data arrives
+        // Cloud-proxied models have a ~90s server-side timeout (NVIDIA).
+        // Use a shorter idle timeout (100s) so we detect failure quickly and retry,
+        // rather than waiting the full 2 minutes for local models.
+        const STREAM_IDLE_TIMEOUT_MS = isCloud ? 100_000 : 2 * 60 * 1000;
 
         try {
             while (true) {
@@ -680,6 +687,20 @@ export class OllamaProvider extends BaseLlmProvider {
                 name: tc.function.name,
                 arguments: tc.function.arguments,
             }));
+        }
+
+        // Detect NVIDIA cloud proxy errors embedded in stream content.
+        // When NVIDIA's backend times out, it returns error text like
+        // "Function process_single_item_agent timed out after 90.0 seconds"
+        // or "API request returned None" as the model's "response".
+        if (isCloud && content) {
+            const lower = content.toLowerCase();
+            if ((lower.includes('timed out') && lower.includes('process_single_item'))
+                || lower.includes('api request returned none')
+                || (lower.includes('timed out after') && lower.includes('seconds'))) {
+                log.warn(`NVIDIA cloud proxy error detected in response for ${params.model}: ${content.slice(0, 200)}`);
+                throw new Error(`Cloud proxy timeout: ${content.slice(0, 150)}`);
+            }
         }
 
         // Resolve content — some models (Qwen3) may put output in `thinking`


### PR DESCRIPTION
## Summary

NVIDIA's cloud proxy imposes a ~90s hard timeout on inference requests to `nemotron-3-super:cloud`. When it fires, the proxy returns error text (e.g. "Function process_single_item_agent timed out after 90.0 seconds") as the model's "response" rather than a proper error — causing garbage output to be treated as valid.

**Four mitigations:**

- **Reduce `num_ctx` for cloud models** (8192 → 4096) — faster prompt evaluation on NVIDIA's side, more likely to fit within the 90s window
- **Shorten stream idle timeout for cloud** (100s vs 2min) — detect failure faster and retry sooner instead of waiting for data that'll never come
- **Detect NVIDIA error patterns in streamed content** — catch "timed out", "process_single_item_agent", and "API request returned None" and throw a retryable error instead of passing garbage text through
- **Classify "cloud proxy timeout" as retryable** — enables automatic retry with exponential backoff (up to 3 attempts)

## Test plan

- [ ] Run Condor (nemotron-3-super:cloud) on a council task and verify it no longer returns NVIDIA error text as the model's answer
- [ ] Verify retries kick in when NVIDIA times out (check logs for "Cloud proxy timeout" + retry messages)
- [ ] Confirm local Ollama models still use the full 8192 context and 2min idle timeout
- [ ] `bun x tsc --noEmit --skipLibCheck` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 **CorvidAgent** · Opus 4.6 · CorvidLabs Team Alpha