### PR TITLE
docs: prep v0.56.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.56.0] - 2026-03-27
+
+### Added
+- **CRVLIB bootstrap** — wire shared agent library MCP tools + sync service into server bootstrap (#1564)
+- **Role-based communication tiers** — directional agent messaging with tier system for structured cross-agent comms (#1567)
+- **Agent signature standardization** — unified signature format on commits, PRs, issues, and comments (#1577)
+- **Ollama: configurable default model** — `OLLAMA_DEFAULT_MODEL` and `OLLAMA_DEFAULT_LOCAL_MODEL` env vars for flexible model selection (#1573, #1575)
+
+### Fixed
+- **Server: restart loop prevention** — `corvid_restart_server` tool no longer triggers infinite restart cycles (#1582)
+- **Ollama: HTTP 500 error classification** — classify HTTP 500 as transient, verify 404/400 as permanent errors with tests (#1574)
+- **Comms: Cursor CLI event types** — capture Cursor CLI event types in agent response subscribers (#1572)
+- **Config: env-driven references** — replace hardcoded CorvidLabs references with env-driven config (#1571)
+- **Library: tool permissions** — add library tools to DEFAULT_ALLOWED_TOOLS for non-web sessions (#1569)
+- **Library: localnet detection** — use MCP context network instead of env var for localnet detection (#1566)
+- **Ollama: Nemotron timeout** — improve Nemotron cloud proxy timeout handling (#1565)
+
+### Chore
+- Merge `doc/` into `docs/` for GitHub Pages compatibility (#1587)
+- Remove `tmp/` from git tracking and add to `.gitignore`
+
 ## [0.55.0] - 2026-03-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.55.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.56.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2108,7 +2108,7 @@
 
       const lines = [
         { type: 'command', text: 'corvid' },
-        { type: 'output', text: 'corvid v0.55.0 \u2014 agent: CorvidAgent (claude-opus-4-6)' },
+        { type: 'output', text: 'corvid v0.56.0 \u2014 agent: CorvidAgent (claude-opus-4-6)' },
         { type: 'output', text: 'project: corvid-agent (/Users/corvid-agent/corvid-agent)' },
         { type: 'blank' },
         { type: 'command', text: 'Harden the AlgoChat bridge reconnect logic' },

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>CorvidAgent — Release Retrospective: v0.1.0 → v0.55.0</title>
+<title>CorvidAgent — Release Retrospective: v0.1.0 → v0.56.0</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap');
 
@@ -454,24 +454,24 @@
 
   <!-- Hero -->
   <section class="hero">
-    <div class="hero-badge">50 days · 55 releases · 997 commits</div>
+    <div class="hero-badge">51 days · 56 releases · 1012 commits</div>
     <h1>CorvidAgent<br>Release Retrospective</h1>
     <p>From a prototype CLI to a full autonomous AI agent platform with on-chain memory, multi-model orchestration, and cross-platform bridges.</p>
     <div class="hero-version-range">
       <span class="version">v0.1.0</span>
       <span class="arrow">→</span>
-      <span class="version">v0.55.0</span>
+      <span class="version">v0.56.0</span>
     </div>
   </section>
 
   <!-- Stats bar -->
   <section class="stats-bar">
     <div class="stat-card">
-      <div class="stat-number">55</div>
+      <div class="stat-number">56</div>
       <div class="stat-label">Releases</div>
     </div>
     <div class="stat-card">
-      <div class="stat-number">997</div>
+      <div class="stat-number">1012</div>
       <div class="stat-label">Commits</div>
     </div>
     <div class="stat-card">
@@ -931,7 +931,7 @@
           <div class="era-title">Scale — Provider Parity & Agent Observatory</div>
           <div class="era-date">Mar 21 – Mar 27, 2026</div>
         </div>
-        <div class="era-versions">v0.42.0 – v0.55.0</div>
+        <div class="era-versions">v0.42.0 – v0.56.0</div>
       </div>
       <div class="era-body">
         <div class="release-card">
@@ -975,6 +975,22 @@
             <li><span class="tag tag-feat">feat</span> <strong>Shared agent library (CRVLIB)</strong> — ARC-69 reusable on-chain agent components</li>
             <li><span class="tag tag-test">test</span> <strong>Flock e2e: 45 tests</strong> — comprehensive e2e suite with inner transaction fee fix for AVM fee-pooling</li>
             <li><span class="tag tag-fix">fix</span> MCP tool permissions, scheduler tenant fallback, Ollama readiness probe</li>
+          </ul>
+        </div>
+        <div class="release-card" style="border-color: rgba(167,139,250,0.3); background: rgba(167,139,250,0.05);">
+          <div class="release-header">
+            <span class="release-version">v0.56.0</span>
+            <span class="release-date">Mar 27</span>
+          </div>
+          <ul class="release-highlights">
+            <li><span class="tag tag-feat">feat</span> <strong>CRVLIB bootstrap</strong> — wire shared agent library MCP tools + sync service into server bootstrap</li>
+            <li><span class="tag tag-feat">feat</span> <strong>Role-based comms tiers</strong> — directional agent messaging with communication tier system</li>
+            <li><span class="tag tag-feat">feat</span> <strong>Agent signature standardization</strong> — unified signature format on commits, PRs, issues, comments</li>
+            <li><span class="tag tag-feat">feat</span> <strong>Ollama: configurable default model</strong> — OLLAMA_DEFAULT_MODEL / OLLAMA_DEFAULT_LOCAL_MODEL env vars</li>
+            <li><span class="tag tag-fix">fix</span> <strong>Restart loop prevention</strong> — corvid_restart_server tool no longer triggers infinite restart cycles</li>
+            <li><span class="tag tag-fix">fix</span> <strong>Ollama: HTTP 500 classification</strong> — classify 500 as transient, verify 404/400 as permanent errors</li>
+            <li><span class="tag tag-fix">fix</span> Env-driven config, library tools permissions, Cursor CLI event types, Nemotron timeout handling</li>
+            <li><span class="tag tag-chore">chore</span> Merge doc/ into docs/ for GitHub Pages compatibility, remove tmp/ from tracking</li>
           </ul>
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.54.0",
+  "version": "0.56.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version to **0.56.0** across package.json, README badge, docs site, and releases page
- Add CHANGELOG entry with 4 features, 7 fixes, 2 chores since v0.55.0
- Update releases page stats (56 releases, 1012 commits) and add v0.56.0 release card

## What's in v0.56.0
**Features:** CRVLIB bootstrap, role-based comms tiers, agent signature standardization, configurable Ollama default model
**Fixes:** restart loop prevention, HTTP 500 error classification, env-driven config, library tool permissions, Nemotron timeouts
**Chore:** doc/ → docs/ merge for GitHub Pages, tmp/ cleanup

## Test plan
- [ ] Version badge renders correctly in README
- [ ] CHANGELOG entry is well-formatted
- [ ] Releases page loads with v0.56.0 card
- [ ] `bun x tsc --noEmit --skipLibCheck` passes clean

🤖 Agent: CorvidAgent | Model: Opus 4.6

---
🤖 **CorvidAgent** · Opus 4.6 · CorvidLabs Team Alpha