### PR TITLE
feat(library): boot-time library loader + librarian permissions spec (#1511)

### DIFF
--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -14,6 +14,7 @@ import { OllamaStallEscalator } from './process/ollama-stall-escalator';
 import { MemorySyncService } from './db/memory-sync';
 import { MemoryGraduationService } from './memory/graduation-service';
 import { LibrarySyncService } from './memory/library-sync';
+import { loadSharedLibrary } from './memory/library-boot';
 import { loadAlgoChatConfig } from './algochat/config';
 import type { AlgoChatBridge } from './algochat/bridge';
 import type { AgentWalletService } from './algochat/agent-wallet';
@@ -106,6 +107,7 @@ export interface ServiceContainer {
     memorySyncService: MemorySyncService;
     graduationService: MemoryGraduationService;
     librarySyncService: LibrarySyncService;
+    sharedLibraryContext: string;
 
     // Work orchestration
     selfTestService: SelfTestService;
@@ -267,6 +269,7 @@ export async function bootstrapServices(db: Database, startTime: number): Promis
     const memorySyncService = new MemorySyncService(db);
     const graduationService = new MemoryGraduationService(db);
     const librarySyncService = new LibrarySyncService(db);
+    const sharedLibraryContext = loadSharedLibrary(db);
 
     // ── AlgoChat state (initialized later by initAlgoChat) ───────────────
     const algochatConfig = loadAlgoChatConfig();
@@ -532,6 +535,7 @@ export async function bootstrapServices(db: Database, startTime: number): Promis
         memorySyncService,
         graduationService,
         librarySyncService,
+        sharedLibraryContext,
         selfTestService,
         workTaskService,
         buddyService,

--- a/server/memory/library-boot.ts
+++ b/server/memory/library-boot.ts
@@ -1,0 +1,68 @@
+/**
+ * Boot-time shared library loader.
+ *
+ * Reads all non-archived CRVLIB entries from the local SQLite cache at startup
+ * and formats them as a context string suitable for injection into agent sessions.
+ *
+ * Called once during bootstrap, after LibrarySyncService is initialized.
+ */
+import type { Database } from 'bun:sqlite';
+import { listLibraryEntries } from '../db/agent-library';
+import type { LibraryCategory } from '../db/agent-library';
+
+/** Category display order — highest-signal content first. */
+const CATEGORY_ORDER: LibraryCategory[] = ['standard', 'reference', 'guide', 'decision', 'runbook'];
+
+const CATEGORY_LABEL: Record<LibraryCategory, string> = {
+    standard: 'Standards',
+    reference: 'References',
+    guide: 'Guides',
+    decision: 'Decisions',
+    runbook: 'Runbooks',
+};
+
+/**
+ * Load all non-archived shared library entries from the local DB and return
+ * a formatted context string grouped by category (standards → references → guides
+ * → decisions → runbooks).
+ *
+ * Returns an empty string if the library is empty.
+ */
+export function loadSharedLibrary(db: Database): string {
+    const entries = listLibraryEntries(db, { limit: 500 });
+    if (entries.length === 0) return '';
+
+    // Group entries by category, preserving insertion order within each group.
+    const grouped = new Map<LibraryCategory, typeof entries>(
+        CATEGORY_ORDER.map((cat) => [cat, []]),
+    );
+    for (const entry of entries) {
+        const bucket = grouped.get(entry.category);
+        if (bucket) {
+            bucket.push(entry);
+        } else {
+            // Unknown future category — append to the last bucket.
+            grouped.get('runbook')!.push(entry);
+        }
+    }
+
+    const lines: string[] = ['## Shared Agent Library (CRVLIB)', ''];
+
+    for (const cat of CATEGORY_ORDER) {
+        const catEntries = grouped.get(cat) ?? [];
+        if (catEntries.length === 0) continue;
+
+        lines.push(`### ${CATEGORY_LABEL[cat]}`);
+        lines.push('');
+
+        for (const entry of catEntries) {
+            const tagSuffix = entry.tags.length > 0 ? ` [${entry.tags.join(', ')}]` : '';
+            lines.push(`**${entry.key}**${tagSuffix} — by ${entry.authorName}`);
+            lines.push('');
+            lines.push(entry.content);
+            lines.push('');
+        }
+    }
+
+    return lines.join('\n');
+}

--- a/specs/memory/arc69-library.spec.md
+++ b/specs/memory/arc69-library.spec.md
@@ -1,10 +1,11 @@
 ---
 module: arc69-library
-version: 1
+version: 2
 status: draft
 files:
   - server/memory/arc69-library.ts
   - server/memory/library-sync.ts
+  - server/memory/library-boot.ts
   - server/db/migrations/106_agent_library.ts
   - server/db/schema/library.ts
   - server/db/agent-library.ts
@@ -56,6 +57,12 @@ Supports multi-page "book" chaining where ASAs link together like chapters — u
 | Export | Description |
 |--------|-------------|
 | `LibrarySyncService` | Periodically indexes all CRVLIB ASAs from localnet into `agent_library`; follows the MemorySyncService pattern |
+
+### Exported Functions — `server/memory/library-boot.ts`
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `loadSharedLibrary` | `(db: Database)` | `string` | Read all non-archived library entries from SQLite at boot and return a formatted context string grouped by category |
 
 ### Exported Functions — `server/db/migrations/106_agent_library.ts`
 
@@ -262,6 +269,75 @@ Content is **plaintext** — no encryption. For single-page entries, `book`, `pa
 | idx_agent_library_book_page | (book, page) WHERE book IS NOT NULL | Book page traversal |
 | idx_agent_library_author | (author_id) | List by author |
 
+## Boot-Time Library Loading
+
+On agent startup, after `LibrarySyncService` is instantiated, `loadSharedLibrary(db)` is called to read all non-archived entries from the `agent_library` SQLite cache and format them as a context string. The result is stored on `ServiceContainer` as `sharedLibraryContext: string`.
+
+### Format
+
+Entries are grouped by category in this order: **standards → references → guides → decisions → runbooks**. Each entry is rendered as:
+
+```
+### Standards
+
+**key** [tag1, tag2] — by AuthorName
+
+<content>
+```
+
+### Bootstrap Integration
+
+- `loadSharedLibrary` is called synchronously during `bootstrapServices`.
+- The result is available immediately on `ServiceContainer.sharedLibraryContext`.
+- Agent session initializers (e.g. `server/mcp/tool-handlers/`) may inject `sharedLibraryContext` into the system prompt so agents start with shared knowledge without additional tool calls.
+- The context string is empty if the library table has no entries yet (first-run or before any sync).
+
+### Invariants
+
+11. **Boot snapshot.** `loadSharedLibrary` reads the DB at startup; it does not subscribe to updates. Sessions started after a new entry is written will not see it until the next server restart. The `corvid_library_read` tool remains available for on-demand lookups.
+12. **Limit.** `loadSharedLibrary` fetches at most 500 entries ordered by `updated_at DESC`. If the library grows beyond 500 entries, the oldest entries may be omitted from boot context.
+
+## Librarian Permission Model
+
+Write access to the shared library (`corvid_library_write` MCP tool) is restricted to agents with the **librarian** role to prevent accidental or malicious corruption of shared knowledge.
+
+### Rules
+
+| Caller | Write access |
+|--------|-------------|
+| CorvidAgent (`90cf34fa-1478-454c-a789-1c87cbb0d552`) | **Allowed** — default librarian |
+| Owner (Leif) | **Allowed** — project owner override |
+| All other agents | **Denied** — returns error |
+
+### Error Response
+
+When an unauthorized agent attempts to write:
+
+```
+Only agents with librarian role can write to the shared library
+```
+
+### Librarians Config
+
+The set of librarian agent IDs is maintained as a constant in `server/mcp/tool-handlers/library.ts`:
+
+```typescript
+const LIBRARIAN_AGENT_IDS: ReadonlySet<string> = new Set([
+    '90cf34fa-1478-454c-a789-1c87cbb0d552', // CorvidAgent — default librarian
+]);
+```
+
+Owner writes bypass the librarian check entirely (owner is determined by checking against the configured owner agent/wallet).
+
+> **Governance note:** `server/mcp/tool-handlers/library.ts` is a Layer 1 (Structural) file — modifications require a supermajority council vote + human approval. The librarian permission check described here documents the intended implementation pending that approval.
+
+### Behavioral Scenario: Unauthorized write
+
+- **Given** agent Magpie (not a librarian) calls `corvid_library_write`
+- **When** the tool handler checks `LIBRARIAN_AGENT_IDS`
+- **Then** returns error: "Only agents with librarian role can write to the shared library"
+- **And** no entry is created or updated
+
 ## Configuration
 
 | Env Var | Default | Description |
@@ -274,3 +350,4 @@ Content is **plaintext** — no encryption. For single-page entries, `book`, `pa
 |------|--------|--------|
 | 2026-03-26 | corvid-agent | Initial spec — shared plaintext library with book chaining |
 | 2026-03-26 | corvid-agent | v1.1: localnet gate, searchForAssets for all-agent discovery, /page-N key convention, asa_id UNIQUE, LibrarySyncService, exported buildNotePayload/parseNotePayload |
+| 2026-03-27 | CorvidAgent | v2.0: boot-time library loader (loadSharedLibrary, ServiceContainer.sharedLibraryContext), librarian permission model for corvid_library_write |


### PR DESCRIPTION
## Summary

- **Task 1 (Boot loader):** Add `server/memory/library-boot.ts` with `loadSharedLibrary(db: Database): string` that reads all non-archived `agent_library` entries from SQLite at startup, groups them by category (standards → references → guides → decisions → runbooks), and returns a formatted context string. Wired into `server/bootstrap.ts` — result stored as `ServiceContainer.sharedLibraryContext: string`, ready for injection into agent session system prompts.

- **Task 2 (Librarian permissions):** `server/mcp/tool-handlers/library.ts` is classified as **Layer 1 (Structural)** and cannot be modified without supermajority council vote + human approval. The permission model is fully documented in the spec instead. When governance approves, the implementation is:
  - Hardcode `LIBRARIAN_AGENT_IDS` set containing CorvidAgent's ID (`90cf34fa-1478-454c-a789-1c87cbb0d552`)
  - Allow owner writes to bypass the check
  - Return `"Only agents with librarian role can write to the shared library"` for unauthorized callers

- **Task 3 (Spec):** Updated `specs/memory/arc69-library.spec.md` to v2.0 with:
  - `loadSharedLibrary` in the Public API table
  - Boot-Time Library Loading section (invariants 11–12, bootstrap integration, format)
  - Librarian Permission Model section (access table, error response, `LIBRARIAN_AGENT_IDS` constant, governance note)

## Validation

- `bun x tsc --noEmit --skipLibCheck` ✅
- `bun run spec:check` ✅ (196 specs, 100% coverage)
- `bun test server/__tests__/arc69-library.test.ts` ✅ (49 pass)
- No lint errors in changed files

## Governance Note

The librarian permission check for `corvid_library_write` requires a Layer 1 governance vote before implementation. This PR delivers everything that can be merged now; the handler change is tracked in the spec and blocked on governance.

🤖 Agent: Jackdaw | Model: Sonnet 4.6