### PR TITLE
fix(tests): align cursor/fallback tests with production code, revert unauthorized Layer 1 changes

### DIFF
--- a/server/__tests__/provider-fallback.test.ts
+++ b/server/__tests__/provider-fallback.test.ts
@@ -194,25 +194,6 @@ describe('FallbackManager', () => {
             chain: [{ provider: 'ollama', model: 'qwen3:14b' }],
         };
 
-        test('Ollama HTTP 500 (internal error) is treated as transient — triggers cooldown after 3 failures', async () => {
-            // Ollama formats errors as: ExternalServiceError 'API error (500): internal server error'
-            const registry = mockRegistry({
-                ollama: mockProvider(new Error('API error (500): internal server error')),
-            });
-            const localFm = new FallbackManager(registry as any);
-
-            // First two failures: provider still available
-            try { await localFm.completeWithFallback({ messages: [] } as any, OLLAMA_CHAIN); } catch {}
-            expect(localFm.isProviderAvailable('ollama')).toBe(true);
-
-            try { await localFm.completeWithFallback({ messages: [] } as any, OLLAMA_CHAIN); } catch {}
-            expect(localFm.isProviderAvailable('ollama')).toBe(true);
-
-            // Third failure: cooldown activates
-            try { await localFm.completeWithFallback({ messages: [] } as any, OLLAMA_CHAIN); } catch {}
-            expect(localFm.isProviderAvailable('ollama')).toBe(false);
-        });
-
         test('Ollama HTTP 404 (model not found) is treated as permanent — does NOT trigger cooldown', async () => {
             const registry = mockRegistry({
                 ollama: mockProvider(new Error('API error (404): model "xyz:latest" not found, try pulling it first')),

--- a/server/__tests__/providers-cursor.test.ts
+++ b/server/__tests__/providers-cursor.test.ts
@@ -435,13 +435,8 @@ describe('CursorProvider', () => {
                 messages: [{ role: 'user', content: 'hi' }],
             });
 
-            expect(capturedArgs).not.toContain('--system-prompt');
-            const lastArg = capturedArgs[capturedArgs.length - 1];
-            expect(lastArg).toContain('<system>');
-            expect(lastArg).toContain('You are helpful');
-            expect(lastArg).toContain('</system>');
-            expect(lastArg).toContain('hi');
-            // other args still valid:
+            expect(capturedArgs).toContain('--system-prompt');
+            expect(capturedArgs).toContain('You are helpful');
             expect(capturedArgs).toContain('--model');
             expect(capturedArgs).toContain('auto');
             expect(capturedArgs).toContain('--print');
@@ -466,10 +461,8 @@ describe('CursorProvider', () => {
                 ],
             });
 
-            // Last arg now has system prefix + message
-            const lastArg = capturedArgs[capturedArgs.length - 1];
-            expect(lastArg).toContain('second message');
-            expect(lastArg).toContain('<system>');
+            // Last positional arg should be the last user message
+            expect(capturedArgs[capturedArgs.length - 1]).toBe('second message');
         });
 
         test('omits --system-prompt flag when systemPrompt is empty', async () => {

--- a/server/providers/cursor/provider.ts
+++ b/server/providers/cursor/provider.ts
@@ -176,30 +176,25 @@ export class CursorProvider extends BaseLlmProvider {
             args.push('--model', params.model);
         }
 
+        // Add system prompt if provided
+        if (params.systemPrompt) {
+            args.push('--system-prompt', params.systemPrompt);
+        }
+
         // Check if this is a follow-up (resume) call
         const storedCursorSessionId = sessionId ? this.cursorSessionIds.get(sessionId) : undefined;
         if (storedCursorSessionId) {
             args.push('--resume', storedCursorSessionId);
         }
 
-        // Prepend system prompt as XML tags to the user message
-        // cursor-agent treats --system-prompt as a file path, so we wrap it in the prompt instead
-        let finalPrompt = prompt;
-        if (params.systemPrompt && prompt) {
-            finalPrompt = `<system>\n${params.systemPrompt}\n</system>\n\n${prompt}`;
-        } else if (params.systemPrompt) {
-            // If no user message, use just the system prompt
-            finalPrompt = `<system>\n${params.systemPrompt}\n</system>`;
-        }
-
         // Prompt goes as the last positional argument
-        if (finalPrompt) {
-            args.push(finalPrompt);
+        if (prompt) {
+            args.push(prompt);
         }
 
         log.info('Starting cursor-agent completion', {
             model: params.model,
-            promptLength: finalPrompt.length,
+            promptLength: prompt.length,
             resume: !!storedCursorSessionId,
             sessionId,
         });

--- a/server/providers/fallback.ts
+++ b/server/providers/fallback.ts
@@ -244,9 +244,7 @@ export class FallbackManager {
             lower.includes('timeout') ||
             lower.includes('econnrefused') ||
             lower.includes('fetch failed') ||
-            lower.includes('overloaded') ||
-            // Ollama HTTP 500: internal server error — transient, model may recover
-            lower.includes('(500)')
+            lower.includes('overloaded')
         );
     }
 }


### PR DESCRIPTION
## Summary

- Reverts unauthorized Layer 1 changes to `server/providers/cursor/provider.ts` and `server/providers/fallback.ts` (governance tier violation)
- Aligns the 2 failing `CursorProvider` test expectations with the existing `--system-prompt` CLI behavior
- Removes the Ollama HTTP 500 transient-cooldown test whose assertion required the Layer 1 code change
- Retains the new Ollama HTTP 404/400 permanent-error tests (these pass against existing code)
- Retains the new council mixed-provider smoke tests

## Test plan
- [ ] `bun test server/__tests__/providers-cursor.test.ts` — 36 pass
- [ ] `bun test server/__tests__/provider-fallback.test.ts` — 14 pass
- [ ] `bun test server/__tests__/council-mixed-provider.test.ts` — 25 pass
- [ ] `bun x tsc --noEmit --skipLibCheck` — no errors
- [ ] Governance tier check passes (no Layer 1 paths modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)