### PR TITLE
fix(ollama): add output sanitizer to strip leaked prompt artifacts

### DIFF
--- a/server/__tests__/response-sanitizer.test.ts
+++ b/server/__tests__/response-sanitizer.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'bun:test';
+import { sanitizeModelOutput } from '../providers/ollama/response-sanitizer';
+
+describe('sanitizeModelOutput', () => {
+    it('strips <think>...</think> blocks', () => {
+        const input = '<think>internal reasoning here</think>The actual response.';
+        expect(sanitizeModelOutput(input)).toBe('The actual response.');
+    });
+
+    it('strips orphaned </think> prefix', () => {
+        const input = '</think>The actual response.';
+        expect(sanitizeModelOutput(input)).toBe('The actual response.');
+    });
+
+    it('strips unclosed <think> at end', () => {
+        const input = 'Response start.\n<think>still thinking...';
+        expect(sanitizeModelOutput(input)).toBe('Response start.');
+    });
+
+    it('strips [Context Summary] lines', () => {
+        const input = '[Context Summary] Original request: something\nActual response here.';
+        expect(sanitizeModelOutput(input)).toBe('Actual response here.');
+    });
+
+    it('strips repeated [Context Summary] chains', () => {
+        const input = '[Context Summary] Original request: [Context Summary] Original request: [Context Summary] Original request: response';
+        const result = sanitizeModelOutput(input);
+        expect(result).not.toContain('[Context Summary]');
+    });
+
+    it('strips <system-reminder> blocks', () => {
+        const input = 'Hello.<system-reminder>secret stuff</system-reminder> Goodbye.';
+        expect(sanitizeModelOutput(input)).toBe('Hello.Goodbye.');
+    });
+
+    it('strips agent metadata lines', () => {
+        const input = 'Condor · nemotron-3-super:cloud · sandbox · sid:580650f9\nActual content.';
+        expect(sanitizeModelOutput(input)).toBe('Actual content.');
+    });
+
+    it('strips channel instruction blocks', () => {
+        const input = '[This message came from Discord. Reply directly in this conversation.] Hello!';
+        expect(sanitizeModelOutput(input)).toBe('Hello!');
+    });
+
+    it('leaves clean content untouched', () => {
+        const input = 'This is a perfectly normal response with no artifacts.';
+        expect(sanitizeModelOutput(input)).toBe(input);
+    });
+
+    it('handles empty content', () => {
+        expect(sanitizeModelOutput('')).toBe('');
+    });
+
+    it('collapses excessive blank lines after stripping', () => {
+        const input = 'Line 1.\n\n\n<think>removed</think>\n\n\nLine 2.';
+        const result = sanitizeModelOutput(input);
+        expect(result).not.toMatch(/\n{3,}/);
+        expect(result).toContain('Line 1.');
+        expect(result).toContain('Line 2.');
+    });
+
+    it('handles the real Condor leak pattern', () => {
+        const input = `Based on the directory listing, I can see the project structure includes:
+client/ (Angular frontend)
+server/ (API routes, WebSocket, process management)
+
+</think>[Context Summary] Original request: [Context Summary] Original request: [Context Summary] Original request: [This message came from Discord. Reply directly in this conversation — do NOT use corvid_send_message or other cross-cha...
+Tools used: 2 tool calls executed.
+Last assistant response:
+Follow-up messages: Do not ask what to do — take action now. Use the tools available to you. Start by reading relevant f...
+Condor · nemotron-3-super:cloud · sandbox · sid:580650f9
+
+IMPORTANT: After completing your current task, you MUST address the user's message above. Do not ignore it.`;
+        const result = sanitizeModelOutput(input);
+        // Should strip most of the leaked content
+        expect(result).not.toContain('[Context Summary]');
+        expect(result).not.toContain('</think>');
+        expect(result).not.toContain('system-reminder');
+        expect(result).not.toContain('Tools used:');
+        expect(result).not.toContain('sid:580650f9');
+    });
+});

--- a/server/providers/ollama/provider.ts
+++ b/server/providers/ollama/provider.ts
@@ -16,6 +16,7 @@ import {
 } from './tool-parser';
 import { createLogger } from '../../lib/logger';
 import { ExternalServiceError } from '../../lib/errors';
+import { sanitizeModelOutput } from './response-sanitizer';
 
 const log = createLogger('OllamaProvider');
 
@@ -762,6 +763,10 @@ export class OllamaProvider extends BaseLlmProvider {
         if (tokensPerSecond > 0 && tokensPerSecond < 5) {
             log.warn(`Very slow inference: ${tokensPerSecond.toFixed(1)} tok/s. On Apple Silicon this should be 30-60 tok/s. Check: (1) Ollama running natively (not in Docker), (2) num_gpu=-1, (3) sufficient memory for model + KV cache.`);
         }
+
+        // Sanitize output — strip leaked thinking tags, context summaries,
+        // system prompt fragments that less-capable models sometimes echo.
+        content = sanitizeModelOutput(content, params.model);
 
         return {
             content,

--- a/server/providers/ollama/response-sanitizer.ts
+++ b/server/providers/ollama/response-sanitizer.ts
@@ -1,0 +1,156 @@
+/**
+ * Output sanitizer for Ollama/local model responses.
+ *
+ * Less-capable models (especially Nemotron, Qwen) sometimes leak internal
+ * context in their responses: thinking tags, context summaries, system prompt
+ * fragments, and tool schema echoes. This module strips those artifacts so
+ * they don't reach the user or calling agent.
+ *
+ * @module
+ */
+
+import { createLogger } from '../../lib/logger';
+
+const log = createLogger('ResponseSanitizer');
+
+// ─── Patterns to strip from model output ────────────────────────────────
+
+interface OutputRule {
+    /** Pattern to detect and strip. */
+    pattern: RegExp;
+    /** Replacement text (empty string = strip entirely). */
+    replacement: string;
+    /** Human-readable label for logging. */
+    label: string;
+}
+
+const OUTPUT_RULES: OutputRule[] = [
+    // <think>...</think> blocks (full or partial)
+    {
+        pattern: /<think>[\s\S]*?<\/think>\s*/g,
+        replacement: '',
+        label: 'think_block',
+    },
+    // Orphaned </think> tags (model starts with or emits closing tag without opener)
+    {
+        pattern: /<\/think>\s*/g,
+        replacement: '',
+        label: 'orphan_think_close',
+    },
+    // Unclosed <think> at end of response
+    {
+        pattern: /\s*<think>[\s\S]*$/,
+        replacement: '',
+        label: 'unclosed_think',
+    },
+
+    // [Context Summary] blocks — context compression artifacts
+    {
+        pattern: /\[Context Summary\][^\n]*(?:\n|$)/g,
+        replacement: '',
+        label: 'context_summary',
+    },
+
+    // Repeated [Context Summary] Original request: chains
+    {
+        pattern: /(?:\[Context Summary\]\s*Original request:\s*)+/g,
+        replacement: '',
+        label: 'context_summary_chain',
+    },
+
+    // System reminder tags leaked into output
+    {
+        pattern: /<system-reminder>[\s\S]*?<\/system-reminder>\s?/g,
+        replacement: '',
+        label: 'system_reminder',
+    },
+
+    // Partial/orphaned system-reminder tags
+    {
+        pattern: /<\/?system-reminder>\s*/g,
+        replacement: '',
+        label: 'system_reminder_fragment',
+    },
+
+    // "Tools used: N tool calls executed" — internal metadata
+    {
+        pattern: /Tools used:\s*\d+\s*tool calls?\s*executed\.?\s*/gi,
+        replacement: '',
+        label: 'tools_metadata',
+    },
+
+    // "Last assistant response:" header leaked
+    {
+        pattern: /Last assistant response:\s*/gi,
+        replacement: '',
+        label: 'last_response_header',
+    },
+
+    // "Follow-up messages: Do not ask what to do" — internal instruction leak
+    {
+        pattern: /Follow-up messages:\s*Do not ask what to do[^\n]*\n?/gi,
+        replacement: '',
+        label: 'followup_instruction',
+    },
+
+    // Agent metadata lines (e.g., "Condor · nemotron-3-super:cloud · sandbox · sid:...")
+    {
+        pattern: /^[A-Z][a-z]+\s+·\s+[\w:./-]+\s+·\s+\w+\s+·\s+sid:[a-f0-9-]+\s*$/gm,
+        replacement: '',
+        label: 'agent_metadata_line',
+    },
+
+    // "\[This message came from Discord..." instruction block
+    {
+        pattern: /\[This message came from (?:Discord|AlgoChat|Telegram)[^\]]*\]\s*/g,
+        replacement: '',
+        label: 'channel_instruction',
+    },
+
+    // "IMPORTANT: After completing your current task..." instruction
+    {
+        pattern: /IMPORTANT:\s*After completing your current task[^\n]*\n?/gi,
+        replacement: '',
+        label: 'task_instruction',
+    },
+];
+
+// ─── Public API ─────────────────────────────────────────────────────────
+
+/**
+ * Sanitize model output to remove leaked internal context.
+ *
+ * @param content - Raw model response text
+ * @param model - Model name (for logging)
+ * @returns Cleaned content string
+ */
+export function sanitizeModelOutput(content: string, model?: string): string {
+    if (!content) return content;
+
+    let cleaned = content;
+    const matchedLabels: string[] = [];
+
+    for (const rule of OUTPUT_RULES) {
+        // Reset lastIndex for stateful regexes
+        rule.pattern.lastIndex = 0;
+        if (rule.pattern.test(cleaned)) {
+            matchedLabels.push(rule.label);
+            rule.pattern.lastIndex = 0;
+            cleaned = cleaned.replace(rule.pattern, rule.replacement);
+        }
+    }
+
+    // Collapse excessive blank lines left by stripping
+    cleaned = cleaned.replace(/\n{3,}/g, '\n\n').trim();
+
+    if (matchedLabels.length > 0) {
+        log.info(`Stripped ${matchedLabels.length} leaked artifact(s) from model output`, {
+            model: model ?? 'unknown',
+            patterns: matchedLabels,
+            originalLength: content.length,
+            cleanedLength: cleaned.length,
+        });
+    }
+
+    return cleaned;
+}


### PR DESCRIPTION
## Summary
- Adds `response-sanitizer.ts` to strip internal context leaked by Ollama models (especially Nemotron)
- Strips: `<think>` tags, `[Context Summary]` blocks, `<system-reminder>` tags, agent metadata lines, channel routing instructions, and other internal artifacts
- Wired into the Ollama provider so all model output is sanitized before being returned
- 12 tests covering all patterns including the real Condor leak pattern

## Context
Condor (nemotron-3-super:cloud) was leaking system prompt fragments, directory listings, context summaries, and thinking tags in its responses to users. This was visible in Discord.

## Test plan
- [x] `bun test server/__tests__/response-sanitizer.test.ts` — 12/12 pass
- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [ ] Verify Condor responses no longer contain leaked artifacts in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6