### PR TITLE
ci: self-hosted runners + dedicated spec workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,8 +23,8 @@ permissions:
 
 jobs:
   checks:
-    name: Checks (ubuntu-only)
-    runs-on: ubuntu-latest
+    name: Checks
+    runs-on: self-hosted
     timeout-minutes: 15
 
     steps:
@@ -38,13 +38,6 @@ jobs:
           GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           GITHUB_ACTOR: ${{ github.actor }}
-
-      - name: Spec validation (strict + 100% coverage)
-        # https://github.com/marketplace/actions/spec-sync
-        uses: CorvidLabs/spec-sync@v2.1.0
-        with:
-          strict: 'true'
-          require-coverage: '100'
 
       - name: Build client
         run: bun run build:client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ permissions:
 
 jobs:
   build:
-    name: Build & Test (ubuntu)
-    runs-on: ubuntu-latest
+    name: Build & Test
+    runs-on: self-hosted
     timeout-minutes: 15
 
     steps:
@@ -41,35 +41,9 @@ jobs:
       - name: Unit tests
         run: bun test
 
-  # macOS (10x multiplier) and Windows (2x) only run on release tags to save CI minutes
-  build-cross-platform:
-    name: Build & Test (${{ matrix.os }})
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, windows-latest]
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: ./.github/actions/setup-workspace
-
-      - name: TypeScript check
-        run: bun x tsc --noEmit --skipLibCheck
-
-      - name: Run database migrations
-        run: bun run migrate:up
-
-      - name: Unit tests
-        # Windows process spawning and dynamic imports are ~3-5x slower;
-        # use 30s per-test timeout there to avoid flaky failures (default 10s via bunfig).
-        run: bun test ${{ matrix.os == 'windows-latest' && '--timeout 30000' || '' }}
-
   review:
     name: PR Review
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: [build]
     if: always() && github.event_name == 'pull_request'
     permissions:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,0 +1,43 @@
+name: Spec Validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "specs/**"
+      - "server/**"
+      - "client/**"
+      - "shared/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "specs/**"
+      - "server/**"
+      - "client/**"
+      - "shared/**"
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  spec-check:
+    name: Spec Validation
+    runs-on: self-hosted
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: ./.github/actions/setup-workspace
+        with:
+          install-client: "false"
+
+      - name: Spec validation (strict + 100% coverage)
+        uses: CorvidLabs/spec-sync@v2.1.0
+        with:
+          strict: 'true'
+          require-coverage: '100'
+
+      - name: Spec check (local)
+        run: bun run spec:check


### PR DESCRIPTION
## Summary
- Switch all CI workflows (`ci.yml`, `checks.yml`) from `ubuntu-latest` to `self-hosted` runner
- Extract spec validation from `checks.yml` into dedicated `spec.yml` workflow with path filtering (only runs when `specs/`, `server/`, `client/`, or `shared/` change)
- Remove cross-platform matrix (macOS/Windows) since those were GitHub-hosted runners

## Test plan
- [ ] Verify self-hosted runner picks up CI jobs
- [ ] Verify `spec.yml` triggers on spec/code changes
- [ ] Verify `spec.yml` does NOT trigger on unrelated changes (e.g., docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)