### PR TITLE
fix(ci): stabilize dead-end embed test + update spec count

### DIFF
--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -43,7 +43,7 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Unit tests | 4,242 test files |
 | E2E tests | 360 across 33 Playwright specs |
 | Security tests | 232 dedicated |
-| Module specs | 200 .spec.md files |
+| Module specs | 201 .spec.md files |
 | Test:code ratio | 1.14x (more test than production) |
 | Dependencies | 17 direct |
 | Version | 0.51.0 |

--- a/server/__tests__/discord-bridge.test.ts
+++ b/server/__tests__/discord-bridge.test.ts
@@ -1269,17 +1269,18 @@ describe('DiscordBridge expired thread session resume', () => {
                 timestamp: new Date().toISOString(),
             });
 
-            // Flush any pending async deliveries (fire-and-forget embeds)
-            await new Promise(r => setTimeout(r, 50));
-
             // Should NOT have started a new process
             expect(pm.startProcess).not.toHaveBeenCalled();
 
-            // Should have sent the dead-end embed
-            const deadEnd = fetchBodies.find((b: unknown) => {
-                const embeds = (b as { embeds?: Array<{ description?: string }> }).embeds;
-                return embeds?.some(e => e.description?.includes('session has expired'));
-            });
+            // Wait for the dead-end embed to appear (async delivery may be in-flight)
+            let deadEnd: unknown;
+            for (let i = 0; i < 40 && !deadEnd; i++) {
+                await new Promise(r => setTimeout(r, 25));
+                deadEnd = fetchBodies.find((b: unknown) => {
+                    const embeds = (b as { embeds?: Array<{ description?: string }> }).embeds;
+                    return embeds?.some(e => e.description?.includes('session has expired'));
+                });
+            }
             expect(deadEnd).toBeDefined();
 
             // Thread session should be cleaned up


### PR DESCRIPTION
## Summary
- Replace fixed 50ms sleep with polling loop (up to 1s) for the dead-end embed assertion in `discord-bridge.test.ts`, fixing CI flake on slow Ubuntu runners
- Update `docs/deep-dive.md` spec count from 200 to 201 (drifted after PR #1627 added new specs)

## Context
PR #1627 was merged with a flaky test and an incorrect stats count. The dead-end embed test fails intermittently on CI because a 50ms sleep isn't enough for async delivery to complete on slow runners. The polling approach retries up to 40 times with 25ms intervals.

## Test plan
- [x] `bun test server/__tests__/discord-bridge.test.ts --test-name-pattern "falls back to dead-end embed"` passes locally
- [ ] CI Build & Test passes
- [ ] CI Stats Check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)