### PR TITLE
feat(cursor): rename CURSOR_MAX_PARALLEL → CURSOR_MAX_CONCURRENT, default 2→4, add getSlotStatus()

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,6 +110,12 @@ ALGORAND_NETWORK=localnet
 # Request timeout in ms (default: 30 min)
 # OLLAMA_REQUEST_TIMEOUT=1800000
 
+# --- Cursor (cursor-agent CLI provider) ----------------------------------------
+# Path to the cursor-agent binary (auto-detected if not set)
+# CURSOR_AGENT_BIN=/path/to/cursor-agent
+# Max concurrent cursor-agent processes (default: 4, queued not rejected when exceeded)
+# CURSOR_MAX_CONCURRENT=4
+
 # --- Multi-Model Provider Routing ---------------------------------------------
 # Comma-separated list of enabled providers.
 # Options: anthropic, ollama

--- a/docs/provider-parity-checklist.md
+++ b/docs/provider-parity-checklist.md
@@ -91,12 +91,12 @@
 
 | Behavior | Claude (baseline) | Ollama | Cursor | Gap? |
 |---|---|---|---|---|
-| Concurrency control | None (SDK manages) | ✅ Weight-based slot acquisition | ❌ No concurrency limit | **Cursor gap** |
+| Concurrency control | None (SDK manages) | ✅ Weight-based slot acquisition | ✅ Slot-based `acquireSlot`/`releaseSlot` (`CURSOR_MAX_CONCURRENT`, default 4) | OK |
 | GPU-aware scheduling | N/A | ✅ Model weight + GPU detection | N/A | OK |
-| Concurrent session handling | SDK handles | `acquireSlot()`/`releaseSlot()` | ❌ Unbounded parallel processes | **Cursor gap** |
+| Concurrent session handling | SDK handles | `acquireSlot()`/`releaseSlot()` | ✅ `acquireSlot()`/`releaseSlot()` with queue | OK |
 
 **Actions:**
-- [ ] [#cursor] Add process-level concurrency limit for cursor-agent spawning (max N parallel processes)
+- [x] [#1532] Add process-level concurrency limit for cursor-agent spawning — done (`CURSOR_MAX_CONCURRENT`, default 4)
 
 ---
 

--- a/server/__tests__/providers-cursor.test.ts
+++ b/server/__tests__/providers-cursor.test.ts
@@ -130,6 +130,61 @@ describe('CursorProvider', () => {
     // ── Slot management ──────────────────────────────────────────────────
 
     describe('acquireSlot / releaseSlot', () => {
+        /** Fill all available slots and return a cleanup function. */
+        async function fillAllSlots(): Promise<() => void> {
+            const max = provider.maxConcurrent;
+            const results = await Promise.all(
+                Array.from({ length: max }, () => provider.acquireSlot('auto')),
+            );
+            expect(results.every(Boolean)).toBe(true);
+            return () => {
+                for (let i = 0; i < max; i++) provider.releaseSlot('auto');
+            };
+        }
+
+        test('maxConcurrent default is 4', () => {
+            expect(provider.maxConcurrent).toBe(4);
+        });
+
+        test('getSlotStatus returns correct initial state', () => {
+            const status = provider.getSlotStatus();
+            expect(status.active).toBe(0);
+            expect(status.max).toBe(provider.maxConcurrent);
+            expect(status.queued).toBe(0);
+        });
+
+        test('getSlotStatus tracks active slots', async () => {
+            const acquired = await provider.acquireSlot('auto');
+            expect(acquired).toBe(true);
+            const status = provider.getSlotStatus();
+            expect(status.active).toBe(1);
+            expect(status.queued).toBe(0);
+            provider.releaseSlot('auto');
+            expect(provider.getSlotStatus().active).toBe(0);
+        });
+
+        test('getSlotStatus tracks queued waiters', async () => {
+            const cleanup = await fillAllSlots();
+
+            const controller = new AbortController();
+            const pending = provider.acquireSlot('auto', controller.signal);
+
+            await new Promise((r) => setTimeout(r, 10));
+            const status = provider.getSlotStatus();
+            expect(status.active).toBe(provider.maxConcurrent);
+            expect(status.queued).toBe(1);
+
+            controller.abort();
+            await pending;
+            cleanup();
+        });
+
+        test('CURSOR_MAX_CONCURRENT env var controls the concurrency limit', () => {
+            // The limit is read at module load time via CURSOR_MAX_CONCURRENT.
+            // Default is 4 when env var is not set.
+            expect(provider.maxConcurrent).toBe(4);
+        });
+
         test('acquireSlot succeeds when slots available', async () => {
             const acquired = await provider.acquireSlot('auto');
             expect(acquired).toBe(true);
@@ -145,14 +200,13 @@ describe('CursorProvider', () => {
 
         test('acquireSlot calls onStatus when queued', async () => {
             // Fill all slots
-            await provider.acquireSlot('auto');
-            await provider.acquireSlot('auto');
+            const cleanup = await fillAllSlots();
 
             const statusMessages: string[] = [];
             const controller = new AbortController();
 
-            // Third request should queue and call onStatus
-            const thirdPromise = provider.acquireSlot('auto', controller.signal, (msg) => {
+            // Next request should queue and call onStatus
+            const pendingPromise = provider.acquireSlot('auto', controller.signal, (msg) => {
                 statusMessages.push(msg);
             });
 
@@ -163,44 +217,60 @@ describe('CursorProvider', () => {
 
             // Cleanup
             controller.abort();
-            await thirdPromise;
-            provider.releaseSlot('auto');
+            await pendingPromise;
+            cleanup();
+        });
+
+        test('acquireSlot queues beyond limit, does not reject', async () => {
+            // Verify that requests beyond maxConcurrent are queued (not rejected)
+            const cleanup = await fillAllSlots();
+
+            let overflowResolved = false;
+            const overflowPromise = provider.acquireSlot('auto').then((result) => {
+                overflowResolved = true;
+                return result;
+            });
+
+            // Should be queued, not yet resolved
+            await new Promise((r) => setTimeout(r, 10));
+            expect(overflowResolved).toBe(false);
+            expect(provider.getSlotStatus().queued).toBe(1);
+
+            // Cleanup — release all slots, overflow gets one
+            cleanup();
+            const result = await overflowPromise;
+            expect(result).toBe(true);
             provider.releaseSlot('auto');
         });
 
         test('releaseSlot unblocks queued requests', async () => {
             // Fill all slots
-            const acquired1 = await provider.acquireSlot('auto');
-            const acquired2 = await provider.acquireSlot('auto');
-            expect(acquired1).toBe(true);
-            expect(acquired2).toBe(true);
+            await fillAllSlots();
 
-            // Third request should queue
-            let thirdResolved = false;
-            const thirdPromise = provider.acquireSlot('auto').then((result) => {
-                thirdResolved = true;
+            // Next request should queue
+            let nextResolved = false;
+            const nextPromise = provider.acquireSlot('auto').then((result) => {
+                nextResolved = true;
                 return result;
             });
 
             // Not yet resolved
             await new Promise((r) => setTimeout(r, 10));
-            expect(thirdResolved).toBe(false);
+            expect(nextResolved).toBe(false);
 
-            // Release one slot — third should resolve
+            // Release one slot — queued request should resolve
             provider.releaseSlot('auto');
-            const result = await thirdPromise;
+            const result = await nextPromise;
             expect(result).toBe(true);
-            expect(thirdResolved).toBe(true);
+            expect(nextResolved).toBe(true);
 
-            // Cleanup
-            provider.releaseSlot('auto');
-            provider.releaseSlot('auto');
+            // Release remaining (maxConcurrent - 1 already held + 1 that resolved from queue)
+            for (let i = 0; i < provider.maxConcurrent; i++) provider.releaseSlot('auto');
         });
 
         test('releaseSlot skips aborted waiters in queue', async () => {
             // Fill all slots
-            await provider.acquireSlot('auto');
-            await provider.acquireSlot('auto');
+            const cleanup = await fillAllSlots();
 
             // Queue two waiters: first will be aborted, second should get the slot
             const controller1 = new AbortController();
@@ -225,7 +295,7 @@ describe('CursorProvider', () => {
             expect(secondResolved).toBe(true);
 
             // Cleanup
-            provider.releaseSlot('auto');
+            cleanup();
             provider.releaseSlot('auto');
         });
 
@@ -239,22 +309,20 @@ describe('CursorProvider', () => {
 
         test('queued request returns false when aborted', async () => {
             // Fill all slots
-            await provider.acquireSlot('auto');
-            await provider.acquireSlot('auto');
+            const cleanup = await fillAllSlots();
 
-            // Third request with abort
+            // Next request with abort
             const controller = new AbortController();
-            const thirdPromise = provider.acquireSlot('auto', controller.signal);
+            const pendingPromise = provider.acquireSlot('auto', controller.signal);
 
             await new Promise((r) => setTimeout(r, 10));
             controller.abort();
 
-            const result = await thirdPromise;
+            const result = await pendingPromise;
             expect(result).toBe(false);
 
             // Cleanup
-            provider.releaseSlot('auto');
-            provider.releaseSlot('auto');
+            cleanup();
         });
     });
 

--- a/server/providers/cursor/provider.ts
+++ b/server/providers/cursor/provider.ts
@@ -36,7 +36,7 @@ import { createLogger } from '../../lib/logger';
 const log = createLogger('CursorProvider');
 
 /** Maximum parallel cursor-agent processes (configurable via env). */
-const MAX_PARALLEL = Number(process.env.CURSOR_MAX_PARALLEL) || 2;
+const MAX_CONCURRENT = Number(process.env.CURSOR_MAX_CONCURRENT) || 4;
 
 /** Timeout for a single cursor-agent completion (ms). */
 const COMPLETION_TIMEOUT_MS = 10 * 60_000; // 10 minutes
@@ -60,8 +60,18 @@ export class CursorProvider extends BaseLlmProvider {
     readonly executionMode: ExecutionMode = 'direct';
 
     private activeSlots = 0;
-    private readonly maxSlots = MAX_PARALLEL;
+    private readonly maxSlots = MAX_CONCURRENT;
     private readonly waitQueue: SlotWaiter[] = [];
+
+    /** Current concurrency slot status for observability. */
+    getSlotStatus(): { active: number; max: number; queued: number } {
+        return { active: this.activeSlots, max: this.maxSlots, queued: this.waitQueue.length };
+    }
+
+    /** Maximum concurrent cursor-agent processes allowed. */
+    get maxConcurrent(): number {
+        return this.maxSlots;
+    }
 
     /** Track cursor session IDs for --resume on follow-up calls. */
     private cursorSessionIds = new Map<string, string>();

--- a/specs/providers/cursor-provider.spec.md
+++ b/specs/providers/cursor-provider.spec.md
@@ -31,11 +31,13 @@ Cursor LLM provider wrapping the cursor-agent CLI as a first-class `LlmProvider`
 | `isAvailable` | `()` | `Promise<boolean>` | Check cursor-agent binary exists and passes `--version` |
 | `acquireSlot` | `(model, signal?, onStatus?)` | `Promise<boolean>` | Acquire a concurrency slot, queues if full |
 | `releaseSlot` | `(model)` | `void` | Release slot and wake next queued waiter |
+| `getSlotStatus` | `()` | `{ active, max, queued }` | Current slot usage for observability |
+| `maxConcurrent` | getter | `number` | Maximum concurrent cursor-agent processes |
 | `doComplete` | `(params)` | `Promise<LlmCompletionResult>` | Spawn cursor-agent, parse stream-json, return result |
 
 ## Invariants
 
-1. **Slot-based concurrency**: `activeSlots` never exceeds `maxSlots` (default 2, configurable via `CURSOR_MAX_PARALLEL`). Never goes negative — clamped to 0
+1. **Slot-based concurrency**: `activeSlots` never exceeds `maxSlots` (default 4, configurable via `CURSOR_MAX_CONCURRENT`). Never goes negative — clamped to 0
 2. **Slot always released**: Every `acquireSlot` returning `true` must have a corresponding `releaseSlot`, even on abort or error
 3. **Abort removes from queue**: If an abort signal fires while queued, the waiter is removed and `acquireSlot` returns `false`
 4. **Completion timeout (10 min)**: Cursor-agent process is killed if no result after 10 minutes
@@ -46,9 +48,9 @@ Cursor LLM provider wrapping the cursor-agent CLI as a first-class `LlmProvider`
 
 ### Scenario: Slot acquisition when full
 
-- **Given** `maxSlots=2` and both slots occupied
-- **When** a third request calls `acquireSlot`
-- **Then** it queues and the `onStatus` callback reports the queue position
+- **Given** `maxSlots=4` (default) and all slots occupied
+- **When** a request beyond the limit calls `acquireSlot`
+- **Then** it queues (not rejected) and the `onStatus` callback reports the queue position
 - **And** when a slot is released, the queued request resolves with `true`
 
 ### Scenario: Abort during slot wait
@@ -99,10 +101,11 @@ Cursor LLM provider wrapping the cursor-agent CLI as a first-class `LlmProvider`
 
 | Env Var | Default | Description |
 |---------|---------|-------------|
-| `CURSOR_MAX_PARALLEL` | `2` | Maximum parallel cursor-agent processes |
+| `CURSOR_MAX_CONCURRENT` | `4` | Maximum parallel cursor-agent processes (queued, not rejected when exceeded) |
 
 ## Change Log
 
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-03-27 | corvid-agent | Initial spec for CursorProvider (#1529) |
+| 2026-03-28 | corvid-agent | Rename CURSOR_MAX_PARALLEL → CURSOR_MAX_CONCURRENT, default 2→4, add getSlotStatus/maxConcurrent (#1532) |


### PR DESCRIPTION
## Summary

- Renames `CURSOR_MAX_PARALLEL` → `CURSOR_MAX_CONCURRENT` to match Ollama provider naming convention
- Increases default concurrency from 2 → 4 for better throughput
- Adds `getSlotStatus()` observability method returning `{ active, queued, maxConcurrent }`
- Updates tests to use `provider.maxConcurrent` instead of hardcoded slot counts
- Updates spec, provider parity checklist, and `.env.example`

Closes #1532

## Test plan

- [x] All 42 cursor provider tests pass
- [x] Full test suite: 9465 pass, 0 fail
- [x] TypeScript type check clean
- [x] Spec check: 200 specs pass
- [x] Lint clean in modified files (pre-existing scripts/ lint issues unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: Jackdaw | Model: Sonnet 4.6