### PR TITLE
fix(client): fix nav dropdowns, session overflow, layout spacing, library 3D access

### DIFF
--- a/client/src/app/features/library/library.component.ts
+++ b/client/src/app/features/library/library.component.ts
@@ -145,7 +145,7 @@ const CATEGORY_COLORS: Record<LibraryCategory, string> = {
     `,
     styles: `
         .library {
-            padding: 1rem;
+            padding: 1.5rem;
             max-width: 1200px;
             margin: 0 auto;
         }

--- a/client/src/app/shared/components/chat-tab-bar.component.ts
+++ b/client/src/app/shared/components/chat-tab-bar.component.ts
@@ -76,7 +76,7 @@ const COLLAPSED_KEY = 'corvid-chat-tabs-collapsed';
             height: 36px;
             padding: 0 0.25rem;
             gap: 0.25rem;
-            overflow: hidden;
+            min-width: 0;
         }
         .tab-bar--collapsed {
             height: 24px;
@@ -116,11 +116,15 @@ const COLLAPSED_KEY = 'corvid-chat-tabs-collapsed';
         .tab-bar__tabs {
             display: flex;
             flex: 1;
+            min-width: 0;
             gap: 2px;
             overflow-x: auto;
-            scrollbar-width: none;
+            scrollbar-width: thin;
+            scrollbar-color: var(--border, #2a2a3e) transparent;
         }
-        .tab-bar__tabs::-webkit-scrollbar { display: none; }
+        .tab-bar__tabs::-webkit-scrollbar { height: 3px; }
+        .tab-bar__tabs::-webkit-scrollbar-track { background: transparent; }
+        .tab-bar__tabs::-webkit-scrollbar-thumb { background: var(--border, #2a2a3e); border-radius: 3px; }
         .tab {
             display: flex;
             align-items: center;

--- a/client/src/app/shared/components/page-shell.component.ts
+++ b/client/src/app/shared/components/page-shell.component.ts
@@ -153,7 +153,7 @@ export interface Breadcrumb {
             flex: 1;
             min-height: 0;
             overflow-y: auto;
-            padding: 0.5rem 1.5rem 1.5rem;
+            padding: 1rem 2rem 2rem;
         }
 
         @media (max-width: 767px) {
@@ -167,7 +167,7 @@ export interface Breadcrumb {
                 padding: 0 1rem;
             }
             .page-shell__content {
-                padding: 0.5rem 1rem 1rem;
+                padding: 0.75rem 1.25rem 1.25rem;
             }
             .page-shell__title {
                 font-size: 1rem;

--- a/client/src/app/shared/components/top-nav.component.ts
+++ b/client/src/app/shared/components/top-nav.component.ts
@@ -63,11 +63,11 @@ const TABS: NavTab[] = [
         label: 'Observe',
         icon: 'eye',
         route: '/observe',
-        matchRoutes: ['/observe'],
+        matchRoutes: ['/observe', '/library'],
         children: [
             { label: 'Comms', icon: 'activity', route: '/observe' },
             { label: 'Memory', icon: 'database', route: '/observe/memory' },
-            { label: 'Library', icon: 'book-open', route: '/observe/library' },
+            { label: 'Library', icon: 'book-open', route: '/library' },
             { label: 'Analytics', icon: 'bar-chart', route: '/observe/analytics' },
             { label: 'Logs', icon: 'terminal', route: '/observe/logs' },
             { label: 'Reputation', icon: 'star', route: '/observe/reputation' },
@@ -259,7 +259,7 @@ const TABS: NavTab[] = [
         .topnav__tabs {
             display: flex;
             align-items: center;
-            gap: 0;
+            gap: 0.25rem;
         }
         .topnav__tab-wrapper {
             position: relative;
@@ -268,7 +268,7 @@ const TABS: NavTab[] = [
             display: flex;
             align-items: center;
             gap: 0.3rem;
-            padding: 0.5rem 0.9rem;
+            padding: 0.5rem 1rem;
             background: none;
             border: none;
             color: var(--text-secondary);
@@ -587,10 +587,14 @@ export class TopNavComponent implements OnInit, OnDestroy {
         event.stopPropagation();
         if (this.openDropdown() === tab.key) {
             this.closeDropdown();
-        } else if (tab.children.length > 1) {
-            this.openDropdown.set(tab.key);
+            return;
         }
-        // Always navigate to the tab's default route on click
+        if (tab.children.length > 1) {
+            this.openDropdown.set(tab.key);
+            // Don't navigate when opening dropdown — let user pick a sub-item
+            return;
+        }
+        // Only navigate for tabs without children (Home, Dashboard)
         this.router.navigate([tab.route]);
     }
 


### PR DESCRIPTION
## Summary
- **Tab dropdown navigation bug**: Clicking a nav tab with sub-items (Sessions, Observe, Agents, Settings) no longer navigates to the default route — it just opens the dropdown so you can pick a sub-item
- **Session tab overflow**: Removed `overflow: hidden` on the tab bar container so horizontal scrolling actually works when you have 8+ sessions. Added a thin scrollbar so it's visible
- **Layout spacing**: Increased content padding from `0.5rem 1.5rem` to `1rem 2rem` — less cramped, more breathing room
- **Library 3D access**: Observe > Library now links to `/library` (which has the Basic/3D toggle) instead of `/observe/library` (browser-only view with no 3D option)

## Test plan
- [ ] Click Sessions/Observe/Agents/Settings tabs — dropdown should open without navigating away
- [ ] Select a sub-item from dropdown — should navigate correctly
- [ ] Open 8+ chat sessions — verify all tabs are visible via horizontal scroll
- [ ] Check content areas have comfortable padding on desktop and mobile
- [ ] Navigate to Observe > Library — should show the view with Basic/3D toggle
- [ ] Toggle to 3D view — Three.js visualization should render

---
🤖 Agent: CorvidAgent | Model: Opus 4.6