### PR TITLE
fix(client): cursor, book reading freeze, newest-first lists

### DIFF
--- a/client/src/app/features/agent-comms/agent-comms.component.ts
+++ b/client/src/app/features/agent-comms/agent-comms.component.ts
@@ -676,13 +676,13 @@ export class AgentCommsComponent implements OnInit, OnDestroy {
             timestamp: timestamp ?? new Date(),
             ...partial,
         };
-        this.rawEntries.update((list) => [...list, entry]);
+        this.rawEntries.update((list) => [entry, ...list]);
         this.totalMessages.update((n) => n + 1);
 
         if (this.autoScroll()) {
             requestAnimationFrame(() => {
                 const el = this.timelineEl()?.nativeElement;
-                if (el) el.scrollTop = el.scrollHeight;
+                if (el) el.scrollTop = 0;
             });
         }
     }
@@ -729,7 +729,7 @@ export class AgentCommsComponent implements OnInit, OnDestroy {
                 this.seenMessageKeys.add(`${m.id}:${m.status}`);
             }
 
-            newEntries.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+            newEntries.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
             this.nextId = 0;
             for (const entry of newEntries) {
                 entry.id = this.nextId++;

--- a/client/src/app/features/agent-comms/agent-network-3d.component.ts
+++ b/client/src/app/features/agent-comms/agent-network-3d.component.ts
@@ -344,19 +344,17 @@ export class AgentNetwork3DComponent implements OnDestroy {
 
     private static readonly PARTICLE_GEOMETRY = new THREE.SphereGeometry(0.12, 6, 6);
 
-    /* ── Pointer lock state ─────────────────────────────── */
-    private isPointerLocked = false;
+    /* ── Drag state ───────────────────────────────────────── */
     private dragStartX = 0;
     private dragStartY = 0;
     private dragMoved = false;
+    private capturedPointerId = -1;
 
     /* ── Event handlers bound once ──────────────────────── */
-    private onMouseDown = (e: MouseEvent) => this.handleMouseDown(e);
-    private onMouseMove = (e: MouseEvent) => this.handleMouseMove(e);
-    private onMouseUp = (e: MouseEvent) => this.handleMouseUp(e);
+    private onPointerDown = (e: PointerEvent) => this.handlePointerDown(e);
+    private onPointerMove = (e: PointerEvent) => this.handlePointerMove(e);
+    private onPointerUp = (e: PointerEvent) => this.handlePointerUp(e);
     private onWheel = (e: WheelEvent) => this.handleWheel(e);
-    private onMouseLeave = () => { /* no-op with pointer lock */ };
-    private onPointerLockChange = () => this.handlePointerLockChange();
 
     constructor() {
         afterNextRender(() => {
@@ -375,15 +373,13 @@ export class AgentNetwork3DComponent implements OnDestroy {
     ngOnDestroy(): void {
         cancelAnimationFrame(this.animId);
         this.resizeObserver?.disconnect();
-        if (this.isPointerLocked) document.exitPointerLock();
-        document.removeEventListener('pointerlockchange', this.onPointerLockChange);
         const canvas = this.canvasRef()?.nativeElement;
         if (canvas) {
-            canvas.removeEventListener('mousedown', this.onMouseDown);
-            canvas.removeEventListener('mousemove', this.onMouseMove);
-            canvas.removeEventListener('mouseup', this.onMouseUp);
+            if (this.capturedPointerId >= 0) canvas.releasePointerCapture(this.capturedPointerId);
+            canvas.removeEventListener('pointerdown', this.onPointerDown);
+            canvas.removeEventListener('pointermove', this.onPointerMove);
+            canvas.removeEventListener('pointerup', this.onPointerUp);
             canvas.removeEventListener('wheel', this.onWheel);
-            canvas.removeEventListener('mouseleave', this.onMouseLeave);
         }
         // Dispose Three.js resources
         this.agentNodes.forEach((n) => {
@@ -457,14 +453,12 @@ export class AgentNetwork3DComponent implements OnDestroy {
         // Starfield
         this.createStarfield();
 
-        // Events
+        // Events — use pointer capture instead of pointer lock for orbit dragging
         canvas.style.cursor = 'crosshair';
-        canvas.addEventListener('mousedown', this.onMouseDown);
-        canvas.addEventListener('mousemove', this.onMouseMove);
-        canvas.addEventListener('mouseup', this.onMouseUp);
+        canvas.addEventListener('pointerdown', this.onPointerDown);
+        canvas.addEventListener('pointermove', this.onPointerMove);
+        canvas.addEventListener('pointerup', this.onPointerUp);
         canvas.addEventListener('wheel', this.onWheel, { passive: false });
-        canvas.addEventListener('mouseleave', this.onMouseLeave);
-        document.addEventListener('pointerlockchange', this.onPointerLockChange);
 
         // Touch events for mobile
         canvas.addEventListener('touchstart', (e) => {
@@ -866,30 +860,24 @@ export class AgentNetwork3DComponent implements OnDestroy {
 
     /* ── Event handlers ─────────────────────────────────── */
 
-    private handleMouseDown(e: MouseEvent): void {
+    private handlePointerDown(e: PointerEvent): void {
+        if (e.button !== 0) return;
         this.dragStartX = e.clientX;
         this.dragStartY = e.clientY;
         this.dragMoved = false;
 
-        // Request pointer lock for orbit dragging
+        // Capture pointer so cursor can't escape the canvas during drag
         const canvas = this.canvasRef().nativeElement;
-        if (!this.isPointerLocked) {
-            canvas.requestPointerLock();
-        }
+        canvas.setPointerCapture(e.pointerId);
+        this.capturedPointerId = e.pointerId;
         this.isDragging = true;
         this.lastMouseX = e.clientX;
         this.lastMouseY = e.clientY;
+        canvas.style.cursor = 'grabbing';
     }
 
-    private handleMouseMove(e: MouseEvent): void {
-        if (this.isPointerLocked && this.isDragging) {
-            // Use movementX/Y for pointer-locked orbit
-            const dx = e.movementX;
-            const dy = e.movementY;
-            if (Math.abs(dx) > 0 || Math.abs(dy) > 0) this.dragMoved = true;
-            this.targetTheta -= dx * 0.003;
-            this.targetPhi = Math.max(0.1, Math.min(Math.PI - 0.1, this.targetPhi - dy * 0.003));
-        } else if (this.isDragging) {
+    private handlePointerMove(e: PointerEvent): void {
+        if (this.isDragging) {
             const dx = e.clientX - this.lastMouseX;
             const dy = e.clientY - this.lastMouseY;
             if (Math.abs(dx) > 3 || Math.abs(dy) > 3) this.dragMoved = true;
@@ -897,42 +885,40 @@ export class AgentNetwork3DComponent implements OnDestroy {
             this.targetPhi = Math.max(0.1, Math.min(Math.PI - 0.1, this.targetPhi - dy * 0.005));
             this.lastMouseX = e.clientX;
             this.lastMouseY = e.clientY;
+            return;
         }
 
-        // Raycasting for hover (only when not pointer-locked)
-        if (!this.isPointerLocked) {
-            const canvas = this.canvasRef().nativeElement;
-            const rect = canvas.getBoundingClientRect();
-            this.mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
-            this.mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+        // Raycasting for hover
+        const canvas = this.canvasRef().nativeElement;
+        const rect = canvas.getBoundingClientRect();
+        this.mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+        this.mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
 
-            this.raycaster.setFromCamera(this.mouse, this.camera!);
-            const meshes = this.agentNodes.map((n) => n.mesh);
-            const intersects = this.raycaster.intersectObjects(meshes);
+        this.raycaster.setFromCamera(this.mouse, this.camera!);
+        const meshes = this.agentNodes.map((n) => n.mesh);
+        const intersects = this.raycaster.intersectObjects(meshes);
 
-            if (intersects.length > 0) {
-                this.hoveredNodeId = intersects[0].object.userData['agentId'] as string;
-                canvas.style.cursor = 'pointer';
-            } else {
-                this.hoveredNodeId = null;
-                canvas.style.cursor = 'crosshair';
-            }
+        if (intersects.length > 0) {
+            this.hoveredNodeId = intersects[0].object.userData['agentId'] as string;
+            canvas.style.cursor = 'pointer';
+        } else {
+            this.hoveredNodeId = null;
+            canvas.style.cursor = 'crosshair';
         }
     }
 
-    private handleMouseUp(e: MouseEvent): void {
+    private handlePointerUp(e: PointerEvent): void {
         this.isDragging = false;
-
-        // Exit pointer lock
-        if (this.isPointerLocked) {
-            document.exitPointerLock();
+        const canvas = this.canvasRef().nativeElement;
+        if (this.capturedPointerId >= 0) {
+            canvas.releasePointerCapture(this.capturedPointerId);
+            this.capturedPointerId = -1;
         }
+        canvas.style.cursor = 'crosshair';
 
         // If didn't drag much, treat as click
         if (!this.dragMoved && this.camera) {
-            const canvas = this.canvasRef().nativeElement;
             const rect = canvas.getBoundingClientRect();
-            // Use original drag start position for click detection
             this.mouse.x = ((this.dragStartX - rect.left) / rect.width) * 2 - 1;
             this.mouse.y = -((this.dragStartY - rect.top) / rect.height) * 2 + 1;
 
@@ -953,15 +939,6 @@ export class AgentNetwork3DComponent implements OnDestroy {
             } else {
                 this.clearSelection();
             }
-        }
-    }
-
-    private handlePointerLockChange(): void {
-        const canvas = this.canvasRef()?.nativeElement;
-        this.isPointerLocked = document.pointerLockElement === canvas;
-        if (!this.isPointerLocked) {
-            this.isDragging = false;
-            if (canvas) canvas.style.cursor = 'crosshair';
         }
     }
 

--- a/client/src/app/features/feed/live-feed.component.ts
+++ b/client/src/app/features/feed/live-feed.component.ts
@@ -679,7 +679,7 @@ export class LiveFeedComponent implements OnInit, OnDestroy {
             }
 
             // Sort all entries by timestamp so agent and algochat messages interleave correctly
-            newEntries.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+            newEntries.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
             // Re-assign IDs after sort
             this.nextId = 0;
             for (const entry of newEntries) {
@@ -698,13 +698,13 @@ export class LiveFeedComponent implements OnInit, OnDestroy {
             timestamp: timestamp ?? new Date(),
             ...partial,
         };
-        this.rawEntries.update((list) => [...list, entry]);
+        this.rawEntries.update((list) => [entry, ...list]);
 
         if (this.autoScroll()) {
             requestAnimationFrame(() => {
                 const el = this.feedList()?.nativeElement;
                 if (el) {
-                    el.scrollTop = el.scrollHeight;
+                    el.scrollTop = 0;
                 }
             });
         }

--- a/client/src/app/features/library/library-3d.component.ts
+++ b/client/src/app/features/library/library-3d.component.ts
@@ -220,6 +220,7 @@ interface BookNode3D {
 })
 export class Library3DComponent implements OnDestroy {
     readonly entries = input.required<LibraryEntry[]>();
+    readonly paused = input(false);
     readonly entrySelect = output<LibraryEntry>();
     readonly bookPageSelect = output<{ entry: LibraryEntry; pages: LibraryEntry[] }>();
 
@@ -310,6 +311,14 @@ export class Library3DComponent implements OnDestroy {
             const entries = this.entries();
             if (this.scene) {
                 this.rebuildBooks(entries);
+            }
+        });
+
+        // Exit pointer lock and clear keys when paused (reading a book)
+        effect(() => {
+            if (this.paused()) {
+                if (document.pointerLockElement) document.exitPointerLock();
+                this.keys.clear();
             }
         });
     }
@@ -632,6 +641,7 @@ export class Library3DComponent implements OnDestroy {
     }
 
     private processMovement(): void {
+        if (this.paused()) return;
         const speed = 0.5;
         const forward = new THREE.Vector3(
             -Math.sin(this.cameraYaw),
@@ -783,6 +793,7 @@ export class Library3DComponent implements OnDestroy {
     }
 
     private handleKeyDown(e: KeyboardEvent): void {
+        if (this.paused()) return;
         this.keys.add(e.key.toLowerCase());
     }
 
@@ -800,6 +811,7 @@ export class Library3DComponent implements OnDestroy {
     }
 
     private handleMouseDown(e: MouseEvent): void {
+        if (this.paused()) return;
         if (e.button === 0) {
             const container = this.containerRef()?.nativeElement;
             if (container && !this.pointerLocked()) {
@@ -814,6 +826,7 @@ export class Library3DComponent implements OnDestroy {
     }
 
     private handleMouseMove(e: MouseEvent): void {
+        if (this.paused()) return;
         if (this.pointerLocked()) {
             // Use movementX/Y for FPS-style look (fix direction: -= for natural feel)
             const dx = e.movementX ?? 0;

--- a/client/src/app/features/library/library.component.ts
+++ b/client/src/app/features/library/library.component.ts
@@ -5,6 +5,8 @@ import {
     signal,
     computed,
     OnInit,
+    OnDestroy,
+    HostListener,
 } from '@angular/core';
 import { LibraryService, type LibraryCategory, type LibraryEntry } from '../../core/services/library.service';
 import { ViewModeService } from '../../core/services/view-mode.service';
@@ -113,6 +115,7 @@ const CATEGORY_COLORS: Record<LibraryCategory, string> = {
             } @else {
                 <app-library-3d
                     [entries]="allEntries()"
+                    [paused]="!!selectedEntry()"
                     (entrySelect)="onEntrySelect($event)"
                     (bookPageSelect)="onBookPageSelect($event)" />
                 @if (selectedEntry()) {
@@ -444,7 +447,7 @@ const CATEGORY_COLORS: Record<LibraryCategory, string> = {
         }
     `,
 })
-export class LibraryComponent implements OnInit {
+export class LibraryComponent implements OnInit, OnDestroy {
     private readonly libraryService = inject(LibraryService);
     private readonly viewModeService = inject(ViewModeService);
 
@@ -475,11 +478,24 @@ export class LibraryComponent implements OnInit {
                     e.content.toLowerCase().includes(q),
             );
         }
-        return entries;
+        // Most recent first
+        return [...entries].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
     });
+
+    private onEscKey = (e: KeyboardEvent) => {
+        if (e.key === 'Escape' && this.selectedEntry()) {
+            e.preventDefault();
+            this.clearSelection();
+        }
+    };
 
     ngOnInit(): void {
         this.libraryService.load({ limit: 200 });
+        window.addEventListener('keydown', this.onEscKey);
+    }
+
+    ngOnDestroy(): void {
+        window.removeEventListener('keydown', this.onEscKey);
     }
 
     protected setViewMode(mode: ViewMode): void {


### PR DESCRIPTION
## Summary

- **Comms 3D**: Replace pointer lock with `setPointerCapture` for orbit dragging — crosshair cursor stays visible, mouse can't escape the canvas during drag, switches to `grabbing` while dragging
- **Library 3D**: Add `paused` input — when a book/note overlay is open, exits pointer lock, freezes WASD movement and mouse look so you can read and interact with the overlay freely
- **Library 3D**: ESC key closes the book overlay
- **Library basic view**: Entries now sorted newest-first
- **Live feed & Comms**: Sort newest-first, prepend new entries to top, auto-scroll goes to top instead of bottom

## Test plan
- [ ] Comms 3D: verify crosshair cursor is visible, drag to orbit works without mouse escaping
- [ ] Library 3D: click a book, verify movement/look is frozen, ESC closes overlay
- [ ] Live feed: verify newest messages appear at top
- [ ] Comms list: verify newest messages appear at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6