### PR TITLE
release: prepare v0.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.57.0] - 2026-03-28
+
+### Added
+- **3D library visualization** — Three.js immersive 3D library browser with FPS mouse look, book grouping, and reading mode (#1630, #1636)
+- **3D comms visualization** — persistent trails, message log panel, and pointer lock orbit for agent communication view (#1637)
+- **3D network visualization** — Three.js agent network constellation with dual-mode toggle (#1626, #1591)
+- **CLI doctor command** — `corvid-agent doctor` health check with first-run welcome banner (#1486, #1627)
+- **UI animations & micro-interactions** — dashboard polish with streamlined layout and Discord progress feedback (#1612, #1607)
+- **Work delegation attribution** — agent ID parameter for delegation tracking (#1606)
+- **Library boot-time loader** — pre-load library at startup with librarian permission spec (#1589)
+- **Discord agent personalization** — avatars and icons in embeds (#1592)
+
+### Fixed
+- **Cursor provider: stream idle timeout** — prevent hung sessions with idle timeout detection (#1639)
+- **Client: cursor/pointer capture** — fix book reading freeze, newest-first lists (#1638)
+- **Client: nav/layout** — fix dropdowns, session overflow, layout spacing, library 3D access (#1635, #1633)
+- **Model-aware context budgets** — overflow error recovery for different model sizes (#1629)
+- **Ollama output sanitizer** — strip leaked prompt artifacts (#1609)
+- **Discord rate limiting** — apply rate limiting to slash command interactions (#1593)
+- **Work: agent signature injection** — inject agent signature into work task PR prompt (#1590)
+
+### Security
+- **path-to-regexp ReDoS** — update to patch regex denial-of-service vulnerability (#1602)
+- **CodeQL alerts** — fix TOCTOU race, fd leak, schema consolidation (#1608)
+
+### Docs & Tests
+- **Hero stats accuracy** — update landing page stats (#1622)
+- **Version/routes spec** — fix version mismatch and update routes spec (#1605)
+- **Ollama council smoke tests** — council participation tests (#1594)
+- **Dead-end embed test** — stabilize for CI (#1631)
+
 ## [0.56.0] - 2026-03-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.56.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.57.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2117,7 +2117,7 @@
 
       const lines = [
         { type: 'command', text: 'corvid' },
-        { type: 'output', text: 'corvid v0.56.0 \u2014 agent: CorvidAgent (claude-opus-4-6)' },
+        { type: 'output', text: 'corvid v0.57.0 \u2014 agent: CorvidAgent (claude-opus-4-6)' },
         { type: 'output', text: 'project: corvid-agent (/Users/corvid-agent/corvid-agent)' },
         { type: 'blank' },
         { type: 'command', text: 'Harden the AlgoChat bridge reconnect logic' },

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>CorvidAgent — Release Retrospective: v0.1.0 → v0.56.0</title>
+<title>CorvidAgent — Release Retrospective: v0.1.0 → v0.57.0</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap');
 
@@ -460,18 +460,18 @@
     <div class="hero-version-range">
       <span class="version">v0.1.0</span>
       <span class="arrow">→</span>
-      <span class="version">v0.56.0</span>
+      <span class="version">v0.57.0</span>
     </div>
   </section>
 
   <!-- Stats bar -->
   <section class="stats-bar">
     <div class="stat-card">
-      <div class="stat-number">56</div>
+      <div class="stat-number">57</div>
       <div class="stat-label">Releases</div>
     </div>
     <div class="stat-card">
-      <div class="stat-number">1012</div>
+      <div class="stat-number">1045</div>
       <div class="stat-label">Commits</div>
     </div>
     <div class="stat-card">
@@ -929,9 +929,9 @@
         <div class="era-icon">&#x1F680;</div>
         <div>
           <div class="era-title">Scale — Provider Parity & Agent Observatory</div>
-          <div class="era-date">Mar 21 – Mar 27, 2026</div>
+          <div class="era-date">Mar 21 – Mar 28, 2026</div>
         </div>
-        <div class="era-versions">v0.42.0 – v0.56.0</div>
+        <div class="era-versions">v0.42.0 – v0.57.0</div>
       </div>
       <div class="era-body">
         <div class="release-card">
@@ -977,6 +977,21 @@
             <li><span class="tag tag-fix">fix</span> MCP tool permissions, scheduler tenant fallback, Ollama readiness probe</li>
           </ul>
         </div>
+        <div class="release-card" style="border-color: rgba(0,229,255,0.3); background: rgba(0,229,255,0.05);">
+          <div class="release-header">
+            <span class="release-version">v0.57.0</span>
+            <span class="release-date">Mar 28</span>
+          </div>
+          <ul class="release-highlights">
+            <li><span class="tag tag-feat">feat</span> <strong>3D library visualization</strong> — immersive Three.js library browser with FPS mouse look and book grouping</li>
+            <li><span class="tag tag-feat">feat</span> <strong>3D comms & network</strong> — persistent trails, message log, agent constellation visualization</li>
+            <li><span class="tag tag-feat">feat</span> <strong>CLI doctor</strong> — health check command with first-run welcome banner</li>
+            <li><span class="tag tag-feat">feat</span> <strong>UI animations</strong> — micro-interactions, streamlined dashboard, Discord progress feedback</li>
+            <li><span class="tag tag-fix">fix</span> <strong>Cursor idle timeout</strong> — prevent hung sessions with stream idle detection</li>
+            <li><span class="tag tag-fix">fix</span> Model-aware context budgets, nav/layout fixes, Ollama output sanitizer</li>
+            <li><span class="tag tag-security">security</span> ReDoS patch (path-to-regexp), CodeQL fixes (TOCTOU, fd leak)</li>
+          </ul>
+        </div>
         <div class="release-card" style="border-color: rgba(167,139,250,0.3); background: rgba(167,139,250,0.05);">
           <div class="release-header">
             <span class="release-version">v0.56.0</span>
@@ -1001,7 +1016,7 @@
   <!-- Footer -->
   <footer class="footer">
     <div class="footer-logo">CorvidAgent</div>
-    <p>Built by <a href="https://github.com/CorvidLabs">CorvidLabs</a> · Feb 6 – Mar 27, 2026</p>
+    <p>Built by <a href="https://github.com/CorvidLabs">CorvidLabs</a> · Feb 6 – Mar 28, 2026</p>
     <p style="margin-top: 8px;">50 days from zero to a full autonomous AI agent platform.</p>
   </footer>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version to 0.57.0 across package.json, README badge, docs landing page, and releases retrospective
- Add full CHANGELOG entry covering 30 commits since v0.56.0
- Update GitHub Pages releases.html with v0.57.0 card, stats (57 releases, 1045 commits), and date range

## v0.57.0 Highlights
- **3D visualizations** — immersive library, comms, and network views with Three.js
- **CLI doctor** — health check command with first-run welcome banner
- **UI animations** — micro-interactions, streamlined dashboard
- **Security** — ReDoS patch, CodeQL fixes (TOCTOU, fd leak)
- **Cursor provider** — stream idle timeout to prevent hung sessions
- **Model-aware context budgets** — overflow error recovery

## After merge
- [ ] Delete the v0.57.0-rc.1 prerelease
- [ ] Create full v0.57.0 release from main
- [ ] Rebuild frontend on server

🤖 Generated with [Claude Code](https://claude.com/claude-code)