### PR TITLE
fix: e2e audit routes and external MCP test slice size

### DIFF
--- a/e2e/ui-audit.ts
+++ b/e2e/ui-audit.ts
@@ -30,10 +30,9 @@ const PAGES: PageAudit[] = [
     { route: '/settings/integrations', name: 'settings-integrations', checks: ['.settings, .page-shell'] },
     { route: '/wallets', name: 'wallets', checks: ['.wallet, .page-shell'] },
     { route: '/spending', name: 'spending', checks: ['.spending, .page-shell'] },
-    { route: '/models', name: 'models', checks: ['.model, .page-shell'] },
-    { route: '/personas', name: 'personas', checks: ['.persona, .page-shell'] },
-    { route: '/skill-bundles', name: 'skill-bundles', checks: ['.skill-bundle, .page-shell'] },
-    { route: '/marketplace', name: 'marketplace', checks: ['.marketplace, .page-shell'] },
+    { route: '/agents/models', name: 'models', checks: ['.model, .page-shell'] },
+    { route: '/agents/personas', name: 'personas', checks: ['.persona, .page-shell'] },
+    { route: '/agents/skill-bundles', name: 'skill-bundles', checks: ['.skill-bundle, .page-shell'] },
 ];
 
 async function main() {

--- a/server/__tests__/process-manager-external-mcp.test.ts
+++ b/server/__tests__/process-manager-external-mcp.test.ts
@@ -41,11 +41,11 @@ describe('External MCP config loading parity (spec invariant #15)', () => {
     });
 
     test('resumeProcess loads external MCP configs for SDK path', () => {
-        // Extract the resumeProcess method body (large method, need 10000 chars)
+        // Extract the resumeProcess method body (large method, need 15000 chars)
         const startIdx = MANAGER_SOURCE.indexOf('resumeProcess(session: Session');
         expect(startIdx).toBeGreaterThan(-1);
 
-        const methodBody = MANAGER_SOURCE.slice(startIdx, startIdx + 10000);
+        const methodBody = MANAGER_SOURCE.slice(startIdx, startIdx + 15000);
 
         // Must call getActiveServersForAgent for resumed SDK sessions
         expect(methodBody).toContain('getActiveServersForAgent(this.db, session.agentId)');
@@ -67,7 +67,7 @@ describe('External MCP config loading parity (spec invariant #15)', () => {
         const startIdx = MANAGER_SOURCE.indexOf('resumeProcess(session: Session');
         expect(startIdx).toBeGreaterThan(-1);
 
-        const methodBody = MANAGER_SOURCE.slice(startIdx, startIdx + 10000);
+        const methodBody = MANAGER_SOURCE.slice(startIdx, startIdx + 15000);
 
         // Must pass externalMcpConfigs to startDirectProcess in resume path
         expect(methodBody).toContain('externalMcpConfigs: resumeExternalMcpConfigs');


### PR DESCRIPTION
## Summary\n- Fix 4 e2e audit timeouts by using resolved routes (`/agents/models`, `/agents/personas`, `/agents/skill-bundles`) instead of redirect shortcuts\n- Remove `/marketplace` from audit (redirects to `/settings/integrations` which is already tested)\n- Fix 2 failing external MCP parity tests by increasing `resumeProcess` slice from 10000 to 15000 chars — method grew beyond the old window\n\n## Test plan\n- [x] e2e UI audit: 23/23 pass (was 20/24)\n- [x] External MCP parity tests: 8/8 pass (was 6/8)\n- [x] TSC: clean\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)