### PR TITLE
fix(a11y): WCAG AA audit — fix contrast and select labels

### DIFF
--- a/client/src/app/features/agents/agent-list.component.ts
+++ b/client/src/app/features/agents/agent-list.component.ts
@@ -88,7 +88,7 @@ const INACTIVE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
                     <span class="toggle-text">Hide inactive</span>
                 </label>
                 <div class="sort-group">
-                    <select class="sort-select" [(ngModel)]="sortBy" (ngModelChange)="sortBy = $event">
+                    <select class="sort-select" [(ngModel)]="sortBy" (ngModelChange)="sortBy = $event" aria-label="Sort agents by">
                         <option value="name">Sort: Name</option>
                         <option value="created">Sort: Created</option>
                         <option value="lastActive">Sort: Last Active</option>

--- a/client/src/app/features/councils/council-list.component.ts
+++ b/client/src/app/features/councils/council-list.component.ts
@@ -70,7 +70,7 @@ interface CouncilCard {
                         }
                     </div>
                     <div class="sort-group">
-                        <select class="sort-select" [(ngModel)]="sortBy" (ngModelChange)="sortBy = $event">
+                        <select class="sort-select" [(ngModel)]="sortBy" (ngModelChange)="sortBy = $event" aria-label="Sort councils by">
                             <option value="name">Sort: Name</option>
                             <option value="updated">Sort: Updated</option>
                             <option value="lastLaunch">Sort: Last Launch</option>

--- a/client/src/app/features/flock-directory/flock-directory.component.ts
+++ b/client/src/app/features/flock-directory/flock-directory.component.ts
@@ -75,18 +75,18 @@ interface FlockStats {
                         spellcheck="false" />
                 </div>
                 <div class="flock-filters">
-                    <select class="flock-filter" [value]="statusFilter()" (change)="onStatusChange($event)">
+                    <select class="flock-filter" [value]="statusFilter()" (change)="onStatusChange($event)" aria-label="Filter by status">
                         <option value="">All Status</option>
                         <option value="active">Active</option>
                         <option value="inactive">Inactive</option>
                     </select>
-                    <select class="flock-filter" [value]="capabilityFilter()" (change)="onCapabilityChange($event)">
+                    <select class="flock-filter" [value]="capabilityFilter()" (change)="onCapabilityChange($event)" aria-label="Filter by capability">
                         <option value="">All Capabilities</option>
                         @for (cap of allCapabilities(); track cap) {
                             <option [value]="cap">{{ cap }}</option>
                         }
                     </select>
-                    <select class="flock-filter" [value]="sortBy()" (change)="onSortByChange($event)">
+                    <select class="flock-filter" [value]="sortBy()" (change)="onSortByChange($event)" aria-label="Sort by">
                         <option value="reputation">Reputation</option>
                         <option value="name">Name</option>
                         <option value="uptime">Uptime</option>

--- a/client/src/app/features/sessions/session-list.component.ts
+++ b/client/src/app/features/sessions/session-list.component.ts
@@ -55,7 +55,7 @@ interface SessionGroup {
                     Failed ({{ countByStatus('error') }})
                 </button>
                 <div class="filter-tabs__spacer"></div>
-                <select class="source-select" [(ngModel)]="sourceFilter" (ngModelChange)="sourceFilter = $event">
+                <select class="source-select" [(ngModel)]="sourceFilter" (ngModelChange)="sourceFilter = $event" aria-label="Filter by source">
                     <option value="">All Sources</option>
                     <option value="web">Web</option>
                     <option value="algochat">AlgoChat</option>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -44,10 +44,10 @@
     --border: #1e2035;
     --border-bright: #2a2d48;
 
-    /* Text — all pass WCAG AA (4.5:1) on --bg-deep #0a0a12 */
+    /* Text — all pass WCAG AA (4.5:1) on surfaces up to --bg-raised */
     --text-primary: #e0e0ec;
     --text-secondary: #8b8eaa;
-    --text-tertiary: #6b6e88;
+    --text-tertiary: #8284a0;
 
     /* Accents */
     --accent-cyan: #00e5ff;

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, gotoWithRetry } from './fixtures';
+import AxeBuilder from '@axe-core/playwright';
+
+/**
+ * Accessibility (a11y) audit — runs axe-core against every major page.
+ * Covers WCAG 2.1 Level AA by default.
+ */
+
+/** Pages that need no seeded data. */
+const STATIC_PAGES = [
+    { name: 'Dashboard', path: '/dashboard' },
+    { name: 'Agents', path: '/agents' },
+    { name: 'New Agent', path: '/agents/new' },
+    { name: 'Sessions', path: '/sessions' },
+    { name: 'Councils', path: '/sessions/councils' },
+    { name: 'Work Tasks', path: '/sessions/work-tasks' },
+    { name: 'Projects', path: '/projects' },
+    { name: 'New Project', path: '/projects/new' },
+    { name: 'Chat', path: '/chat' },
+    { name: 'Library', path: '/library' },
+    { name: 'Comms', path: '/observe/comms' },
+    { name: 'Memory', path: '/observe/memory' },
+    { name: 'Analytics', path: '/observe/analytics' },
+    { name: 'Logs', path: '/observe/logs' },
+    { name: 'Reputation', path: '/observe/reputation' },
+    { name: 'Settings', path: '/settings' },
+    { name: 'Settings Security', path: '/settings/security' },
+    { name: 'Settings Access', path: '/settings/access-control' },
+    { name: 'Settings Automation', path: '/settings/automation' },
+    { name: 'Settings Integrations', path: '/settings/integrations' },
+    { name: 'Models', path: '/agents/models' },
+    { name: 'Personas', path: '/agents/personas' },
+    { name: 'Skill Bundles', path: '/agents/skill-bundles' },
+    { name: 'Flock Directory', path: '/agents/flock-directory' },
+    { name: 'Marketplace', path: '/marketplace' },
+];
+
+test.describe('Accessibility audit', () => {
+    for (const { name, path } of STATIC_PAGES) {
+        test(`${name} (${path}) has no critical a11y violations`, async ({ page }) => {
+            await gotoWithRetry(page, path);
+            await page.waitForLoadState('networkidle');
+            // Give Angular time to render
+            await page.waitForTimeout(1000);
+
+            const results = await new AxeBuilder({ page })
+                .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
+                .analyze();
+
+            const critical = results.violations.filter(
+                (v) => v.impact === 'critical' || v.impact === 'serious',
+            );
+
+            if (critical.length > 0) {
+                const summary = critical.map((v) => {
+                    const nodes = v.nodes.slice(0, 3).map((n) => n.html).join('\n    ');
+                    return `[${v.impact}] ${v.id}: ${v.description}\n  Help: ${v.helpUrl}\n  Nodes:\n    ${nodes}`;
+                }).join('\n\n');
+                console.log(`\n=== A11y violations on ${name} (${path}) ===\n${summary}\n`);
+            }
+
+            // Fail on critical/serious violations
+            expect(critical, `${name} has ${critical.length} critical/serious a11y violations`).toHaveLength(0);
+        });
+    }
+});


### PR DESCRIPTION
## Summary
- Ran axe-core WCAG 2.1 AA audit across **25 pages** — found **2 violation types** on 13 pages
- **color-contrast** (serious, 11 pages): `--text-tertiary` `#6b6e88` failed 4.5:1 ratio on card/surface backgrounds. Bumped to `#8284a0` (4.85:1 minimum)
- **select-name** (critical, 3 pages): sort/filter `<select>` elements missing accessible names. Added `aria-label` to all 6 instances (agents, councils, sessions, flock-directory)
- Added `e2e/accessibility.spec.ts` with `@axe-core/playwright` for ongoing WCAG regression testing

## Files changed
- `client/src/styles.css` — bump `--text-tertiary` color
- `client/src/app/features/agents/agent-list.component.ts` — aria-label on sort select
- `client/src/app/features/councils/council-list.component.ts` — aria-label on sort select
- `client/src/app/features/sessions/session-list.component.ts` — aria-label on source filter
- `client/src/app/features/flock-directory/flock-directory.component.ts` — aria-label on 3 filter selects
- `e2e/accessibility.spec.ts` — new axe-core a11y e2e test (25 pages)

## Test plan
- [x] axe-core audit: 25/25 pages pass (0 critical/serious violations)
- [x] TSC: 0 errors
- [x] Visual check that tertiary text is still readable but visually subdued

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6