### PR TITLE
feat(ui): Phase 1 UI polish — animations and micro-interactions

### DIFF
--- a/client/src/app/animations/route-transitions.ts
+++ b/client/src/app/animations/route-transitions.ts
@@ -1,11 +1,20 @@
-import { animate, query, style, transition, trigger } from '@angular/animations';
+import { animate, group, query, style, transition, trigger } from '@angular/animations';
 
-/** Subtle enter-only transition on primary route outlet (transform + opacity). Duration matches `:root --motion-route-ms`. */
+/** Smooth crossfade route transition with exit fade-out and enter slide-up. Duration matches `:root --motion-route-ms`. */
 export const pageRouteAnimation = trigger('pageRoute', [
     transition('* => *', [
-        query(':enter', [
-            style({ opacity: 0, transform: 'translateY(8px)' }),
-            animate('220ms cubic-bezier(0.22, 1, 0.36, 1)', style({ opacity: 1, transform: 'translateY(0)' })),
+        query(':enter, :leave', [
+            style({ position: 'absolute', top: 0, left: 0, width: '100%' }),
         ], { optional: true }),
+        group([
+            query(':leave', [
+                style({ opacity: 1, transform: 'translateY(0)' }),
+                animate('160ms cubic-bezier(0.4, 0, 1, 1)', style({ opacity: 0, transform: 'translateY(-4px)' })),
+            ], { optional: true }),
+            query(':enter', [
+                style({ opacity: 0, transform: 'translateY(12px)' }),
+                animate('280ms 80ms cubic-bezier(0.22, 1, 0.36, 1)', style({ opacity: 1, transform: 'translateY(0)' })),
+            ], { optional: true }),
+        ]),
     ]),
 ]);

--- a/client/src/app/shared/components/command-palette.component.ts
+++ b/client/src/app/shared/components/command-palette.component.ts
@@ -85,15 +85,17 @@ interface CommandItem {
             position: fixed;
             inset: 0;
             z-index: 9999;
-            background: var(--overlay);
+            background: var(--overlay-heavy);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
             display: flex;
             justify-content: center;
             padding-top: 15vh;
-            animation: fadeIn 0.1s ease;
+            animation: backdropIn 0.15s ease;
         }
-        @keyframes fadeIn {
-            from { opacity: 0; }
-            to { opacity: 1; }
+        @keyframes backdropIn {
+            from { opacity: 0; backdrop-filter: blur(0); }
+            to { opacity: 1; backdrop-filter: blur(8px); }
         }
         .palette {
             width: 560px;
@@ -101,11 +103,16 @@ interface CommandItem {
             background: var(--bg-surface, #1a1a2e);
             border: 1px solid var(--border-bright, #333);
             border-radius: 12px;
-            box-shadow: 0 16px 48px var(--shadow-deep);
+            box-shadow: 0 16px 48px var(--shadow-deep), 0 0 80px rgba(0, 229, 255, 0.06);
             display: flex;
             flex-direction: column;
             overflow: hidden;
             align-self: flex-start;
+            animation: paletteIn 0.2s cubic-bezier(0.22, 1, 0.36, 1);
+        }
+        @keyframes paletteIn {
+            from { opacity: 0; transform: scale(0.95) translateY(-8px); }
+            to { opacity: 1; transform: scale(1) translateY(0); }
         }
         .palette__search {
             display: flex;
@@ -182,6 +189,9 @@ interface CommandItem {
         .palette__item--active {
             background: var(--accent-cyan-dim, var(--accent-cyan-subtle));
             color: var(--text-primary, #eee);
+        }
+        .palette__item--active {
+            box-shadow: inset 3px 0 0 var(--accent-cyan);
         }
         .palette__item-icon {
             width: 24px;

--- a/client/src/app/shared/components/sidebar.component.ts
+++ b/client/src/app/shared/components/sidebar.component.ts
@@ -165,13 +165,14 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
             scrollbar-color: var(--border-bright) transparent;
         }
         .sidebar__link {
-            display: block;
+            display: flex;
+            align-items: center;
             padding: 0.75rem 1.5rem;
             color: var(--text-secondary);
             text-decoration: none;
             font-size: 0.85rem;
             letter-spacing: 0.03em;
-            transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, text-shadow 0.2s ease;
+            transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, text-shadow 0.2s ease, padding-left 0.15s ease;
             border-left: 3px solid transparent;
             position: relative;
         }
@@ -185,13 +186,14 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
             width: 3px;
             background: var(--accent-cyan);
             transform: scaleY(0);
-            transition: transform 0.2s ease;
+            transition: transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
             border-radius: 0 2px 2px 0;
         }
         @media (hover: hover) {
             .sidebar__link:hover {
                 background: var(--bg-hover);
                 color: var(--accent-cyan);
+                padding-left: 1.65rem;
             }
             .sidebar__link:hover::before {
                 transform: scaleY(1);
@@ -202,10 +204,17 @@ const STORAGE_KEY = 'sidebar_sections_collapsed';
             background: linear-gradient(90deg, var(--accent-cyan-subtle) 0%, transparent 100%);
             border-left: 3px solid var(--accent-cyan);
             text-shadow: 0 0 8px var(--accent-cyan-border);
-            animation: sidebarActiveGlow 0.3s ease-out;
+            animation: sidebarActiveGlow 0.35s cubic-bezier(0.22, 1, 0.36, 1);
         }
         @keyframes sidebarActiveGlow {
-            from { background: transparent; border-left-color: transparent; }
+            from {
+                background: transparent;
+                border-left-color: transparent;
+                padding-left: 1rem;
+            }
+            to {
+                padding-left: 1.5rem;
+            }
         }
         .sidebar__link--active::before {
             display: none;

--- a/client/src/app/shared/components/toast-container.component.ts
+++ b/client/src/app/shared/components/toast-container.component.ts
@@ -60,29 +60,31 @@ import type { NotificationType } from '../../core/models/notification.model';
             align-items: flex-start;
             gap: 0.5rem;
             padding: 0.75rem 1rem;
-            border-radius: var(--radius);
+            border-radius: var(--radius-lg);
             border: 1px solid;
             font-size: 0.8rem;
             pointer-events: auto;
-            animation: toast-in 0.3s ease-out;
-            backdrop-filter: blur(8px);
+            animation: toast-in 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
             position: relative;
             overflow: hidden;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
         }
 
         /* Stagger toasts */
         .toast:nth-child(1) { animation-delay: 0ms; }
-        .toast:nth-child(2) { animation-delay: 60ms; }
-        .toast:nth-child(3) { animation-delay: 120ms; }
+        .toast:nth-child(2) { animation-delay: 80ms; }
+        .toast:nth-child(3) { animation-delay: 160ms; }
 
         @keyframes toast-in {
             from {
                 opacity: 0;
-                transform: translateX(1rem);
+                transform: translateX(1.5rem) scale(0.95);
             }
             to {
                 opacity: 1;
-                transform: translateX(0);
+                transform: translateX(0) scale(1);
             }
         }
 

--- a/client/src/app/shared/directives/reveal-on-scroll.directive.ts
+++ b/client/src/app/shared/directives/reveal-on-scroll.directive.ts
@@ -1,0 +1,86 @@
+import { Directive, ElementRef, Input, OnInit, OnDestroy, inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
+/**
+ * Reveals an element with a fade+slide animation when it enters the viewport.
+ * Usage: `<div appRevealOnScroll>` or `<div appRevealOnScroll="slideRight">`
+ * Variants: slideUp (default), slideRight, scaleIn, fadeOnly
+ */
+@Directive({ selector: '[appRevealOnScroll]' })
+export class RevealOnScrollDirective implements OnInit, OnDestroy {
+    @Input('appRevealOnScroll') variant: '' | 'slideUp' | 'slideRight' | 'scaleIn' | 'fadeOnly' = '';
+    @Input() revealDelay = 0;
+    @Input() revealThreshold = 0.15;
+
+    private readonly el = inject(ElementRef);
+    private readonly platformId = inject(PLATFORM_ID);
+    private observer: IntersectionObserver | null = null;
+
+    ngOnInit(): void {
+        if (!isPlatformBrowser(this.platformId)) return;
+
+        // Check reduced motion preference
+        if (globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+            this.el.nativeElement.style.opacity = '1';
+            return;
+        }
+
+        const element = this.el.nativeElement as HTMLElement;
+        element.style.opacity = '0';
+        element.style.willChange = 'opacity, transform';
+
+        this.observer = new IntersectionObserver(
+            (entries) => {
+                for (const entry of entries) {
+                    if (entry.isIntersecting) {
+                        this.reveal(entry.target as HTMLElement);
+                        this.observer?.unobserve(entry.target);
+                    }
+                }
+            },
+            { threshold: this.revealThreshold, rootMargin: '0px 0px -40px 0px' },
+        );
+        this.observer.observe(element);
+    }
+
+    ngOnDestroy(): void {
+        this.observer?.disconnect();
+    }
+
+    private reveal(el: HTMLElement): void {
+        const v = this.variant || 'slideUp';
+        const delay = this.revealDelay;
+
+        const keyframes: Keyframe[] = (() => {
+            switch (v) {
+                case 'slideRight':
+                    return [
+                        { opacity: 0, transform: 'translateX(-16px)' },
+                        { opacity: 1, transform: 'translateX(0)' },
+                    ];
+                case 'scaleIn':
+                    return [
+                        { opacity: 0, transform: 'scale(0.92)' },
+                        { opacity: 1, transform: 'scale(1)' },
+                    ];
+                case 'fadeOnly':
+                    return [
+                        { opacity: 0 },
+                        { opacity: 1 },
+                    ];
+                default: // slideUp
+                    return [
+                        { opacity: 0, transform: 'translateY(16px)' },
+                        { opacity: 1, transform: 'translateY(0)' },
+                    ];
+            }
+        })();
+
+        el.animate(keyframes, {
+            duration: 400,
+            delay,
+            easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+            fill: 'forwards',
+        });
+    }
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -391,11 +391,13 @@ select:focus-visible {
 .btn--primary { background: transparent; color: var(--accent-cyan); border-color: var(--accent-cyan); }
 .btn--primary:hover:not(:disabled) {
     background: var(--accent-cyan-dim);
-    box-shadow: var(--glow-cyan);
-    transform: translateY(-1px);
+    box-shadow: var(--glow-cyan), 0 4px 16px rgba(0, 229, 255, 0.1);
+    transform: translateY(-2px);
+    border-color: var(--accent-cyan);
 }
 .btn--primary:active:not(:disabled) {
-    transform: translateY(0);
+    transform: translateY(0) scale(0.97);
+    transition-duration: 0.08s;
 }
 .btn--primary:disabled { opacity: 0.3; cursor: not-allowed; }
 .btn--secondary { background: transparent; color: var(--text-secondary); border-color: var(--border-bright); }
@@ -475,6 +477,15 @@ button:active:not(:disabled) {
 @keyframes subtlePulse {
     0%, 100% { opacity: 0.6; transform: translateX(-50%) scale(1); }
     50% { opacity: 1; transform: translateX(-50%) scale(1.05); }
+}
+
+/* ── Ambient glow — subtle breathing effect for hero/feature cards ── */
+@keyframes ambientGlow {
+    0%, 100% { box-shadow: 0 0 20px rgba(0, 229, 255, 0.04), 0 0 60px rgba(0, 229, 255, 0.02); }
+    50% { box-shadow: 0 0 30px rgba(0, 229, 255, 0.08), 0 0 80px rgba(0, 229, 255, 0.04); }
+}
+.ambient-glow {
+    animation: ambientGlow 4s ease-in-out infinite;
 }
 
 /* ── Staggered entrance animation ── */
@@ -979,31 +990,38 @@ select:focus {
     position: fixed;
     bottom: 2rem;
     right: 2rem;
-    width: 36px;
-    height: 36px;
+    width: 38px;
+    height: 38px;
     border-radius: 50%;
-    background: var(--bg-raised);
+    background: var(--glass-bg);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
     border: 1px solid var(--border-bright);
     color: var(--accent-cyan);
-    font-size: 1rem;
+    font-size: 0.9rem;
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
     opacity: 0;
-    transform: translateY(8px);
-    transition: opacity 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+    transform: translateY(12px) scale(0.8);
+    transition: opacity 0.25s cubic-bezier(0.22, 1, 0.36, 1), transform 0.25s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.2s ease, border-color 0.2s ease;
     pointer-events: none;
     z-index: 50;
 }
 .scroll-to-top--visible {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) scale(1);
     pointer-events: auto;
 }
 .scroll-to-top:hover {
-    box-shadow: var(--glow-cyan);
+    box-shadow: var(--glow-cyan), 0 4px 16px rgba(0, 0, 0, 0.3);
     border-color: var(--accent-cyan);
+    transform: translateY(-2px) scale(1.05);
+}
+.scroll-to-top:active {
+    transform: translateY(0) scale(0.95);
+    transition-duration: 0.08s;
 }
 
 /* ── Page skeleton loading ── */


### PR DESCRIPTION
## Summary
- **Route transitions**: smooth crossfade with exit fade-out + enter slide-up (previously enter-only)
- **Command palette**: scale-in animation, blurred backdrop, subtle cyan glow, active item indicator
- **Sidebar**: hover nudge micro-animation, spring-eased active glow, flex layout
- **Toasts**: glass blur, scale entrance, deeper shadow, larger border radius
- **Scroll-to-top**: glassmorphism background, spring scale entrance, hover lift effect
- **Buttons**: enhanced primary hover glow with secondary shadow, snappy active press
- **New `RevealOnScrollDirective`**: IntersectionObserver-based scroll reveal with 4 animation variants (slideUp, slideRight, scaleIn, fadeOnly) — ready for pages to adopt
- **New `.ambient-glow` utility**: breathing glow effect for hero/feature cards
- All animations respect `prefers-reduced-motion`

## Test plan
- [ ] Navigate between pages — verify smooth crossfade (old page fades out, new slides in)
- [ ] Open command palette (Cmd+K) — verify scale-in animation and blurred backdrop
- [ ] Hover sidebar links — verify nudge and cyan glow line
- [ ] Trigger a toast notification — verify glass effect and slide-in
- [ ] Scroll down on any long page — verify scroll-to-top button appears with scale animation
- [ ] Test with `prefers-reduced-motion: reduce` — all animations should be suppressed
- [ ] Mobile: verify sidebar, toasts, and command palette still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)