### PR TITLE
feat(ui): Phase 2 UI polish — depth, stagger, micro-interactions

### DIFF
--- a/client/src/app/features/dashboard/dashboard.component.css
+++ b/client/src/app/features/dashboard/dashboard.component.css
@@ -1,7 +1,8 @@
 .dashboard { padding: 1.25rem; overflow-y: auto; height: 100%; animation: dashEnter 0.3s ease-out; }
 @keyframes dashEnter {
-    from { opacity: 0; transform: translateY(12px); }
-    to { opacity: 1; transform: translateY(0); }
+    from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+    60% { filter: blur(0); }
+    to { opacity: 1; transform: translateY(0); filter: blur(0); }
 }
 
 /* Sandbox banner */
@@ -105,8 +106,8 @@
     animation: pulse-dot .6s infinite;
 }
 @keyframes pulse-dot {
-    0%, 100% { opacity: 1; }
-    50% { opacity: .3; }
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: .3; transform: scale(0.7); }
 }
 .dash-toolbar__right { display: flex; gap: .5rem; align-items: center; }
 
@@ -161,7 +162,21 @@
 /* Widget grid — fluid with container queries */
 .widget-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; align-items: start; align-content: start; }
 .widget--full { grid-column: 1 / -1; }
-.widget { transition: outline .15s, transform 0.2s ease, box-shadow 0.25s ease; border-radius: var(--radius-lg); }
+.widget {
+    transition: outline .15s, transform 0.2s ease, box-shadow 0.25s ease;
+    border-radius: var(--radius-lg);
+    animation: widgetEnter 0.4s ease-out both;
+}
+.widget:nth-child(1) { animation-delay: 0ms; }
+.widget:nth-child(2) { animation-delay: 60ms; }
+.widget:nth-child(3) { animation-delay: 120ms; }
+.widget:nth-child(4) { animation-delay: 180ms; }
+.widget:nth-child(5) { animation-delay: 240ms; }
+.widget:nth-child(6) { animation-delay: 300ms; }
+@keyframes widgetEnter {
+    from { opacity: 0; transform: translateY(16px) scale(0.98); }
+    to { opacity: 1; transform: translateY(0) scale(1); }
+}
 .widget--drag-over { outline: 2px dashed var(--accent-cyan); outline-offset: 4px; }
 .widget[draggable="true"] { cursor: grab; }
 .widget[draggable="true"]:active { cursor: grabbing; }
@@ -177,13 +192,14 @@
 .metrics-row { display: grid; grid-template-columns: repeat(auto-fill,minmax(140px,1fr)); gap: .75rem; }
 .metric-card {
     padding: .75rem 1rem; display: flex; flex-direction: column; gap: .2rem;
-    transition: border-color .2s, box-shadow .25s, transform .2s;
+    transition: border-color .2s, box-shadow .3s, transform .25s cubic-bezier(0.34, 1.56, 0.64, 1);
     background: var(--bg-surface); border: 1px solid var(--border); border-radius: var(--radius-lg);
+    backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
 }
 .metric-card:hover {
-    border-color: var(--border-bright);
-    transform: translateY(-1px);
-    box-shadow: 0 4px 16px var(--shadow-deep), 0 0 12px var(--accent-cyan-subtle);
+    border-color: var(--accent-cyan-border);
+    transform: translateY(-3px) scale(1.02);
+    box-shadow: 0 8px 24px var(--shadow-deep), 0 0 20px var(--accent-cyan-subtle), inset 0 1px 0 rgba(255,255,255,0.04);
 }
 .metric-card--highlight { border-color: var(--accent-amber); border-style: dashed; }
 .metric-card__header { display: flex; align-items: center; gap: .35rem; }
@@ -233,9 +249,14 @@
 .agent-card {
     display: block; background: var(--bg-raised); border: 1px solid var(--border);
     border-radius: var(--radius); padding: .75rem; text-decoration: none;
-    color: inherit; cursor: pointer; transition: border-color .15s,box-shadow .15s;
+    color: inherit; cursor: pointer;
+    transition: border-color .2s, box-shadow .3s, transform .25s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
-.agent-card:hover { border-color: var(--accent-cyan); box-shadow: 0 0 12px var(--accent-cyan-subtle); }
+.agent-card:hover {
+    border-color: var(--accent-cyan);
+    box-shadow: 0 6px 20px var(--shadow-deep), 0 0 16px var(--accent-cyan-subtle);
+    transform: translateY(-2px);
+}
 .agent-card__top { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: .5rem; }
 .agent-card__info, .agent-card__stat { display: flex; flex-direction: column; gap: .1rem; }
 .agent-card__name-row { display: flex; align-items: center; gap: .35rem; }
@@ -458,6 +479,28 @@
     border-radius: var(--radius-sm); transition: all .15s;
 }
 .empty-state__link:hover { background: var(--accent-cyan-subtle); border-color: var(--accent-cyan); }
+
+/* Staggered list entrance */
+.session-item, .activity-item {
+    animation: listItemEnter 0.3s ease-out both;
+}
+.session-item:nth-child(1), .activity-item:nth-child(1) { animation-delay: 0ms; }
+.session-item:nth-child(2), .activity-item:nth-child(2) { animation-delay: 40ms; }
+.session-item:nth-child(3), .activity-item:nth-child(3) { animation-delay: 80ms; }
+.session-item:nth-child(4), .activity-item:nth-child(4) { animation-delay: 120ms; }
+.session-item:nth-child(5), .activity-item:nth-child(5) { animation-delay: 160ms; }
+@keyframes listItemEnter {
+    from { opacity: 0; transform: translateX(-8px); }
+    to { opacity: 1; transform: translateX(0); }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    .widget, .session-item, .activity-item { animation: none; }
+    .metric-card:hover { transform: none; }
+    .agent-card:hover { transform: none; }
+    .connection-badge__dot { animation: none; }
+}
 
 /* Responsive */
 @media (max-width:768px) {

--- a/client/src/app/shared/components/empty-state.component.ts
+++ b/client/src/app/shared/components/empty-state.component.ts
@@ -51,6 +51,11 @@ import { RouterLink } from '@angular/router';
                     rgba(30, 32, 53, 0.15) 4px
                 );
             transition: border-color 0.3s ease;
+            animation: emptyEnter 0.5s ease-out both;
+        }
+        @keyframes emptyEnter {
+            from { opacity: 0; transform: scale(0.96); }
+            to { opacity: 1; transform: scale(1); }
         }
         .empty-state:hover {
             border-color: var(--border-bright);
@@ -65,8 +70,8 @@ import { RouterLink } from '@angular/router';
             animation: gentleFloat 3s ease-in-out infinite;
         }
         @keyframes gentleFloat {
-            0%, 100% { transform: translateY(0); }
-            50% { transform: translateY(-6px); }
+            0%, 100% { transform: translateY(0); filter: drop-shadow(0 4px 6px rgba(0,0,0,0.3)); }
+            50% { transform: translateY(-6px); filter: drop-shadow(0 10px 12px rgba(0,0,0,0.15)); }
         }
         .empty-state__title {
             margin: 0 0 0.5rem;
@@ -117,6 +122,7 @@ import { RouterLink } from '@angular/router';
             color: var(--text-tertiary);
         }
         @media (prefers-reduced-motion: reduce) {
+            .empty-state { animation: none; }
             .empty-state__icon { animation: none; }
             .empty-state__action:hover { transform: none; }
             .empty-state__action:active { transform: none; }

--- a/client/src/app/shared/components/header.component.ts
+++ b/client/src/app/shared/components/header.component.ts
@@ -60,7 +60,9 @@ import type { AlgoChatNetwork } from '../../core/models/session.model';
             justify-content: space-between;
             padding: 0 1.5rem;
             height: 56px;
-            background: var(--bg-surface);
+            background: rgba(15, 16, 24, 0.85);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
             color: var(--text-primary);
             border-bottom: 1px solid var(--border);
         }
@@ -100,12 +102,16 @@ import type { AlgoChatNetwork } from '../../core/models/session.model';
             background: transparent;
             color: var(--text-tertiary);
             cursor: pointer;
-            transition: background 0.15s, color 0.15s, box-shadow 0.15s;
+            transition: background 0.15s, color 0.15s, box-shadow 0.15s, transform 0.15s;
             text-transform: uppercase;
         }
         .network-btn:hover:not(:disabled):not(.network-btn--active) {
             background: var(--bg-hover);
             color: var(--text-secondary);
+            transform: translateY(-1px);
+        }
+        .network-btn:active:not(:disabled) {
+            transform: scale(0.95);
         }
         .network-btn:disabled {
             opacity: 0.4;
@@ -162,7 +168,17 @@ import type { AlgoChatNetwork } from '../../core/models/session.model';
             width: 100%;
             background: var(--text-secondary);
             border-radius: 1px;
-            transition: background 0.15s;
+            transition: transform 0.25s ease, opacity 0.2s, background 0.15s;
+            transform-origin: center;
+        }
+        :host-context(.sidebar-open) .header__hamburger-icon span:nth-child(1) {
+            transform: translateY(6px) rotate(45deg);
+        }
+        :host-context(.sidebar-open) .header__hamburger-icon span:nth-child(2) {
+            opacity: 0; transform: scaleX(0);
+        }
+        :host-context(.sidebar-open) .header__hamburger-icon span:nth-child(3) {
+            transform: translateY(-6px) rotate(-45deg);
         }
 
         /* Show hamburger only on mobile */

--- a/client/src/app/shared/components/mobile-bottom-nav.component.ts
+++ b/client/src/app/shared/components/mobile-bottom-nav.component.ts
@@ -65,10 +65,11 @@ const NAV_ITEMS: BottomNavItem[] = [
             align-items: stretch;
             justify-content: space-around;
             height: 56px;
-            background: var(--glass-bg-solid);
-            backdrop-filter: blur(12px);
-            -webkit-backdrop-filter: blur(12px);
+            background: rgba(15, 16, 24, 0.88);
+            backdrop-filter: blur(16px) saturate(1.2);
+            -webkit-backdrop-filter: blur(16px) saturate(1.2);
             border-top: 1px solid var(--border-faint);
+            box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.3);
             padding-bottom: env(safe-area-inset-bottom, 0);
         }
 
@@ -103,6 +104,12 @@ const NAV_ITEMS: BottomNavItem[] = [
             height: 2px;
             background: var(--accent-cyan);
             border-radius: 0 0 2px 2px;
+            animation: navIndicator 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+            box-shadow: 0 0 8px rgba(0, 229, 255, 0.4);
+        }
+        @keyframes navIndicator {
+            from { transform: scaleX(0); }
+            to { transform: scaleX(1); }
         }
 
         .bottom-nav__label {
@@ -132,6 +139,23 @@ const NAV_ITEMS: BottomNavItem[] = [
             justify-content: center;
             line-height: 1;
             box-shadow: 0 0 6px rgba(0, 229, 255, 0.4);
+            animation: badgePop 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+        }
+        @keyframes badgePop {
+            from { transform: scale(0); }
+            to { transform: scale(1); }
+        }
+
+        /* Add active icon scale */
+        .bottom-nav__item--active .bottom-nav__icon-wrapper {
+            transform: scale(1.1);
+            transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+        }
+        .bottom-nav__icon-wrapper {
+            transition: transform 0.15s;
+        }
+        .bottom-nav__item:active .bottom-nav__icon-wrapper {
+            transform: scale(0.9);
         }
     `,
 })

--- a/client/src/app/shared/components/status-badge.component.ts
+++ b/client/src/app/shared/components/status-badge.component.ts
@@ -25,10 +25,13 @@ import { Component, ChangeDetectionStrategy, input } from '@angular/core';
         }
         .status-badge--idle { background: var(--bg-raised); color: var(--text-secondary); border-color: var(--border-bright); }
         .status-badge--loading { background: var(--accent-cyan-dim, var(--accent-cyan-dim)); color: var(--accent-cyan, #00c8ff); border-color: var(--accent-cyan-border); }
-        .status-badge--running { background: var(--accent-green-dim); color: var(--accent-green); border-color: var(--accent-green-border); }
+        .status-badge--running { background: var(--accent-green-dim); color: var(--accent-green); border-color: var(--accent-green-border); box-shadow: 0 0 6px rgba(52, 211, 153, 0.15); }
         .status-badge--thinking { background: var(--accent-purple-dim, var(--accent-purple-subtle)); color: var(--accent-purple, #a855f7); border-color: var(--accent-purple-border); animation: statusPulse 1.5s ease-in-out infinite; }
         .status-badge--tool_use { background: var(--accent-cyan-dim, var(--accent-cyan-dim)); color: var(--accent-cyan, #00c8ff); border-color: var(--accent-cyan-border); animation: statusPulse 1s ease-in-out infinite; }
-        @keyframes statusPulse { 0%, 100% { opacity: 1; box-shadow: none; } 50% { opacity: 0.7; box-shadow: 0 0 6px 1px currentColor; } }
+        @keyframes statusPulse {
+            0%, 100% { opacity: 1; box-shadow: none; transform: scale(1); }
+            50% { opacity: 0.8; box-shadow: 0 0 8px 2px currentColor; transform: scale(1.04); }
+        }
         .status-badge--paused { background: var(--accent-amber-dim); color: var(--accent-amber); border-color: var(--accent-amber-border); }
         .status-badge--stopped { background: var(--bg-raised); color: var(--text-tertiary); border-color: var(--border); }
         .status-badge--error { background: var(--accent-red-dim); color: var(--accent-red); border-color: var(--accent-red-border); }
@@ -39,8 +42,8 @@ import { Component, ChangeDetectionStrategy, input } from '@angular/core';
         .status-badge--branching,
         .status-badge--validating { background: var(--accent-cyan-dim, var(--accent-cyan-dim)); color: var(--accent-cyan, #00c8ff); border-color: var(--accent-cyan-border); animation: statusPulse 1.5s ease-in-out infinite; }
         .status-badge--cancelled { background: var(--bg-raised); color: var(--text-tertiary); border-color: var(--border); }
-        .status-badge--active { background: var(--accent-green-dim); color: var(--accent-green); border-color: var(--accent-green-border); }
-        .status-badge--connected { background: var(--accent-green-dim); color: var(--accent-green); border-color: var(--accent-green-border); }
+        .status-badge--active { background: var(--accent-green-dim); color: var(--accent-green); border-color: var(--accent-green-border); box-shadow: 0 0 6px rgba(52, 211, 153, 0.15); }
+        .status-badge--connected { background: var(--accent-green-dim); color: var(--accent-green); border-color: var(--accent-green-border); box-shadow: 0 0 6px rgba(52, 211, 153, 0.15); }
         .status-badge--disconnected { background: var(--accent-red-dim); color: var(--accent-red); border-color: var(--accent-red-border); }
     `,
 })

--- a/client/src/app/shared/components/terminal-chat.component.ts
+++ b/client/src/app/shared/components/terminal-chat.component.ts
@@ -65,7 +65,11 @@ interface AutocompleteItem {
                 }
                 @if (thinking()) {
                     <div class="terminal__thinking" aria-label="Agent is thinking">
-                        <span class="terminal__thinking-dot"></span>
+                        <span class="terminal__thinking-dots">
+                            <span class="terminal__thinking-dot"></span>
+                            <span class="terminal__thinking-dot"></span>
+                            <span class="terminal__thinking-dot"></span>
+                        </span>
                         <span>thinking...</span>
                     </div>
                 }
@@ -150,6 +154,11 @@ interface AutocompleteItem {
             white-space: pre-wrap;
             position: relative;
             padding-right: 2rem;
+            animation: msgEnter 0.3s ease-out both;
+        }
+        @keyframes msgEnter {
+            from { opacity: 0; transform: translateY(6px); }
+            to { opacity: 1; transform: translateY(0); }
         }
         .terminal__line--inbound .terminal__prompt { color: var(--accent-cyan); }
         .terminal__line--outbound .terminal__prompt { color: #7ee787; }
@@ -262,16 +271,23 @@ interface AutocompleteItem {
             font-size: 0.75rem;
             padding: 0.25rem 0;
         }
+        .terminal__thinking-dots {
+            display: flex;
+            gap: 3px;
+            align-items: center;
+        }
         .terminal__thinking-dot {
-            width: 6px;
-            height: 6px;
+            width: 5px;
+            height: 5px;
             border-radius: 50%;
             background: #f0883e;
-            animation: pulse 1.5s ease-in-out infinite;
+            animation: thinkWave 1.4s ease-in-out infinite;
         }
-        @keyframes pulse {
-            0%, 100% { opacity: 0.3; transform: scale(0.8); }
-            50% { opacity: 1; transform: scale(1.2); }
+        .terminal__thinking-dot:nth-child(2) { animation-delay: 0.15s; }
+        .terminal__thinking-dot:nth-child(3) { animation-delay: 0.3s; }
+        @keyframes thinkWave {
+            0%, 80%, 100% { opacity: 0.3; transform: scale(0.7) translateY(0); }
+            40% { opacity: 1; transform: scale(1.1) translateY(-4px); }
         }
         .terminal__empty {
             color: #484f58;
@@ -349,14 +365,21 @@ interface AutocompleteItem {
             right: 0;
             max-height: 220px;
             overflow-y: auto;
-            background: #161b22;
+            background: rgba(22, 27, 34, 0.95);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
             border: 1px solid #30363d;
             border-radius: var(--radius, 6px);
-            box-shadow: 0 4px 16px var(--shadow-deep);
+            box-shadow: 0 8px 24px rgba(0,0,0,0.4), 0 0 12px rgba(0,229,255,0.05);
             z-index: 10;
             margin-bottom: 4px;
             scrollbar-width: thin;
             scrollbar-color: #30363d transparent;
+            animation: acEnter 0.15s ease-out;
+        }
+        @keyframes acEnter {
+            from { opacity: 0; transform: translateY(4px) scale(0.98); }
+            to { opacity: 1; transform: translateY(0) scale(1); }
         }
         .autocomplete__item {
             display: flex;
@@ -372,6 +395,7 @@ interface AutocompleteItem {
         }
         .autocomplete__item--active {
             border-left: 2px solid var(--accent-cyan, #00e5ff);
+            background: rgba(0, 229, 255, 0.06);
         }
         .autocomplete__label {
             color: #f0f6fc;


### PR DESCRIPTION
## Summary
- **Dashboard**: Staggered widget entrance animations with blur-in, enhanced metric card hover (spring easing, glass backdrop, cyan glow border), agent card lift effect, staggered list items for sessions and activity feed
- **Header**: Glassmorphism backdrop blur, network button press feedback, hamburger icon animated X transform on sidebar open
- **Terminal chat**: Message slide-in entrance, 3-dot wave thinking indicator, glass autocomplete overlay with scale entrance, active item glow
- **Status badges**: Pulse animation now includes scale transform, running/active/connected states get subtle ambient glow
- **Empty state**: Scale-in entrance animation, floating icon dynamic drop shadow
- **Mobile bottom nav**: Enhanced glass blur with shadow, active indicator spring animation with glow, badge pop-in, icon scale tap feedback

## Test plan
- [ ] Dashboard loads with staggered widget animations
- [ ] Metric cards hover with spring lift + glow border
- [ ] Agent cards hover with subtle lift
- [ ] Header shows glass blur effect
- [ ] Terminal chat messages slide in on arrival
- [ ] Thinking indicator shows 3-dot wave animation
- [ ] Status badges pulse with scale on thinking/tool_use
- [ ] Empty states fade in with scale
- [ ] Mobile bottom nav active indicator animates on tab switch
- [ ] `prefers-reduced-motion` disables all animations
- [ ] Build passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)