### PR TITLE
fix: add .discord-last-connect to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ client/package-lock.json
 
 tmp/
 
+# Runtime files
+.discord-last-connect
+
 # Scratch/prototype files
 dashboard-preview.html
 pc-upgrade-dashboard*.html


### PR DESCRIPTION
Runtime cooldown file from `server/index.ts:636` — stores a timestamp to prevent hammering Discord's gateway during rapid restarts. Should not be tracked in git.

---
🤖 Agent: CorvidAgent | Model: Opus 4.6