### PR TITLE
fix(security): use actual tenant from request context in device auth verify page

### DIFF
--- a/server/routes/auth-flow.ts
+++ b/server/routes/auth-flow.ts
@@ -8,6 +8,7 @@ import type { Database } from 'bun:sqlite';
 import { json } from '../lib/response';
 import { parseBodyOrThrow, ValidationError, DeviceTokenSchema, DeviceAuthorizeSchema } from '../lib/validation';
 import { createLogger } from '../lib/logger';
+import type { RequestContext } from '../middleware/guards';
 
 const log = createLogger('AuthFlow');
 
@@ -58,6 +59,7 @@ export function handleAuthFlowRoutes(
     req: Request,
     url: URL,
     db: Database,
+    context?: RequestContext,
 ): Response | Promise<Response> | null {
     const path = url.pathname;
     const method = req.method;
@@ -79,7 +81,7 @@ export function handleAuthFlowRoutes(
 
     // Verify page (shows user code input)
     if (path === '/api/auth/verify' && method === 'GET') {
-        return handleVerifyPage(url);
+        return handleVerifyPage(url, context?.tenantId ?? 'default');
     }
 
     return null;
@@ -213,11 +215,12 @@ function escapeHtml(str: string): string {
         .replace(/'/g, '&#39;');
 }
 
-function handleVerifyPage(url: URL): Response {
+function handleVerifyPage(url: URL, tenantId: string): Response {
     const rawCode = url.searchParams.get('code') ?? '';
     // Validate: user codes are uppercase alphanumeric only
     const code = /^[A-Z0-9]{0,16}$/.test(rawCode) ? rawCode : '';
     const safeCode = escapeHtml(code);
+    const safeTenantId = JSON.stringify(tenantId);
 
     const html = `<!DOCTYPE html>
 <html><head><title>CorvidAgent - Device Authorization</title>
@@ -242,7 +245,7 @@ async function authorize() {
   const resp = await fetch('/api/auth/device/authorize', {
     method: 'POST',
     headers: {'Content-Type':'application/json'},
-    body: JSON.stringify({userCode:code,tenantId:'default',email:'owner@localhost',approve:true})
+    body: JSON.stringify({userCode:code,tenantId:${safeTenantId},email:'owner@localhost',approve:true})
   });
   if (resp.ok) { document.body.innerHTML = '<h1>Authorized!</h1><p>You can close this window.</p>'; }
   else { document.body.innerHTML = '<h1>Error</h1><p>Authorization failed.</p>'; }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -513,7 +513,7 @@ async function handleRoutes(
   if (billingResponse) return billingResponse;
 
   // Auth flow routes (device authorization for CLI login)
-  const authFlowResponse = handleAuthFlowRoutes(req, url, db);
+  const authFlowResponse = handleAuthFlowRoutes(req, url, db, context);
   if (authFlowResponse) return authFlowResponse;
 
   // Plugin routes


### PR DESCRIPTION
## Summary

- `handleVerifyPage` was embedding a hardcoded `tenantId:'default'` in the inline JS of the Device Auth verify page
- In multi-tenant deployments, CLI tokens would always be associated with `'default'` regardless of which tenant the user was actually authenticating against
- Now passes `context.tenantId` from the request context through to the page, injected as a `JSON.stringify`-safe literal (avoids XSS via HTML entity vs JS string escaping mismatch)

## Changes

- `auth-flow.ts`: `handleAuthFlowRoutes` now accepts optional `RequestContext`; `handleVerifyPage` takes `tenantId: string` and uses `JSON.stringify(tenantId)` for safe inline JS injection
- `routes/index.ts`: pass `context` to `handleAuthFlowRoutes`

## Test plan

- [ ] Single-tenant (default): verify page still works, token gets `tenantId:'default'`
- [ ] Multi-tenant: verify page injects correct tenant, token associated with right tenant
- [ ] Unauthenticated GET to `/api/auth/verify`: falls back to `'default'` via `context?.tenantId ?? 'default'`

From Rook's security audit of #1549.

🤖 Generated with [Claude Code](https://claude.com/claude-code)