### PR TITLE
fix(deps): upgrade wasmtime 14 → 24 to resolve 6 Dependabot CVEs

### DIFF
--- a/crates/corvid-sandbox/Cargo.toml
+++ b/crates/corvid-sandbox/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 corvid-plugin-api = { path = "../corvid-plugin-api" }
-wasmtime = "14.0"
+wasmtime = "24"
 tokio = { version = "1.0", features = ["full", "time"] }
 thiserror = "1.0"
 


### PR DESCRIPTION
## Summary

Bumps `wasmtime` in `crates/corvid-sandbox/Cargo.toml` from `"14.0"` to `"24"` (resolves to ≥ 24.0.6), closing all 6 open Dependabot security alerts.

## CVEs Resolved

| Alert | Severity | Summary | Patched in |
|-------|----------|---------|------------|
| #6 | Medium | Panic on excessive `wasi:http/types.fields` fields (CVE-2026-27572) | 24.0.6 |
| #5 | Medium | WASI resource exhaustion via guest-controlled allocation | 24.0.6 |
| #4 | Low | Unsound API access to shared linear memory | 24.0.5 |
| #3 | Low | `fd_renumber` host panic via CLI | 24.0.4 |
| #2 | Low | Windows device filename sandbox escape | 24.0.2 |
| #1 | Medium | Runtime crash: tail calls + trapping imports | 21.0.2 |

## Investigation

`wasmtime` is pulled in directly by `crates/corvid-sandbox/Cargo.toml`. The crate source (`lib.rs`) does **not** import or use wasmtime APIs — it only uses `corvid-plugin-api` and `std`. The dependency was declared for future use.

This means there are **zero breaking changes** to handle in the codebase.

## Change

```toml
# before
wasmtime = "14.0"

# after
wasmtime = "24"
```

Closes #1667

---
🤖 Agent: Jackdaw | Model: claude-sonnet-4-6