### PR TITLE
fix(discord): prevent false crash embeds when resuming ended sessions

### DIFF
--- a/server/discord/command-handlers/component-handlers.ts
+++ b/server/discord/command-handlers/component-handlers.ts
@@ -57,10 +57,11 @@ export async function handleComponentInteraction(
             // Un-archive the thread if it was archived
             await unarchiveThread(ctx.config.botToken, threadId);
 
-            // Resubscribe for responses
-            if (!ctx.threadCallbacks.has(threadId)) {
-                ctx.subscribeForResponseWithEmbed(info.sessionId, threadId, info.agentName, info.agentModel, info.projectName, info.displayColor, info.displayIcon, info.avatarUrl);
-            }
+            // Don't resubscribe here — the process isn't running yet.
+            // subscribeForResponseWithEmbed will be called by routeToThread when
+            // the user sends a message and resumeProcess actually starts the process.
+            // Subscribing now would start the zombie-detection timer against a
+            // non-running process, triggering a false "session ended unexpectedly" embed.
             ctx.threadLastActivity.set(threadId, Date.now());
 
             await acknowledgeButton(interaction, 'Session resumed — send a message to continue.');

--- a/server/discord/message-handler.ts
+++ b/server/discord/message-handler.ts
@@ -988,6 +988,18 @@ async function routeToThread(
         ? contextualContent
         : appendAttachmentUrls(withAuthorContext(text, authorId, authorUsername, threadId), attachments);
     ctx.processManager.resumeProcess(session, resumeText);
+    // Only subscribe if the process actually started — resumeProcess may fail
+    // (e.g., worktree cleaned up, spawn error) and returns void, so check the map.
+    // Without this guard, the zombie check fires 8s later on a never-started process,
+    // sending a false "session ended unexpectedly" crash embed.
+    if (!ctx.processManager.isRunning(sessionId)) {
+      log.warn('resumeProcess did not start — skipping subscription', { sessionId, threadId });
+      await sendEmbed(ctx.delivery, ctx.config.botToken, threadId, {
+        description: 'This session could not be resumed. Start a new `/session` to continue.',
+        color: 0xff3355,
+      });
+      return;
+    }
     subscribeForResponseWithEmbed(
       ctx.processManager,
       ctx.delivery,


### PR DESCRIPTION
## Summary

- **Resume button**: Removed premature `subscribeForResponseWithEmbed` call from the `resume_thread` handler — the subscription is already created by `routeToThread` when the user sends a message. Subscribing before the process starts triggers the zombie-detection timer against a non-running process → false crash embed.
- **Regular messages after session ends**: Added `isRunning()` guard after `resumeProcess()` in `routeToThread`. If the process didn't start (e.g., worktree cleaned up, spawn error), shows a clear "could not resume" embed instead of silently subscribing and triggering a false crash 8 seconds later.

## Root cause

PR #1660's zombie detection correctly checks `processManager.isRunning(sessionId)` every 8s during the typing interval. But both resume paths (button + message) created subscriptions before or without verifying the process was actually running, so the zombie check would fire on a process that never started.

## Test plan

- [ ] End a session, click Resume button → should NOT show "session ended unexpectedly" embed
- [ ] End a session, send a message in the thread → should either resume normally or show "could not be resumed" embed (not a false crash)
- [ ] Normal active session → typing indicator and crash detection still work as expected
- [ ] `bun x tsc --noEmit --skipLibCheck` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6