### PR TITLE
fix(discord): resume sessions when old process can't restart

### DIFF
--- a/server/discord/message-handler.ts
+++ b/server/discord/message-handler.ts
@@ -993,11 +993,24 @@ async function routeToThread(
     // Without this guard, the zombie check fires 8s later on a never-started process,
     // sending a false "session ended unexpectedly" crash embed.
     if (!ctx.processManager.isRunning(sessionId)) {
-      log.warn('resumeProcess did not start — skipping subscription', { sessionId, threadId });
-      await sendEmbed(ctx.delivery, ctx.config.botToken, threadId, {
-        description: 'This session could not be resumed. Start a new `/session` to continue.',
-        color: 0xff3355,
-      });
+      log.warn('resumeProcess did not start — creating fresh session in thread', { sessionId, threadId });
+      // Clear stale mapping and create a brand new session, same as expired sessions
+      ctx.threadSessions.delete(threadId);
+      const resumed = await resumeExpiredThreadSession(
+        ctx,
+        threadId,
+        threadInfo,
+        text,
+        authorId,
+        authorUsername,
+        attachments,
+      );
+      if (!resumed) {
+        await sendEmbed(ctx.delivery, ctx.config.botToken, threadId, {
+          description: 'This session could not be resumed. Start a new `/session` to continue.',
+          color: 0xff3355,
+        });
+      }
       return;
     }
     subscribeForResponseWithEmbed(


### PR DESCRIPTION
## Summary
- When `resumeProcess` fails (worktree cleaned up, spawn error), instead of showing a dead-end error ("This session could not be resumed"), fall through to `resumeExpiredThreadSession` which creates a brand new session in the same thread
- Preserves the zombie-detection guard from PR #1674 (no false crash embeds)
- Sessions can always be resumed by sending a message, even after the underlying process dies

**Root cause**: PR #1674 added an `isRunning` check after `resumeProcess` to prevent false crash embeds, but showed a hard error when resume failed instead of creating a fresh session. This blocked all session resumption after sessions ended.

## Test plan
- [ ] End a session naturally (let it complete)
- [ ] Send a message in the thread — should create a fresh session and respond
- [ ] Mention the bot in a thread with a dead session — should resume
- [ ] Verify no zombie "Still working" intervals after session ends (PR #1660 fix preserved)
- [ ] Verify no false "session ended unexpectedly" crash embeds (PR #1674 fix preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)