### PR TITLE
fix(discord): persist conversation summary across session resumes

### DIFF
--- a/server/db/migrations/110_session_conversation_summary.ts
+++ b/server/db/migrations/110_session_conversation_summary.ts
@@ -1,0 +1,16 @@
+import type { Database } from 'bun:sqlite';
+
+export function up(db: Database): void {
+    const cols = db.query('PRAGMA table_info(sessions)').all() as Array<{ name: string }>;
+
+    if (!cols.some((c) => c.name === 'conversation_summary')) {
+        db.exec('ALTER TABLE sessions ADD COLUMN conversation_summary TEXT DEFAULT NULL');
+    }
+}
+
+export function down(db: Database): void {
+    const cols = db.query('PRAGMA table_info(sessions)').all() as Array<{ name: string }>;
+    if (cols.some((c) => c.name === 'conversation_summary')) {
+        db.exec('ALTER TABLE sessions DROP COLUMN conversation_summary');
+    }
+}

--- a/server/db/schema/sessions.ts
+++ b/server/db/schema/sessions.ts
@@ -48,6 +48,7 @@ export const tables: string[] = [
         credits_consumed  REAL DEFAULT 0,
         restart_pending              INTEGER NOT NULL DEFAULT 0,
         server_restart_initiated_at  TEXT DEFAULT NULL,
+        conversation_summary         TEXT DEFAULT NULL,
         tenant_id                    TEXT NOT NULL DEFAULT 'default',
         created_at        TEXT DEFAULT (datetime('now')),
         updated_at        TEXT DEFAULT (datetime('now'))

--- a/server/db/sessions.ts
+++ b/server/db/sessions.ts
@@ -202,6 +202,23 @@ export function updateSessionAlgoSpent(db: Database, id: string, microAlgos: num
     ).run(microAlgos, id);
 }
 
+export function updateSessionSummary(db: Database, id: string, summary: string): void {
+    db.query("UPDATE sessions SET conversation_summary = ?, updated_at = datetime('now') WHERE id = ?").run(summary, id);
+}
+
+/**
+ * Get the conversation summary from the most recent session in a Discord thread.
+ * Used when creating a fresh session to carry over context from the previous one.
+ */
+export function getPreviousThreadSessionSummary(db: Database, threadId: string): string | null {
+    const row = db.query(
+        `SELECT conversation_summary FROM sessions
+         WHERE name = ? AND source = 'discord' AND conversation_summary IS NOT NULL
+         ORDER BY created_at DESC LIMIT 1`
+    ).get(`Discord thread:${threadId}`) as { conversation_summary: string } | null;
+    return row?.conversation_summary ?? null;
+}
+
 export function deleteSession(db: Database, id: string, tenantId: string = DEFAULT_TENANT_ID): boolean {
     if (!validateTenantOwnership(db, 'sessions', id, tenantId)) return false;
     const result = writeTransaction(db, (db) => {

--- a/server/discord/message-handler.ts
+++ b/server/discord/message-handler.ts
@@ -12,7 +12,7 @@ import { recordAudit } from '../db/audit';
 import { updateDiscordConfig } from '../db/discord-config';
 import { getMentionSession, saveMentionSession } from '../db/discord-mention-sessions';
 import { listProjects } from '../db/projects';
-import { createSession, getSession } from '../db/sessions';
+import { createSession, getSession, getPreviousThreadSessionSummary } from '../db/sessions';
 import type { DeliveryTracker } from '../lib/delivery-tracker';
 import { createLogger } from '../lib/logger';
 import { buildOllamaComplexityWarning } from '../lib/ollama-complexity-warning';
@@ -854,10 +854,16 @@ async function resumeExpiredThreadSession(
   });
   ctx.threadLastActivity.set(threadId, Date.now());
 
+  // Carry over context from the previous session in this thread (if any)
+  const previousSummary = getPreviousThreadSessionSummary(ctx.db, threadId);
+  const contextPrefix = previousSummary
+    ? `[Previous session context — the session was resumed, here is what was discussed before]\n${previousSummary}\n\n[New message from user]\n`
+    : '';
+
   // Start the process with the user's message (include attachment URLs in text so
   // the agent sees them even though startProcess only accepts strings).
   const textWithUrls = appendAttachmentUrls(withAuthorContext(text, authorId, authorUsername, threadId), attachments);
-  ctx.processManager.startProcess(newSession, textWithUrls);
+  ctx.processManager.startProcess(newSession, contextPrefix + textWithUrls);
 
   subscribeForResponseWithEmbed(
     ctx.processManager,
@@ -876,8 +882,11 @@ async function resumeExpiredThreadSession(
   );
 
   // Brief non-blocking notification
+  const resumeDesc = previousSummary
+    ? `Session resumed with **${agent.name}** (previous context carried over).`
+    : `Session resumed with **${agent.name}**.`;
   sendEmbed(ctx.delivery, ctx.config.botToken, threadId, {
-    description: `Session resumed with **${agent.name}**.`,
+    description: resumeDesc,
     color: 0x57f287,
   }).catch((err) =>
     log.debug('Failed to send resume embed', { error: err instanceof Error ? err.message : String(err) }),

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -14,7 +14,7 @@ import { LlmProviderRegistry } from '../providers/registry';
 import type { LlmProviderType } from '../providers/types';
 import type { ScheduleActionType } from '../../shared/types/schedules';
 import { hasClaudeAccess } from '../providers/router';
-import { getSession, getSessionMessages, updateSessionPid, updateSessionStatus, updateSessionCost, addSessionMessage, getParticipantForSession } from '../db/sessions';
+import { getSession, getSessionMessages, updateSessionPid, updateSessionStatus, updateSessionCost, addSessionMessage, getParticipantForSession, updateSessionSummary } from '../db/sessions';
 import { saveMemory } from '../db/agent-memories';
 import { McpServiceContainer, type McpServices } from './mcp-service-container';
 import { resolveSessionConfig } from './session-config-resolver';
@@ -1407,6 +1407,10 @@ export class ProcessManager {
             this.saveSessionSummaryToMemory(sessionId);
         }
 
+        // Always persist conversation summary to session record (even on crash)
+        // so resumed sessions can pick up context from the previous conversation
+        this.persistConversationSummary(sessionId);
+
         if (code !== 0) {
             const isAutoRestartable = meta?.source === 'algochat' && (meta?.restartCount ?? 0) < MAX_RESTARTS;
             this.eventBus.emit(sessionId, {
@@ -1492,6 +1496,30 @@ export class ProcessManager {
             log.info('Session summary saved to memory', { sessionId, key });
         } catch (err) {
             log.warn('Failed to save session summary to memory', {
+                sessionId,
+                error: err instanceof Error ? err.message : String(err),
+            });
+        }
+    }
+
+    /**
+     * Persist a conversation summary to the session record so that when a new
+     * session is created in the same thread, it can carry over context.
+     * Runs on every exit (including crashes) — fire-and-forget.
+     */
+    private persistConversationSummary(sessionId: string): void {
+        try {
+            const messages = getSessionMessages(this.db, sessionId);
+            const conversational = messages.filter(m => m.role === 'user' || m.role === 'assistant');
+            if (conversational.length === 0) return;
+
+            const summary = summarizeConversation(
+                conversational.map(m => ({ role: m.role, content: m.content })),
+            );
+            updateSessionSummary(this.db, sessionId, summary);
+            log.debug('Persisted conversation summary to session', { sessionId });
+        } catch (err) {
+            log.warn('Failed to persist conversation summary', {
                 sessionId,
                 error: err instanceof Error ? err.message : String(err),
             });


### PR DESCRIPTION
## Summary
- When a Discord thread session ends (clean or crash), the conversation is summarized and stored in the `sessions` table
- When a new session is created in the same thread, the previous summary is fetched and injected into the initial prompt so the agent knows what was previously discussed
- Resume embed now indicates when context was carried over

## Changes
- **Migration 110**: Adds `conversation_summary` TEXT column to `sessions`
- **`server/db/sessions.ts`**: New `updateSessionSummary()` and `getPreviousThreadSessionSummary()` helpers
- **`server/process/manager.ts`**: `persistConversationSummary()` runs on every session exit (including crashes)
- **`server/discord/message-handler.ts`**: `resumeExpiredThreadSession()` fetches and prepends previous context

## Test plan
- [ ] Verify migration runs cleanly on fresh DB
- [ ] Start a Discord thread session, have a conversation, let it expire
- [ ] Send a new message in the same thread — verify the resume embed says "previous context carried over"
- [ ] Verify the agent remembers what was discussed in the previous session
- [ ] Force-kill a session process, then resume — verify summary is still persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)