### PR TITLE
fix(sessions): recover from zero-turn death loop instead of killing session

### DIFF
--- a/server/discord/message-handler.ts
+++ b/server/discord/message-handler.ts
@@ -760,6 +760,13 @@ async function handleMentionReplyResume(
         ? contextualContent
         : appendAttachmentUrls(withAuthorContext(cleanText, authorId, authorUsername, channelId), attachments);
     ctx.processManager.resumeProcess(session, resumeText);
+
+    // If resumeProcess failed (e.g. death loop reset, spawn error), fall back to a new session
+    if (!ctx.processManager.isRunning(sessionId)) {
+      log.warn('Mention resumeProcess did not start — creating new mention session', { sessionId, channelId });
+      await handleMentionReply(ctx, channelId, _userId, messageId, text, mentions, authorId, authorUsername, attachments);
+      return;
+    }
   }
 
   subscribeForAdaptiveInlineResponse(

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -729,25 +729,64 @@ export class ProcessManager {
             const lastN = allSystemMsgs.slice(-ZERO_TURN_CIRCUIT_BREAKER_THRESHOLD);
             const allZeroTurn = lastN.every((m) => /Turns: 0/.test(m.content));
             if (allZeroTurn) {
-                log.error('Zero-turn death loop detected — refusing to resume', {
+                log.warn('Zero-turn death loop detected — resetting session context', {
                     sessionId: session.id,
                     consecutiveZeroTurns: lastN.length,
                 });
-                updateSessionStatus(this.db, session.id, 'error');
-                addSessionMessage(this.db, session.id, 'system',
-                    `Session stuck in zero-turn death loop (${lastN.length} consecutive 0-turn completions). ` +
-                    'Context is likely too bloated. Please start a fresh session.');
+
+                // Generate a conversation summary before clearing messages
+                try {
+                    const ctxProject = session.projectId ? getProject(this.db, session.projectId) : null;
+                    const projectContext = ctxProject ? { name: ctxProject.name, workingDir: ctxProject.workingDir } : undefined;
+                    const summary = summarizeConversation(recentMessages, projectContext);
+                    updateSessionSummary(this.db, session.id, summary);
+                    // Store in meta so buildResumePrompt can inject it
+                    const existingMeta = this.sessionMeta.get(session.id);
+                    if (existingMeta) {
+                        existingMeta.contextSummary = summary;
+                        existingMeta.turnCount = 0;
+                    } else {
+                        this.sessionMeta.set(session.id, {
+                            startedAt: Date.now(),
+                            source: session.source ?? 'unknown',
+                            restartCount: 0,
+                            lastKnownCostUsd: 0,
+                            turnCount: 0,
+                            lastActivityAt: Date.now(),
+                            contextSummary: summary,
+                        });
+                    }
+                    log.info(`Generated context summary before death-loop reset (${summary.length} chars)`);
+                } catch (err) {
+                    log.warn('Failed to generate summary for death-loop reset', { error: err });
+                }
+
+                // Purge session messages to break the death loop — the summary preserves context
+                this.db.query('DELETE FROM session_messages WHERE session_id = ?').run(session.id);
+                updateSessionStatus(this.db, session.id, 'idle');
+
+                // Clean up stale process state
+                const existingProcess = this.processes.get(session.id);
+                if (existingProcess) {
+                    existingProcess.kill();
+                    this.processes.delete(session.id);
+                }
+                updateSessionPid(this.db, session.id, null);
+                this.timerManager.cleanupSession(session.id);
+                this.approvalManager.cancelSession(session.id);
+
                 this.eventBus.emit(session.id, {
                     type: 'session_error',
                     session_id: session.id,
                     error: {
-                        message: `Zero-turn death loop detected (${lastN.length} consecutive 0-turn completions). Start a fresh session.`,
-                        errorType: 'crash',
-                        severity: 'error',
-                        recoverable: false,
+                        message: 'Session context was bloated — restarting with fresh context.',
+                        errorType: 'context_exhausted',
+                        severity: 'info',
+                        recoverable: true,
                     },
                 } as ClaudeStreamEvent);
-                return;
+
+                // Fall through to start a fresh process with clean context
             }
         }
 


### PR DESCRIPTION
## Summary
- **Process manager**: Death loop circuit breaker now generates a conversation summary, purges bloated session messages, and falls through to start a fresh process — instead of marking the session as permanently dead
- **Discord mention handler**: Added `isRunning` safety check after `resumeProcess` (matching the thread handler), so mention sessions fall back to creating a new session instead of silently dying

## Context
The zero-iteration death loop circuit breaker was a one-way door: once triggered, sessions were marked `error` with `recoverable: false` and no automatic recovery. Users saw "session ended unexpectedly" with no way back except manually starting a fresh session. This was blocking Magpie mention sessions.

## Test plan
- [ ] Verify sessions that hit the death loop circuit breaker now auto-recover with context preserved
- [ ] Verify mention session replies work after a death loop reset
- [ ] Verify thread sessions still fall back to fresh sessions correctly
- [ ] Verify conversation summary is generated and injected into the fresh process

🤖 Generated with [Claude Code](https://claude.com/claude-code)