### PR TITLE
release: prep v0.59.0 changelog, docs, and GitHub Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.59.0] - 2026-03-29
+
+### Added
+- **Library tag filtering & page navigation** — tag-based filtering, paginated browsing, and better display titles (#1684)
+- **Documentation expansion** — recipes, use-case gallery, and docs index for onboarding (#1675)
+- **Map-based command registry** — replaced switch dispatcher with extensible map-based command registry + migration 110 (#1682)
+
+### Fixed
+- **Library 3D book rendering** — use totalPages from grouped API, add title field, markdown rendering, sort/stats (#1681)
+- **Discord session resume** — create fresh session when old one can't restart (#1677)
+- **Discord autocomplete** — use static import for discordFetch in autocomplete handler (#1679)
+- **Discord conversation summary** — persist conversation summary across session resumes (#1680)
+- **Session death loop** — recover from zero-turn death loop instead of killing session permanently (#1683)
+- **Markdown rendering** — add marked dependency and fix implicit any types in markdown pipe
+
+### Refactored
+- **ThreadSessionManager** — extract session/mention state, add security startup checks (#1678)
+
 ## [0.58.0] - 2026-03-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.58.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.59.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>

--- a/docs/blog.html
+++ b/docs/blog.html
@@ -800,6 +800,41 @@
   <main id="main-content" class="container">
     <div class="posts-grid" id="posts-container">
 
+      <!-- Post: v0.59.0 — Library Polish, Command Registry, Discord Resilience -->
+      <article class="post post--full" id="v0-59-release"
+               data-tags="milestone,engineering" data-date="2026-03-29"
+               data-search="v0.59 library tag filtering pagination display titles command registry map dispatcher discord session resume autocomplete conversation summary death loop ThreadSessionManager security markdown rendering recipes documentation onboarding">
+        <div class="post-meta">
+          <time datetime="2026-03-29">2026-03-29</time>
+          <span class="post-tag tag-milestone">MILESTONE</span>
+          <span class="post-tag tag-engineering">ENGINEERING</span>
+        </div>
+        <h2><a href="#v0-59-release">v0.59.0 &mdash; Library Polish, Command Registry, Discord Resilience</a></h2>
+
+        <p><strong>TL;DR:</strong> The library gets tag filtering and pagination, Discord&rsquo;s command dispatcher is now a clean extensible map, the ThreadSessionManager got a security-focused refactor, and four Discord resilience bugs were squashed. Plus: new documentation with recipes and a use-case gallery.</p>
+
+        <h3>Library: Browse by Tags, Navigate by Pages</h3>
+        <p>The library UI now supports <strong>tag-based filtering</strong> &mdash; click a tag to see only matching entries. Pagination keeps large collections navigable, and display titles are smarter: the system extracts meaningful names from ARC-69 metadata instead of showing raw keys. The 3D book rendering also got fixes: <code>totalPages</code> now comes from the grouped API instead of being guessed client-side, and a proper <code>title</code> field is used throughout.</p>
+
+        <h3>Command Registry: Maps Over Switches</h3>
+        <p>The Discord command dispatcher was a growing <code>switch</code> statement &mdash; one case per command, hard to extend, easy to miss. It&rsquo;s now a <strong>map-based registry</strong>: each command registers itself as a handler, and the dispatcher is a simple lookup. Adding new commands means adding one entry, not touching a monolithic switch. Migration 110 updates the schema to support this.</p>
+
+        <h3>Discord Resilience</h3>
+        <p>Four separate Discord bugs fixed in one sweep:</p>
+        <ul>
+          <li><strong>Session resume:</strong> When an old session can&rsquo;t restart, a fresh session is created instead of hanging.</li>
+          <li><strong>Autocomplete:</strong> Static import for <code>discordFetch</code> fixes a race condition in the autocomplete handler.</li>
+          <li><strong>Conversation summary:</strong> Summaries now persist across session resumes &mdash; context no longer lost on restart.</li>
+          <li><strong>Death loop recovery:</strong> Zero-turn death loops are now recovered instead of permanently killing the session.</li>
+        </ul>
+
+        <h3>ThreadSessionManager Refactor</h3>
+        <p>Session and mention state are now properly extracted into their own concerns, and <strong>security startup checks</strong> verify the environment before accepting connections. This is part of ongoing hardening work driven by Rook&rsquo;s security reviews.</p>
+
+        <h3>Documentation: Recipes &amp; Gallery</h3>
+        <p>New docs landed: a <strong>recipes index</strong> with step-by-step guides (your first agent, production deployment, etc.), a <strong>use-case gallery</strong> showcasing what corvid-agent can build, and a docs index to tie it all together. Onboarding just got a lot smoother.</p>
+      </article>
+
       <!-- Post: v0.58.0 — Book Reader, Dashboard Modernize, AAA Accessibility -->
       <article class="post post--full" id="v0-58-release"
                data-tags="milestone,engineering" data-date="2026-03-29"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1744,7 +1744,7 @@
             <span class="terminal-cmd">corvid-agent</span>
           </div>
           <div class="terminal-output" style="padding-left: 1.2rem;">
-            <span class="terminal-cmd" style="font-weight: bold;">corvid</span> v0.58.0 — agent: CorvidAgent <span style="color: var(--text-dim);">(claude-opus-4-6)</span>
+            <span class="terminal-cmd" style="font-weight: bold;">corvid</span> v0.59.0 — agent: CorvidAgent <span style="color: var(--text-dim);">(claude-opus-4-6)</span>
           </div>
           <div class="terminal-output" style="padding-left: 1.2rem;">
             <span style="color: var(--text-dim);">project: corvid-agent (/Users/corvid-agent/corvid-agent)</span>
@@ -2126,7 +2126,7 @@
 
       const lines = [
         { type: 'command', text: 'corvid' },
-        { type: 'output', text: 'corvid v0.58.0 \u2014 agent: CorvidAgent (claude-opus-4-6)' },
+        { type: 'output', text: 'corvid v0.59.0 \u2014 agent: CorvidAgent (claude-opus-4-6)' },
         { type: 'output', text: 'project: corvid-agent (/Users/corvid-agent/corvid-agent)' },
         { type: 'blank' },
         { type: 'command', text: 'Harden the AlgoChat bridge reconnect logic' },

--- a/docs/recipes/production-deployment.md
+++ b/docs/recipes/production-deployment.md
@@ -72,7 +72,7 @@ curl http://localhost:3000/api/health
 
 Expected:
 ```json
-{"status":"ok","version":"0.58.0","uptime":120,"agents":1}
+{"status":"ok","version":"0.59.0","uptime":120,"agents":1}
 ```
 
 ### 4. Set up automatic restarts

--- a/docs/recipes/your-first-agent.md
+++ b/docs/recipes/your-first-agent.md
@@ -59,8 +59,8 @@ bun run dev
 
 Expected output:
 ```
-corvid-agent v0.58.0
-✓ Database initialized (migrations: 109)
+corvid-agent v0.59.0
+✓ Database initialized (migrations: 111)
 ✓ Agent "CorvidAgent" ready
 ✓ Server listening on http://localhost:3000
 ```

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>CorvidAgent — Release Retrospective: v0.1.0 → v0.58.0</title>
+<title>CorvidAgent — Release Retrospective: v0.1.0 → v0.59.0</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap');
 
@@ -473,24 +473,24 @@
 
   <!-- Hero -->
   <section class="hero">
-    <div class="hero-badge">52 days · 58 releases · 1081 commits</div>
+    <div class="hero-badge">52 days · 59 releases · 1090 commits</div>
     <h1>CorvidAgent<br>Release Retrospective</h1>
     <p>From a prototype CLI to a full autonomous AI agent platform with on-chain memory, multi-model orchestration, and cross-platform bridges.</p>
     <div class="hero-version-range">
       <span class="version">v0.1.0</span>
       <span class="arrow">→</span>
-      <span class="version">v0.58.0</span>
+      <span class="version">v0.59.0</span>
     </div>
   </section>
 
   <!-- Stats bar -->
   <section class="stats-bar">
     <div class="stat-card">
-      <div class="stat-number">58</div>
+      <div class="stat-number">59</div>
       <div class="stat-label">Releases</div>
     </div>
     <div class="stat-card">
-      <div class="stat-number">1081</div>
+      <div class="stat-number">1090</div>
       <div class="stat-label">Commits</div>
     </div>
     <div class="stat-card">
@@ -950,7 +950,7 @@
           <div class="era-title">Scale — Provider Parity & Agent Observatory</div>
           <div class="era-date">Mar 21 – Mar 29, 2026</div>
         </div>
-        <div class="era-versions">v0.42.0 – v0.58.0</div>
+        <div class="era-versions">v0.42.0 – v0.59.0</div>
       </div>
       <div class="era-body">
         <div class="release-card">
@@ -997,6 +997,21 @@
           </ul>
         </div>
         <div class="release-card" style="border-color: rgba(0,229,255,0.3); background: rgba(0,229,255,0.05);">
+          <div class="release-header">
+            <span class="release-version">v0.59.0</span>
+            <span class="release-date">Mar 29</span>
+          </div>
+          <ul class="release-highlights">
+            <li><span class="tag tag-feat">feat</span> <strong>Library tag filtering &amp; pagination</strong> — tag-based filtering, paginated browsing, better display titles</li>
+            <li><span class="tag tag-feat">feat</span> <strong>Documentation expansion</strong> — recipes, use-case gallery, and docs index for onboarding</li>
+            <li><span class="tag tag-feat">feat</span> <strong>Map-based command registry</strong> — replaced switch dispatcher with extensible command map</li>
+            <li><span class="tag tag-fix">fix</span> <strong>Library 3D rendering</strong> — totalPages from grouped API, title field, markdown rendering</li>
+            <li><span class="tag tag-fix">fix</span> <strong>Discord resilience</strong> — session resume, autocomplete import, conversation summary persistence</li>
+            <li><span class="tag tag-fix">fix</span> <strong>Session death loop</strong> — recover from zero-turn death loop instead of killing permanently</li>
+            <li><span class="tag tag-chore">refactor</span> <strong>ThreadSessionManager</strong> — extract session/mention state, security startup checks</li>
+          </ul>
+        </div>
+        <div class="release-card" style="border-color: rgba(167,139,250,0.3); background: rgba(167,139,250,0.05);">
           <div class="release-header">
             <span class="release-version">v0.58.0</span>
             <span class="release-date">Mar 29</span>
@@ -1053,7 +1068,7 @@
   <footer class="footer">
     <div class="footer-logo">CorvidAgent</div>
     <p>Built by <a href="https://github.com/CorvidLabs">CorvidLabs</a> · Feb 6 – Mar 29, 2026</p>
-    <p style="margin-top: 8px;">51 days from zero to a full autonomous AI agent platform.</p>
+    <p style="margin-top: 8px;">52 days from zero to a full autonomous AI agent platform.</p>
   </footer>
 
 </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Version bump to 0.59.0 across package.json, README badge, docs, and recipe examples
- New CHANGELOG.md section covering 3 additions, 6 fixes, 1 refactor
- New release card on docs/releases.html with updated hero stats (59 releases, 1090 commits)
- New blog post on docs/blog.html for v0.59.0

## v0.59.0 Highlights
- Library tag filtering, pagination, better display titles
- Map-based command registry replacing switch dispatcher
- Documentation expansion (recipes, use-case gallery)
- Library 3D book rendering fixes (totalPages, title field, markdown)
- Discord resilience fixes (session resume, autocomplete, summary persistence, death loop)
- ThreadSessionManager refactor with security startup checks

## Test plan
- [ ] Verify docs/releases.html renders correctly on GitHub Pages
- [ ] Verify docs/blog.html renders correctly
- [ ] Verify docs/index.html terminal mockup shows v0.59.0
- [ ] Confirm CHANGELOG.md formatting is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6