### PR TITLE
release: prep v0.59.1 changelog, docs, and GitHub Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.59.1] - 2026-03-29
+
+### Fixed
+- **Docker build** — add missing `marked` dependency to client package.json (#1687)
+
 ## [0.59.0] - 2026-03-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.59.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.59.1-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1744,7 +1744,7 @@
             <span class="terminal-cmd">corvid-agent</span>
           </div>
           <div class="terminal-output" style="padding-left: 1.2rem;">
-            <span class="terminal-cmd" style="font-weight: bold;">corvid</span> v0.59.0 — agent: CorvidAgent <span style="color: var(--text-dim);">(claude-opus-4-6)</span>
+            <span class="terminal-cmd" style="font-weight: bold;">corvid</span> v0.59.1 — agent: CorvidAgent <span style="color: var(--text-dim);">(claude-opus-4-6)</span>
           </div>
           <div class="terminal-output" style="padding-left: 1.2rem;">
             <span style="color: var(--text-dim);">project: corvid-agent (/Users/corvid-agent/corvid-agent)</span>
@@ -2126,7 +2126,7 @@
 
       const lines = [
         { type: 'command', text: 'corvid' },
-        { type: 'output', text: 'corvid v0.59.0 \u2014 agent: CorvidAgent (claude-opus-4-6)' },
+        { type: 'output', text: 'corvid v0.59.1 \u2014 agent: CorvidAgent (claude-opus-4-6)' },
         { type: 'output', text: 'project: corvid-agent (/Users/corvid-agent/corvid-agent)' },
         { type: 'blank' },
         { type: 'command', text: 'Harden the AlgoChat bridge reconnect logic' },

--- a/docs/recipes/production-deployment.md
+++ b/docs/recipes/production-deployment.md
@@ -72,7 +72,7 @@ curl http://localhost:3000/api/health
 
 Expected:
 ```json
-{"status":"ok","version":"0.59.0","uptime":120,"agents":1}
+{"status":"ok","version":"0.59.1","uptime":120,"agents":1}
 ```
 
 ### 4. Set up automatic restarts

--- a/docs/recipes/your-first-agent.md
+++ b/docs/recipes/your-first-agent.md
@@ -59,7 +59,7 @@ bun run dev
 
 Expected output:
 ```
-corvid-agent v0.59.0
+corvid-agent v0.59.1
 ✓ Database initialized (migrations: 111)
 ✓ Agent "CorvidAgent" ready
 ✓ Server listening on http://localhost:3000

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>CorvidAgent — Release Retrospective: v0.1.0 → v0.59.0</title>
+<title>CorvidAgent — Release Retrospective: v0.1.0 → v0.59.1</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap');
 
@@ -479,7 +479,7 @@
     <div class="hero-version-range">
       <span class="version">v0.1.0</span>
       <span class="arrow">→</span>
-      <span class="version">v0.59.0</span>
+      <span class="version">v0.59.1</span>
     </div>
   </section>
 
@@ -950,7 +950,7 @@
           <div class="era-title">Scale — Provider Parity & Agent Observatory</div>
           <div class="era-date">Mar 21 – Mar 29, 2026</div>
         </div>
-        <div class="era-versions">v0.42.0 – v0.59.0</div>
+        <div class="era-versions">v0.42.0 – v0.59.1</div>
       </div>
       <div class="era-body">
         <div class="release-card">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version to `0.59.1` across package.json, README badge, changelog, docs, and GitHub Pages
- Add changelog entry for the `marked` dependency fix (#1687)
- Update version references in index.html, releases.html, and recipe docs

## Test plan
- [x] Version badge shows 0.59.1
- [x] GitHub Pages renders updated version in terminal demo
- [x] After merge, move the `v0.59.1` tag to include this commit, then Docker Publish should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)