### PR TITLE
fix(discord): harden autocomplete handler + add agent to schedule create

### DIFF
--- a/server/discord/command-handlers/autocomplete-handler.ts
+++ b/server/discord/command-handlers/autocomplete-handler.ts
@@ -30,68 +30,87 @@ function findFocusedOption(options: DiscordInteractionOption[] | undefined): Dis
 }
 
 export async function handleAutocomplete(ctx: InteractionContext, interaction: DiscordInteractionData): Promise<void> {
-  const options = interaction.data?.options ?? [];
-  const focused = findFocusedOption(options);
-
-  const query = focused ? String(focused.value ?? '').toLowerCase() : '';
   let choices: { name: string; value: string }[] = [];
 
-  if (focused?.name === 'agent') {
-    const agents = listAgents(ctx.db);
-    choices = agents
-      .filter((a) => !query || a.name.toLowerCase().includes(query))
-      .slice(0, 25)
-      .map((a) => ({
-        name: `${a.name} (${a.model || 'unknown'})`.slice(0, 100),
-        value: a.name,
-      }));
-  } else if (focused?.name === 'project') {
-    const projects = listProjects(ctx.db);
-    choices = projects
-      .filter(
-        (p) => !query || p.name.toLowerCase().includes(query) || (p.description ?? '').toLowerCase().includes(query),
-      )
-      .slice(0, 25)
-      .map((p) => ({
-        name: `${p.name}${p.description ? ` — ${p.description}` : ''}`.slice(0, 100),
-        value: p.name,
-      }));
-  } else if (focused?.name === 'skill') {
-    const bundles = listBundles(ctx.db);
-    choices = bundles
-      .filter((b) => !query || b.name.toLowerCase().includes(query) || b.description.toLowerCase().includes(query))
-      .slice(0, 25)
-      .map((b) => ({
-        name: `${b.name}${b.description ? ` — ${b.description}` : ''}`.slice(0, 100),
-        value: b.name,
-      }));
-  } else if (focused?.name === 'buddy') {
-    const agents = listAgents(ctx.db);
-    choices = agents
-      .filter((a) => !query || a.name.toLowerCase().includes(query))
-      .slice(0, 25)
-      .map((a) => ({
-        name: `${a.name} (${a.model || 'unknown'})`.slice(0, 100),
-        value: a.name,
-      }));
-  } else if (focused?.name === 'council_name') {
-    const councils = listCouncils(ctx.db);
-    choices = councils
-      .filter((c) => !query || c.name.toLowerCase().includes(query))
-      .slice(0, 25)
-      .map((c) => ({
-        name: `${c.name}${c.description ? ` — ${c.description}` : ''}`.slice(0, 100),
-        value: c.name,
-      }));
-  } else if (focused?.name === 'persona') {
-    const personas = listPersonas(ctx.db);
-    choices = personas
-      .filter((p) => !query || p.name.toLowerCase().includes(query))
-      .slice(0, 25)
-      .map((p) => ({
-        name: `${p.name}${p.archetype !== 'custom' ? ` (${p.archetype})` : ''}`.slice(0, 100),
-        value: p.name,
-      }));
+  try {
+    const options = interaction.data?.options ?? [];
+    const focused = findFocusedOption(options);
+
+    if (!focused) {
+      log.warn('Autocomplete: no focused option in payload', {
+        command: interaction.data?.name,
+        options: JSON.stringify(options).slice(0, 300),
+      });
+    }
+
+    const query = focused ? String(focused.value ?? '').toLowerCase() : '';
+
+    if (focused?.name === 'agent' || focused?.name === 'agent_id') {
+      const agents = listAgents(ctx.db);
+      log.debug('Autocomplete agent query', { query, agentCount: agents.length, field: focused.name });
+      choices = agents
+        .filter((a) => !query || a.name.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((a) => ({
+          name: `${a.name} (${a.model || 'unknown'})`.slice(0, 100),
+          value: a.name,
+        }));
+    } else if (focused?.name === 'project') {
+      const projects = listProjects(ctx.db);
+      choices = projects
+        .filter(
+          (p) => !query || p.name.toLowerCase().includes(query) || (p.description ?? '').toLowerCase().includes(query),
+        )
+        .slice(0, 25)
+        .map((p) => ({
+          name: `${p.name}${p.description ? ` — ${p.description}` : ''}`.slice(0, 100),
+          value: p.name,
+        }));
+    } else if (focused?.name === 'skill') {
+      const bundles = listBundles(ctx.db);
+      choices = bundles
+        .filter((b) => !query || b.name.toLowerCase().includes(query) || b.description.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((b) => ({
+          name: `${b.name}${b.description ? ` — ${b.description}` : ''}`.slice(0, 100),
+          value: b.name,
+        }));
+    } else if (focused?.name === 'buddy') {
+      const agents = listAgents(ctx.db);
+      choices = agents
+        .filter((a) => !query || a.name.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((a) => ({
+          name: `${a.name} (${a.model || 'unknown'})`.slice(0, 100),
+          value: a.name,
+        }));
+    } else if (focused?.name === 'council_name') {
+      const councils = listCouncils(ctx.db);
+      choices = councils
+        .filter((c) => !query || c.name.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((c) => ({
+          name: `${c.name}${c.description ? ` — ${c.description}` : ''}`.slice(0, 100),
+          value: c.name,
+        }));
+    } else if (focused?.name === 'persona') {
+      const personas = listPersonas(ctx.db);
+      choices = personas
+        .filter((p) => !query || p.name.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((p) => ({
+          name: `${p.name}${p.archetype !== 'custom' ? ` (${p.archetype})` : ''}`.slice(0, 100),
+          value: p.name,
+        }));
+    } else if (focused) {
+      log.warn('Autocomplete: unhandled focused field', { field: focused.name, command: interaction.data?.name });
+    }
+  } catch (err) {
+    log.error('Autocomplete: error building choices — sending empty list', {
+      command: interaction.data?.name,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    choices = [];
   }
 
   const response = await discordFetch(
@@ -111,12 +130,6 @@ export async function handleAutocomplete(ctx: InteractionContext, interaction: D
     log.error('Failed to respond to autocomplete', {
       status: response.status,
       error: error.slice(0, 200),
-    });
-  }
-
-  if (!focused) {
-    log.debug('Autocomplete: no focused option in payload — sent empty choices', {
-      command: interaction.data?.name,
     });
   }
 }

--- a/server/discord/command-handlers/schedule-commands.ts
+++ b/server/discord/command-handlers/schedule-commands.ts
@@ -128,6 +128,7 @@ async function handleScheduleCreate(
     getOption: (name: string) => string | undefined,
 ): Promise<void> {
     const name = getOption('name');
+    const agentName = getOption('agent');
     const cron = getOption('cron');
     const actionType = getOption('action_type') ?? 'discord_post';
     const channelId = getOption('channel');
@@ -138,13 +139,13 @@ async function handleScheduleCreate(
         return;
     }
 
-    // Resolve agent (use first agent as default)
+    // Resolve agent by name, or fall back to first agent
     const agents = listAgents(ctx.db);
     if (agents.length === 0) {
         await respondToInteraction(interaction, 'No agents configured.');
         return;
     }
-    const agent = agents[0];
+    const agent = (agentName && agents.find(a => a.name === agentName)) || agents[0];
 
     // If using a template, resolve it
     if (templateId) {

--- a/server/discord/commands.ts
+++ b/server/discord/commands.ts
@@ -184,6 +184,7 @@ export async function registerSlashCommands(_db: Database, config: DiscordBridge
           type: 1,
           options: [
             { name: 'name', description: 'Schedule name', type: 3, required: true },
+            { name: 'agent', description: 'Agent to run the schedule', type: 3, required: false, autocomplete: true },
             { name: 'cron', description: 'Cron expression (e.g. "0 9 * * *" for 9am daily)', type: 3 },
             {
               name: 'action_type',


### PR DESCRIPTION
## Summary
- Wrapped the Discord autocomplete handler in try-catch so it **always** responds to Discord (even on error). Previously, if any DB call threw, the handler would bubble up and Discord would time out — showing no options.
- Added warn-level logging for unhandled focused fields and missing focused options to aid debugging.
- Added `agent` autocomplete option to `/schedule create` so users can pick which agent runs the schedule (was silently defaulting to the first agent).
- Also handles `agent_id` as a focused field name (future-proofing).

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` passes
- [x] `bun test server/__tests__/discord-bridge.test.ts` — 35/35 pass
- [x] Verify in Discord: `/session`, `/work`, `/message` agent dropdowns populate
- [x] Verify `/schedule create` now shows agent dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)