### PR TITLE
fix(scheduling): add agent_id filter to schedule list + get action

### DIFF
--- a/server/mcp/direct-tools.ts
+++ b/server/mcp/direct-tools.ts
@@ -448,7 +448,7 @@ export function buildDirectTools(ctx: McpToolContext | null, codingCtx?: CodingT
         parameters: {
             type: 'object',
             properties: {
-                action: { type: 'string', enum: ['list', 'create', 'update', 'pause', 'resume', 'history'], description: 'What to do' },
+                action: { type: 'string', enum: ['list', 'create', 'update', 'get', 'pause', 'resume', 'history'], description: 'What to do' },
                 name: { type: 'string', description: 'Schedule name (for create/update)' },
                 description: { type: 'string', description: 'Schedule description (for create/update)' },
                 cron_expression: { type: 'string', description: 'Cron expression (for create/update)' },
@@ -472,6 +472,7 @@ export function buildDirectTools(ctx: McpToolContext | null, codingCtx?: CodingT
                 },
                 approval_policy: { type: 'string', description: 'auto, owner_approve, or council_approve (for create/update)' },
                 max_executions: { type: 'number', description: 'Maximum number of executions (for create/update)' },
+                agent_id: { type: 'string', description: 'Agent ID — filter by agent (for list), or assign schedule to agent (for create/update). Omit on list to see all schedules.' },
                 schedule_id: { type: 'string', description: 'Schedule ID (for update/pause/resume/history)' },
                 output_destinations: {
                     type: 'array',

--- a/server/mcp/sdk-tools.ts
+++ b/server/mcp/sdk-tools.ts
@@ -264,7 +264,7 @@ export function createCorvidMcpServer(ctx: McpToolContext, pluginTools?: ReturnT
                 })).optional().describe('Actions to perform (for create/update)'),
                 approval_policy: z.string().optional().describe('auto, owner_approve, or council_approve (for create/update)'),
                 max_executions: z.number().optional().describe('Maximum number of executions (for create/update)'),
-                agent_id: z.string().optional().describe('Agent ID to assign this schedule to (for create/update). Defaults to the calling agent.'),
+                agent_id: z.string().optional().describe('Agent ID — filter by agent (for list), or assign schedule to agent (for create/update). Omit on list to see all schedules.'),
                 schedule_id: z.string().optional().describe('Schedule ID (for get/update/pause/resume/history)'),
                 output_destinations: z.array(z.object({
                     type: z.string().describe('Destination type: discord_channel, algochat_agent, or algochat_address'),

--- a/server/mcp/tool-handlers/scheduling.ts
+++ b/server/mcp/tool-handlers/scheduling.ts
@@ -26,12 +26,14 @@ export async function handleManageSchedule(
     try {
         switch (args.action) {
             case 'list': {
-                const schedules = listSchedules(ctx.db, ctx.agentId);
+                // If agent_id provided, filter to that agent; otherwise return all schedules
+                const schedules = listSchedules(ctx.db, args.agent_id);
                 if (schedules.length === 0) return textResult('No schedules found.');
                 const lines = schedules.map((s) =>
-                    `- ${s.name} [${s.id}] status=${s.status} executions=${s.executionCount}${s.nextRunAt ? ` next=${s.nextRunAt}` : ''}`
+                    `- [${s.agentId.slice(0, 8)}] ${s.name} [${s.id}] status=${s.status} executions=${s.executionCount}${s.nextRunAt ? ` next=${s.nextRunAt}` : ''}`
                 );
-                return textResult(`Your schedules:\n\n${lines.join('\n')}`);
+                const header = args.agent_id ? `Schedules for agent ${args.agent_id}:` : `All schedules (${schedules.length}):`;
+                return textResult(`${header}\n\n${lines.join('\n')}`);
             }
 
             case 'create': {


### PR DESCRIPTION
## Summary
- Schedule `list` now accepts optional `agent_id` to filter by agent; omitting returns all schedules
- Added `get` action to direct-tools enum for single schedule retrieval
- List output now prefixes each schedule with the agent ID for clarity
- Aligned `agent_id` description between direct-tools and sdk-tools

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` passes
- [ ] Verify `corvid_manage_schedule list` returns all schedules
- [ ] Verify `corvid_manage_schedule list agent_id=<id>` filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)