### PR TITLE
release: prep v0.59.1 changelog, README version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.59.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.59.1-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>CorvidAgent — Release Retrospective: v0.1.0 → v0.59.0</title>
+<title>CorvidAgent — Release Retrospective: v0.1.0 → v0.59.1</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap');
 
@@ -994,6 +994,17 @@
             <li><span class="tag tag-feat">feat</span> <strong>Shared agent library (CRVLIB)</strong> — ARC-69 reusable on-chain agent components</li>
             <li><span class="tag tag-test">test</span> <strong>Flock e2e: 45 tests</strong> — comprehensive e2e suite with inner transaction fee fix for AVM fee-pooling</li>
             <li><span class="tag tag-fix">fix</span> MCP tool permissions, scheduler tenant fallback, Ollama readiness probe</li>
+          </ul>
+        </div>
+        <div class="release-card" style="border-color: rgba(0,229,255,0.3); background: rgba(0,229,255,0.05);">
+          <div class="release-header">
+            <span class="release-version">v0.59.1</span>
+            <span class="release-date">Mar 29</span>
+          </div>
+          <ul class="release-highlights">
+            <li><span class="tag tag-fix">fix</span> <strong>Discord autocomplete hardening</strong> — agent-aware autocomplete, error guards, schedule create agent option</li>
+            <li><span class="tag tag-fix">fix</span> <strong>Schedule tool improvements</strong> — agent_id filter for list, new get action, better output formatting</li>
+            <li><span class="tag tag-fix">fix</span> <strong>Markdown pipe dependency</strong> — add missing <code>marked</code> package for client markdown rendering</li>
           </ul>
         </div>
         <div class="release-card" style="border-color: rgba(0,229,255,0.3); background: rgba(0,229,255,0.05);">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version badge in README and package.json to 0.59.1
- Add v0.59.1 entry to releases.html covering PRs #1693 and #1694
- Update releases page title range

## Changes in v0.59.1
- **fix(discord):** harden autocomplete handler + add agent option to schedule create (#1693)
- **fix(scheduling):** add agent_id filter to schedule list + get action (#1694)
- **fix(client):** add missing `marked` dependency for markdown pipe (#1687)