### PR TITLE
fix(specs): resolve DB schema drift across 15 spec files

### DIFF
--- a/specs/db/agent-memories.spec.md
+++ b/specs/db/agent-memories.spec.md
@@ -121,6 +121,8 @@ Pure data-access layer for agent memory CRUD operations including save, recall, 
 | asa_id | INTEGER | DEFAULT NULL | ARC-69 ASA ID for long-term memories (localnet only). NULL for permanent (plain txn) memories |
 | status | TEXT | DEFAULT 'confirmed' | Lifecycle status: pending, confirmed, failed |
 | archived | INTEGER | NOT NULL, DEFAULT 0 | Soft-delete flag (0 = active, 1 = archived) |
+| book | TEXT | DEFAULT NULL | Book grouping for organized memory collections (e.g. 'operational', 'contacts') |
+| page | INTEGER | DEFAULT NULL | Page number within a book for ordered content |
 | created_at | TEXT | DEFAULT datetime('now') | Creation timestamp |
 | updated_at | TEXT | DEFAULT datetime('now') | Last modification timestamp |
 
@@ -131,6 +133,14 @@ Pure data-access layer for agent memory CRUD operations including save, recall, 
 | idx_agent_memories_agent_key | (agent_id, key) | UNIQUE | Enforces one memory per agent+key pair, used for upsert |
 | idx_agent_memories_agent | (agent_id) | INDEX | Speeds up per-agent queries |
 | idx_agent_memories_asa | (agent_id, asa_id) WHERE asa_id IS NOT NULL | INDEX | Fast lookup of memory by ASA ID |
+| idx_agent_memories_book_page | (agent_id, book, page) WHERE book IS NOT NULL | INDEX | Fast lookup of memories within a book |
+
+### Triggers
+
+| Trigger | Event | Description |
+|---------|-------|-------------|
+| trg_agent_memories_book_page_insert | BEFORE INSERT | Enforces book and page must both be set or both be NULL |
+| trg_agent_memories_book_page_update | BEFORE UPDATE | Enforces book and page must both be set or both be NULL |
 
 ## Change Log
 

--- a/specs/db/agents.spec.md
+++ b/specs/db/agents.spec.md
@@ -160,6 +160,13 @@ Pure data-access layer for agent CRUD operations, wallet management, and funding
 | voice_preset | TEXT | DEFAULT 'alloy' | Voice preset for TTS (alloy, echo, fable, onyx, nova, shimmer) |
 | wallet_address | TEXT | DEFAULT NULL | Algorand wallet address |
 | wallet_mnemonic_encrypted | TEXT | DEFAULT NULL | AES-encrypted wallet mnemonic |
+| display_color | TEXT | DEFAULT NULL | Custom hex color for UI display (e.g. '#FF5733') |
+| display_icon | TEXT | DEFAULT NULL | Custom icon identifier for UI display |
+| avatar_url | TEXT | DEFAULT NULL | URL to agent's avatar image |
+| disabled | INTEGER | DEFAULT 0 | Whether agent is disabled (boolean) |
+| conversation_mode | TEXT | NOT NULL, DEFAULT 'private' | Conversation access mode: 'private', 'allowlist', 'public' |
+| conversation_rate_limit_window | INTEGER | NOT NULL, DEFAULT 3600 | Rate limit window in seconds for conversations |
+| conversation_rate_limit_max | INTEGER | NOT NULL, DEFAULT 10 | Max conversations per rate limit window |
 | wallet_funded_algo | REAL | DEFAULT 0 | Total ALGO funded to this agent |
 | tenant_id | TEXT | NOT NULL, DEFAULT 'default' | Tenant isolation identifier |
 | created_at | TEXT | DEFAULT datetime('now') | Creation timestamp |

--- a/specs/db/buddy.spec.md
+++ b/specs/db/buddy.spec.md
@@ -102,6 +102,10 @@ CRUD helpers for buddy mode database tables: pairings (which agents can pair), s
 
 **Unique constraint**: `(agent_id, buddy_agent_id)`
 
+**Indexes:**
+- `idx_buddy_pairings_agent` on `agent_id`
+- `idx_buddy_pairings_buddy` on `buddy_agent_id`
+
 ### buddy_sessions
 
 | Column | Type | Constraints | Description |
@@ -120,6 +124,12 @@ CRUD helpers for buddy mode database tables: pairings (which agents can pair), s
 | created_at | TEXT | NOT NULL, DEFAULT datetime('now') | Creation timestamp |
 | completed_at | TEXT | | Completion timestamp (set on terminal status) |
 
+**Indexes:**
+- `idx_buddy_sessions_lead` on `lead_agent_id`
+- `idx_buddy_sessions_buddy` on `buddy_agent_id`
+- `idx_buddy_sessions_work_task` on `work_task_id`
+- `idx_buddy_sessions_status` on `status`
+
 ### buddy_messages
 
 | Column | Type | Constraints | Description |
@@ -131,6 +141,8 @@ CRUD helpers for buddy mode database tables: pairings (which agents can pair), s
 | role | TEXT | NOT NULL | Message role: 'lead' or 'buddy' |
 | content | TEXT | NOT NULL | Message content |
 | created_at | TEXT | NOT NULL, DEFAULT datetime('now') | Creation timestamp |
+
+**Indexes:** `idx_buddy_messages_session` on `buddy_session_id`
 
 ## Change Log
 

--- a/specs/db/contacts.spec.md
+++ b/specs/db/contacts.spec.md
@@ -119,6 +119,8 @@ Cross-platform contact identity mapping. Provides CRUD operations for unified co
 | `created_at` | TEXT | DEFAULT datetime('now') | Creation timestamp |
 | `updated_at` | TEXT | DEFAULT datetime('now') | Last update timestamp |
 
+**Indexes:** `idx_contacts_tenant_name` on `(tenant_id, display_name)`
+
 ### contact_platform_links
 
 | Column | Type | Constraints | Description |
@@ -130,6 +132,10 @@ Cross-platform contact identity mapping. Provides CRUD operations for unified co
 | `platform_id` | TEXT | NOT NULL | Platform-specific identifier |
 | `verified` | INTEGER | NOT NULL, DEFAULT 0 | Whether the link has been verified |
 | `created_at` | TEXT | DEFAULT datetime('now') | Creation timestamp |
+
+**Indexes:**
+- `idx_contact_platform_links_unique` on `(tenant_id, platform, platform_id)` UNIQUE
+- `idx_contact_platform_links_contact` on `contact_id`
 
 ## Change Log
 

--- a/specs/db/councils.spec.md
+++ b/specs/db/councils.spec.md
@@ -10,6 +10,9 @@ db_tables:
   - council_launches
   - council_launch_logs
   - council_discussion_messages
+  - governance_votes
+  - governance_member_votes
+  - governance_proposals
 depends_on:
   - specs/db/schema.spec.md
   - specs/tenant/tenant.spec.md
@@ -142,6 +145,8 @@ Provides the data-access layer for the council deliberation system: CRUD operati
 | tenant_id | TEXT | NOT NULL DEFAULT 'default', INDEXED | Tenant isolation identifier (added v56) |
 | created_at | TEXT | DEFAULT datetime('now') | Creation timestamp |
 | on_chain_mode | TEXT | DEFAULT 'full' | On-chain mode: 'off', 'metadata', 'full' (added v68) |
+| quorum_type | TEXT | DEFAULT NULL | Quorum type for governance: 'simple_majority', 'supermajority', 'unanimous' |
+| quorum_threshold | REAL | DEFAULT NULL | Quorum threshold as a fraction (e.g. 0.67 for 2/3 majority) |
 | updated_at | TEXT | DEFAULT datetime('now') | Last modification timestamp |
 
 ### council_members
@@ -167,11 +172,13 @@ Provides the data-access layer for the council deliberation system: CRUD operati
 | current_discussion_round | INTEGER | DEFAULT 0 | Current round number during discussion (added v9) |
 | total_discussion_rounds | INTEGER | DEFAULT 0 | Total planned discussion rounds (added v9) |
 | chat_session_id | TEXT | DEFAULT NULL | Follow-up chat session ID (added v22) |
+| vote_type | TEXT | DEFAULT NULL | Vote type for governance launches (e.g. 'approve_reject') |
+| governance_tier | INTEGER | DEFAULT NULL | Governance tier level (higher = more scrutiny) |
 | synthesis_txid | TEXT | DEFAULT NULL | On-chain transaction ID for the synthesis (added v68) |
 | tenant_id | TEXT | NOT NULL DEFAULT 'default', INDEXED | Tenant isolation identifier (added v56) |
 | created_at | TEXT | DEFAULT datetime('now') | Creation timestamp |
 
-**Indexes:** `idx_council_launches_council` on `council_id`, `idx_council_launches_tenant` on `tenant_id`
+**Indexes:** `idx_council_launches_council` on `council_id`, `idx_council_launches_tenant` on `tenant_id`, `idx_council_launches_council_created` on `(council_id, created_at DESC)`
 
 ### council_launch_logs
 
@@ -201,6 +208,55 @@ Provides the data-access layer for the council deliberation system: CRUD operati
 | created_at | TEXT | DEFAULT datetime('now') | Creation timestamp |
 
 **Indexes:** `idx_cdm_launch` on `launch_id`
+
+### governance_votes
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | INTEGER | PRIMARY KEY AUTOINCREMENT | Auto-incrementing identifier |
+| launch_id | TEXT | NOT NULL, FK -> council_launches(id) | Associated council launch |
+| governance_tier | INTEGER | DEFAULT NULL | Governance tier level |
+| affected_paths | TEXT | DEFAULT NULL | JSON array of file paths affected by the proposal |
+| status | TEXT | DEFAULT NULL | Vote status: 'open', 'closed', 'approved', 'rejected' |
+| human_approved | INTEGER | DEFAULT NULL | Whether a human approved the vote (boolean) |
+| human_approved_by | TEXT | DEFAULT NULL | Identifier of the human who approved |
+| human_approved_at | TEXT | DEFAULT NULL | Timestamp of human approval |
+| tenant_id | TEXT | DEFAULT NULL | Tenant isolation identifier |
+| created_at | TEXT | DEFAULT datetime('now') | Creation timestamp |
+| resolved_at | TEXT | DEFAULT NULL | When the vote was resolved |
+
+### governance_member_votes
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | INTEGER | PRIMARY KEY AUTOINCREMENT | Auto-incrementing identifier |
+| governance_vote_id | INTEGER | NOT NULL, FK -> governance_votes(id) | Parent governance vote |
+| agent_id | TEXT | NOT NULL | Voting agent ID |
+| vote | TEXT | NOT NULL, CHECK(IN 'approve','reject','abstain') | The agent's vote |
+| reason | TEXT | DEFAULT NULL | Explanation for the vote |
+| created_at | TEXT | DEFAULT datetime('now') | When the vote was cast |
+
+### governance_proposals
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | TEXT | PRIMARY KEY | UUID identifier |
+| council_id | TEXT | NOT NULL, FK -> councils(id) | Associated council |
+| title | TEXT | NOT NULL | Proposal title |
+| description | TEXT | DEFAULT NULL | Proposal description |
+| author_id | TEXT | DEFAULT NULL | Agent who authored the proposal |
+| status | TEXT | DEFAULT NULL | Proposal status |
+| decision | TEXT | DEFAULT NULL | Final decision |
+| governance_tier | INTEGER | DEFAULT NULL | Governance tier level |
+| affected_paths | TEXT | DEFAULT NULL | JSON array of affected file paths |
+| quorum_threshold | REAL | DEFAULT NULL | Required quorum threshold |
+| minimum_voters | INTEGER | DEFAULT NULL | Minimum number of voters required |
+| launch_id | TEXT | DEFAULT NULL | Associated council launch |
+| tenant_id | TEXT | DEFAULT NULL | Tenant isolation identifier |
+| created_at | TEXT | DEFAULT datetime('now') | Creation timestamp |
+| updated_at | TEXT | DEFAULT datetime('now') | Last modification timestamp |
+| decided_at | TEXT | DEFAULT NULL | When the decision was made |
+| enacted_at | TEXT | DEFAULT NULL | When the decision was enacted |
 
 ## Change Log
 

--- a/specs/db/discord-config.spec.md
+++ b/specs/db/discord-config.spec.md
@@ -6,6 +6,8 @@ files:
   - server/db/discord-config.ts
 db_tables:
   - discord_config
+  - discord_muted_users
+  - discord_processed_messages
 depends_on: []
 ---
 
@@ -102,6 +104,24 @@ DB-backed runtime configuration for the Discord integration. Static settings (bo
 | `key` | TEXT | PRIMARY KEY | Config key name (e.g. `mode`, `public_mode`) |
 | `value` | TEXT | NOT NULL | Config value as string |
 | `updated_at` | TEXT | NOT NULL, DEFAULT `datetime('now')` | Last update timestamp |
+
+### discord_muted_users
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `user_id` | TEXT | PRIMARY KEY | Discord user ID of the muted user |
+| `muted_by` | TEXT | DEFAULT NULL | Who muted this user (agent ID or 'system') |
+| `created_at` | TEXT | NOT NULL, DEFAULT `datetime('now')` | When the user was muted |
+
+### discord_processed_messages
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `message_id` | TEXT | PRIMARY KEY | Discord message ID that was processed |
+| `channel_id` | TEXT | NOT NULL | Discord channel ID where the message was sent |
+| `created_at` | TEXT | NOT NULL, DEFAULT `datetime('now')` | When the message was processed |
+
+**Indexes:** `idx_discord_processed_messages_created` on `created_at`
 
 ## Configuration
 

--- a/specs/db/discord-mention-sessions.spec.md
+++ b/specs/db/discord-mention-sessions.spec.md
@@ -103,6 +103,7 @@ Persists Discord mention-reply session mappings so they survive server restarts.
 | `agent_model` | TEXT | NOT NULL | Model identifier used for the session |
 | `project_name` | TEXT | | Project name for embed footer context (migration 093) |
 | `channel_id` | TEXT | | Discord channel ID where the mention originated (migration 096) |
+| `conversation_only` | INTEGER | DEFAULT 0 | Whether this session is conversation-only mode (no work tasks) |
 | `created_at` | TEXT | DEFAULT `datetime('now')` | When the mapping was created |
 
 ### Indexes

--- a/specs/db/personas.spec.md
+++ b/specs/db/personas.spec.md
@@ -134,6 +134,8 @@ Data-access and prompt-composition layer for composable agent personas. Personas
 | sort_order | INTEGER | DEFAULT 0 | Order in which personas are composed (lower = first) |
 | | | PRIMARY KEY (agent_id, persona_id) | Composite primary key prevents duplicate assignments |
 
+**Indexes:** `idx_agent_persona_assignments_agent` on `agent_id`
+
 ## Change Log
 
 | Date | Author | Change |

--- a/specs/db/projects.spec.md
+++ b/specs/db/projects.spec.md
@@ -116,12 +116,16 @@ Pure data-access layer for project CRUD operations. Projects are the top-level o
 | `working_dir` | TEXT | NOT NULL | Filesystem path to the project working directory |
 | `claude_md` | TEXT | DEFAULT `''` | Custom CLAUDE.md content injected into agent sessions |
 | `env_vars` | TEXT | DEFAULT `'{}'` | JSON-serialized key-value pairs of environment variables |
+| `git_url` | TEXT | DEFAULT NULL | Git remote URL for cloneable projects |
+| `dir_strategy` | TEXT | NOT NULL, DEFAULT `'persistent'` | Directory strategy: 'persistent' (fixed dir) or 'clone' (fresh clone per session) |
+| `base_clone_path` | TEXT | DEFAULT NULL | Base filesystem path for clone-strategy projects |
 | `tenant_id` | TEXT | NOT NULL DEFAULT `'default'` | Multi-tenant isolation key (added in migration 57) |
 | `created_at` | TEXT | DEFAULT `datetime('now')` | ISO 8601 creation timestamp |
 | `updated_at` | TEXT | DEFAULT `datetime('now')` | ISO 8601 last-update timestamp |
 
 **Indexes:**
 - `idx_projects_tenant` on `tenant_id`
+- `idx_projects_tenant_name` on `(tenant_id, name COLLATE NOCASE)` UNIQUE — prevents duplicate project names per tenant
 
 ## Change Log
 

--- a/specs/db/reputation-db.spec.md
+++ b/specs/db/reputation-db.spec.md
@@ -7,6 +7,8 @@ files:
 db_tables:
   - agent_reputation
   - reputation_events
+  - reputation_attestations
+  - reputation_history
 depends_on: []
 ---
 
@@ -100,6 +102,7 @@ Pure data-access layer for reading and deleting agent reputation scores and repu
 | `security_compliance` | INTEGER | DEFAULT `0` | Security compliance component (0-100) |
 | `activity_level` | INTEGER | DEFAULT `0` | Recent activity level component (0-100) |
 | `attestation_hash` | TEXT | DEFAULT `NULL` | On-chain attestation hash if published |
+| `tenant_id` | TEXT | DEFAULT NULL | Tenant isolation identifier |
 | `computed_at` | TEXT | DEFAULT `datetime('now')` | ISO 8601 timestamp of last score computation |
 
 ### reputation_events
@@ -116,6 +119,37 @@ Pure data-access layer for reading and deleting agent reputation scores and repu
 **Indexes:**
 - `idx_reputation_events_agent` on `agent_id`
 - `idx_reputation_events_type` on `event_type`
+
+### reputation_attestations
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `agent_id` | TEXT | PK part | Agent whose reputation is attested |
+| `hash` | TEXT | PK part | Attestation hash |
+| `payload` | TEXT | DEFAULT NULL | JSON-serialized attestation payload |
+| `txid` | TEXT | DEFAULT NULL | On-chain transaction ID |
+| `published_at` | TEXT | DEFAULT NULL | When the attestation was published on-chain |
+| `created_at` | TEXT | DEFAULT `datetime('now')` | Creation timestamp |
+
+### reputation_history
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INTEGER | PRIMARY KEY AUTOINCREMENT | Auto-incrementing identifier |
+| `agent_id` | TEXT | NOT NULL | Agent whose reputation is tracked |
+| `overall_score` | INTEGER | NOT NULL | Composite reputation score at this point in time |
+| `trust_level` | TEXT | NOT NULL | Trust level at this point in time |
+| `task_completion` | INTEGER | NOT NULL, DEFAULT 0 | Task completion component |
+| `peer_rating` | INTEGER | NOT NULL, DEFAULT 0 | Peer rating component |
+| `credit_pattern` | INTEGER | NOT NULL, DEFAULT 0 | Credit pattern component |
+| `security_compliance` | INTEGER | NOT NULL, DEFAULT 0 | Security compliance component |
+| `activity_level` | INTEGER | NOT NULL, DEFAULT 0 | Activity level component |
+| `computed_at` | TEXT | NOT NULL, DEFAULT `datetime('now')` | When this snapshot was computed |
+
+**Indexes:**
+- `idx_reputation_history_agent` on `agent_id`
+- `idx_reputation_history_computed` on `computed_at`
+- `idx_reputation_history_agent_time` on `(agent_id, computed_at)`
 
 ## Change Log
 

--- a/specs/db/schedules.spec.md
+++ b/specs/db/schedules.spec.md
@@ -140,6 +140,9 @@ Provides full CRUD and query operations for agent schedules (cron-based and even
 | `max_budget_per_run` | REAL | DEFAULT NULL | Optional cost cap per execution in USD |
 | `notify_address` | TEXT | DEFAULT NULL | Address for notifications (added in migration) |
 | `trigger_events` | TEXT | DEFAULT NULL | JSON array of ScheduleTriggerEvent objects (added in migration) |
+| `output_destinations` | TEXT | DEFAULT NULL | JSON array of output destination configs (e.g. Discord channel, AlgoChat address) |
+| `execution_mode` | TEXT | DEFAULT 'independent' | Execution mode: 'independent' (default) or 'pipeline' for multi-step execution |
+| `pipeline_steps` | TEXT | DEFAULT NULL | JSON array of pipeline step definitions (used when execution_mode='pipeline') |
 | `tenant_id` | TEXT | NOT NULL, DEFAULT 'default' | Multi-tenant isolation (added in migration) |
 | `last_run_at` | TEXT | DEFAULT NULL | Timestamp of last execution |
 | `next_run_at` | TEXT | DEFAULT NULL | Computed next scheduled run time |
@@ -162,10 +165,11 @@ Provides full CRUD and query operations for agent schedules (cron-based and even
 | `work_task_id` | TEXT | DEFAULT NULL | Associated work task ID if applicable |
 | `cost_usd` | REAL | DEFAULT 0 | Cost of this execution in USD |
 | `config_snapshot` | TEXT | DEFAULT NULL | JSON snapshot of config at execution time (added in migration 25) |
+| `tenant_id` | TEXT | NOT NULL, DEFAULT 'default' | Multi-tenant isolation key |
 | `started_at` | TEXT | DEFAULT (datetime('now')) | Execution start timestamp |
 | `completed_at` | TEXT | DEFAULT NULL | Execution completion timestamp |
 
-**Indexes:** `idx_schedule_executions_schedule(schedule_id)`, `idx_schedule_executions_status(status)`
+**Indexes:** `idx_schedule_executions_schedule(schedule_id)`, `idx_schedule_executions_status(status)`, `idx_schedule_executions_schedule_status(schedule_id, status, started_at DESC)`
 
 ## Change Log
 | Date | Author | Change |

--- a/specs/db/session-metrics.spec.md
+++ b/specs/db/session-metrics.spec.md
@@ -117,6 +117,11 @@ Persists structured tool-chain analytics collected during direct-process executi
 | needs_summary | INTEGER | NOT NULL DEFAULT 0 | Whether a summary epilogue was needed |
 | created_at | TEXT | DEFAULT datetime('now') | When metrics were recorded |
 
+**Indexes:**
+- `idx_session_metrics_session` on `session_id`
+- `idx_session_metrics_model` on `model`
+- `idx_session_metrics_created` on `created_at`
+
 ## Configuration
 
 No environment variables. This module is a pure data layer.

--- a/specs/db/sessions.spec.md
+++ b/specs/db/sessions.spec.md
@@ -132,13 +132,16 @@ No business logic lives here -- just SQL queries with row-to-domain mapping.
 | initial_prompt | TEXT | DEFAULT '' | First prompt sent |
 | pid | INTEGER | nullable | OS process ID when running |
 | total_cost_usd | REAL | DEFAULT 0 | Cumulative API cost |
-| total_algo_spent | INTEGER | DEFAULT 0 | Cumulative microALGOs spent |
+| total_algo_spent | REAL | DEFAULT 0 | Cumulative microALGOs spent |
 | total_turns | INTEGER | DEFAULT 0 | Number of conversation turns |
 | council_launch_id | TEXT | nullable | Links to council_launches if part of a council |
 | council_role | TEXT | nullable | chairman/member/synthesizer |
 | work_dir | TEXT | nullable | Override working directory (e.g. git worktree) |
 | conversation_summary | TEXT | DEFAULT NULL | Conversation summary for cross-session context carry-over |
-| credits_consumed | INTEGER | DEFAULT 0 | Credits consumed by this session |
+| credits_consumed | REAL | DEFAULT 0 | Credits consumed by this session |
+| restart_pending | INTEGER | NOT NULL, DEFAULT 0 | Whether a restart is pending for this session (boolean) |
+| server_restart_initiated_at | TEXT | DEFAULT NULL | Timestamp when a server restart was initiated for this session |
+| tenant_id | TEXT | NOT NULL, DEFAULT 'default' | Multi-tenant isolation key |
 | created_at | TEXT | DEFAULT datetime('now') | Creation timestamp |
 | updated_at | TEXT | DEFAULT datetime('now') | Last modification timestamp |
 

--- a/specs/db/variants.spec.md
+++ b/specs/db/variants.spec.md
@@ -122,6 +122,8 @@ Data-access layer for agent variant profiles — preset combinations of skill bu
 | variant_id | TEXT | NOT NULL, FK agent_variants(id) ON DELETE CASCADE | Applied variant |
 | created_at | TEXT | NOT NULL DEFAULT datetime('now') | When the variant was applied |
 
+**Indexes:** `idx_agent_variant_assignments_variant` on `variant_id`
+
 ## Change Log
 
 | Date | Author | Change |

--- a/specs/db/work-tasks.spec.md
+++ b/specs/db/work-tasks.spec.md
@@ -128,7 +128,7 @@ Provides CRUD, query, and lifecycle operations for work tasks -- autonomous agen
 | created_at | TEXT | DEFAULT datetime('now') | ISO 8601 creation timestamp |
 | completed_at | TEXT | DEFAULT NULL | ISO 8601 completion timestamp (set on completed/failed) |
 
-**Indexes:** `idx_work_tasks_agent(agent_id)`, `idx_work_tasks_status(status)`, `idx_work_tasks_session(session_id)`, `idx_work_tasks_pending_dispatch(status, project_id, priority DESC, created_at ASC)`
+**Indexes:** `idx_work_tasks_agent(agent_id)`, `idx_work_tasks_status(status)`, `idx_work_tasks_session(session_id)`, `idx_work_tasks_tenant(tenant_id)`, `idx_work_tasks_pending_dispatch(status, project_id, priority DESC, created_at ASC)`
 
 ## Change Log
 | Date | Author | Change |


### PR DESCRIPTION
## Summary

Full audit of every DB spec against actual migrations (078_baseline through 111). **15 spec files** were materially wrong — every one is now fixed and `spec:check` passes clean (200/200).

### Root cause
Governance features, display customization, conversation access, memory books, pipeline schedules, and other features were added to the schema via migrations but the corresponding specs were never updated. Spec-sync doesn't validate column definitions — it only checks file existence, table names in frontmatter, and exported symbols.

### High-severity fixes (missing columns/tables)
- **agents**: +7 columns (display_color, display_icon, avatar_url, disabled, conversation_mode, conversation_rate_limit_window, conversation_rate_limit_max)
- **sessions**: +3 columns (restart_pending, server_restart_initiated_at, tenant_id), fix total_algo_spent/credits_consumed types (INTEGER→REAL)
- **projects**: +3 columns (git_url, dir_strategy, base_clone_path), +unique index
- **schedules**: +3 columns (output_destinations, execution_mode, pipeline_steps), +tenant_id on executions, +compound index
- **agent-memories**: +2 columns (book, page), +index, +triggers
- **councils**: +2 columns on councils, +2 on launches, +3 governance tables (governance_votes, governance_member_votes, governance_proposals), +index
- **discord-config**: +2 tables (discord_muted_users, discord_processed_messages)
- **reputation-db**: +tenant_id, +2 tables (reputation_attestations, reputation_history)

### Medium-severity fixes (missing indexes)
- **buddy**: +7 indexes
- **session-metrics**: +3 indexes
- **contacts**: +3 indexes
- **personas**: +1 index
- **variants**: +1 index
- **work-tasks**: +1 index
- **discord-mention-sessions**: +1 column (conversation_only)

### Still needed (separate issues)
- Spec-sync enhancement to validate DB column definitions (#1698)
- New specs for uncovered tables: flock_directory_config, flock_test_results, response_feedback, memory_observations, agent_conversation_*, agent_library (#1699)

## Test plan
- [x] `bun run spec:check` — 200/200 pass, 0 warnings, 0 failures
- [x] Visual review of each spec against migration source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6