### PR TITLE
fix(health): wire getAuthConfig into healthDeps so API key status is reported correctly

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -368,6 +368,7 @@ const server = Bun.serve<WsData>({
           getSchedulerStats: () => schedulerService.getStats(),
           getMentionPollingStats: () => mentionPollingService.getStats(),
           getWorkflowStats: () => workflowService.getStats(),
+          getAuthConfig: () => authConfig,
         };
 
         const healthResponse = await handleHealthRoutes(req, url, healthDeps, db);


### PR DESCRIPTION
## Summary
Fixed health check always reporting `apiKey: { configured: false }` regardless of actual auth state.

The `healthDeps` object in `server/index.ts` was missing the `getAuthConfig` dependency, causing `checkApiKey(undefined)` to always return `{ status: 'healthy', configured: false }`, masking the real authentication state from health check responses.

The `authConfig` was already loaded at module level but never passed into `healthDeps`. This commit wires it in as a getter function, enabling accurate API key expiration reporting for operators.

## Changes
- Added `getAuthConfig: () => authConfig` to `healthDeps` object (server/index.ts:371)

## Validation
- ✅ `bun x tsc --noEmit --skipLibCheck` (no errors)
- ✅ `bun run spec:check` (200/200 specs passed)
- ✓ Tests running

Fixes #1697

Generated with [Claude Code](https://claude.com/claude-code)