### PR TITLE
fix(security): eliminate TOCTOU race conditions (CodeQL #318, #319)

### DIFF
--- a/cli/commands/provision.ts
+++ b/cli/commands/provision.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, mkdirSync, openSync, closeSync, constants as fsConstants } from 'fs';
+import { writeFileSync, mkdirSync, openSync, closeSync, renameSync, constants as fsConstants } from 'fs';
 import { join } from 'path';
 import { randomBytes } from 'crypto';
 import { c, printError, printSuccess, printWarning, printHeader } from '../render';
@@ -116,10 +116,12 @@ export async function provisionCommand(options: ProvisionOptions): Promise<void>
     }
     printSuccess(`Config written to ${envPath}`);
 
-    // Step 6: Write identity card (non-secret metadata for sharing)
+    // Step 6: Write identity card (non-secret metadata for sharing, atomic write)
     const identityCard = buildIdentityCard({ name, address, network, role, template });
     const cardPath = join(outputDir, 'identity.json');
-    writeFileSync(cardPath, JSON.stringify(identityCard, null, 2) + '\n', { mode: 0o644 });
+    const tmpCardPath = `${cardPath}.${process.pid}.tmp`;
+    writeFileSync(tmpCardPath, JSON.stringify(identityCard, null, 2) + '\n', { mode: 0o644 });
+    renameSync(tmpCardPath, cardPath);
     printSuccess(`Identity card written to ${cardPath}`);
 
     // Step 7: Print next steps

--- a/server/index.ts
+++ b/server/index.ts
@@ -529,14 +529,14 @@ const server = Bun.serve<WsData>({
         return instrumentResponse(apiResponse, route);
       }
 
-      // Serve Angular static files (open directly to avoid TOCTOU race)
+      // Serve Angular static files (read atomically to avoid TOCTOU race)
       {
         const filePath = join(CLIENT_DIST, url.pathname);
         if (!filePath.endsWith('/')) {
           try {
-            const file = Bun.file(filePath);
-            // Bun.file() is lazy — .size triggers the actual stat atomically
-            if (file.size > 0) {
+            // Read file content atomically — no separate existence check
+            const bytes = await Bun.file(filePath).bytes();
+            if (bytes.length > 0) {
               const headers: Record<string, string> = {};
               const basename = url.pathname.split('/').pop() ?? '';
               // Angular outputHashing:"all" produces files like main.abc1234f.js
@@ -547,7 +547,7 @@ const server = Bun.serve<WsData>({
               } else {
                 headers['Cache-Control'] = 'public, max-age=3600';
               }
-              return instrumentResponse(new Response(file, { headers }), '/static');
+              return instrumentResponse(new Response(bytes, { headers }), '/static');
             }
           } catch { /* file not found, fall through */ }
         }
@@ -555,10 +555,11 @@ const server = Bun.serve<WsData>({
         // SPA fallback - serve index.html for unmatched routes
         try {
           const indexPath = join(CLIENT_DIST, 'index.html');
-          const indexFile = Bun.file(indexPath);
-          if (indexFile.size > 0) {
+          // Read atomically — no separate existence check
+          const indexBytes = await Bun.file(indexPath).bytes();
+          if (indexBytes.length > 0) {
             return instrumentResponse(
-              new Response(indexFile, {
+              new Response(indexBytes, {
                 headers: {
                   'Content-Type': 'text/html',
                   'Cache-Control': 'no-cache, no-store, must-revalidate',


### PR DESCRIPTION
## Summary
- **server/index.ts** (#319): Replaced `file.size > 0` check-then-serve pattern with atomic `await Bun.file().bytes()` read, eliminating the TOCTOU window between stat and response creation
- **cli/commands/provision.ts** (#318): Changed `identity.json` write from plain `writeFileSync` to atomic tmp+rename pattern, preventing race conditions during file creation

## CodeQL Alerts Addressed
| Alert | Severity | File | Status |
|-------|----------|------|--------|
| #319 | High | server/index.ts:495 | Fixed |
| #318 | High | cli/commands/provision.ts:110 | Fixed |
| #312-317 | High | server/__tests__/skill-loader.test.ts | Already fixed (stale alerts) |
| #320 | Warning | cli/commands/init.ts:462 | False positive (line points into template literal) |
| #321-323 | Note | Angular components | Angular DI side-effect pattern / type-only imports |

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` passes clean
- [x] 9502/9507 tests pass (5 pre-existing failures unrelated to changes)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6