### PR TITLE
fix(deps): upgrade path-to-regexp >=8.4.0 to patch HIGH vuln (GHSA-j3q9-mxjg-w52f)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
     "express-rate-limit": ">=8.2.2",
     "hono": ">=4.12.7",
     "minimatch": ">=9.0.7",
+    "path-to-regexp": ">=8.4.0",
     "qs": ">=6.14.2",
   },
   "packages": {
@@ -526,7 +527,7 @@
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
-    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+    "path-to-regexp": ["path-to-regexp@8.4.0", "", {}, "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg=="],
 
     "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
 

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "qs": ">=6.14.2",
     "hono": ">=4.12.7",
     "@hono/node-server": ">=1.19.10",
-    "express-rate-limit": ">=8.2.2"
+    "express-rate-limit": ">=8.2.2",
+    "path-to-regexp": ">=8.4.0"
   }
 }


### PR DESCRIPTION
## Summary

- Adds `path-to-regexp: >=8.4.0` to `package.json` overrides, forcing `8.4.0` over the vulnerable `8.3.0`
- Resolves **HIGH** vuln GHSA-j3q9-mxjg-w52f: path-to-regexp DoS via sequential optional groups
- Transitive chain: `@modelcontextprotocol/sdk → express → router → path-to-regexp`

## Verification

```
bun audit → No vulnerabilities found ✓
bun x tsc --noEmit --skipLibCheck → clean ✓
```

## RC Gating

Closes the "No CRITICAL/HIGH dependency vulnerabilities" gate on #310.

## Test plan
- [x] `bun audit` reports no vulnerabilities
- [x] TypeScript check passes
- [x] `path-to-regexp@8.4.0` confirmed in lockfile

Closes part of #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)