### PR TITLE
feat(docs): deploy docs/blog via GitHub Pages from main repo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Adds a GitHub Pages deployment workflow that serves the `docs/` directory on pushes to main
- Moves the docs/blog site from the separate `corvid-agent/corvid-agent.github.io` repo into `CorvidLabs/corvid-agent`
- All existing docs content is already in `docs/` — this just adds the deployment pipeline

## Notes
- After merge, enable GitHub Pages in repo settings (Source: GitHub Actions)
- There are ~76 references to `corvid-agent.github.io` in the docs HTML — these can be updated once the new domain/URL is decided
- The new default URL will be `corvidlabs.github.io/corvid-agent/` unless a custom domain is configured

## Test plan
- [ ] Merge and verify GitHub Pages deployment triggers
- [ ] Confirm site loads at the new URL
- [ ] Decide on custom domain or update internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6