### PR TITLE
fix(discord): persist and recover mention sessions across restarts

### DIFF
--- a/server/__tests__/discord-thread-session-manager.test.ts
+++ b/server/__tests__/discord-thread-session-manager.test.ts
@@ -145,8 +145,8 @@ describe('ThreadSessionManager — TTL cleanup', () => {
         expect(mgr.processedMessageIds.size).toBe(1000);
     });
 
-    test('runCleanup removes expired mention sessions (older than 30 min)', () => {
-        const expiredTs = Date.now() - 31 * 60 * 1000;
+    test('runCleanup removes expired mention sessions (older than 6 hours)', () => {
+        const expiredTs = Date.now() - 6.1 * 60 * 60 * 1000; // 6h 6m ago
         const freshTs = Date.now() - 5 * 60 * 1000;
 
         mgr.trackMentionSession('old-msg', makeMentionInfo({ sessionId: 'old' }), expiredTs);
@@ -160,14 +160,14 @@ describe('ThreadSessionManager — TTL cleanup', () => {
     });
 
     test('runCleanup does not remove mention sessions exactly at TTL boundary', () => {
-        // Exactly 30 minutes ago — should NOT be expired (condition is strictly >)
-        const borderTs = Date.now() - 30 * 60 * 1000;
+        // Exactly 6 hours ago — should NOT be expired (condition is strictly >)
+        const borderTs = Date.now() - 6 * 60 * 60 * 1000;
         mgr.trackMentionSession('border-msg', makeMentionInfo(), borderTs);
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (mgr as any).runCleanup();
 
-        // 30 min exactly: `now - ts > MENTION_TTL_MS` is false so session survives
+        // 6h exactly: `now - ts > MENTION_TTL_MS` is false so session survives
         expect(mgr.mentionSessions.has('border-msg')).toBe(true);
     });
 });

--- a/server/db/discord-mention-sessions.ts
+++ b/server/db/discord-mention-sessions.ts
@@ -2,69 +2,109 @@ import type { Database } from 'bun:sqlite';
 import type { MentionSessionInfo } from '../discord/message-handler';
 
 interface MentionSessionRow {
-    bot_message_id: string;
-    session_id: string;
-    agent_name: string;
-    agent_model: string;
-    project_name: string | null;
-    channel_id: string | null;
-    conversation_only: number | null;
-    created_at: string;
+  bot_message_id: string;
+  session_id: string;
+  agent_name: string;
+  agent_model: string;
+  project_name: string | null;
+  channel_id: string | null;
+  conversation_only: number | null;
+  created_at: string;
 }
 
 /**
  * Persist a mention-reply session mapping to the database.
  */
-export function saveMentionSession(
-    db: Database,
-    botMessageId: string,
-    info: MentionSessionInfo,
-): void {
-    db.query(
-        `INSERT OR REPLACE INTO discord_mention_sessions (bot_message_id, session_id, agent_name, agent_model, project_name, channel_id, conversation_only)
+export function saveMentionSession(db: Database, botMessageId: string, info: MentionSessionInfo): void {
+  db.query(
+    `INSERT OR REPLACE INTO discord_mention_sessions (bot_message_id, session_id, agent_name, agent_model, project_name, channel_id, conversation_only)
          VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    ).run(botMessageId, info.sessionId, info.agentName, info.agentModel, info.projectName ?? null, info.channelId ?? null, info.conversationOnly ? 1 : 0);
+  ).run(
+    botMessageId,
+    info.sessionId,
+    info.agentName,
+    info.agentModel,
+    info.projectName ?? null,
+    info.channelId ?? null,
+    info.conversationOnly ? 1 : 0,
+  );
 }
 
 /**
  * Look up a mention-reply session by bot message ID.
  * Returns null if not found.
  */
-export function getMentionSession(
-    db: Database,
-    botMessageId: string,
-): MentionSessionInfo | null {
-    const row = db.query(
-        `SELECT m.*, a.display_color, a.display_icon, a.avatar_url
+export function getMentionSession(db: Database, botMessageId: string): MentionSessionInfo | null {
+  const row = db
+    .query(
+      `SELECT m.*, a.display_color, a.display_icon, a.avatar_url
          FROM discord_mention_sessions m
          LEFT JOIN sessions s ON s.id = m.session_id
          LEFT JOIN agents a ON a.id = s.agent_id
          WHERE m.bot_message_id = ?`,
-    ).get(botMessageId) as (MentionSessionRow & { display_color: string | null; display_icon: string | null; avatar_url: string | null }) | null;
+    )
+    .get(botMessageId) as
+    | (MentionSessionRow & { display_color: string | null; display_icon: string | null; avatar_url: string | null })
+    | null;
 
-    if (!row) return null;
+  if (!row) return null;
 
-    return {
-        sessionId: row.session_id,
-        agentName: row.agent_name,
-        agentModel: row.agent_model,
-        projectName: row.project_name || undefined,
-        displayColor: row.display_color ?? undefined,
-        displayIcon: row.display_icon ?? undefined,
-        avatarUrl: row.avatar_url ?? undefined,
-        channelId: row.channel_id || undefined,
-        conversationOnly: row.conversation_only === 1,
-    };
+  return {
+    sessionId: row.session_id,
+    agentName: row.agent_name,
+    agentModel: row.agent_model,
+    projectName: row.project_name || undefined,
+    displayColor: row.display_color ?? undefined,
+    displayIcon: row.display_icon ?? undefined,
+    avatarUrl: row.avatar_url ?? undefined,
+    channelId: row.channel_id || undefined,
+    conversationOnly: row.conversation_only === 1,
+  };
 }
 
 /**
  * Delete all mention session mappings for a given session ID.
  */
-export function deleteMentionSessionsBySessionId(
-    db: Database,
-    sessionId: string,
-): void {
-    db.query('DELETE FROM discord_mention_sessions WHERE session_id = ?').run(sessionId);
+export function deleteMentionSessionsBySessionId(db: Database, sessionId: string): void {
+  db.query('DELETE FROM discord_mention_sessions WHERE session_id = ?').run(sessionId);
+}
+
+/**
+ * Load recent mention sessions from the database (e.g. for recovery after restart).
+ * @param maxAgeHours Maximum age in hours (default: 24)
+ */
+export function getRecentMentionSessions(
+  db: Database,
+  maxAgeHours: number = 24,
+): Array<{ botMessageId: string; info: MentionSessionInfo; createdAt: string }> {
+  const rows = db
+    .query(
+      `SELECT m.*, a.display_color, a.display_icon, a.avatar_url
+         FROM discord_mention_sessions m
+         LEFT JOIN sessions s ON s.id = m.session_id
+         LEFT JOIN agents a ON a.id = s.agent_id
+         WHERE m.created_at > datetime('now', '-' || ? || ' hours')
+         ORDER BY m.created_at DESC`,
+    )
+    .all(maxAgeHours) as Array<
+    MentionSessionRow & { display_color: string | null; display_icon: string | null; avatar_url: string | null }
+  >;
+
+  return rows.map((row) => ({
+    botMessageId: row.bot_message_id,
+    info: {
+      sessionId: row.session_id,
+      agentName: row.agent_name,
+      agentModel: row.agent_model,
+      projectName: row.project_name || undefined,
+      displayColor: row.display_color ?? undefined,
+      displayIcon: row.display_icon ?? undefined,
+      avatarUrl: row.avatar_url ?? undefined,
+      channelId: row.channel_id || undefined,
+      conversationOnly: row.conversation_only === 1,
+    },
+    createdAt: row.created_at,
+  }));
 }
 
 /**
@@ -83,12 +123,9 @@ export function updateMentionSessionActivity(
  * Remove mention session entries older than the specified age.
  * @param maxAgeDays Maximum age in days (default: 7)
  */
-export function pruneOldMentionSessions(
-    db: Database,
-    maxAgeDays: number = 7,
-): number {
-    const result = db.query(
-        `DELETE FROM discord_mention_sessions WHERE created_at < datetime('now', '-' || ? || ' days')`,
-    ).run(maxAgeDays);
-    return result.changes;
+export function pruneOldMentionSessions(db: Database, maxAgeDays: number = 7): number {
+  const result = db
+    .query(`DELETE FROM discord_mention_sessions WHERE created_at < datetime('now', '-' || ? || ' days')`)
+    .run(maxAgeDays);
+  return result.changes;
 }

--- a/server/discord/bridge.ts
+++ b/server/discord/bridge.ts
@@ -50,6 +50,7 @@ import { handleReaction as handleReactionImpl, type ReactionHandlerContext } fro
 import {
   archiveStaleThreads as archiveStaleThreadsImpl,
   createStandaloneThread as createStandaloneThreadImpl,
+  recoverActiveMentionSessions,
   recoverActiveThreadSessions,
   recoverActiveThreadSubscriptions,
   subscribeForAdaptiveInlineResponse,
@@ -155,6 +156,9 @@ export class DiscordBridge {
           this.config.botToken,
           this.tsm.threadSessions,
           this.tsm.threadCallbacks,
+        );
+        recoverActiveMentionSessions(this.db, this.tsm.mentionSessions, (botMessageId, info, createdAt) =>
+          this.tsm.trackMentionSession(botMessageId, info, createdAt),
         );
       },
     });

--- a/server/discord/thread-manager.ts
+++ b/server/discord/thread-manager.ts
@@ -17,21 +17,21 @@ import type { DeliveryTracker } from '../lib/delivery-tracker';
 import { extractContentText, extractContentImageUrls } from '../process/types';
 import { createLogger } from '../lib/logger';
 import {
-    sendEmbed,
-    sendReplyEmbed,
-    editEmbed,
-    sendEmbedWithButtons,
-    sendEmbedWithFiles,
-    buildActionRow,
-    sendTypingIndicator,
-    agentColor,
-    hexColorToInt,
-    splitEmbedDescription,
-    collapseCodeBlocks,
-    buildFooterText,
-    buildFooterWithStats,
-    buildAgentAuthor,
-    type DiscordFileAttachment,
+  sendEmbed,
+  sendReplyEmbed,
+  editEmbed,
+  sendEmbedWithButtons,
+  sendEmbedWithFiles,
+  buildActionRow,
+  sendTypingIndicator,
+  agentColor,
+  hexColorToInt,
+  splitEmbedDescription,
+  collapseCodeBlocks,
+  buildFooterText,
+  buildFooterWithStats,
+  buildAgentAuthor,
+  type DiscordFileAttachment,
 } from './embeds';
 
 // Re-export from focused sub-modules so existing consumers don't need to update imports.
@@ -46,51 +46,59 @@ const log = createLogger('DiscordThreadManager');
 
 /** Drop whitespace-only chunks so Discord never receives empty-looking embed bodies. */
 function visibleEmbedParts(text: string): string[] {
-    return splitEmbedDescription(text.trim())
-        .map((p) => p.trim())
-        .filter((p) => p.length > 0);
+  return splitEmbedDescription(text.trim())
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
 }
 
 /** Exported for testing. Maps an error type to a user-facing embed title, description, and color. */
-export function sessionErrorEmbed(errorType: string, fallbackMessage?: string): { title: string; description: string; color: number } {
-    switch (errorType) {
-        case 'context_exhausted':
-            return {
-                title: 'Context Limit Reached',
-                description: 'The conversation ran out of context space. Send a message to continue with fresh context — the agent will pick up where it left off.',
-                color: 0xf0b232,
-            };
-        case 'credits_exhausted':
-            return {
-                title: 'Credits Exhausted',
-                description: 'Session paused — credits have been used up. Top up credits in Settings > Spending, then send a message to resume.',
-                color: 0xf0b232,
-            };
-        case 'timeout':
-            return {
-                title: 'Session Timed Out',
-                description: 'The session exceeded its time limit. Send a message to restart — try breaking your request into smaller steps.',
-                color: 0xf0b232,
-            };
-        case 'crash':
-            return {
-                title: 'Session Crashed',
-                description: 'The agent session crashed unexpectedly. Press Resume to restart, or send a new message. If this keeps happening, check the dashboard for details.',
-                color: 0xff3355,
-            };
-        case 'spawn_error':
-            return {
-                title: 'Failed to Start',
-                description: 'The agent session could not be started. Check that the agent\'s provider (API key, model) is configured correctly in the dashboard.',
-                color: 0xff3355,
-            };
-        default:
-            return {
-                title: 'Session Error',
-                description: (fallbackMessage || 'An unexpected error occurred.').slice(0, 4096),
-                color: 0xff3355,
-            };
-    }
+export function sessionErrorEmbed(
+  errorType: string,
+  fallbackMessage?: string,
+): { title: string; description: string; color: number } {
+  switch (errorType) {
+    case 'context_exhausted':
+      return {
+        title: 'Context Limit Reached',
+        description:
+          'The conversation ran out of context space. Send a message to continue with fresh context — the agent will pick up where it left off.',
+        color: 0xf0b232,
+      };
+    case 'credits_exhausted':
+      return {
+        title: 'Credits Exhausted',
+        description:
+          'Session paused — credits have been used up. Top up credits in Settings > Spending, then send a message to resume.',
+        color: 0xf0b232,
+      };
+    case 'timeout':
+      return {
+        title: 'Session Timed Out',
+        description:
+          'The session exceeded its time limit. Send a message to restart — try breaking your request into smaller steps.',
+        color: 0xf0b232,
+      };
+    case 'crash':
+      return {
+        title: 'Session Crashed',
+        description:
+          'The agent session crashed unexpectedly. Press Resume to restart, or send a new message. If this keeps happening, check the dashboard for details.',
+        color: 0xff3355,
+      };
+    case 'spawn_error':
+      return {
+        title: 'Failed to Start',
+        description:
+          "The agent session could not be started. Check that the agent's provider (API key, model) is configured correctly in the dashboard.",
+        color: 0xff3355,
+      };
+    default:
+      return {
+        title: 'Session Error',
+        description: (fallbackMessage || 'An unexpected error occurred.').slice(0, 4096),
+        color: 0xff3355,
+      };
+  }
 }
 
 /**
@@ -98,389 +106,442 @@ export function sessionErrorEmbed(errorType: string, fallbackMessage?: string): 
  * Shows agent name and model in the embed footer.
  */
 export function subscribeForResponseWithEmbed(
-    processManager: ProcessManager,
-    delivery: DeliveryTracker,
-    botToken: string,
-    db: Database,
-    threadCallbacks: Map<string, ThreadCallbackInfo>,
-    sessionId: string,
-    threadId: string,
-    agentName: string,
-    agentModel: string,
-    projectName?: string,
-    displayColor?: string | null,
-    displayIcon?: string | null,
-    avatarUrl?: string | null,
+  processManager: ProcessManager,
+  delivery: DeliveryTracker,
+  botToken: string,
+  db: Database,
+  threadCallbacks: Map<string, ThreadCallbackInfo>,
+  sessionId: string,
+  threadId: string,
+  agentName: string,
+  agentModel: string,
+  projectName?: string,
+  displayColor?: string | null,
+  displayIcon?: string | null,
+  avatarUrl?: string | null,
 ): void {
-    // Unsubscribe the previous callback for this thread to prevent duplicates
-    const prev = threadCallbacks.get(threadId);
-    if (prev) {
-        processManager.unsubscribe(prev.sessionId, prev.callback);
+  // Unsubscribe the previous callback for this thread to prevent duplicates
+  const prev = threadCallbacks.get(threadId);
+  if (prev) {
+    processManager.unsubscribe(prev.sessionId, prev.callback);
+  }
+
+  let buffer = '';
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastStatusTime = 0;
+  let lastTypingTime = 0;
+  let receivedAnyContent = false;
+  const STATUS_DEBOUNCE_MS = 3000;
+  const TYPING_REFRESH_MS = 8000;
+  const TYPING_TIMEOUT_MS = 4 * 60 * 1000; // 4 minute safety timeout
+  const ACK_DELAY_MS = 5000; // send acknowledgment if no content within 5s
+  const PROGRESS_INTERVAL_MS = 60_000; // periodic progress every 60s
+  let receivedAnyActivity = false; // tracks any activity (content OR tool use)
+  let sentErrorMessage = false; // dedup: prevent repeated error messages for same session
+  const startTime = Date.now();
+
+  // Acknowledgment: if no content arrives within ACK_DELAY_MS, send a brief status embed
+  const ackTimer = setTimeout(() => {
+    if (!receivedAnyContent && !sentErrorMessage) {
+      sendEmbed(delivery, botToken, threadId, {
+        description: 'Received — working on it...',
+        color: 0x95a5a6,
+        author,
+        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'thinking' }) },
+      }).catch((err) => {
+        log.debug('Ack embed failed', { threadId, error: err instanceof Error ? err.message : String(err) });
+      });
+    }
+  }, ACK_DELAY_MS);
+
+  // Periodic progress for long-running operations
+  const progressInterval = setInterval(() => {
+    if (receivedAnyContent || sentErrorMessage) return;
+    if (!processManager.isRunning(sessionId)) {
+      clearInterval(progressInterval);
+      return;
+    }
+    const elapsed = Math.round((Date.now() - startTime) / 1000);
+    sendEmbed(delivery, botToken, threadId, {
+      description: `Still working (${elapsed}s elapsed)...`,
+      color: 0x95a5a6,
+      author,
+      footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'working...' }) },
+    }).catch((err) => {
+      log.debug('Progress embed failed', { threadId, error: err instanceof Error ? err.message : String(err) });
+    });
+  }, PROGRESS_INTERVAL_MS);
+
+  // Keep typing indicator alive continuously until response completes
+  const typingInterval = setInterval(() => {
+    // Check if the process is still alive
+    if (!processManager.isRunning(sessionId)) {
+      clearTyping();
+      log.warn('Process died while typing indicator active', { sessionId, threadId });
+      if (!receivedAnyContent && !sentErrorMessage) {
+        sentErrorMessage = true;
+        sendEmbedWithButtons(
+          delivery,
+          botToken,
+          threadId,
+          {
+            description: 'The agent session ended unexpectedly. Send a message to resume.',
+            color: 0xff3355,
+            author,
+            footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'crashed' }) },
+          },
+          [buildActionRow({ label: 'Resume', customId: 'resume_thread', style: ButtonStyle.SUCCESS, emoji: '🔄' })],
+        ).catch((err) => {
+          log.warn('Failed to send crash embed', { threadId, error: err instanceof Error ? err.message : String(err) });
+        });
+      }
+      threadCallbacks.delete(threadId);
+      return;
+    }
+    sendTypingIndicator(botToken, threadId).catch((err) => {
+      log.debug('Typing indicator failed', { threadId, error: err instanceof Error ? err.message : String(err) });
+    });
+  }, TYPING_REFRESH_MS);
+
+  // Safety timeout: clear typing if no terminal event arrives
+  const typingSafetyTimeout = setTimeout(() => {
+    clearTyping();
+    log.warn('Typing indicator safety timeout reached', { sessionId, threadId });
+    if (!receivedAnyActivity) {
+      sendEmbed(delivery, botToken, threadId, {
+        description: 'The agent appears to be taking too long. It may still be working \u2014 send a message to check.',
+        color: 0xf0b232,
+      }).catch((err) => {
+        log.warn('Failed to send timeout embed', { threadId, error: err instanceof Error ? err.message : String(err) });
+      });
+    }
+  }, TYPING_TIMEOUT_MS);
+
+  const clearTyping = () => {
+    clearInterval(typingInterval);
+    clearTimeout(typingSafetyTimeout);
+    clearTimeout(ackTimer);
+    clearInterval(progressInterval);
+  };
+
+  const color = hexColorToInt(displayColor) ?? agentColor(agentName);
+  const author = buildAgentAuthor({ agentName, displayIcon, avatarUrl });
+
+  const flush = async () => {
+    if (!buffer) return;
+    const text = buffer;
+    buffer = '';
+
+    const parts = visibleEmbedParts(text);
+    for (const part of parts) {
+      await sendEmbed(delivery, botToken, threadId, {
+        description: part,
+        color,
+        author,
+        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
+      });
+    }
+  };
+
+  /** Download an image URL and send as a Discord file attachment in the thread. */
+  const sendThreadImageUrl = async (imageUrl: string) => {
+    try {
+      const resp = await fetch(imageUrl);
+      if (!resp.ok) {
+        log.warn('Failed to fetch image for Discord thread', { imageUrl, status: resp.status });
+        return;
+      }
+      const data = new Uint8Array(await resp.arrayBuffer());
+      const ct = resp.headers.get('content-type') ?? 'image/png';
+      const ext =
+        ct.includes('jpeg') || ct.includes('jpg')
+          ? 'jpg'
+          : ct.includes('gif')
+            ? 'gif'
+            : ct.includes('webp')
+              ? 'webp'
+              : 'png';
+      const filename = `image.${ext}`;
+      const attachment: DiscordFileAttachment = { name: filename, data, contentType: ct };
+      await sendEmbedWithFiles(
+        delivery,
+        botToken,
+        threadId,
+        {
+          image: { url: `attachment://${filename}` },
+          color,
+          author,
+          footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
+        },
+        [attachment],
+      );
+    } catch (err) {
+      log.warn('Failed to send image to Discord thread', {
+        imageUrl,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const callback: EventCallback = (_sid, event) => {
+    if (event.type === 'assistant' && event.message) {
+      const msg = event.message as { content?: unknown };
+      const contentBlocks = msg.content as string | import('../process/types').ContentBlock[] | undefined;
+      const content = collapseCodeBlocks(extractContentText(contentBlocks)).trim();
+
+      if (content) {
+        if (!receivedAnyContent) {
+          // Cancel ack + progress now that real content is arriving
+          clearTimeout(ackTimer);
+          clearInterval(progressInterval);
+        }
+        receivedAnyContent = true;
+        receivedAnyActivity = true;
+        buffer += content;
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => flush(), 1500);
+      }
+
+      // Send any image content blocks as file attachments
+      const imageUrls = extractContentImageUrls(contentBlocks);
+      for (const imageUrl of imageUrls) {
+        receivedAnyContent = true;
+        receivedAnyActivity = true;
+        sendThreadImageUrl(imageUrl);
+      }
+
+      const now = Date.now();
+      if (now - lastTypingTime >= TYPING_REFRESH_MS) {
+        lastTypingTime = now;
+        sendTypingIndicator(botToken, threadId).catch((err) => {
+          log.debug('Typing indicator failed', { threadId, error: err instanceof Error ? err.message : String(err) });
+        });
+      }
     }
 
-    let buffer = '';
-    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-    let lastStatusTime = 0;
-    let lastTypingTime = 0;
-    let receivedAnyContent = false;
-    const STATUS_DEBOUNCE_MS = 3000;
-    const TYPING_REFRESH_MS = 8000;
-    const TYPING_TIMEOUT_MS = 4 * 60 * 1000; // 4 minute safety timeout
-    const ACK_DELAY_MS = 5000; // send acknowledgment if no content within 5s
-    const PROGRESS_INTERVAL_MS = 60_000; // periodic progress every 60s
-    let receivedAnyActivity = false; // tracks any activity (content OR tool use)
-    let sentErrorMessage = false; // dedup: prevent repeated error messages for same session
-    const startTime = Date.now();
-
-    // Acknowledgment: if no content arrives within ACK_DELAY_MS, send a brief status embed
-    const ackTimer = setTimeout(() => {
-        if (!receivedAnyContent && !sentErrorMessage) {
-            sendEmbed(delivery, botToken, threadId, {
-                description: 'Received — working on it...',
-                color: 0x95a5a6,
-                author,
-                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'thinking' }) },
-            }).catch((err) => {
-                log.debug('Ack embed failed', { threadId, error: err instanceof Error ? err.message : String(err) });
-            });
-        }
-    }, ACK_DELAY_MS);
-
-    // Periodic progress for long-running operations
-    const progressInterval = setInterval(() => {
-        if (receivedAnyContent || sentErrorMessage) return;
-        if (!processManager.isRunning(sessionId)) { clearInterval(progressInterval); return; }
-        const elapsed = Math.round((Date.now() - startTime) / 1000);
-        sendEmbed(delivery, botToken, threadId, {
-            description: `Still working (${elapsed}s elapsed)...`,
+    if (event.type === 'tool_status' && event.statusMessage) {
+      const statusText = event.statusMessage.trim();
+      if (statusText) {
+        receivedAnyActivity = true;
+        const now = Date.now();
+        if (now - lastStatusTime >= STATUS_DEBOUNCE_MS) {
+          lastStatusTime = now;
+          sendEmbed(delivery, botToken, threadId, {
+            description: `⏳ ${statusText}`,
             color: 0x95a5a6,
             author,
             footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'working...' }) },
-        }).catch((err) => {
-            log.debug('Progress embed failed', { threadId, error: err instanceof Error ? err.message : String(err) });
-        });
-    }, PROGRESS_INTERVAL_MS);
-
-    // Keep typing indicator alive continuously until response completes
-    const typingInterval = setInterval(() => {
-        // Check if the process is still alive
-        if (!processManager.isRunning(sessionId)) {
-            clearTyping();
-            log.warn('Process died while typing indicator active', { sessionId, threadId });
-            if (!receivedAnyContent && !sentErrorMessage) {
-                sentErrorMessage = true;
-                sendEmbedWithButtons(delivery, botToken, threadId, {
-                    description: 'The agent session ended unexpectedly. Send a message to resume.',
-                    color: 0xff3355,
-                    author,
-                    footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'crashed' }) },
-                }, [
-                    buildActionRow(
-                        { label: 'Resume', customId: 'resume_thread', style: ButtonStyle.SUCCESS, emoji: '🔄' },
-                    ),
-                ]).catch((err) => {
-                    log.warn('Failed to send crash embed', { threadId, error: err instanceof Error ? err.message : String(err) });
-                });
-            }
-            threadCallbacks.delete(threadId);
-            return;
+          }).catch((err) => {
+            log.debug('Tool status embed failed', {
+              threadId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
         }
-        sendTypingIndicator(botToken, threadId).catch((err) => {
+        if (now - lastTypingTime >= TYPING_REFRESH_MS) {
+          lastTypingTime = now;
+          sendTypingIndicator(botToken, threadId).catch((err) => {
             log.debug('Typing indicator failed', { threadId, error: err instanceof Error ? err.message : String(err) });
+          });
+        }
+      }
+    }
+
+    if (event.type === 'context_warning') {
+      const warning = event as { level?: string; message?: string; usagePercent?: number };
+      if (warning.level === 'critical') {
+        sendEmbed(delivery, botToken, threadId, {
+          description: `⚠️ ${warning.message || `Context usage at ${warning.usagePercent}%`}`,
+          color: 0xf0b232, // yellow/warning
+          author,
+          footer: {
+            text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'context warning' }),
+          },
+        }).catch((err) => {
+          log.debug('Context warning embed failed', {
+            threadId,
+            error: err instanceof Error ? err.message : String(err),
+          });
         });
-    }, TYPING_REFRESH_MS);
+      }
+    }
 
-    // Safety timeout: clear typing if no terminal event arrives
-    const typingSafetyTimeout = setTimeout(() => {
-        clearTyping();
-        log.warn('Typing indicator safety timeout reached', { sessionId, threadId });
-        if (!receivedAnyActivity) {
-            sendEmbed(delivery, botToken, threadId, {
-                description: 'The agent appears to be taking too long. It may still be working \u2014 send a message to check.',
-                color: 0xf0b232,
-            }).catch((err) => {
-                log.warn('Failed to send timeout embed', { threadId, error: err instanceof Error ? err.message : String(err) });
-            });
-        }
-    }, TYPING_TIMEOUT_MS);
+    if (event.type === 'result') {
+      clearTyping();
+      if (debounceTimer) clearTimeout(debounceTimer);
+      flush();
+      processManager.unsubscribe(sessionId, callback);
+      threadCallbacks.delete(threadId);
 
-    const clearTyping = () => {
-        clearInterval(typingInterval);
-        clearTimeout(typingSafetyTimeout);
-        clearTimeout(ackTimer);
-        clearInterval(progressInterval);
-    };
-
-    const color = hexColorToInt(displayColor) ?? agentColor(agentName);
-    const author = buildAgentAuthor({ agentName, displayIcon, avatarUrl });
-
-    const flush = async () => {
-        if (!buffer) return;
-        const text = buffer;
-        buffer = '';
-
-        const parts = visibleEmbedParts(text);
-        for (const part of parts) {
-            await sendEmbed(delivery, botToken, threadId, {
-                description: part,
-                color,
-                author,
-                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
-            });
-        }
-    };
-
-    /** Download an image URL and send as a Discord file attachment in the thread. */
-    const sendThreadImageUrl = async (imageUrl: string) => {
+      // Gather stats and send completion embed (async, fire-and-forget)
+      (async () => {
+        const fields: Array<{ name: string; value: string; inline?: boolean }> = [];
+        let statsTurns = 0;
+        let statsFiles = 0;
+        let statsCommits = 0;
+        let statsTools = 0;
         try {
-            const resp = await fetch(imageUrl);
-            if (!resp.ok) {
-                log.warn('Failed to fetch image for Discord thread', { imageUrl, status: resp.status });
-                return;
-            }
-            const data = new Uint8Array(await resp.arrayBuffer());
-            const ct = resp.headers.get('content-type') ?? 'image/png';
-            const ext = ct.includes('jpeg') || ct.includes('jpg') ? 'jpg' : ct.includes('gif') ? 'gif' : ct.includes('webp') ? 'webp' : 'png';
-            const filename = `image.${ext}`;
-            const attachment: DiscordFileAttachment = { name: filename, data, contentType: ct };
-            await sendEmbedWithFiles(delivery, botToken, threadId, {
-                image: { url: `attachment://${filename}` },
-                color,
-                author,
-                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
-            }, [attachment]);
-        } catch (err) {
-            log.warn('Failed to send image to Discord thread', { imageUrl, error: err instanceof Error ? err.message : String(err) });
-        }
-    };
+          const row = db
+            .query<
+              {
+                total_turns: number;
+                work_dir: string | null;
+                created_at: string;
+              },
+              [string]
+            >('SELECT total_turns, work_dir, created_at FROM sessions WHERE id = ?')
+            .get(sessionId);
 
-    const callback: EventCallback = (_sid, event) => {
-        if (event.type === 'assistant' && event.message) {
-            const msg = event.message as { content?: unknown };
-            const contentBlocks = msg.content as string | import('../process/types').ContentBlock[] | undefined;
-            const content = collapseCodeBlocks(extractContentText(contentBlocks)).trim();
+          // Fetch tool call count from session_metrics
+          const metricsRow = db
+            .query<{ tool_call_count: number }, [string]>(
+              'SELECT tool_call_count FROM session_metrics WHERE session_id = ? ORDER BY created_at DESC LIMIT 1',
+            )
+            .get(sessionId);
+          if (metricsRow) {
+            statsTools = metricsRow.tool_call_count;
+          }
 
-            if (content) {
-                if (!receivedAnyContent) {
-                    // Cancel ack + progress now that real content is arriving
-                    clearTimeout(ackTimer);
-                    clearInterval(progressInterval);
-                }
-                receivedAnyContent = true;
-                receivedAnyActivity = true;
-                buffer += content;
-                if (debounceTimer) clearTimeout(debounceTimer);
-                debounceTimer = setTimeout(() => flush(), 1500);
+          if (row) {
+            // Duration — normalizeTimestamp appends Z so JS parses SQLite UTC correctly
+            const createdAt = normalizeTimestamp(row.created_at);
+            const startMs = new Date(createdAt).getTime();
+            const durationMs = Date.now() - startMs;
+            fields.push({ name: 'Duration', value: formatDuration(durationMs), inline: true });
+
+            // Turns
+            statsTurns = row.total_turns;
+            if (row.total_turns > 0) {
+              fields.push({ name: 'Turns', value: String(row.total_turns), inline: true });
             }
 
-            // Send any image content blocks as file attachments
-            const imageUrls = extractContentImageUrls(contentBlocks);
-            for (const imageUrl of imageUrls) {
-                receivedAnyContent = true;
-                receivedAnyActivity = true;
-                sendThreadImageUrl(imageUrl);
+            // Tool calls
+            if (statsTools > 0) {
+              fields.push({ name: 'Tool Calls', value: String(statsTools), inline: true });
             }
 
-            const now = Date.now();
-            if (now - lastTypingTime >= TYPING_REFRESH_MS) {
-                lastTypingTime = now;
-                sendTypingIndicator(botToken, threadId).catch((err) => {
-                    log.debug('Typing indicator failed', { threadId, error: err instanceof Error ? err.message : String(err) });
-                });
-            }
-        }
+            // Worktree branch + git stats
+            if (row.work_dir) {
+              const branchMatch = row.work_dir.match(/\/([^/]+)$/);
+              const branch = branchMatch ? branchMatch[1] : row.work_dir;
+              fields.push({ name: 'Branch', value: `\`${branch}\``, inline: true });
 
-        if (event.type === 'tool_status' && event.statusMessage) {
-            const statusText = event.statusMessage.trim();
-            if (statusText) {
-                receivedAnyActivity = true;
-                const now = Date.now();
-                if (now - lastStatusTime >= STATUS_DEBOUNCE_MS) {
-                    lastStatusTime = now;
-                    sendEmbed(delivery, botToken, threadId, {
-                        description: `⏳ ${statusText}`,
-                        color: 0x95a5a6,
-                        author,
-                        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'working...' }) },
-                    }).catch((err) => {
-                        log.debug('Tool status embed failed', { threadId, error: err instanceof Error ? err.message : String(err) });
+              // Gather git stats from worktree
+              try {
+                const [filesOutput, commitsOutput] = await Promise.all([
+                  (async () => {
+                    const p = Bun.spawn(['git', 'diff', 'main...HEAD', '--name-only'], {
+                      cwd: row.work_dir!,
+                      stdout: 'pipe',
+                      stderr: 'pipe',
                     });
-                }
-                if (now - lastTypingTime >= TYPING_REFRESH_MS) {
-                    lastTypingTime = now;
-                    sendTypingIndicator(botToken, threadId).catch((err) => {
-                        log.debug('Typing indicator failed', { threadId, error: err instanceof Error ? err.message : String(err) });
+                    const out = await new Response(p.stdout).text();
+                    const code = await p.exited;
+                    return code === 0 ? out.trim() : '';
+                  })(),
+                  (async () => {
+                    const p = Bun.spawn(['git', 'rev-list', '--count', 'main...HEAD'], {
+                      cwd: row.work_dir!,
+                      stdout: 'pipe',
+                      stderr: 'pipe',
                     });
-                }
-            }
-        }
-
-        if (event.type === 'context_warning') {
-            const warning = event as { level?: string; message?: string; usagePercent?: number };
-            if (warning.level === 'critical') {
-                sendEmbed(delivery, botToken, threadId, {
-                    description: `⚠️ ${warning.message || `Context usage at ${warning.usagePercent}%`}`,
-                    color: 0xf0b232, // yellow/warning
-                    author,
-                    footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'context warning' }) },
-                }).catch((err) => {
-                    log.debug('Context warning embed failed', { threadId, error: err instanceof Error ? err.message : String(err) });
-                });
-            }
-        }
-
-        if (event.type === 'result') {
-            clearTyping();
-            if (debounceTimer) clearTimeout(debounceTimer);
-            flush();
-            processManager.unsubscribe(sessionId, callback);
-            threadCallbacks.delete(threadId);
-
-            // Gather stats and send completion embed (async, fire-and-forget)
-            (async () => {
-                const fields: Array<{ name: string; value: string; inline?: boolean }> = [];
-                let statsTurns = 0;
-                let statsFiles = 0;
-                let statsCommits = 0;
-                let statsTools = 0;
-                try {
-                    const row = db.query<{
-                        total_turns: number;
-                        work_dir: string | null;
-                        created_at: string;
-                    }, [string]>(
-                        'SELECT total_turns, work_dir, created_at FROM sessions WHERE id = ?',
-                    ).get(sessionId);
-
-                    // Fetch tool call count from session_metrics
-                    const metricsRow = db.query<{ tool_call_count: number }, [string]>(
-                        'SELECT tool_call_count FROM session_metrics WHERE session_id = ? ORDER BY created_at DESC LIMIT 1',
-                    ).get(sessionId);
-                    if (metricsRow) {
-                        statsTools = metricsRow.tool_call_count;
-                    }
-
-                    if (row) {
-                        // Duration — normalizeTimestamp appends Z so JS parses SQLite UTC correctly
-                        const createdAt = normalizeTimestamp(row.created_at);
-                        const startMs = new Date(createdAt).getTime();
-                        const durationMs = Date.now() - startMs;
-                        fields.push({ name: 'Duration', value: formatDuration(durationMs), inline: true });
-
-                        // Turns
-                        statsTurns = row.total_turns;
-                        if (row.total_turns > 0) {
-                            fields.push({ name: 'Turns', value: String(row.total_turns), inline: true });
-                        }
-
-                        // Tool calls
-                        if (statsTools > 0) {
-                            fields.push({ name: 'Tool Calls', value: String(statsTools), inline: true });
-                        }
-
-                        // Worktree branch + git stats
-                        if (row.work_dir) {
-                            const branchMatch = row.work_dir.match(/\/([^/]+)$/);
-                            const branch = branchMatch ? branchMatch[1] : row.work_dir;
-                            fields.push({ name: 'Branch', value: `\`${branch}\``, inline: true });
-
-                            // Gather git stats from worktree
-                            try {
-                                const [filesOutput, commitsOutput] = await Promise.all([
-                                    (async () => {
-                                        const p = Bun.spawn(['git', 'diff', 'main...HEAD', '--name-only'], { cwd: row.work_dir!, stdout: 'pipe', stderr: 'pipe' });
-                                        const out = await new Response(p.stdout).text();
-                                        const code = await p.exited;
-                                        return code === 0 ? out.trim() : '';
-                                    })(),
-                                    (async () => {
-                                        const p = Bun.spawn(['git', 'rev-list', '--count', 'main...HEAD'], { cwd: row.work_dir!, stdout: 'pipe', stderr: 'pipe' });
-                                        const out = await new Response(p.stdout).text();
-                                        const code = await p.exited;
-                                        return code === 0 ? out.trim() : '';
-                                    })(),
-                                ]);
-
-                                statsFiles = filesOutput ? filesOutput.split('\n').length : 0;
-                                if (statsFiles > 0) {
-                                    fields.push({ name: 'Files Changed', value: String(statsFiles), inline: true });
-                                }
-
-                                statsCommits = parseInt(commitsOutput, 10) || 0;
-                                if (statsCommits > 0) {
-                                    fields.push({ name: 'Commits', value: String(statsCommits), inline: true });
-                                }
-                            } catch (gitErr) {
-                                log.debug('Failed to gather git stats for completion embed', {
-                                    sessionId,
-                                    error: gitErr instanceof Error ? gitErr.message : String(gitErr),
-                                });
-                            }
-                        }
-                    }
-                } catch (err) {
-                    log.debug('Failed to fetch session stats for completion embed', {
-                        sessionId,
-                        error: err instanceof Error ? err.message : String(err),
-                    });
-                }
-
-                const footerCtx = { agentName, agentModel, sessionId, projectName, status: 'done' };
-                const footerStats = { filesChanged: statsFiles, turns: statsTurns, tools: statsTools, commits: statsCommits };
-                await sendEmbedWithButtons(delivery, botToken, threadId, {
-                    description: 'Session complete. Send a message to continue the conversation.',
-                    color: 0x57f287,
-                    author,
-                    ...(fields.length > 0 ? { fields } : {}),
-                    footer: { text: buildFooterWithStats(footerCtx, footerStats) },
-                }, [
-                    buildActionRow(
-                        { label: 'Continue', customId: 'resume_thread', style: ButtonStyle.SUCCESS, emoji: '💬' },
-                        { label: 'Archive Thread', customId: 'archive_thread', style: ButtonStyle.SECONDARY, emoji: '📦' },
-                    ),
+                    const out = await new Response(p.stdout).text();
+                    const code = await p.exited;
+                    return code === 0 ? out.trim() : '';
+                  })(),
                 ]);
-            })().catch((err) => {
-                log.debug('Session complete embed failed', { threadId, error: err instanceof Error ? err.message : String(err) });
-            });
+
+                statsFiles = filesOutput ? filesOutput.split('\n').length : 0;
+                if (statsFiles > 0) {
+                  fields.push({ name: 'Files Changed', value: String(statsFiles), inline: true });
+                }
+
+                statsCommits = parseInt(commitsOutput, 10) || 0;
+                if (statsCommits > 0) {
+                  fields.push({ name: 'Commits', value: String(statsCommits), inline: true });
+                }
+              } catch (gitErr) {
+                log.debug('Failed to gather git stats for completion embed', {
+                  sessionId,
+                  error: gitErr instanceof Error ? gitErr.message : String(gitErr),
+                });
+              }
+            }
+          }
+        } catch (err) {
+          log.debug('Failed to fetch session stats for completion embed', {
+            sessionId,
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
 
-        if (event.type === 'session_error') {
-            clearTyping();
-            if (sentErrorMessage) return; // dedup: only show one error per session lifecycle
-            sentErrorMessage = true;
+        const footerCtx = { agentName, agentModel, sessionId, projectName, status: 'done' };
+        const footerStats = { filesChanged: statsFiles, turns: statsTurns, tools: statsTools, commits: statsCommits };
+        await sendEmbedWithButtons(
+          delivery,
+          botToken,
+          threadId,
+          {
+            description: 'Session complete. Send a message to continue the conversation.',
+            color: 0x57f287,
+            author,
+            ...(fields.length > 0 ? { fields } : {}),
+            footer: { text: buildFooterWithStats(footerCtx, footerStats) },
+          },
+          [
+            buildActionRow(
+              { label: 'Continue', customId: 'resume_thread', style: ButtonStyle.SUCCESS, emoji: '💬' },
+              { label: 'Archive Thread', customId: 'archive_thread', style: ButtonStyle.SECONDARY, emoji: '📦' },
+            ),
+          ],
+        );
+      })().catch((err) => {
+        log.debug('Session complete embed failed', {
+          threadId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
 
-            const errEvent = event as { error?: { message?: string; errorType?: string; recoverable?: boolean } };
-            const errorType = errEvent.error?.errorType || 'unknown';
+    if (event.type === 'session_error') {
+      clearTyping();
+      if (sentErrorMessage) return; // dedup: only show one error per session lifecycle
+      sentErrorMessage = true;
 
-            // Differentiated messages per error type
-            const { title, description, color } = sessionErrorEmbed(errorType, errEvent.error?.message);
+      const errEvent = event as { error?: { message?: string; errorType?: string; recoverable?: boolean } };
+      const errorType = errEvent.error?.errorType || 'unknown';
 
-            sendEmbedWithButtons(delivery, botToken, threadId, {
-                title,
-                description,
-                color,
-                author,
-                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: errorType }) },
-            }, [
-                buildActionRow(
-                    { label: 'Resume', customId: 'resume_thread', style: ButtonStyle.SUCCESS, emoji: '🔄' },
-                ),
-            ]).catch((err) => {
-                log.debug('Session error embed failed', { threadId, error: err instanceof Error ? err.message : String(err) });
-            });
-        }
+      // Differentiated messages per error type
+      const { title, description, color } = sessionErrorEmbed(errorType, errEvent.error?.message);
 
-        if (event.type === 'session_exited') {
-            clearTyping();
-            if (debounceTimer) clearTimeout(debounceTimer);
-            flush();
-            processManager.unsubscribe(sessionId, callback);
-            threadCallbacks.delete(threadId);
-        }
-    };
+      sendEmbedWithButtons(
+        delivery,
+        botToken,
+        threadId,
+        {
+          title,
+          description,
+          color,
+          author,
+          footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: errorType }) },
+        },
+        [buildActionRow({ label: 'Resume', customId: 'resume_thread', style: ButtonStyle.SUCCESS, emoji: '🔄' })],
+      ).catch((err) => {
+        log.debug('Session error embed failed', { threadId, error: err instanceof Error ? err.message : String(err) });
+      });
+    }
 
-    processManager.subscribe(sessionId, callback);
-    threadCallbacks.set(threadId, { sessionId, callback });
+    if (event.type === 'session_exited') {
+      clearTyping();
+      if (debounceTimer) clearTimeout(debounceTimer);
+      flush();
+      processManager.unsubscribe(sessionId, callback);
+      threadCallbacks.delete(threadId);
+    }
+  };
+
+  processManager.subscribe(sessionId, callback);
+  threadCallbacks.set(threadId, { sessionId, callback });
 }
 
 /**
@@ -488,150 +549,161 @@ export function subscribeForResponseWithEmbed(
  * Used for one-off @mention responses.
  */
 export function subscribeForInlineResponse(
-    processManager: ProcessManager,
-    delivery: DeliveryTracker,
-    botToken: string,
-    sessionId: string,
-    channelId: string,
-    replyToMessageId: string,
-    agentName: string,
-    agentModel: string,
-    onBotMessage?: (botMessageId: string) => void,
-    projectName?: string,
-    displayColor?: string | null,
-    displayIcon?: string | null,
-    avatarUrl?: string | null,
+  processManager: ProcessManager,
+  delivery: DeliveryTracker,
+  botToken: string,
+  sessionId: string,
+  channelId: string,
+  replyToMessageId: string,
+  agentName: string,
+  agentModel: string,
+  onBotMessage?: (botMessageId: string) => void,
+  projectName?: string,
+  displayColor?: string | null,
+  displayIcon?: string | null,
+  avatarUrl?: string | null,
 ): void {
-    let buffer = '';
-    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-    let receivedAnyContent = false;
-    const TYPING_REFRESH_MS = 8000;
-    const TYPING_TIMEOUT_MS = 4 * 60 * 1000; // 4 minute safety timeout
-    const ACK_DELAY_MS = 5000;
-    let receivedAnyActivity = false; // tracks any activity (content OR tool use)
-    const color = hexColorToInt(displayColor) ?? agentColor(agentName);
-    const author = buildAgentAuthor({ agentName, displayIcon, avatarUrl });
+  let buffer = '';
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let receivedAnyContent = false;
+  const TYPING_REFRESH_MS = 8000;
+  const TYPING_TIMEOUT_MS = 4 * 60 * 1000; // 4 minute safety timeout
+  const ACK_DELAY_MS = 5000;
+  let receivedAnyActivity = false; // tracks any activity (content OR tool use)
+  const color = hexColorToInt(displayColor) ?? agentColor(agentName);
+  const author = buildAgentAuthor({ agentName, displayIcon, avatarUrl });
 
-    // Acknowledgment: if no content arrives within ACK_DELAY_MS, send a brief status
-    const ackTimer = setTimeout(() => {
-        if (!receivedAnyContent) {
-            sendEmbed(delivery, botToken, channelId, {
-                description: 'Received — working on it...',
-                color: 0x95a5a6,
-                author,
-            }).catch((err) => {
-                log.debug('Ack embed failed (inline)', { channelId, error: err instanceof Error ? err.message : String(err) });
-            });
-        }
-    }, ACK_DELAY_MS);
+  // Acknowledgment: if no content arrives within ACK_DELAY_MS, send a brief status
+  const ackTimer = setTimeout(() => {
+    if (!receivedAnyContent) {
+      sendEmbed(delivery, botToken, channelId, {
+        description: 'Received — working on it...',
+        color: 0x95a5a6,
+        author,
+      }).catch((err) => {
+        log.debug('Ack embed failed (inline)', { channelId, error: err instanceof Error ? err.message : String(err) });
+      });
+    }
+  }, ACK_DELAY_MS);
 
-    // Keep typing indicator alive continuously until response completes
-    const typingInterval = setInterval(() => {
-        // Check if the process is still alive
-        if (!processManager.isRunning(sessionId)) {
-            clearTyping();
-            log.warn('Process died while typing indicator active (inline)', { sessionId, channelId });
-            if (!receivedAnyContent) {
-                sendEmbed(delivery, botToken, channelId, {
-                    description: 'The agent session ended unexpectedly. Send a message to start a new session.',
-                    color: 0xff3355,
-                }).catch((err) => {
-                    log.warn('Failed to send crash embed', { channelId, error: err instanceof Error ? err.message : String(err) });
-                });
-            }
-            return;
-        }
-        sendTypingIndicator(botToken, channelId).catch((err) => {
-            log.debug('Typing indicator failed (inline)', { channelId, error: err instanceof Error ? err.message : String(err) });
+  // Keep typing indicator alive continuously until response completes
+  const typingInterval = setInterval(() => {
+    // Check if the process is still alive
+    if (!processManager.isRunning(sessionId)) {
+      clearTyping();
+      log.warn('Process died while typing indicator active (inline)', { sessionId, channelId });
+      if (!receivedAnyContent) {
+        sendEmbed(delivery, botToken, channelId, {
+          description: 'The agent session ended unexpectedly. Send a message to start a new session.',
+          color: 0xff3355,
+        }).catch((err) => {
+          log.warn('Failed to send crash embed', {
+            channelId,
+            error: err instanceof Error ? err.message : String(err),
+          });
         });
-    }, TYPING_REFRESH_MS);
+      }
+      return;
+    }
+    sendTypingIndicator(botToken, channelId).catch((err) => {
+      log.debug('Typing indicator failed (inline)', {
+        channelId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }, TYPING_REFRESH_MS);
 
-    // Safety timeout: clear typing if no terminal event arrives
-    const typingSafetyTimeout = setTimeout(() => {
-        clearInterval(typingInterval);
-        log.warn('Typing indicator safety timeout reached (inline)', { sessionId, channelId });
-        if (!receivedAnyActivity) {
-            sendEmbed(delivery, botToken, channelId, {
-                description: 'The agent appears to be taking too long. It may still be working \u2014 send a message to check.',
-                color: 0xf0b232,
-            }).catch((err) => {
-                log.warn('Failed to send timeout embed', { channelId, error: err instanceof Error ? err.message : String(err) });
-            });
+  // Safety timeout: clear typing if no terminal event arrives
+  const typingSafetyTimeout = setTimeout(() => {
+    clearInterval(typingInterval);
+    log.warn('Typing indicator safety timeout reached (inline)', { sessionId, channelId });
+    if (!receivedAnyActivity) {
+      sendEmbed(delivery, botToken, channelId, {
+        description: 'The agent appears to be taking too long. It may still be working \u2014 send a message to check.',
+        color: 0xf0b232,
+      }).catch((err) => {
+        log.warn('Failed to send timeout embed', {
+          channelId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
+  }, TYPING_TIMEOUT_MS);
+
+  const clearTyping = () => {
+    clearInterval(typingInterval);
+    clearTimeout(typingSafetyTimeout);
+    clearTimeout(ackTimer);
+  };
+
+  // Import sendReplyEmbed inline to avoid circular dependency
+  const { sendReplyEmbed } = require('./embeds') as typeof import('./embeds');
+
+  const flush = async () => {
+    if (!buffer) return;
+    const text = buffer;
+    buffer = '';
+
+    const parts = visibleEmbedParts(text);
+    for (let i = 0; i < parts.length; i++) {
+      let sentId: string | null = null;
+      const embedPayload = {
+        description: parts[i],
+        color,
+        author,
+        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
+      };
+      if (i === 0) {
+        sentId = await sendReplyEmbed(delivery, botToken, channelId, replyToMessageId, embedPayload);
+        // Fall back to non-reply if the referenced message no longer exists
+        if (!sentId) {
+          log.debug('Reply embed failed, falling back to non-reply send', { channelId, replyToMessageId });
+          sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
         }
-    }, TYPING_TIMEOUT_MS);
+      } else {
+        sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
+      }
+      if (sentId && onBotMessage) {
+        onBotMessage(sentId);
+      }
+    }
+  };
 
-    const clearTyping = () => {
-        clearInterval(typingInterval);
-        clearTimeout(typingSafetyTimeout);
-        clearTimeout(ackTimer);
-    };
+  const inlineCallback: EventCallback = (_sid, event) => {
+    if (event.type === 'assistant' && event.message) {
+      const msg = event.message as { content?: unknown };
+      const content = collapseCodeBlocks(
+        extractContentText(msg.content as string | import('../process/types').ContentBlock[] | undefined),
+      ).trim();
+      if (content) {
+        receivedAnyContent = true;
+        receivedAnyActivity = true;
+        buffer += content;
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => flush(), 1500);
+      }
+    }
 
-    // Import sendReplyEmbed inline to avoid circular dependency
-    const { sendReplyEmbed } = require('./embeds') as typeof import('./embeds');
+    if (event.type === 'tool_status') {
+      receivedAnyActivity = true;
+    }
 
-    const flush = async () => {
-        if (!buffer) return;
-        const text = buffer;
-        buffer = '';
+    if (event.type === 'result') {
+      clearTyping();
+      if (debounceTimer) clearTimeout(debounceTimer);
+      flush();
+      processManager.unsubscribe(sessionId, inlineCallback);
+    }
 
-        const parts = visibleEmbedParts(text);
-        for (let i = 0; i < parts.length; i++) {
-            let sentId: string | null = null;
-            const embedPayload = {
-                description: parts[i],
-                color,
-                author,
-                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
-            };
-            if (i === 0) {
-                sentId = await sendReplyEmbed(delivery, botToken, channelId, replyToMessageId, embedPayload);
-                // Fall back to non-reply if the referenced message no longer exists
-                if (!sentId) {
-                    log.debug('Reply embed failed, falling back to non-reply send', { channelId, replyToMessageId });
-                    sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
-                }
-            } else {
-                sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
-            }
-            if (sentId && onBotMessage) {
-                onBotMessage(sentId);
-            }
-        }
-    };
+    if (event.type === 'session_error' || event.type === 'session_exited') {
+      clearTyping();
+      if (debounceTimer) clearTimeout(debounceTimer);
+      flush();
+      processManager.unsubscribe(sessionId, inlineCallback);
+    }
+  };
 
-    const inlineCallback: EventCallback = (_sid, event) => {
-        if (event.type === 'assistant' && event.message) {
-            const msg = event.message as { content?: unknown };
-            const content = collapseCodeBlocks(extractContentText(msg.content as string | import('../process/types').ContentBlock[] | undefined)).trim();
-            if (content) {
-                receivedAnyContent = true;
-                receivedAnyActivity = true;
-                buffer += content;
-                if (debounceTimer) clearTimeout(debounceTimer);
-                debounceTimer = setTimeout(() => flush(), 1500);
-            }
-        }
-
-        if (event.type === 'tool_status') {
-            receivedAnyActivity = true;
-        }
-
-        if (event.type === 'result') {
-            clearTyping();
-            if (debounceTimer) clearTimeout(debounceTimer);
-            flush();
-            processManager.unsubscribe(sessionId, inlineCallback);
-        }
-
-        if (event.type === 'session_error' || event.type === 'session_exited') {
-            clearTyping();
-            if (debounceTimer) clearTimeout(debounceTimer);
-            flush();
-            processManager.unsubscribe(sessionId, inlineCallback);
-        }
-    };
-
-    processManager.subscribe(sessionId, inlineCallback);
+  processManager.subscribe(sessionId, inlineCallback);
 }
 
 /**
@@ -642,277 +714,315 @@ export function subscribeForInlineResponse(
  * - Quick conversational replies never see a progress embed
  */
 export function subscribeForAdaptiveInlineResponse(
-    processManager: ProcessManager,
-    delivery: DeliveryTracker,
-    botToken: string,
-    sessionId: string,
-    channelId: string,
-    replyToMessageId: string,
-    agentName: string,
-    agentModel: string,
-    onBotMessage?: (botMessageId: string) => void,
-    projectName?: string,
-    displayColor?: string | null,
-    displayIcon?: string | null,
-    avatarUrl?: string | null,
+  processManager: ProcessManager,
+  delivery: DeliveryTracker,
+  botToken: string,
+  sessionId: string,
+  channelId: string,
+  replyToMessageId: string,
+  agentName: string,
+  agentModel: string,
+  onBotMessage?: (botMessageId: string) => void,
+  projectName?: string,
+  displayColor?: string | null,
+  displayIcon?: string | null,
+  avatarUrl?: string | null,
 ): void {
-    let buffer = '';
-    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-    let receivedAnyContent = false;
-    let lastStatusTime = 0;
-    const STATUS_DEBOUNCE_MS = 3000;
-    const TYPING_REFRESH_MS = 8000;
-    const TYPING_TIMEOUT_MS = 4 * 60 * 1000;
-    let receivedAnyActivity = false;
-    const color = hexColorToInt(displayColor) ?? agentColor(agentName);
-    const author = buildAgentAuthor({ agentName, displayIcon, avatarUrl });
+  let buffer = '';
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let receivedAnyContent = false;
+  let lastStatusTime = 0;
+  const STATUS_DEBOUNCE_MS = 3000;
+  const TYPING_REFRESH_MS = 8000;
+  const TYPING_TIMEOUT_MS = 4 * 60 * 1000;
+  let receivedAnyActivity = false;
+  const color = hexColorToInt(displayColor) ?? agentColor(agentName);
+  const author = buildAgentAuthor({ agentName, displayIcon, avatarUrl });
 
-    // Progress embed state — only created when tool use is detected
-    let progressMessageId: string | null = null;
-    let progressMode = false;
+  // Progress embed state — only created when tool use is detected
+  let progressMessageId: string | null = null;
+  let progressMode = false;
 
-    // Keep typing indicator alive continuously until response completes
-    const typingInterval = setInterval(() => {
-        if (!processManager.isRunning(sessionId)) {
-            clearTyping();
-            log.warn('Process died while typing indicator active (adaptive)', { sessionId, channelId });
-            if (!receivedAnyContent) {
-                sendEmbed(delivery, botToken, channelId, {
-                    description: 'The agent session ended unexpectedly. Send a message to start a new session.',
-                    color: 0xff3355,
-                }).catch((err) => {
-                    log.warn('Failed to send crash embed', { channelId, error: err instanceof Error ? err.message : String(err) });
-                });
-            }
-            return;
-        }
-        sendTypingIndicator(botToken, channelId).catch((err) => {
-            log.debug('Typing indicator failed (adaptive)', { channelId, error: err instanceof Error ? err.message : String(err) });
-        });
-    }, TYPING_REFRESH_MS);
-
-    const typingSafetyTimeout = setTimeout(() => {
-        clearInterval(typingInterval);
-        log.warn('Typing indicator safety timeout reached (adaptive)', { sessionId, channelId });
-        if (!receivedAnyActivity) {
-            sendEmbed(delivery, botToken, channelId, {
-                description: 'The agent appears to be taking too long. It may still be working \u2014 send a message to check.',
-                color: 0xf0b232,
-            }).catch((err) => {
-                log.warn('Failed to send timeout embed', { channelId, error: err instanceof Error ? err.message : String(err) });
-            });
-        }
-    }, TYPING_TIMEOUT_MS);
-
-    const clearTyping = () => {
-        clearInterval(typingInterval);
-        clearTimeout(typingSafetyTimeout);
-    };
-
-    const flush = async () => {
-        if (!buffer) return;
-        const text = buffer;
-        buffer = '';
-
-        const parts = visibleEmbedParts(text);
-        for (let i = 0; i < parts.length; i++) {
-            let sentId: string | null = null;
-            const embedPayload = {
-                description: parts[i],
-                color,
-                author,
-                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
-            };
-            if (i === 0) {
-                sentId = await sendReplyEmbed(delivery, botToken, channelId, replyToMessageId, embedPayload);
-                // Fall back to non-reply if the referenced message no longer exists
-                if (!sentId) {
-                    log.debug('Reply embed failed, falling back to non-reply send', { channelId, replyToMessageId });
-                    sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
-                }
-            } else {
-                sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
-            }
-            if (sentId && onBotMessage) {
-                onBotMessage(sentId);
-            }
-        }
-    };
-
-    /** Upgrade to progress mode — post the progress embed on first tool use. */
-    const upgradeToProgressMode = () => {
-        if (progressMode) return;
-        progressMode = true;
+  // Keep typing indicator alive continuously until response completes
+  const typingInterval = setInterval(() => {
+    if (!processManager.isRunning(sessionId)) {
+      clearTyping();
+      log.warn('Process died while typing indicator active (adaptive)', { sessionId, channelId });
+      if (!receivedAnyContent) {
         sendEmbed(delivery, botToken, channelId, {
-            description: 'Working on your request...',
+          description: 'The agent session ended unexpectedly. Send a message to start a new session.',
+          color: 0xff3355,
+        }).catch((err) => {
+          log.warn('Failed to send crash embed', {
+            channelId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+      }
+      return;
+    }
+    sendTypingIndicator(botToken, channelId).catch((err) => {
+      log.debug('Typing indicator failed (adaptive)', {
+        channelId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }, TYPING_REFRESH_MS);
+
+  const typingSafetyTimeout = setTimeout(() => {
+    clearInterval(typingInterval);
+    log.warn('Typing indicator safety timeout reached (adaptive)', { sessionId, channelId });
+    if (!receivedAnyActivity) {
+      sendEmbed(delivery, botToken, channelId, {
+        description: 'The agent appears to be taking too long. It may still be working \u2014 send a message to check.',
+        color: 0xf0b232,
+      }).catch((err) => {
+        log.warn('Failed to send timeout embed', {
+          channelId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
+  }, TYPING_TIMEOUT_MS);
+
+  const clearTyping = () => {
+    clearInterval(typingInterval);
+    clearTimeout(typingSafetyTimeout);
+  };
+
+  const flush = async () => {
+    if (!buffer) return;
+    const text = buffer;
+    buffer = '';
+
+    const parts = visibleEmbedParts(text);
+    for (let i = 0; i < parts.length; i++) {
+      let sentId: string | null = null;
+      const embedPayload = {
+        description: parts[i],
+        color,
+        author,
+        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
+      };
+      if (i === 0) {
+        sentId = await sendReplyEmbed(delivery, botToken, channelId, replyToMessageId, embedPayload);
+        // Fall back to non-reply if the referenced message no longer exists
+        if (!sentId) {
+          log.debug('Reply embed failed, falling back to non-reply send', { channelId, replyToMessageId });
+          sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
+        }
+      } else {
+        sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
+      }
+      if (sentId && onBotMessage) {
+        onBotMessage(sentId);
+      }
+    }
+  };
+
+  /** Upgrade to progress mode — post the progress embed on first tool use. */
+  const upgradeToProgressMode = () => {
+    if (progressMode) return;
+    progressMode = true;
+    sendEmbed(delivery, botToken, channelId, {
+      description: 'Working on your request...',
+      color: 0x5865f2,
+      author,
+      footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'starting...' }) },
+    })
+      .then((msgId) => {
+        progressMessageId = msgId;
+      })
+      .catch((err) => {
+        log.debug('Failed to send progress embed', {
+          channelId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+  };
+
+  /** Download an image from a URL and send it as a Discord file attachment. */
+  const sendImageUrl = async (imageUrl: string) => {
+    try {
+      const resp = await fetch(imageUrl);
+      if (!resp.ok) {
+        log.warn('Failed to fetch image for Discord', { imageUrl, status: resp.status });
+        return;
+      }
+      const data = new Uint8Array(await resp.arrayBuffer());
+      const ct = resp.headers.get('content-type') ?? 'image/png';
+      const ext =
+        ct.includes('jpeg') || ct.includes('jpg')
+          ? 'jpg'
+          : ct.includes('gif')
+            ? 'gif'
+            : ct.includes('webp')
+              ? 'webp'
+              : 'png';
+      const filename = `image.${ext}`;
+      const attachment: DiscordFileAttachment = { name: filename, data, contentType: ct };
+      await sendEmbedWithFiles(
+        delivery,
+        botToken,
+        channelId,
+        {
+          image: { url: `attachment://${filename}` },
+          color,
+          author,
+          footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
+        },
+        [attachment],
+      );
+    } catch (err) {
+      log.warn('Failed to send image to Discord', {
+        imageUrl,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const adaptiveCallback: EventCallback = (_sid, event) => {
+    if (event.type === 'assistant' && event.message) {
+      const msg = event.message as { content?: unknown };
+      const contentBlocks = msg.content as string | import('../process/types').ContentBlock[] | undefined;
+      const content = collapseCodeBlocks(extractContentText(contentBlocks)).trim();
+      if (content) {
+        receivedAnyContent = true;
+        receivedAnyActivity = true;
+        buffer += content;
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => flush(), 1500);
+      }
+
+      // Send any image content blocks as file attachments
+      const imageUrls = extractContentImageUrls(contentBlocks);
+      for (const imageUrl of imageUrls) {
+        receivedAnyContent = true;
+        receivedAnyActivity = true;
+        sendImageUrl(imageUrl);
+      }
+    }
+
+    if (event.type === 'tool_status' && event.statusMessage) {
+      const statusText = event.statusMessage.trim();
+      if (statusText) {
+        receivedAnyActivity = true;
+        // Upgrade to progress mode on first tool use
+        upgradeToProgressMode();
+        const now = Date.now();
+        if (now - lastStatusTime >= STATUS_DEBOUNCE_MS && progressMessageId) {
+          lastStatusTime = now;
+          editEmbed(delivery, botToken, channelId, progressMessageId, {
+            description: `\u23f3 ${statusText}`,
             color: 0x5865f2,
             author,
-            footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'starting...' }) },
-        }).then((msgId) => {
-            progressMessageId = msgId;
-        }).catch((err) => {
-            log.debug('Failed to send progress embed', { channelId, error: err instanceof Error ? err.message : String(err) });
-        });
-    };
-
-    /** Download an image from a URL and send it as a Discord file attachment. */
-    const sendImageUrl = async (imageUrl: string) => {
-        try {
-            const resp = await fetch(imageUrl);
-            if (!resp.ok) {
-                log.warn('Failed to fetch image for Discord', { imageUrl, status: resp.status });
-                return;
-            }
-            const data = new Uint8Array(await resp.arrayBuffer());
-            const ct = resp.headers.get('content-type') ?? 'image/png';
-            const ext = ct.includes('jpeg') || ct.includes('jpg') ? 'jpg' : ct.includes('gif') ? 'gif' : ct.includes('webp') ? 'webp' : 'png';
-            const filename = `image.${ext}`;
-            const attachment: DiscordFileAttachment = { name: filename, data, contentType: ct };
-            await sendEmbedWithFiles(delivery, botToken, channelId, {
-                image: { url: `attachment://${filename}` },
-                color,
-                author,
-                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
-            }, [attachment]);
-        } catch (err) {
-            log.warn('Failed to send image to Discord', { imageUrl, error: err instanceof Error ? err.message : String(err) });
-        }
-    };
-
-    const adaptiveCallback: EventCallback = (_sid, event) => {
-        if (event.type === 'assistant' && event.message) {
-            const msg = event.message as { content?: unknown };
-            const contentBlocks = msg.content as string | import('../process/types').ContentBlock[] | undefined;
-            const content = collapseCodeBlocks(extractContentText(contentBlocks)).trim();
-            if (content) {
-                receivedAnyContent = true;
-                receivedAnyActivity = true;
-                buffer += content;
-                if (debounceTimer) clearTimeout(debounceTimer);
-                debounceTimer = setTimeout(() => flush(), 1500);
-            }
-
-            // Send any image content blocks as file attachments
-            const imageUrls = extractContentImageUrls(contentBlocks);
-            for (const imageUrl of imageUrls) {
-                receivedAnyContent = true;
-                receivedAnyActivity = true;
-                sendImageUrl(imageUrl);
-            }
-        }
-
-        if (event.type === 'tool_status' && event.statusMessage) {
-            const statusText = event.statusMessage.trim();
-            if (statusText) {
-                receivedAnyActivity = true;
-                // Upgrade to progress mode on first tool use
-                upgradeToProgressMode();
-                const now = Date.now();
-                if (now - lastStatusTime >= STATUS_DEBOUNCE_MS && progressMessageId) {
-                    lastStatusTime = now;
-                    editEmbed(delivery, botToken, channelId, progressMessageId, {
-                        description: `\u23f3 ${statusText}`,
-                        color: 0x5865f2,
-                        author,
-                        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'working...' }) },
-                    }).catch((err) => {
-                        log.debug('Progress embed edit failed', { channelId, error: err instanceof Error ? err.message : String(err) });
-                    });
-                }
-            }
-        }
-
-        if (event.type === 'result') {
-            clearTyping();
-            if (debounceTimer) clearTimeout(debounceTimer);
-            flush().then(() => {
-                // Only mark progress embed as done if we upgraded to progress mode
-                if (progressMode && progressMessageId) {
-                    editEmbed(delivery, botToken, channelId, progressMessageId, {
-                        description: '\u2705 Done',
-                        color: 0x57f287,
-                        author,
-                        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'done' }) },
-                    }).catch((err) => {
-                        log.debug('Final progress embed edit failed', { channelId, error: err instanceof Error ? err.message : String(err) });
-                    });
-                }
-            }).catch((err) => {
-                log.debug('Final flush failed', { channelId, error: err instanceof Error ? err.message : String(err) });
+            footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'working...' }) },
+          }).catch((err) => {
+            log.debug('Progress embed edit failed', {
+              channelId,
+              error: err instanceof Error ? err.message : String(err),
             });
-            processManager.unsubscribe(sessionId, adaptiveCallback);
+          });
         }
+      }
+    }
 
-        if (event.type === 'session_error') {
-            clearTyping();
-            if (debounceTimer) clearTimeout(debounceTimer);
-            // Flush any buffered content before showing the error
-            flush().catch(() => {});
+    if (event.type === 'result') {
+      clearTyping();
+      if (debounceTimer) clearTimeout(debounceTimer);
+      flush()
+        .then(() => {
+          // Only mark progress embed as done if we upgraded to progress mode
+          if (progressMode && progressMessageId) {
+            editEmbed(delivery, botToken, channelId, progressMessageId, {
+              description: '\u2705 Done',
+              color: 0x57f287,
+              author,
+              footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'done' }) },
+            }).catch((err) => {
+              log.debug('Final progress embed edit failed', {
+                channelId,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            });
+          }
+        })
+        .catch((err) => {
+          log.debug('Final flush failed', { channelId, error: err instanceof Error ? err.message : String(err) });
+        });
+      processManager.unsubscribe(sessionId, adaptiveCallback);
+    }
 
-            const errEvent = event as { error?: { message?: string; errorType?: string } };
-            const errorType = errEvent.error?.errorType || 'unknown';
+    if (event.type === 'session_error') {
+      clearTyping();
+      if (debounceTimer) clearTimeout(debounceTimer);
+      // Flush any buffered content before showing the error
+      flush().catch(() => {});
 
-            let title: string;
-            let description: string;
-            let errColor: number;
-            switch (errorType) {
-                case 'context_exhausted':
-                    title = 'Context Limit Reached';
-                    description = 'The conversation ran out of context space. Send a message to start a new session.';
-                    errColor = 0xf0b232;
-                    break;
-                case 'credits_exhausted':
-                    title = 'Credits Exhausted';
-                    description = 'Session paused — credits have been used up. Add credits to resume.';
-                    errColor = 0xf0b232;
-                    break;
-                case 'spawn_error':
-                    title = 'Failed to Start';
-                    description = 'The agent session could not be started. This may be a configuration issue.';
-                    errColor = 0xff3355;
-                    break;
-                default:
-                    title = 'Session Error';
-                    description = (errEvent.error?.message || 'An unexpected error occurred.').slice(0, 4096);
-                    errColor = 0xff3355;
-                    break;
-            }
+      const errEvent = event as { error?: { message?: string; errorType?: string } };
+      const errorType = errEvent.error?.errorType || 'unknown';
 
-            // If we have a progress embed, update it with the error; otherwise send a new one
-            if (progressMode && progressMessageId) {
-                editEmbed(delivery, botToken, channelId, progressMessageId, {
-                    title,
-                    description,
-                    color: errColor,
-                    author,
-                    footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: errorType }) },
-                }).catch((err) => {
-                    log.debug('Error embed edit failed', { channelId, error: err instanceof Error ? err.message : String(err) });
-                });
-            } else {
-                sendEmbed(delivery, botToken, channelId, {
-                    title,
-                    description,
-                    color: errColor,
-                    author,
-                    footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: errorType }) },
-                }).catch((err) => {
-                    log.debug('Error embed send failed', { channelId, error: err instanceof Error ? err.message : String(err) });
-                });
-            }
+      let title: string;
+      let description: string;
+      let errColor: number;
+      switch (errorType) {
+        case 'context_exhausted':
+          title = 'Context Limit Reached';
+          description = 'The conversation ran out of context space. Send a message to start a new session.';
+          errColor = 0xf0b232;
+          break;
+        case 'credits_exhausted':
+          title = 'Credits Exhausted';
+          description = 'Session paused — credits have been used up. Add credits to resume.';
+          errColor = 0xf0b232;
+          break;
+        case 'spawn_error':
+          title = 'Failed to Start';
+          description = 'The agent session could not be started. This may be a configuration issue.';
+          errColor = 0xff3355;
+          break;
+        default:
+          title = 'Session Error';
+          description = (errEvent.error?.message || 'An unexpected error occurred.').slice(0, 4096);
+          errColor = 0xff3355;
+          break;
+      }
 
-            processManager.unsubscribe(sessionId, adaptiveCallback);
-        }
+      // If we have a progress embed, update it with the error; otherwise send a new one
+      if (progressMode && progressMessageId) {
+        editEmbed(delivery, botToken, channelId, progressMessageId, {
+          title,
+          description,
+          color: errColor,
+          author,
+          footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: errorType }) },
+        }).catch((err) => {
+          log.debug('Error embed edit failed', { channelId, error: err instanceof Error ? err.message : String(err) });
+        });
+      } else {
+        sendEmbed(delivery, botToken, channelId, {
+          title,
+          description,
+          color: errColor,
+          author,
+          footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: errorType }) },
+        }).catch((err) => {
+          log.debug('Error embed send failed', { channelId, error: err instanceof Error ? err.message : String(err) });
+        });
+      }
 
-        if (event.type === 'session_exited') {
-            clearTyping();
-            if (debounceTimer) clearTimeout(debounceTimer);
-            flush().catch(() => {});
-            processManager.unsubscribe(sessionId, adaptiveCallback);
-        }
-    };
+      processManager.unsubscribe(sessionId, adaptiveCallback);
+    }
 
-    processManager.subscribe(sessionId, adaptiveCallback);
+    if (event.type === 'session_exited') {
+      clearTyping();
+      if (debounceTimer) clearTimeout(debounceTimer);
+      flush().catch(() => {});
+      processManager.unsubscribe(sessionId, adaptiveCallback);
+    }
+  };
+
+  processManager.subscribe(sessionId, adaptiveCallback);
 }
 
 /**
@@ -921,233 +1031,282 @@ export function subscribeForAdaptiveInlineResponse(
  * the final response as a new reply — reducing message spam for @mentions.
  */
 export function subscribeForInlineProgressResponse(
-    processManager: ProcessManager,
-    delivery: DeliveryTracker,
-    botToken: string,
-    sessionId: string,
-    channelId: string,
-    replyToMessageId: string,
-    agentName: string,
-    agentModel: string,
-    onBotMessage?: (botMessageId: string) => void,
-    projectName?: string,
-    displayColor?: string | null,
-    displayIcon?: string | null,
-    avatarUrl?: string | null,
+  processManager: ProcessManager,
+  delivery: DeliveryTracker,
+  botToken: string,
+  sessionId: string,
+  channelId: string,
+  replyToMessageId: string,
+  agentName: string,
+  agentModel: string,
+  onBotMessage?: (botMessageId: string) => void,
+  projectName?: string,
+  displayColor?: string | null,
+  displayIcon?: string | null,
+  avatarUrl?: string | null,
 ): void {
-    let buffer = '';
-    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-    let receivedAnyContent = false;
-    let lastStatusTime = 0;
-    const STATUS_DEBOUNCE_MS = 3000;
-    const TYPING_REFRESH_MS = 8000;
-    const TYPING_TIMEOUT_MS = 4 * 60 * 1000; // 4 minute safety timeout
-    let receivedAnyActivity = false;
-    const color = hexColorToInt(displayColor) ?? agentColor(agentName);
-    const author = buildAgentAuthor({ agentName, displayIcon, avatarUrl });
-    let progressMessageId: string | null = null;
+  let buffer = '';
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let receivedAnyContent = false;
+  let lastStatusTime = 0;
+  const STATUS_DEBOUNCE_MS = 3000;
+  const TYPING_REFRESH_MS = 8000;
+  const TYPING_TIMEOUT_MS = 4 * 60 * 1000; // 4 minute safety timeout
+  let receivedAnyActivity = false;
+  const color = hexColorToInt(displayColor) ?? agentColor(agentName);
+  const author = buildAgentAuthor({ agentName, displayIcon, avatarUrl });
+  let progressMessageId: string | null = null;
 
-    // Post the initial progress embed immediately
-    sendEmbed(delivery, botToken, channelId, {
-        description: 'Working on your request...',
-        color: 0x5865f2, // blurple
-        author,
-        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'starting...' }) },
-    }).then((msgId) => {
-        progressMessageId = msgId;
-    }).catch((err) => {
-        log.debug('Failed to send initial progress embed', { channelId, error: err instanceof Error ? err.message : String(err) });
+  // Post the initial progress embed immediately
+  sendEmbed(delivery, botToken, channelId, {
+    description: 'Working on your request...',
+    color: 0x5865f2, // blurple
+    author,
+    footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'starting...' }) },
+  })
+    .then((msgId) => {
+      progressMessageId = msgId;
+    })
+    .catch((err) => {
+      log.debug('Failed to send initial progress embed', {
+        channelId,
+        error: err instanceof Error ? err.message : String(err),
+      });
     });
 
-    // Keep typing indicator alive continuously until response completes
-    const typingInterval = setInterval(() => {
-        if (!processManager.isRunning(sessionId)) {
-            clearTyping();
-            log.warn('Process died while typing indicator active (inline-progress)', { sessionId, channelId });
-            if (!receivedAnyContent) {
-                sendEmbed(delivery, botToken, channelId, {
-                    description: 'The agent session ended unexpectedly. Send a message to start a new session.',
-                    color: 0xff3355,
-                }).catch((err) => {
-                    log.warn('Failed to send crash embed', { channelId, error: err instanceof Error ? err.message : String(err) });
-                });
-            }
-            return;
-        }
-        sendTypingIndicator(botToken, channelId).catch((err) => {
-            log.debug('Typing indicator failed (inline-progress)', { channelId, error: err instanceof Error ? err.message : String(err) });
+  // Keep typing indicator alive continuously until response completes
+  const typingInterval = setInterval(() => {
+    if (!processManager.isRunning(sessionId)) {
+      clearTyping();
+      log.warn('Process died while typing indicator active (inline-progress)', { sessionId, channelId });
+      if (!receivedAnyContent) {
+        sendEmbed(delivery, botToken, channelId, {
+          description: 'The agent session ended unexpectedly. Send a message to start a new session.',
+          color: 0xff3355,
+        }).catch((err) => {
+          log.warn('Failed to send crash embed', {
+            channelId,
+            error: err instanceof Error ? err.message : String(err),
+          });
         });
-    }, TYPING_REFRESH_MS);
+      }
+      return;
+    }
+    sendTypingIndicator(botToken, channelId).catch((err) => {
+      log.debug('Typing indicator failed (inline-progress)', {
+        channelId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }, TYPING_REFRESH_MS);
 
-    // Safety timeout: clear typing if no terminal event arrives
-    const typingSafetyTimeout = setTimeout(() => {
-        clearInterval(typingInterval);
-        log.warn('Typing indicator safety timeout reached (inline-progress)', { sessionId, channelId });
-        if (!receivedAnyActivity) {
-            sendEmbed(delivery, botToken, channelId, {
-                description: 'The agent appears to be taking too long. It may still be working \u2014 send a message to check.',
-                color: 0xf0b232,
-            }).catch((err) => {
-                log.warn('Failed to send timeout embed', { channelId, error: err instanceof Error ? err.message : String(err) });
+  // Safety timeout: clear typing if no terminal event arrives
+  const typingSafetyTimeout = setTimeout(() => {
+    clearInterval(typingInterval);
+    log.warn('Typing indicator safety timeout reached (inline-progress)', { sessionId, channelId });
+    if (!receivedAnyActivity) {
+      sendEmbed(delivery, botToken, channelId, {
+        description: 'The agent appears to be taking too long. It may still be working \u2014 send a message to check.',
+        color: 0xf0b232,
+      }).catch((err) => {
+        log.warn('Failed to send timeout embed', {
+          channelId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
+  }, TYPING_TIMEOUT_MS);
+
+  const clearTyping = () => {
+    clearInterval(typingInterval);
+    clearTimeout(typingSafetyTimeout);
+  };
+
+  const flush = async () => {
+    if (!buffer) return;
+    const text = buffer;
+    buffer = '';
+
+    const parts = visibleEmbedParts(text);
+    for (let i = 0; i < parts.length; i++) {
+      let sentId: string | null = null;
+      const embedPayload = {
+        description: parts[i],
+        color,
+        author,
+        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
+      };
+      if (i === 0) {
+        sentId = await sendReplyEmbed(delivery, botToken, channelId, replyToMessageId, embedPayload);
+        // Fall back to non-reply if the referenced message no longer exists
+        if (!sentId) {
+          log.debug('Reply embed failed, falling back to non-reply send', { channelId, replyToMessageId });
+          sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
+        }
+      } else {
+        sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
+      }
+      if (sentId && onBotMessage) {
+        onBotMessage(sentId);
+      }
+    }
+  };
+
+  /** Download an image URL and send as a Discord file attachment. */
+  const sendProgressImageUrl = async (imageUrl: string) => {
+    try {
+      const resp = await fetch(imageUrl);
+      if (!resp.ok) {
+        log.warn('Failed to fetch image for Discord (progress)', { imageUrl, status: resp.status });
+        return;
+      }
+      const data = new Uint8Array(await resp.arrayBuffer());
+      const ct = resp.headers.get('content-type') ?? 'image/png';
+      const ext =
+        ct.includes('jpeg') || ct.includes('jpg')
+          ? 'jpg'
+          : ct.includes('gif')
+            ? 'gif'
+            : ct.includes('webp')
+              ? 'webp'
+              : 'png';
+      const filename = `image.${ext}`;
+      const attachment: DiscordFileAttachment = { name: filename, data, contentType: ct };
+      await sendEmbedWithFiles(
+        delivery,
+        botToken,
+        channelId,
+        {
+          image: { url: `attachment://${filename}` },
+          color,
+          author,
+          footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
+        },
+        [attachment],
+      );
+    } catch (err) {
+      log.warn('Failed to send image to Discord (progress)', {
+        imageUrl,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const progressCallback: EventCallback = (_sid, event) => {
+    if (event.type === 'assistant' && event.message) {
+      const msg = event.message as { content?: unknown };
+      const contentBlocks = msg.content as string | import('../process/types').ContentBlock[] | undefined;
+      const content = collapseCodeBlocks(extractContentText(contentBlocks)).trim();
+      if (content) {
+        receivedAnyContent = true;
+        receivedAnyActivity = true;
+        buffer += content;
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => flush(), 1500);
+      }
+
+      // Send any image content blocks as file attachments
+      const imageUrls = extractContentImageUrls(contentBlocks);
+      for (const imageUrl of imageUrls) {
+        receivedAnyContent = true;
+        receivedAnyActivity = true;
+        sendProgressImageUrl(imageUrl);
+      }
+    }
+
+    if (event.type === 'tool_status' && event.statusMessage) {
+      const statusText = event.statusMessage.trim();
+      if (statusText) {
+        receivedAnyActivity = true;
+        const now = Date.now();
+        if (now - lastStatusTime >= STATUS_DEBOUNCE_MS && progressMessageId) {
+          lastStatusTime = now;
+          editEmbed(delivery, botToken, channelId, progressMessageId, {
+            description: `\u23f3 ${statusText}`,
+            color: 0x5865f2,
+            author,
+            footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'working...' }) },
+          }).catch((err) => {
+            log.debug('Progress embed edit failed', {
+              channelId,
+              error: err instanceof Error ? err.message : String(err),
             });
+          });
         }
-    }, TYPING_TIMEOUT_MS);
+      }
+    }
 
-    const clearTyping = () => {
-        clearInterval(typingInterval);
-        clearTimeout(typingSafetyTimeout);
-    };
-
-    const flush = async () => {
-        if (!buffer) return;
-        const text = buffer;
-        buffer = '';
-
-        const parts = visibleEmbedParts(text);
-        for (let i = 0; i < parts.length; i++) {
-            let sentId: string | null = null;
-            const embedPayload = {
-                description: parts[i],
-                color,
-                author,
-                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
-            };
-            if (i === 0) {
-                sentId = await sendReplyEmbed(delivery, botToken, channelId, replyToMessageId, embedPayload);
-                // Fall back to non-reply if the referenced message no longer exists
-                if (!sentId) {
-                    log.debug('Reply embed failed, falling back to non-reply send', { channelId, replyToMessageId });
-                    sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
-                }
-            } else {
-                sentId = await sendEmbed(delivery, botToken, channelId, embedPayload);
-            }
-            if (sentId && onBotMessage) {
-                onBotMessage(sentId);
-            }
-        }
-    };
-
-    /** Download an image URL and send as a Discord file attachment. */
-    const sendProgressImageUrl = async (imageUrl: string) => {
-        try {
-            const resp = await fetch(imageUrl);
-            if (!resp.ok) {
-                log.warn('Failed to fetch image for Discord (progress)', { imageUrl, status: resp.status });
-                return;
-            }
-            const data = new Uint8Array(await resp.arrayBuffer());
-            const ct = resp.headers.get('content-type') ?? 'image/png';
-            const ext = ct.includes('jpeg') || ct.includes('jpg') ? 'jpg' : ct.includes('gif') ? 'gif' : ct.includes('webp') ? 'webp' : 'png';
-            const filename = `image.${ext}`;
-            const attachment: DiscordFileAttachment = { name: filename, data, contentType: ct };
-            await sendEmbedWithFiles(delivery, botToken, channelId, {
-                image: { url: `attachment://${filename}` },
-                color,
-                author,
-                footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }) },
-            }, [attachment]);
-        } catch (err) {
-            log.warn('Failed to send image to Discord (progress)', { imageUrl, error: err instanceof Error ? err.message : String(err) });
-        }
-    };
-
-    const progressCallback: EventCallback = (_sid, event) => {
-        if (event.type === 'assistant' && event.message) {
-            const msg = event.message as { content?: unknown };
-            const contentBlocks = msg.content as string | import('../process/types').ContentBlock[] | undefined;
-            const content = collapseCodeBlocks(extractContentText(contentBlocks)).trim();
-            if (content) {
-                receivedAnyContent = true;
-                receivedAnyActivity = true;
-                buffer += content;
-                if (debounceTimer) clearTimeout(debounceTimer);
-                debounceTimer = setTimeout(() => flush(), 1500);
-            }
-
-            // Send any image content blocks as file attachments
-            const imageUrls = extractContentImageUrls(contentBlocks);
-            for (const imageUrl of imageUrls) {
-                receivedAnyContent = true;
-                receivedAnyActivity = true;
-                sendProgressImageUrl(imageUrl);
-            }
-        }
-
-        if (event.type === 'tool_status' && event.statusMessage) {
-            const statusText = event.statusMessage.trim();
-            if (statusText) {
-                receivedAnyActivity = true;
-                const now = Date.now();
-                if (now - lastStatusTime >= STATUS_DEBOUNCE_MS && progressMessageId) {
-                    lastStatusTime = now;
-                    editEmbed(delivery, botToken, channelId, progressMessageId, {
-                        description: `\u23f3 ${statusText}`,
-                        color: 0x5865f2,
-                        author,
-                        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'working...' }) },
-                    }).catch((err) => {
-                        log.debug('Progress embed edit failed', { channelId, error: err instanceof Error ? err.message : String(err) });
-                    });
-                }
-            }
-        }
-
-        if (event.type === 'result') {
-            clearTyping();
-            if (debounceTimer) clearTimeout(debounceTimer);
-            flush().then(() => {
-                // Mark progress embed as done
-                if (progressMessageId) {
-                    editEmbed(delivery, botToken, channelId, progressMessageId, {
-                        description: '\u2705 Done',
-                        color: 0x57f287, // green
-                        author,
-                        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'done' }) },
-                    }).catch((err) => {
-                        log.debug('Final progress embed edit failed', { channelId, error: err instanceof Error ? err.message : String(err) });
-                    });
-                }
+    if (event.type === 'result') {
+      clearTyping();
+      if (debounceTimer) clearTimeout(debounceTimer);
+      flush()
+        .then(() => {
+          // Mark progress embed as done
+          if (progressMessageId) {
+            editEmbed(delivery, botToken, channelId, progressMessageId, {
+              description: '\u2705 Done',
+              color: 0x57f287, // green
+              author,
+              footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status: 'done' }) },
             }).catch((err) => {
-                log.debug('Final flush failed', { channelId, error: err instanceof Error ? err.message : String(err) });
+              log.debug('Final progress embed edit failed', {
+                channelId,
+                error: err instanceof Error ? err.message : String(err),
+              });
             });
-            processManager.unsubscribe(sessionId, progressCallback);
-        }
+          }
+        })
+        .catch((err) => {
+          log.debug('Final flush failed', { channelId, error: err instanceof Error ? err.message : String(err) });
+        });
+      processManager.unsubscribe(sessionId, progressCallback);
+    }
 
-        if (event.type === 'session_error' || event.type === 'session_exited') {
-            clearTyping();
-            processManager.unsubscribe(sessionId, progressCallback);
-        }
-    };
+    if (event.type === 'session_error' || event.type === 'session_exited') {
+      clearTyping();
+      processManager.unsubscribe(sessionId, progressCallback);
+    }
+  };
 
-    processManager.subscribe(sessionId, progressCallback);
+  processManager.subscribe(sessionId, progressCallback);
 }
 
 /**
  * Recover event subscriptions for active Discord sessions after server restart.
  */
 export function recoverActiveThreadSubscriptions(
-    db: Database,
-    processManager: ProcessManager,
-    delivery: DeliveryTracker,
-    botToken: string,
-    threadSessions: Map<string, ThreadSessionInfo>,
-    threadCallbacks: Map<string, ThreadCallbackInfo>,
+  db: Database,
+  processManager: ProcessManager,
+  delivery: DeliveryTracker,
+  botToken: string,
+  threadSessions: Map<string, ThreadSessionInfo>,
+  threadCallbacks: Map<string, ThreadCallbackInfo>,
 ): void {
-    try {
-        const rows = db.query(
-            `SELECT s.id, s.name, a.name as agent_name, a.model as agent_model, a.display_color, a.display_icon, a.avatar_url, p.name as project_name
+  try {
+    const rows = db
+      .query(
+        `SELECT s.id, s.name, a.name as agent_name, a.model as agent_model, a.display_color, a.display_icon, a.avatar_url, p.name as project_name
              FROM sessions s
              LEFT JOIN agents a ON a.id = s.agent_id
              LEFT JOIN projects p ON p.id = s.project_id
              WHERE s.source = 'discord' AND s.status = 'running'
                AND s.name LIKE 'Discord thread:%'`,
-        ).all() as { id: string; name: string; agent_name: string; agent_model: string; display_color: string | null; display_icon: string | null; avatar_url: string | null; project_name: string | null }[];
+      )
+      .all() as {
+      id: string;
+      name: string;
+      agent_name: string;
+      agent_model: string;
+      display_color: string | null;
+      display_icon: string | null;
+      avatar_url: string | null;
+      project_name: string | null;
+    }[];
 
-        let recovered = 0;
-        for (const row of rows) {
-            const threadId = row.name.replace('Discord thread:', '');
-            if (!threadId || threadCallbacks.has(threadId)) continue;
+    let recovered = 0;
+    for (const row of rows) {
+      const threadId = row.name.replace('Discord thread:', '');
+      if (!threadId || threadCallbacks.has(threadId)) continue;
 
             if (!threadSessions.has(threadId)) {
                 const info = {
@@ -1166,21 +1325,65 @@ export function recoverActiveThreadSubscriptions(
                 saveThreadSession(db, threadId, info);
             }
 
-            subscribeForResponseWithEmbed(
-                processManager, delivery, botToken, db, threadCallbacks,
-                row.id, threadId, row.agent_name || 'Agent', row.agent_model || 'unknown',
-                row.project_name || undefined,
-                row.display_color, row.display_icon, row.avatar_url,
-            );
-            recovered++;
-        }
-
-        if (recovered > 0) {
-            log.info('Recovered Discord thread subscriptions', { count: recovered });
-        }
-    } catch (err) {
-        log.warn('Failed to recover thread subscriptions', { error: err instanceof Error ? err.message : String(err) });
+      subscribeForResponseWithEmbed(
+        processManager,
+        delivery,
+        botToken,
+        db,
+        threadCallbacks,
+        row.id,
+        threadId,
+        row.agent_name || 'Agent',
+        row.agent_model || 'unknown',
+        row.project_name || undefined,
+        row.display_color,
+        row.display_icon,
+        row.avatar_url,
+      );
+      recovered++;
     }
+
+    if (recovered > 0) {
+      log.info('Recovered Discord thread subscriptions', { count: recovered });
+    }
+  } catch (err) {
+    log.warn('Failed to recover thread subscriptions', { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+/**
+ * Recover mention sessions from the database after server restart.
+ * Populates the in-memory mentionSessions map with recent entries so that
+ * reply-based session resumption works immediately without a DB lookup per message.
+ */
+export function recoverActiveMentionSessions(
+  db: Database,
+  mentionSessions: Map<string, import('./message-handler').MentionSessionInfo>,
+  trackFn?: (botMessageId: string, info: import('./message-handler').MentionSessionInfo, createdAt?: number) => void,
+): void {
+  try {
+    const { getRecentMentionSessions } =
+      require('../db/discord-mention-sessions') as typeof import('../db/discord-mention-sessions');
+    const recent = getRecentMentionSessions(db, 24);
+
+    let recovered = 0;
+    for (const entry of recent) {
+      if (mentionSessions.has(entry.botMessageId)) continue;
+      const createdAtMs = new Date(`${entry.createdAt}Z`).getTime();
+      if (trackFn) {
+        trackFn(entry.botMessageId, entry.info, createdAtMs);
+      } else {
+        mentionSessions.set(entry.botMessageId, entry.info);
+      }
+      recovered++;
+    }
+
+    if (recovered > 0) {
+      log.info('Recovered Discord mention sessions', { count: recovered });
+    }
+  } catch (err) {
+    log.warn('Failed to recover mention sessions', { error: err instanceof Error ? err.message : String(err) });
+  }
 }
 
 /**
@@ -1221,17 +1424,17 @@ export function recoverActiveThreadSessions(
  * Priority: config default > first agent.
  */
 export function resolveDefaultAgent(
-    db: Database,
-    config: DiscordBridgeConfig,
+  db: Database,
+  config: DiscordBridgeConfig,
 ): import('../../shared/types').Agent | null {
-    const { listAgents } = require('../db/agents') as typeof import('../db/agents');
-    const agents = listAgents(db);
-    if (agents.length === 0) return null;
+  const { listAgents } = require('../db/agents') as typeof import('../db/agents');
+  const agents = listAgents(db);
+  if (agents.length === 0) return null;
 
-    if (config.defaultAgentId) {
-        const defaultAgent = agents.find(a => a.id === config.defaultAgentId);
-        if (defaultAgent) return defaultAgent;
-    }
+  if (config.defaultAgentId) {
+    const defaultAgent = agents.find((a) => a.id === config.defaultAgentId);
+    if (defaultAgent) return defaultAgent;
+  }
 
-    return agents[0];
+  return agents[0];
 }

--- a/server/discord/thread-session-manager.ts
+++ b/server/discord/thread-session-manager.ts
@@ -10,7 +10,7 @@ import type { ThreadCallbackInfo, ThreadSessionInfo } from './thread-session-map
 
 export type { ThreadCallbackInfo, ThreadSessionInfo };
 
-const MENTION_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const MENTION_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const PROCESSED_IDS_CAP = 1000;
 


### PR DESCRIPTION
## Summary

Fixes #1749 — Discord mention sessions (non-thread @mentions) were lost after 30min TTL expiry or server restarts, causing context loss in channel conversations.

- **Add `recoverActiveMentionSessions()`** — loads recent mention sessions from DB into memory on gateway ready, parallel to existing thread recovery
- **Add `getRecentMentionSessions()` DB function** — fetches sessions created within the last 24 hours
- **Increase mention TTL from 30min → 6h** — the 500-entry memory cap still prevents unbounded growth, and the DB fallback covers sessions older than 6h
- **Wire recovery into `bridge.ts` `onReady`** — sessions are now available immediately after restart without waiting for user interaction

### Root cause
Thread sessions had a `recoverActiveThreadSubscriptions()` function that ran on startup, but mention sessions had no equivalent. The in-memory `mentionSessions` map was empty after restart, and sessions were only recovered reactively when a user happened to reply to a specific bot message (triggering a DB lookup). The 30min TTL also aggressively evicted sessions that were still conversationally active.

## Test plan
- [x] Existing `discord-thread-session-manager.test.ts` updated for 6h TTL — all 12 tests pass
- [x] Full test suite passes (9538 pass, 0 fail)
- [x] TypeScript compiles clean
- [x] Manual: restart server, verify mention sessions survive and reply-based resume works

---
🤖 Agent: CorvidAgent | Model: Opus 4.6