### PR TITLE
feat(discord): persist thread-session mappings to SQLite

### DIFF
--- a/server/db/discord-mention-sessions.ts
+++ b/server/db/discord-mention-sessions.ts
@@ -68,6 +68,18 @@ export function deleteMentionSessionsBySessionId(
 }
 
 /**
+ * Update the last_activity_at timestamp for a mention session.
+ */
+export function updateMentionSessionActivity(
+    db: Database,
+    botMessageId: string,
+): void {
+    db.query(
+        `UPDATE discord_mention_sessions SET last_activity_at = datetime('now') WHERE bot_message_id = ?`,
+    ).run(botMessageId);
+}
+
+/**
  * Remove mention session entries older than the specified age.
  * @param maxAgeDays Maximum age in days (default: 7)
  */

--- a/server/db/discord-thread-sessions.ts
+++ b/server/db/discord-thread-sessions.ts
@@ -1,0 +1,148 @@
+import type { Database } from 'bun:sqlite';
+import type { ThreadSessionInfo } from '../discord/thread-session-map';
+
+interface ThreadSessionRow {
+    thread_id: string;
+    session_id: string;
+    agent_name: string;
+    agent_model: string;
+    owner_user_id: string;
+    topic: string | null;
+    project_name: string | null;
+    display_color: string | null;
+    display_icon: string | null;
+    avatar_url: string | null;
+    creator_perm_level: number | null;
+    buddy_agent_id: string | null;
+    buddy_agent_name: string | null;
+    buddy_max_rounds: number | null;
+    last_activity_at: string;
+    created_at: string;
+}
+
+/**
+ * Persist a thread session mapping to the database.
+ */
+export function saveThreadSession(
+    db: Database,
+    threadId: string,
+    info: ThreadSessionInfo,
+): void {
+    db.query(
+        `INSERT OR REPLACE INTO discord_thread_sessions
+         (thread_id, session_id, agent_name, agent_model, owner_user_id, topic, project_name,
+          display_color, display_icon, avatar_url, creator_perm_level,
+          buddy_agent_id, buddy_agent_name, buddy_max_rounds, last_activity_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+    ).run(
+        threadId,
+        info.sessionId,
+        info.agentName,
+        info.agentModel,
+        info.ownerUserId || '',
+        info.topic ?? null,
+        info.projectName ?? null,
+        info.displayColor ?? null,
+        info.displayIcon ?? null,
+        info.avatarUrl ?? null,
+        info.creatorPermLevel ?? null,
+        info.buddyConfig?.buddyAgentId ?? null,
+        info.buddyConfig?.buddyAgentName ?? null,
+        info.buddyConfig?.maxRounds ?? null,
+    );
+}
+
+/**
+ * Look up a thread session by Discord thread ID.
+ */
+export function getThreadSession(
+    db: Database,
+    threadId: string,
+): ThreadSessionInfo | null {
+    const row = db.query(
+        `SELECT * FROM discord_thread_sessions WHERE thread_id = ?`,
+    ).get(threadId) as ThreadSessionRow | null;
+
+    if (!row) return null;
+    return rowToInfo(row);
+}
+
+/**
+ * Update the last_activity_at timestamp for a thread session.
+ */
+export function updateThreadSessionActivity(
+    db: Database,
+    threadId: string,
+): void {
+    db.query(
+        `UPDATE discord_thread_sessions SET last_activity_at = datetime('now') WHERE thread_id = ?`,
+    ).run(threadId);
+}
+
+/**
+ * Bulk-load recent thread sessions for startup recovery.
+ * @param maxAgeHours Maximum age in hours (default: 48)
+ */
+export function getRecentThreadSessions(
+    db: Database,
+    maxAgeHours: number = 48,
+): { threadId: string; info: ThreadSessionInfo; lastActivityAt: number }[] {
+    const rows = db.query(
+        `SELECT * FROM discord_thread_sessions
+         WHERE last_activity_at > datetime('now', '-' || ? || ' hours')
+         ORDER BY last_activity_at DESC`,
+    ).all(maxAgeHours) as ThreadSessionRow[];
+
+    return rows.map((row) => ({
+        threadId: row.thread_id,
+        info: rowToInfo(row),
+        lastActivityAt: new Date(row.last_activity_at.endsWith('Z') ? row.last_activity_at : row.last_activity_at + 'Z').getTime(),
+    }));
+}
+
+/**
+ * Delete a thread session (e.g. on archival).
+ */
+export function deleteThreadSession(
+    db: Database,
+    threadId: string,
+): void {
+    db.query('DELETE FROM discord_thread_sessions WHERE thread_id = ?').run(threadId);
+}
+
+/**
+ * Remove thread session entries older than the specified age.
+ * @param maxAgeDays Maximum age in days (default: 14)
+ */
+export function pruneOldThreadSessions(
+    db: Database,
+    maxAgeDays: number = 14,
+): number {
+    const result = db.query(
+        `DELETE FROM discord_thread_sessions WHERE last_activity_at < datetime('now', '-' || ? || ' days')`,
+    ).run(maxAgeDays);
+    return result.changes;
+}
+
+function rowToInfo(row: ThreadSessionRow): ThreadSessionInfo {
+    const info: ThreadSessionInfo = {
+        sessionId: row.session_id,
+        agentName: row.agent_name,
+        agentModel: row.agent_model,
+        ownerUserId: row.owner_user_id,
+        topic: row.topic || undefined,
+        projectName: row.project_name || undefined,
+        displayColor: row.display_color ?? undefined,
+        displayIcon: row.display_icon ?? undefined,
+        avatarUrl: row.avatar_url ?? undefined,
+        creatorPermLevel: row.creator_perm_level ?? undefined,
+    };
+    if (row.buddy_agent_id && row.buddy_agent_name) {
+        info.buddyConfig = {
+            buddyAgentId: row.buddy_agent_id,
+            buddyAgentName: row.buddy_agent_name,
+            maxRounds: row.buddy_max_rounds ?? undefined,
+        };
+    }
+    return info;
+}

--- a/server/db/migrations/112_discord_thread_sessions.ts
+++ b/server/db/migrations/112_discord_thread_sessions.ts
@@ -1,0 +1,35 @@
+import type { Database } from 'bun:sqlite';
+
+export function up(db: Database): void {
+    db.run(`CREATE TABLE IF NOT EXISTS discord_thread_sessions (
+        thread_id          TEXT PRIMARY KEY,
+        session_id         TEXT NOT NULL,
+        agent_name         TEXT NOT NULL,
+        agent_model        TEXT NOT NULL,
+        owner_user_id      TEXT NOT NULL DEFAULT '',
+        topic              TEXT,
+        project_name       TEXT,
+        display_color      TEXT,
+        display_icon       TEXT,
+        avatar_url         TEXT,
+        creator_perm_level INTEGER,
+        buddy_agent_id     TEXT,
+        buddy_agent_name   TEXT,
+        buddy_max_rounds   INTEGER,
+        last_activity_at   TEXT NOT NULL DEFAULT (datetime('now')),
+        created_at         TEXT NOT NULL DEFAULT (datetime('now'))
+    )`);
+
+    db.run(`CREATE INDEX IF NOT EXISTS idx_discord_thread_sessions_session ON discord_thread_sessions(session_id)`);
+    db.run(`CREATE INDEX IF NOT EXISTS idx_discord_thread_sessions_activity ON discord_thread_sessions(last_activity_at)`);
+
+    // Add last_activity_at to mention sessions for unified activity tracking
+    const cols = db.query('PRAGMA table_info(discord_mention_sessions)').all() as Array<{ name: string }>;
+    if (!cols.some((c) => c.name === 'last_activity_at')) {
+        db.run(`ALTER TABLE discord_mention_sessions ADD COLUMN last_activity_at TEXT DEFAULT (datetime('now'))`);
+    }
+}
+
+export function down(db: Database): void {
+    db.run(`DROP TABLE IF EXISTS discord_thread_sessions`);
+}

--- a/server/db/schema/discord.ts
+++ b/server/db/schema/discord.ts
@@ -29,9 +29,30 @@ export const tables: string[] = [
         channel_id  TEXT NOT NULL,
         created_at  TEXT NOT NULL DEFAULT (datetime('now'))
     )`,
+
+  `CREATE TABLE IF NOT EXISTS discord_thread_sessions (
+        thread_id          TEXT PRIMARY KEY,
+        session_id         TEXT NOT NULL,
+        agent_name         TEXT NOT NULL,
+        agent_model        TEXT NOT NULL,
+        owner_user_id      TEXT NOT NULL DEFAULT '',
+        topic              TEXT,
+        project_name       TEXT,
+        display_color      TEXT,
+        display_icon       TEXT,
+        avatar_url         TEXT,
+        creator_perm_level INTEGER,
+        buddy_agent_id     TEXT,
+        buddy_agent_name   TEXT,
+        buddy_max_rounds   INTEGER,
+        last_activity_at   TEXT NOT NULL DEFAULT (datetime('now')),
+        created_at         TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
 ];
 
 export const indexes: string[] = [
   `CREATE INDEX IF NOT EXISTS idx_discord_mention_sessions_session ON discord_mention_sessions(session_id)`,
   `CREATE INDEX IF NOT EXISTS idx_discord_processed_messages_created ON discord_processed_messages(created_at)`,
+  `CREATE INDEX IF NOT EXISTS idx_discord_thread_sessions_session ON discord_thread_sessions(session_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_discord_thread_sessions_activity ON discord_thread_sessions(last_activity_at)`,
 ];

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -48,7 +48,7 @@ type Domain = {
 
 // ── Schema version (bump when adding new migrations) ────────────────
 
-const SCHEMA_VERSION = 111;
+const SCHEMA_VERSION = 112;
 
 // ── Build MIGRATIONS dict ───────────────────────────────────────────
 
@@ -182,6 +182,12 @@ const MIGRATIONS: Record<number, string[]> = {
     111: [
         // Library entry titles
         `ALTER TABLE agent_library ADD COLUMN title TEXT DEFAULT NULL`,
+    ],
+    112: [
+        // Thread session persistence: dedicated table + unified activity tracking
+        ...discord.tables.filter((s) => s.includes('discord_thread_sessions')),
+        ...discord.indexes.filter((s) => s.includes('discord_thread_sessions')),
+        `ALTER TABLE discord_mention_sessions ADD COLUMN last_activity_at TEXT DEFAULT (datetime('now'))`,
     ],
 };
 

--- a/server/discord/bridge.ts
+++ b/server/discord/bridge.ts
@@ -24,6 +24,7 @@
 import type { Database } from 'bun:sqlite';
 import { getAgent } from '../db/agents';
 import { getDiscordConfig } from '../db/discord-config';
+import { saveThreadSession, pruneOldThreadSessions } from '../db/discord-thread-sessions';
 import { getSession } from '../db/sessions';
 import { type DeliveryTracker, getDeliveryTracker } from '../lib/delivery-tracker';
 import { createLogger } from '../lib/logger';
@@ -49,6 +50,7 @@ import { handleReaction as handleReactionImpl, type ReactionHandlerContext } fro
 import {
   archiveStaleThreads as archiveStaleThreadsImpl,
   createStandaloneThread as createStandaloneThreadImpl,
+  recoverActiveThreadSessions,
   recoverActiveThreadSubscriptions,
   subscribeForAdaptiveInlineResponse,
   subscribeForResponseWithEmbed as subscribeImpl,
@@ -141,6 +143,11 @@ export class DiscordBridge {
           this.botUserId = botUserId;
         }
         log.info('Discord bridge received gateway ready', { sessionId, botUserId });
+        recoverActiveThreadSessions(
+          this.db,
+          this.tsm.threadSessions,
+          this.tsm.threadLastActivity,
+        );
         recoverActiveThreadSubscriptions(
           this.db,
           this.processManager,
@@ -195,9 +202,12 @@ export class DiscordBridge {
           this.tsm.threadSessions,
           this.tsm.threadCallbacks,
           this.STALE_THREAD_MS,
+          this.db,
         ).catch((err) => {
           log.warn('Stale thread check failed', { error: err instanceof Error ? err.message : String(err) });
         });
+        // Prune old thread session DB entries (>14 days)
+        try { pruneOldThreadSessions(this.db); } catch { /* non-critical */ }
       },
       10 * 60 * 1000,
     );
@@ -240,7 +250,7 @@ export class DiscordBridge {
       const displayColor = agent?.displayColor;
       const displayIcon = agent?.displayIcon;
       const avatarUrl = agent?.avatarUrl;
-      this.tsm.threadSessions.set(threadId, {
+      const threadInfo = {
         sessionId,
         agentName,
         agentModel,
@@ -249,7 +259,9 @@ export class DiscordBridge {
         displayColor,
         displayIcon,
         avatarUrl,
-      });
+      };
+      this.tsm.threadSessions.set(threadId, threadInfo);
+      saveThreadSession(this.db, threadId, threadInfo);
       this.subscribeForResponseWithEmbed(
         sessionId,
         threadId,

--- a/server/discord/command-handlers/component-handlers.ts
+++ b/server/discord/command-handlers/component-handlers.ts
@@ -10,6 +10,7 @@ import type { DiscordInteractionData } from '../types';
 import { PermissionLevel } from '../types';
 import type { ThreadSessionInfo } from '../thread-manager';
 import { archiveThread } from '../thread-manager';
+import { deleteThreadSession, updateThreadSessionActivity } from '../../db/discord-thread-sessions';
 import { createLogger } from '../../lib/logger';
 import {
     respondToInteraction,
@@ -63,6 +64,7 @@ export async function handleComponentInteraction(
             // Subscribing now would start the zombie-detection timer against a
             // non-running process, triggering a false "session ended unexpectedly" embed.
             ctx.threadLastActivity.set(threadId, Date.now());
+            updateThreadSessionActivity(ctx.db, threadId);
 
             await acknowledgeButton(interaction, 'Session resumed — send a message to continue.');
             break;
@@ -89,6 +91,7 @@ export async function handleComponentInteraction(
             }
             ctx.threadSessions.delete(threadId);
             ctx.threadLastActivity.delete(threadId);
+            deleteThreadSession(ctx.db, threadId);
 
             // Stop the process if still running
             if (info && ctx.processManager.isRunning(info.sessionId)) {
@@ -185,6 +188,9 @@ function tryRecoverThreadFromCtx(
             projectName: row.project_name || undefined,
         };
         ctx.threadSessions.set(threadId, info);
+        // Persist to dedicated thread sessions table for future fast recovery
+        const { saveThreadSession } = require('../../db/discord-thread-sessions') as typeof import('../../db/discord-thread-sessions');
+        saveThreadSession(ctx.db, threadId, info);
         return info;
     } catch (err) {
         log.error('Failed to recover thread session from DB', {

--- a/server/discord/command-handlers/session-commands.ts
+++ b/server/discord/command-handlers/session-commands.ts
@@ -9,6 +9,7 @@ import type { DiscordInteractionData } from '../types';
 import { PermissionLevel, ButtonStyle } from '../types';
 import type { SessionSource } from '../../../shared/types';
 import { listAgents } from '../../db/agents';
+import { saveThreadSession } from '../../db/discord-thread-sessions';
 import { createSession } from '../../db/sessions';
 import { listProjects } from '../../db/projects';
 import { createLogger } from '../../lib/logger';
@@ -143,7 +144,7 @@ export async function handleSessionCommand(
         workDir,
     });
 
-    ctx.threadSessions.set(threadId, {
+    const threadInfo = {
         sessionId: session.id,
         agentName: agent.name,
         agentModel: agent.model || 'unknown',
@@ -159,8 +160,10 @@ export async function handleSessionCommand(
             buddyAgentName: buddyAgent.name,
             maxRounds: buddyRounds ? Math.max(1, Math.min(10, parseInt(buddyRounds, 10))) : undefined,
         } : undefined,
-    });
+    };
+    ctx.threadSessions.set(threadId, threadInfo);
     ctx.threadLastActivity.set(threadId, Date.now());
+    saveThreadSession(ctx.db, threadId, threadInfo);
 
     ctx.processManager.startProcess(session, topic);
     ctx.subscribeForResponseWithEmbed(session.id, threadId, agent.name, agent.model || 'unknown', project.name, agent.displayColor, agent.displayIcon, agent.avatarUrl);

--- a/server/discord/message-handler.ts
+++ b/server/discord/message-handler.ts
@@ -10,7 +10,8 @@ import type { SessionSource } from '../../shared/types';
 import { listAgents } from '../db/agents';
 import { recordAudit } from '../db/audit';
 import { updateDiscordConfig } from '../db/discord-config';
-import { getMentionSession, saveMentionSession } from '../db/discord-mention-sessions';
+import { getMentionSession, saveMentionSession, updateMentionSessionActivity } from '../db/discord-mention-sessions';
+import { saveThreadSession, updateThreadSessionActivity, deleteThreadSession } from '../db/discord-thread-sessions';
 import { listProjects } from '../db/projects';
 import { createSession, getSession, getPreviousThreadSessionSummary } from '../db/sessions';
 import type { DeliveryTracker } from '../lib/delivery-tracker';
@@ -358,6 +359,7 @@ export async function handleMessage(ctx: MessageHandlerContext, data: DiscordMes
       }
     }
     if (existingSession) {
+      updateMentionSessionActivity(ctx.db, refId);
       await handleMentionReplyResume(
         ctx,
         channelId,
@@ -847,7 +849,7 @@ async function resumeExpiredThreadSession(
     workDir,
   });
 
-  ctx.threadSessions.set(threadId, {
+  const threadInfo = {
     sessionId: newSession.id,
     agentName: agent.name,
     agentModel: agent.model || 'unknown',
@@ -858,8 +860,10 @@ async function resumeExpiredThreadSession(
     displayIcon: agent.displayIcon,
     avatarUrl: agent.avatarUrl,
     creatorPermLevel: previousInfo.creatorPermLevel,
-  });
+  };
+  ctx.threadSessions.set(threadId, threadInfo);
   ctx.threadLastActivity.set(threadId, Date.now());
+  saveThreadSession(ctx.db, threadId, threadInfo);
 
   // Carry over context from the previous session in this thread (if any)
   const previousSummary = getPreviousThreadSessionSummary(ctx.db, threadId);
@@ -915,12 +919,15 @@ async function routeToThread(
   attachments?: DiscordAttachment[],
 ): Promise<void> {
   ctx.threadLastActivity.set(threadId, Date.now());
+  updateThreadSessionActivity(ctx.db, threadId);
 
   let threadInfo = ctx.threadSessions.get(threadId);
 
   if (!threadInfo) {
     threadInfo = tryRecoverThread(ctx.db, ctx.threadSessions, threadId) ?? undefined;
     if (!threadInfo) return;
+    // Persist legacy-recovered session to dedicated table
+    saveThreadSession(ctx.db, threadId, threadInfo);
   }
 
   // Thread permission isolation: BASIC users cannot interact with threads
@@ -958,6 +965,7 @@ async function routeToThread(
   const session = getSession(ctx.db, sessionId);
   if (!session) {
     ctx.threadSessions.delete(threadId);
+    deleteThreadSession(ctx.db, threadId);
     // Automatically resume: create a new session in the same thread
     const resumed = await resumeExpiredThreadSession(
       ctx,
@@ -1012,6 +1020,7 @@ async function routeToThread(
       log.warn('resumeProcess did not start — creating fresh session in thread', { sessionId, threadId });
       // Clear stale mapping and create a brand new session, same as expired sessions
       ctx.threadSessions.delete(threadId);
+      deleteThreadSession(ctx.db, threadId);
       const resumed = await resumeExpiredThreadSession(
         ctx,
         threadId,

--- a/server/discord/thread-lifecycle.ts
+++ b/server/discord/thread-lifecycle.ts
@@ -4,8 +4,10 @@
  * Handles thread creation, archival, and stale thread cleanup via the Discord REST API.
  */
 
+import type { Database } from 'bun:sqlite';
 import type { ProcessManager } from '../process/manager';
 import type { DeliveryTracker } from '../lib/delivery-tracker';
+import { deleteThreadSession } from '../db/discord-thread-sessions';
 import { createLogger } from '../lib/logger';
 import {
     sendEmbedWithButtons,
@@ -85,6 +87,7 @@ export async function archiveStaleThreads(
     threadSessions: Map<string, ThreadSessionInfo>,
     threadCallbacks: Map<string, ThreadCallbackInfo>,
     staleThresholdMs: number,
+    db?: Database,
 ): Promise<void> {
     const now = Date.now();
     const staleThreads: string[] = [];
@@ -109,6 +112,7 @@ export async function archiveStaleThreads(
             await archiveThread(botToken, threadId);
             threadLastActivity.delete(threadId);
             threadSessions.delete(threadId);
+            if (db) deleteThreadSession(db, threadId);
             const cb = threadCallbacks.get(threadId);
             if (cb) {
                 processManager.unsubscribe(cb.sessionId, cb.callback);

--- a/server/discord/thread-manager.ts
+++ b/server/discord/thread-manager.ts
@@ -1150,7 +1150,7 @@ export function recoverActiveThreadSubscriptions(
             if (!threadId || threadCallbacks.has(threadId)) continue;
 
             if (!threadSessions.has(threadId)) {
-                threadSessions.set(threadId, {
+                const info = {
                     sessionId: row.id,
                     agentName: row.agent_name || 'Agent',
                     agentModel: row.agent_model || 'unknown',
@@ -1159,7 +1159,11 @@ export function recoverActiveThreadSubscriptions(
                     displayColor: row.display_color ?? undefined,
                     displayIcon: row.display_icon ?? undefined,
                     avatarUrl: row.avatar_url ?? undefined,
-                });
+                };
+                threadSessions.set(threadId, info);
+                // Persist to dedicated table for future fast recovery
+                const { saveThreadSession } = require('../db/discord-thread-sessions') as typeof import('../db/discord-thread-sessions');
+                saveThreadSession(db, threadId, info);
             }
 
             subscribeForResponseWithEmbed(
@@ -1176,6 +1180,39 @@ export function recoverActiveThreadSubscriptions(
         }
     } catch (err) {
         log.warn('Failed to recover thread subscriptions', { error: err instanceof Error ? err.message : String(err) });
+    }
+}
+
+/**
+ * Bulk-recover thread sessions from the discord_thread_sessions table on startup.
+ * Populates the in-memory threadSessions and threadLastActivity maps so threads
+ * are immediately available without lazy recovery.
+ */
+export function recoverActiveThreadSessions(
+    db: Database,
+    threadSessions: Map<string, ThreadSessionInfo>,
+    threadLastActivity: Map<string, number>,
+): number {
+    try {
+        const { getRecentThreadSessions } = require('../db/discord-thread-sessions') as typeof import('../db/discord-thread-sessions');
+        const rows = getRecentThreadSessions(db, 48);
+
+        let recovered = 0;
+        for (const { threadId, info, lastActivityAt } of rows) {
+            if (!threadSessions.has(threadId)) {
+                threadSessions.set(threadId, info);
+                threadLastActivity.set(threadId, lastActivityAt);
+                recovered++;
+            }
+        }
+
+        if (recovered > 0) {
+            log.info('Recovered thread sessions from DB', { count: recovered });
+        }
+        return recovered;
+    } catch (err) {
+        log.warn('Failed to recover thread sessions', { error: err instanceof Error ? err.message : String(err) });
+        return 0;
     }
 }
 

--- a/server/discord/thread-session-map.ts
+++ b/server/discord/thread-session-map.ts
@@ -94,6 +94,11 @@ export function tryRecoverThread(
             avatarUrl: row.avatar_url ?? undefined,
         };
         threadSessions.set(threadId, info);
+        // Persist to dedicated thread sessions table for future fast recovery
+        try {
+            const { saveThreadSession } = require('../db/discord-thread-sessions') as typeof import('../db/discord-thread-sessions');
+            saveThreadSession(db, threadId, info);
+        } catch { /* non-critical — table may not exist during migration */ }
         log.info('Recovered thread session from DB', { threadId, sessionId: row.id });
         return info;
     } catch (err) {


### PR DESCRIPTION
## Summary
- Adds `discord_thread_sessions` SQLite table to persist thread↔session mappings across server restarts
- Bulk-recovers active thread sessions on startup via `recoverActiveThreadSessions()`
- Keeps DB in sync as threads are created, resumed, archived, and cleaned up
- Adds `last_activity_at` tracking to both thread and mention sessions
- Includes migration 112 and 14-day auto-prune for old entries

## Context
Thread sessions were only kept in-memory, so every server restart lost all active Discord thread associations. Users had to re-create sessions in threads after any restart. This makes thread sessions durable.

## Test plan
- [ ] Verify migration 112 runs cleanly on fresh and existing DBs
- [ ] Start a thread session, restart server, confirm thread still responds
- [ ] Verify stale thread archival also cleans up DB entries
- [ ] Check `/session` command persists to DB immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6