### PR TITLE
fix(lint): clean up Biome lint warnings for release prep

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/scripts/ci-security-scan.ts
+++ b/scripts/ci-security-scan.ts
@@ -11,8 +11,8 @@
  *   3. SQL injection  — string interpolation in SQL queries
  */
 
-import { scanDiff as scanCode, formatScanReport as formatCodeReport } from '../server/lib/code-scanner';
-import { scanDiff as scanFetch, formatScanReport as formatFetchReport } from '../server/lib/fetch-detector';
+import { formatScanReport as formatCodeReport, scanDiff as scanCode } from '../server/lib/code-scanner';
+import { formatScanReport as formatFetchReport, scanDiff as scanFetch } from '../server/lib/fetch-detector';
 
 let failed = false;
 
@@ -119,7 +119,7 @@ try {
 
 // ── Summary ────────────────────────────────────────────────────────────
 
-console.log('\n' + '='.repeat(50));
+console.log(`\n${'='.repeat(50)}`);
 if (failed) {
     console.log('SECURITY SCAN FAILED — see findings above.');
     process.exit(1);

--- a/scripts/governance-check.ts
+++ b/scripts/governance-check.ts
@@ -24,14 +24,10 @@
 // A missing governance module means we cannot verify path safety → block everything.
 
 let classifyPath: typeof import('../server/councils/governance').classifyPath;
-let assessImpact: typeof import('../server/councils/governance').assessImpact;
-let GOVERNANCE_TIERS: typeof import('../server/councils/governance').GOVERNANCE_TIERS;
 
 try {
     const governance = await import('../server/councils/governance');
     classifyPath = governance.classifyPath;
-    assessImpact = governance.assessImpact;
-    GOVERNANCE_TIERS = governance.GOVERNANCE_TIERS;
 } catch (err) {
     console.error(
         '✗ FATAL: Failed to load governance module — fail-closed.\n' +
@@ -85,7 +81,6 @@ function extractChangedFiles(diffOutput: string): string[] {
 const baseRef = process.env.GITHUB_BASE_REF;
 const actor = process.env.GITHUB_ACTOR;
 const headRef = process.env.GITHUB_HEAD_REF;
-const isCI = !!process.env.CI;
 const isAutomatedByActor = isAutomatedActor(actor);
 const isAutomatedByBranch = isAutomatedBranch(headRef);
 const isAutomated = isAutomatedByActor || isAutomatedByBranch;

--- a/scripts/localnet-fund.ts
+++ b/scripts/localnet-fund.ts
@@ -41,7 +41,7 @@ async function main() {
 
   // Get dispenser account from KMD
   const parsed = new URL(KMD_URL);
-  const kmd = new algosdk.Kmd(KMD_TOKEN, `${parsed.protocol}//${parsed.hostname}`, parseInt(parsed.port || '4002'));
+  const kmd = new algosdk.Kmd(KMD_TOKEN, `${parsed.protocol}//${parsed.hostname}`, parseInt(parsed.port || '4002', 10));
   const wallets = await kmd.listWallets();
   const defaultWallet = wallets.wallets.find((w: { name: string }) => w.name === 'unencrypted-default-wallet');
   if (!defaultWallet) {

--- a/scripts/screenshot.ts
+++ b/scripts/screenshot.ts
@@ -18,9 +18,9 @@
  * Output: prints JSON with screenshot paths for programmatic consumption.
  */
 
-import { chromium, type Browser, type Page } from 'playwright';
-import { mkdirSync, rmSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { type Browser, chromium, type Page } from 'playwright';
 
 // ── Config ──────────────────────────────────────────────────────────────────
 

--- a/scripts/version-check.ts
+++ b/scripts/version-check.ts
@@ -8,7 +8,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 const ROOT = resolve(import.meta.dir, '..');
 

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -1,9 +1,9 @@
 import type { AgentMessage } from './types/algochat';
-import type { CouncilLaunchLog, CouncilDiscussionMessage } from './types/councils';
-import type { WorkTask } from './types/work-tasks';
+import type { CouncilDiscussionMessage, CouncilLaunchLog } from './types/councils';
 import type { AgentSchedule, ScheduleExecution } from './types/schedules';
-import type { WebhookRegistration, WebhookDelivery, MentionPollingConfig } from './types/webhooks';
-import type { WorkflowRun, WorkflowNodeRun } from './types/workflows';
+import type { MentionPollingConfig, WebhookDelivery, WebhookRegistration } from './types/webhooks';
+import type { WorkTask } from './types/work-tasks';
+import type { WorkflowNodeRun, WorkflowRun } from './types/workflows';
 
 // ── Client → Server messages ─────────────────────────────────────────
 
@@ -219,37 +219,37 @@ export type StreamEventType = StreamEvent['eventType'];
 export function isClientMessage(data: unknown): data is ClientMessage {
     if (typeof data !== 'object' || data === null) return false;
     const msg = data as Record<string, unknown>;
-    if (typeof msg['type'] !== 'string') return false;
+    if (typeof msg.type !== 'string') return false;
 
-    switch (msg['type']) {
+    switch (msg.type) {
         case 'auth':
-            return typeof msg['key'] === 'string';
+            return typeof msg.key === 'string';
         case 'subscribe':
         case 'unsubscribe':
-            return typeof msg['sessionId'] === 'string';
+            return typeof msg.sessionId === 'string';
         case 'send_message':
-            return typeof msg['sessionId'] === 'string' && typeof msg['content'] === 'string';
+            return typeof msg.sessionId === 'string' && typeof msg.content === 'string';
         case 'chat_send':
-            return typeof msg['agentId'] === 'string' && typeof msg['content'] === 'string'
-                && (msg['projectId'] === undefined || typeof msg['projectId'] === 'string')
-                && (msg['tools'] === undefined || Array.isArray(msg['tools']));
+            return typeof msg.agentId === 'string' && typeof msg.content === 'string'
+                && (msg.projectId === undefined || typeof msg.projectId === 'string')
+                && (msg.tools === undefined || Array.isArray(msg.tools));
         case 'agent_reward':
-            return typeof msg['agentId'] === 'string' && typeof msg['microAlgos'] === 'number';
+            return typeof msg.agentId === 'string' && typeof msg.microAlgos === 'number';
         case 'agent_invoke':
-            return typeof msg['fromAgentId'] === 'string' && typeof msg['toAgentId'] === 'string'
-                && typeof msg['content'] === 'string';
+            return typeof msg.fromAgentId === 'string' && typeof msg.toAgentId === 'string'
+                && typeof msg.content === 'string';
         case 'approval_response':
-            return typeof msg['requestId'] === 'string'
-                && (msg['behavior'] === 'allow' || msg['behavior'] === 'deny');
+            return typeof msg.requestId === 'string'
+                && (msg.behavior === 'allow' || msg.behavior === 'deny');
         case 'create_work_task':
-            return typeof msg['agentId'] === 'string' && typeof msg['description'] === 'string'
-                && (msg['projectId'] === undefined || typeof msg['projectId'] === 'string');
+            return typeof msg.agentId === 'string' && typeof msg.description === 'string'
+                && (msg.projectId === undefined || typeof msg.projectId === 'string');
         case 'schedule_approval':
-            return typeof msg['executionId'] === 'string' && typeof msg['approved'] === 'boolean';
+            return typeof msg.executionId === 'string' && typeof msg.approved === 'boolean';
         case 'pong':
             return true;
         case 'question_response':
-            return typeof msg['questionId'] === 'string' && typeof msg['answer'] === 'string';
+            return typeof msg.questionId === 'string' && typeof msg.answer === 'string';
         default:
             return false;
     }


### PR DESCRIPTION
## Summary
- Update Biome schema version (2.4.0 → 2.4.10)
- Fix import ordering in `ci-security-scan.ts`, `screenshot.ts`, `version-check.ts`, `ws-protocol.ts`
- Remove unused variables (`assessImpact`, `GOVERNANCE_TIERS`, `isCI`) in `governance-check.ts`
- Use literal keys instead of bracket notation in `ws-protocol.ts`
- Add missing `parseInt` radix in `localnet-fund.ts`
- Convert string concatenation to template literal in `ci-security-scan.ts`

## Test plan
- [x] TSC compiles clean
- [x] All 9,582 tests pass
- [x] Biome lint clean on all changed files

---
🤖 Agent: CorvidAgent | Model: Opus 4.6