### PR TITLE
docs(specs): add context.md to all 52 spec directories

### DIFF
--- a/specs/a2a/context.md
+++ b/specs/a2a/context.md
@@ -1,0 +1,21 @@
+# A2A Protocol — Context
+
+## Why This Module Exists
+
+The corvid-agent platform is designed for multi-agent collaboration, not just single-agent operation. The A2A (Agent-to-Agent) protocol enables agents on different hosts or platforms to discover each other's capabilities and delegate tasks. Without this, agents are limited to intra-platform communication via AlgoChat or direct process invocation.
+
+## Architectural Role
+
+A2A sits at the **inter-platform boundary** — it's how corvid-agent talks to agents that aren't part of the local deployment. It complements AlgoChat (which handles on-chain messaging between known agents) by providing a standard HTTP-based protocol for task delegation with agents discovered via their Agent Card.
+
+## Key Design Decisions
+
+- **Agent Cards over static config**: Rather than hardcoding remote agent endpoints, A2A uses discoverable Agent Card documents (JSON-LD) that describe capabilities, skills, and endpoints. This makes the system extensible without config changes.
+- **Invocation guard**: Outbound A2A calls go through an invocation guard to prevent infinite recursion (agent A calls B calls A). This is critical in a multi-agent system where delegation chains can form.
+- **Poll-based results**: A2A tasks are asynchronous — the caller submits a task and polls for completion. This avoids long-lived HTTP connections and works across firewalls.
+
+## Relationship to Other Modules
+
+- **Flock Directory**: Discovers which agents are available and what they can do (local registry). A2A extends this to remote agents.
+- **Process Manager**: A2A inbound tasks create sessions via the process manager, same as any other agent interaction.
+- **Work Tasks**: A2A task results feed back into the work task system when used for delegated work.

--- a/specs/algochat/context.md
+++ b/specs/algochat/context.md
@@ -1,0 +1,23 @@
+# AlgoChat — Context
+
+## Why This Module Exists
+
+AlgoChat is the **primary communication backbone** of the corvid-agent platform. It provides tamper-proof, on-chain messaging between agents and operators using the Algorand blockchain. Every message is a verifiable transaction, making the conversation history immutable and auditable. This is foundational to the platform's trust model — you can prove what any agent said.
+
+## Architectural Role
+
+AlgoChat is the **messaging layer** that bridges human operators (via mobile wallets) and AI agents. It's the main way Leif and other operators interact with agents outside of the web dashboard. All slash commands (`/status`, `/work`, `/council`, etc.) are available over AlgoChat, making it a full control plane.
+
+## Key Design Decisions
+
+- **PSK contacts for mobile**: Mobile wallets can't do public-key exchange easily, so AlgoChat uses pre-shared keys (PSKs) with a URI scheme (`algochat-psk://`) for easy onboarding via QR code.
+- **Localnet for development**: On localnet, AlgoChat runs on a local Algorand node with free transactions, enabling rapid development. On mainnet, it uses real ALGO for transaction fees.
+- **Owner authorization**: On-chain messages from non-owner addresses are rejected. This is the security boundary — only authorized operators can control agents via AlgoChat.
+- **Group message reassembly**: Algorand transaction notes have size limits, so long messages are split into chunks with `[GRP:N/M]` prefixes and reassembled transparently.
+
+## Relationship to Other Modules
+
+- **Channels**: AlgoChat implements the `ChannelAdapter` interface, making it one of several messaging channels (alongside Discord, Slack, Telegram, WebSocket).
+- **Process Manager**: Incoming AlgoChat messages create or resume agent sessions.
+- **Memory**: ARC-69 memories and CRVLIB entries are stored on the same Algorand localnet that AlgoChat uses.
+- **Notifications**: AlgoChat is one of the notification delivery channels for owner questions and alerts.

--- a/specs/ast/context.md
+++ b/specs/ast/context.md
@@ -1,0 +1,20 @@
+# AST — Context
+
+## Why This Module Exists
+
+Agents need to navigate and understand codebases to do useful work. The AST module provides structured code intelligence — function signatures, class hierarchies, import/export maps — without requiring agents to read entire files. This makes code search and navigation fast and precise, especially for large projects.
+
+## Architectural Role
+
+AST is a **developer tooling service** that powers the `corvid_code_symbols` and `corvid_find_references` MCP tools. It sits between the raw filesystem and agent sessions, providing a queryable symbol index.
+
+## Key Design Decisions
+
+- **Tree-sitter over regex**: Uses tree-sitter for accurate parsing rather than regex-based extraction. This handles edge cases (nested functions, decorators, generics) that regex would miss.
+- **mtime-based caching**: Only re-parses files that have changed since the last index build. This makes repeated queries fast without stale data.
+- **Per-project indexes**: Each project gets its own symbol index, supporting multi-project deployments.
+
+## Relationship to Other Modules
+
+- **MCP Tools**: The AST service backs the code navigation MCP tools that agents use during sessions.
+- **Work Tasks**: Agents working on code changes use AST queries to understand the codebase before making modifications.

--- a/specs/billing/context.md
+++ b/specs/billing/context.md
@@ -1,0 +1,21 @@
+# Billing — Context
+
+## Why This Module Exists
+
+As corvid-agent moves toward a multi-tenant SaaS model, usage needs to be metered and billed. The billing module tracks API usage, manages subscriptions, and integrates with Stripe for payment processing. This enables the platform to sustain itself financially while providing transparent usage accounting.
+
+## Architectural Role
+
+Billing is a **cross-cutting concern** that meters usage across all agent interactions (sessions, tool calls, LLM tokens) and manages the credit system that gates access to paid features.
+
+## Key Design Decisions
+
+- **Credit-based model**: Rather than direct per-call pricing, the platform uses credits that can be purchased and consumed. This simplifies the billing UX and enables prepaid usage.
+- **Stripe integration**: Stripe handles payment processing, subscription management, and invoicing. The billing module syncs state bidirectionally.
+- **Usage records**: Every metered event is recorded for audit and dispute resolution.
+
+## Relationship to Other Modules
+
+- **Credits (DB)**: The credit ledger tracks balances. Billing module manages the lifecycle (purchase, consumption, refunds).
+- **Marketplace**: The escrow system uses credits for inter-agent transactions.
+- **Usage Monitor**: Tracks and alerts on usage patterns that may indicate runaway costs.

--- a/specs/browser/context.md
+++ b/specs/browser/context.md
@@ -1,0 +1,20 @@
+# Browser Service — Context
+
+## Why This Module Exists
+
+Some agent tasks require web interaction — scraping pages, filling forms, taking screenshots, testing web UIs. The browser service provides a managed Playwright instance that agents can use via the `corvid_browser` MCP tool without needing to manage browser lifecycle themselves.
+
+## Architectural Role
+
+Browser is a **shared infrastructure service** — a single headless Chrome instance that all agent sessions share. It's lazily initialized (only started when first used) to avoid wasting resources.
+
+## Key Design Decisions
+
+- **System Chrome, not bundled**: Uses the system-installed Chrome rather than a bundled Chromium. This reduces binary size and leverages the host's GPU acceleration.
+- **Headless by default**: Runs headless for server deployments. Can be switched to headed mode for debugging.
+- **Shared instance**: One browser instance serves all agents to avoid memory bloat from multiple browser processes.
+
+## Relationship to Other Modules
+
+- **MCP Tools**: The `corvid_browser` tool delegates to this service.
+- **Deep Research**: The research tool uses the browser for web page fetching when needed.

--- a/specs/buddy/context.md
+++ b/specs/buddy/context.md
@@ -1,0 +1,21 @@
+# Buddy Service — Context
+
+## Why This Module Exists
+
+Not every collaboration needs a full council. The buddy system provides lightweight paired review — one agent writes, another reviews, and they iterate. It's the middle ground between solo work and council deliberation, designed for tasks that benefit from a second opinion without the overhead of multi-agent voting and synthesis.
+
+## Architectural Role
+
+Buddy mode is an **orchestration pattern** that sits above the process manager. It creates two agent sessions (lead + buddy) and manages the back-and-forth review loop.
+
+## Key Design Decisions
+
+- **LGTM short-circuit**: The buddy can approve early by responding with LGTM, avoiding unnecessary review rounds.
+- **Max rounds cap**: Prevents infinite review loops. After maxRounds, the lead's output stands.
+- **Lighter than councils**: No voting, no synthesis phase, no quorum — just request-response. This keeps latency low and cost down.
+
+## Relationship to Other Modules
+
+- **Councils**: Buddy mode is the simpler alternative. Councils handle multi-agent deliberation with voting; buddy mode handles simple review.
+- **Process Manager**: Both lead and buddy sessions are managed by the process manager.
+- **Work Tasks**: Buddy mode can be triggered as part of a work task pipeline.

--- a/specs/channels/context.md
+++ b/specs/channels/context.md
@@ -1,0 +1,21 @@
+# Channels — Context
+
+## Why This Module Exists
+
+corvid-agent communicates through many platforms — AlgoChat, Discord, Slack, Telegram, WebSocket, and more. The channels module defines a unified interface so the rest of the system doesn't need to know which platform a message came from. This is the abstraction layer that makes the system channel-agnostic.
+
+## Architectural Role
+
+Channels is an **interface layer** — it defines the contract (`ChannelAdapter`, `SessionMessage`) that all messaging integrations implement. It contains no business logic itself, just types and the adapter pattern.
+
+## Key Design Decisions
+
+- **Adapter pattern**: Each platform implements `ChannelAdapter`, normalizing platform-specific quirks (threads, reactions, file uploads) into a common format.
+- **SessionMessage as lingua franca**: All inbound messages are converted to `SessionMessage` before reaching the agent. All outbound responses are `SessionMessage` objects that adapters render for their platform.
+- **No platform dependencies**: The channels module itself has zero external dependencies. Platform-specific SDKs live in the bridge modules.
+
+## Relationship to Other Modules
+
+- **AlgoChat, Discord, Slack, Telegram, WebSocket**: Each implements the `ChannelAdapter` interface.
+- **Process Manager**: Receives normalized `SessionMessage` objects regardless of source channel.
+- **Notifications**: Uses channel adapters for multi-channel notification delivery.

--- a/specs/cli/context.md
+++ b/specs/cli/context.md
@@ -1,0 +1,20 @@
+# CLI — Context
+
+## Why This Module Exists
+
+Operators need a quick way to verify that a corvid-agent deployment is healthy — are all dependencies available? Is the database accessible? Are API keys valid? The CLI doctor command provides a single-command health check that catches common deployment issues before they cause runtime failures.
+
+## Architectural Role
+
+The CLI is a **diagnostic tool** that runs outside the server process. It validates the deployment environment independently, making it useful for both initial setup and ongoing troubleshooting.
+
+## Key Design Decisions
+
+- **Comprehensive checks**: Validates Bun/Node.js versions, database connectivity, AI provider keys, server ports, AlgoChat/Algorand connectivity, and GitHub tokens in one pass.
+- **Actionable suggestions**: Each failing check includes a specific fix suggestion, not just a pass/fail status.
+- **Independent of server**: Runs as a standalone command, not requiring the server to be running.
+
+## Relationship to Other Modules
+
+- **Config**: Uses the config loader to find and validate configuration.
+- **Health**: Complements the runtime health monitor — CLI doctor checks pre-boot health, the health monitor checks runtime health.

--- a/specs/client/context.md
+++ b/specs/client/context.md
@@ -1,0 +1,22 @@
+# Client — Context
+
+## Why This Module Exists
+
+The web dashboard is the primary GUI for corvid-agent. It provides a mobile-first Angular application where operators can chat with agents, monitor system health, manage schedules, review work tasks, and observe agent memory. The sidebar navigation module specifically handles routing between all these features.
+
+## Architectural Role
+
+The client is the **presentation layer** — a standalone Angular 21 SPA that communicates with the server via REST APIs and WebSocket. It's built with standalone components and lazy-loaded routes for performance.
+
+## Key Design Decisions
+
+- **Mobile-first**: Designed for phone-sized screens first, with responsive expansion for desktop. This reflects the primary use case of operators managing agents on the go.
+- **Chat as home page**: The default landing is `/chat`, emphasizing that agent conversation is the primary interaction model.
+- **No audience segmentation**: All features are visible to all users. Access control is handled server-side.
+- **Responsive sidebar**: Collapses to an overlay on mobile, persists collapsed/expanded state in localStorage.
+
+## Relationship to Other Modules
+
+- **WebSocket**: Real-time updates (session events, council progress, notifications) flow through the WS handler.
+- **Routes**: The client consumes all REST API endpoints defined in the routes module.
+- **Dashboard**: The dashboard routes serve memory brain viewer and other observability data to the client.

--- a/specs/config/context.md
+++ b/specs/config/context.md
@@ -1,0 +1,20 @@
+# Config — Context
+
+## Why This Module Exists
+
+corvid-agent needs to run in multiple environments — local development, production servers, CI — each with different settings. The config loader provides a single entry point that resolves configuration from files or environment variables, applies defaults, and validates the result. This eliminates scattered `process.env` reads throughout the codebase.
+
+## Architectural Role
+
+Config is a **boot-time service** — it runs once at startup and provides the resolved configuration to all other modules. It's one of the first things initialized.
+
+## Key Design Decisions
+
+- **Three loading strategies**: Explicit path → auto-discovered file → environment variables. This covers all deployment patterns.
+- **Backward compatibility with .env**: Existing `.env`-based deployments continue to work while structured config files are preferred for new setups.
+- **Fail-fast validation**: Missing required configuration causes immediate, clear errors at startup rather than cryptic failures at runtime.
+
+## Relationship to Other Modules
+
+- **Every module**: Nearly every server module consumes configuration. The config loader is a foundational dependency.
+- **CLI Doctor**: Validates config as part of its health checks.

--- a/specs/councils/context.md
+++ b/specs/councils/context.md
@@ -1,0 +1,23 @@
+# Councils — Context
+
+## Why This Module Exists
+
+Some decisions are too important for a single agent. Councils enable structured multi-agent deliberation — multiple agents discuss a topic, propose solutions, vote, and a synthesis is produced. This is the governance mechanism for the platform, used for architectural decisions, security reviews, and any task that benefits from diverse perspectives.
+
+## Architectural Role
+
+Councils are an **orchestration layer** — they coordinate multiple agent sessions through a defined lifecycle: responding → discussing → reviewing → synthesizing. Each stage has specific rules about who participates and how results are aggregated.
+
+## Key Design Decisions
+
+- **Stage-based lifecycle**: Councils progress through well-defined stages rather than free-form discussion. This prevents endless debate and ensures convergence.
+- **Quorum requirements**: At least 2 agents required. This prevents rubber-stamp single-agent councils.
+- **Opus for synthesis**: The synthesis stage uses the most capable model (Opus) to ensure the final output captures the nuance of the discussion.
+- **45-minute safety timeout**: Prevents councils from running indefinitely if agents stall.
+
+## Relationship to Other Modules
+
+- **Process Manager**: Each participating agent runs as a managed process.
+- **Providers**: Council stages use different models for different roles (Haiku for initial responses, Sonnet for discussion, Opus for synthesis).
+- **AlgoChat**: Councils can be launched via `/council` slash command over AlgoChat.
+- **Permissions**: Council decisions on governance topics (Layer 1 changes) require formal votes.

--- a/specs/dashboard/context.md
+++ b/specs/dashboard/context.md
@@ -1,0 +1,21 @@
+# Dashboard — Context
+
+## Why This Module Exists
+
+Operators need visibility into what agents know and remember. The dashboard's unified memory view combines the former Brain Viewer and Memory Browser into a single interface that shows all agent memories across both storage tiers (on-chain and SQLite), their sync status, and relationships.
+
+## Architectural Role
+
+The dashboard is a **read-only observability layer** — it queries the memory system and presents it visually. It doesn't modify memories; it just makes them inspectable.
+
+## Key Design Decisions
+
+- **Unified view**: Merged two separate views (Brain Viewer + Memory Browser) into one. Operators shouldn't have to switch between views to understand an agent's memory state.
+- **Three view modes**: Overview (stats), Browse (searchable list), and 3D (spatial graph). Different modes serve different needs — quick health check vs. deep exploration.
+- **Sync health indicators**: Shows whether on-chain and SQLite memories are in sync, which is critical for debugging memory issues.
+
+## Relationship to Other Modules
+
+- **Memory**: Reads from both the ARC-69 on-chain memory and the SQLite agent_memories table.
+- **Routes**: Dashboard endpoints live under `/api/dashboard/` with dashboard auth guard.
+- **Client**: The Angular frontend renders the memory views using data from these API endpoints.

--- a/specs/db/context.md
+++ b/specs/db/context.md
@@ -1,0 +1,22 @@
+# Database — Context
+
+## Why This Module Exists
+
+SQLite is the single persistent data store for corvid-agent. The db module provides all database access — schema definitions, migrations, and CRUD operations for every table. It's the data foundation that every other module builds on.
+
+## Architectural Role
+
+The db module is **infrastructure** — it sits at the bottom of the dependency graph. Nearly every server module depends on it for state persistence. It manages connection lifecycle, schema versioning, and provides typed query functions.
+
+## Key Design Decisions
+
+- **SQLite over Postgres**: SQLite is embedded, zero-config, and sufficient for single-node deployments. Multi-tenant scaling would require migration to Postgres.
+- **Migration-based schema**: All schema changes go through numbered migration files, ensuring reproducible database state.
+- **Agent blocklist**: A dedicated blocklist table enables instant security response — blocking an agent is a single DB write that takes effect immediately.
+- **Multiple spec files**: The db module has many spec files (agent-blocklist, sessions, credits, etc.) because it covers all domain tables. Each spec covers one logical grouping.
+
+## Relationship to Other Modules
+
+- **Every module**: The db module is the most depended-upon module in the system. Sessions, memories, schedules, permissions, webhooks, and more all store state here.
+- **Memory**: The agent_memories table is the SQLite tier of the two-tier memory system.
+- **Migrations**: Schema changes are applied in order at startup.

--- a/specs/discord/context.md
+++ b/specs/discord/context.md
@@ -1,0 +1,22 @@
+# Discord — Context
+
+## Why This Module Exists
+
+Discord is the primary team communication channel for CorvidLabs. The Discord bridge enables agents to participate in Discord conversations — responding to mentions, managing threads, and executing operator commands. The agent config commands specifically allow hot-swapping agent skills and personas without restarting.
+
+## Architectural Role
+
+Discord is a **channel bridge** — it implements the `ChannelAdapter` interface and translates between Discord's API (slash commands, mentions, threads) and corvid-agent's session model.
+
+## Key Design Decisions
+
+- **Slash commands for config**: `/agent-skill` and `/agent-persona` use Discord's native slash command system for discoverability and validation.
+- **Next-session activation**: Config changes take effect on the agent's next session, not the current one. This prevents mid-conversation personality shifts.
+- **Thread-based sessions**: Each Discord thread maps to an agent session, keeping conversations isolated.
+
+## Relationship to Other Modules
+
+- **Channels**: Implements `ChannelAdapter`.
+- **Process Manager**: Creates agent sessions for Discord interactions.
+- **Notifications**: Discord is a notification delivery channel.
+- **AlgoChat**: Messages can bridge between Discord and AlgoChat (the two main operator channels).

--- a/specs/docs/context.md
+++ b/specs/docs/context.md
@@ -1,0 +1,21 @@
+# Docs — Context
+
+## Why This Module Exists
+
+The REST API and MCP tool catalog need to be discoverable and documented. The docs module auto-generates OpenAPI 3.1 documentation from the route registry and serves a Swagger UI, making the API self-documenting. This helps both developers and agents understand what endpoints are available.
+
+## Architectural Role
+
+Docs is a **meta-service** — it introspects the route registry to generate documentation rather than implementing business logic. It runs alongside the main server.
+
+## Key Design Decisions
+
+- **Auto-generated from registry**: Documentation is derived from code, not maintained separately. This prevents docs from drifting out of sync with the actual API.
+- **Swagger UI included**: A built-in UI endpoint means developers can explore the API from a browser without external tools.
+- **MCP tool catalog**: Documents not just REST endpoints but also MCP tools available to agents.
+
+## Relationship to Other Modules
+
+- **Routes**: Reads the route registry to enumerate all endpoints.
+- **MCP**: Reads MCP tool definitions for the tool catalog.
+- **OpenAPI**: The openapi module handles the detailed schema generation; docs provides the serving layer.

--- a/specs/events/context.md
+++ b/specs/events/context.md
@@ -1,0 +1,21 @@
+# Event Broadcasting — Context
+
+## Why This Module Exists
+
+The web dashboard needs real-time updates — when a council progresses, a schedule fires, or a notification arrives, the UI should reflect it immediately without polling. The event broadcasting module wires backend service events to tenant-scoped WebSocket topics, providing a single integration point for real-time delivery.
+
+## Architectural Role
+
+Events is the **pub/sub glue** between backend services and the WebSocket layer. It was extracted from the main server index file as part of god-module decomposition to keep the codebase modular.
+
+## Key Design Decisions
+
+- **Tenant-scoped topics**: Events are broadcast to specific tenant topics, not globally. This is preparation for multi-tenant support.
+- **Single integration point**: All event routing goes through this module rather than having services directly call WebSocket APIs. This makes it easy to audit and extend.
+- **Extraction from god module**: This was carved out of `server/index.ts` specifically to reduce that file's complexity.
+
+## Relationship to Other Modules
+
+- **WebSocket**: Events are delivered to clients via the WS handler.
+- **Tenant**: Uses tenant resolution to scope events.
+- **Councils, Scheduler, Webhooks, Workflows, Notifications**: All emit events that this module routes.

--- a/specs/exam/context.md
+++ b/specs/exam/context.md
@@ -1,0 +1,21 @@
+# Exam — Context
+
+## Why This Module Exists
+
+Agents need to be tested — not just unit tests on the codebase, but functional tests of agent behavior. The exam module creates a dedicated test project and agent, then runs a suite of cases (unit, e2e, or both) against it. This validates that agents can actually perform tasks correctly, not just that the code compiles.
+
+## Architectural Role
+
+Exam is a **quality assurance tool** — it spawns real agent sessions and evaluates their output against expected results. It's orthogonal to traditional testing (bun test) and focuses on agent behavioral correctness.
+
+## Key Design Decisions
+
+- **Dedicated test project**: Creates an isolated project for test runs so exam results don't pollute real projects.
+- **Agent-driven auto-fix**: When tests fail, the exam runner can spawn an agent session to attempt automatic fixes, creating a self-healing loop.
+- **Case-based structure**: Test cases are defined declaratively in `cases.ts`, making it easy to add new behavioral tests.
+
+## Relationship to Other Modules
+
+- **Process Manager**: Exam runs create real agent sessions.
+- **Projects/Agents/Sessions (DB)**: Uses the standard project and agent infrastructure.
+- **Self-Test**: Self-test is the simpler variant; exam is the full suite.

--- a/specs/feedback/context.md
+++ b/specs/feedback/context.md
@@ -1,0 +1,22 @@
+# Feedback (Outcome Tracker) — Context
+
+## Why This Module Exists
+
+Agents need to learn from their work outcomes. The outcome tracker monitors PR lifecycle events (opened, merged, closed) by polling GitHub, records state transitions, and produces weekly analyses. This data feeds the improvement loop, enabling data-driven decisions about which agents and approaches produce the best results.
+
+## Architectural Role
+
+Feedback is part of the **learning/improvement pipeline** — it collects outcome data that the improvement module uses for analysis and recommendations.
+
+## Key Design Decisions
+
+- **PR-centric metrics**: PRs are the primary unit of work output, so tracking their fate (merged vs. closed) is a strong signal of work quality.
+- **Weekly cadence**: Analysis runs weekly rather than per-PR to capture patterns rather than reacting to individual outcomes.
+- **GitHub polling**: Polls GitHub for PR status changes rather than relying on webhooks, making it resilient to missed webhook deliveries.
+
+## Relationship to Other Modules
+
+- **Improvement**: Consumes feedback data for daily reviews and improvement recommendations.
+- **GitHub**: Polls GitHub for PR status.
+- **Memory**: Stores analysis results as agent memories for long-term learning.
+- **Work Tasks**: Correlates PR outcomes with the work tasks that produced them.

--- a/specs/flock-directory/context.md
+++ b/specs/flock-directory/context.md
@@ -1,0 +1,22 @@
+# Flock Directory — Context
+
+## Why This Module Exists
+
+When a task arrives that could be delegated, the system needs to know which agent is best suited for it. The Flock Directory is an on-chain registry of agent capabilities, and the capability router uses it to match tasks to agents based on skills, reputation, workload, and uptime.
+
+## Architectural Role
+
+The Flock Directory is the **agent discovery and routing layer**. It answers "who can do this?" and "who should do this?" — bridging the gap between incoming work and the multi-agent team.
+
+## Key Design Decisions
+
+- **On-chain registry**: Agent capabilities are registered on-chain for verifiability. Other platforms can query it to discover corvid-agent's capabilities.
+- **Multi-factor routing**: Task routing considers capabilities (can they do it?), reputation (how well do they do it?), workload (are they available?), and uptime (are they online?). Not just skill matching.
+- **Conflict resolution**: When multiple agents match, a conflict resolver picks the best candidate based on weighted scoring.
+
+## Relationship to Other Modules
+
+- **Work Tasks**: The capability router is invoked when a work task needs delegation.
+- **Reputation**: Agent reputation scores influence routing decisions.
+- **A2A**: Remote agents discovered via A2A can also be registered in the flock directory.
+- **AlgoChat**: Agent directory lookups are used to distinguish agent-to-agent messages from human messages.

--- a/specs/github/context.md
+++ b/specs/github/context.md
@@ -1,0 +1,22 @@
+# GitHub — Context
+
+## Why This Module Exists
+
+Agents interact with GitHub extensively — creating PRs, reviewing code, starring repos, filing issues. The GitHub module wraps the `gh` CLI to provide these operations with a safety layer: a repo blocklist that prevents agents from accidentally modifying off-limits repositories.
+
+## Architectural Role
+
+GitHub is an **external integration module** — it mediates all agent interactions with GitHub, enforcing access controls.
+
+## Key Design Decisions
+
+- **`gh` CLI over REST API**: Uses the GitHub CLI rather than direct API calls. This leverages the CLI's built-in auth management and avoids token handling complexity.
+- **Repo blocklist**: A configurable deny-list prevents write operations (PRs, pushes, issues) against protected repositories. This is a critical safety mechanism.
+- **Organization: CorvidLabs**: All repos live under the `CorvidLabs` GitHub organization, NOT `corvid-agent`.
+
+## Relationship to Other Modules
+
+- **Work Tasks**: Work task completion often involves creating PRs via this module.
+- **Polling**: The auto-merge poller uses GitHub operations to merge approved PRs.
+- **Feedback**: The outcome tracker polls GitHub for PR status.
+- **Webhooks**: GitHub webhook events trigger agent actions via the webhook service.

--- a/specs/health/context.md
+++ b/specs/health/context.md
@@ -1,0 +1,22 @@
+# Health — Context
+
+## Why This Module Exists
+
+A production system needs continuous health monitoring. The health module periodically checks system vitals (memory, CPU, disk, database, provider availability, middleware pipeline) and stores snapshots for trend analysis. When health degrades, it triggers notifications to operators.
+
+## Architectural Role
+
+Health is an **observability service** that runs on a timer, collecting and persisting health snapshots. It complements the CLI doctor (which checks pre-boot health) with runtime monitoring.
+
+## Key Design Decisions
+
+- **Snapshot-based**: Health data is stored as periodic snapshots rather than streaming metrics. This keeps storage bounded and makes trend analysis straightforward.
+- **Provider health tracking**: Monitors LLM provider availability (API key validity, rate limits, error rates), which is critical since provider outages directly impact agent functionality.
+- **Notification integration**: Health degradation triggers operator notifications through the notification service.
+
+## Relationship to Other Modules
+
+- **Performance**: Performance module collects similar metrics but focuses on system-level stats. Health is higher-level ("is the system working?").
+- **Notifications**: Sends alerts when health degrades below thresholds.
+- **Improvement**: Health data feeds into the improvement module's daily review.
+- **Scheduler**: Health-aware scheduling gates or boosts tasks based on system health.

--- a/specs/improvement/context.md
+++ b/specs/improvement/context.md
@@ -1,0 +1,25 @@
+# Improvement — Context
+
+## Why This Module Exists
+
+corvid-agent is designed to get better over time without manual tuning. The improvement module is the **self-improvement engine** — it collects health data, analyzes PR outcomes, and produces daily reviews with actionable recommendations. These recommendations feed back into agent behavior, creating a continuous improvement loop.
+
+## Architectural Role
+
+Improvement is a **periodic analysis service** — it runs daily, aggregates data from multiple sources, and produces structured insights that agents can act on.
+
+## Key Design Decisions
+
+- **Daily review cadence**: Runs once per day, analyzing the previous day's activity. This is frequent enough to catch issues quickly but not so frequent that it generates noise.
+- **Multi-source analysis**: Combines health snapshots, PR outcomes, reputation scores, and memory data for a holistic view.
+- **Agent-actionable output**: Recommendations are structured so agents (not just humans) can understand and act on them.
+- **Work task integration**: Can automatically create work tasks for improvement recommendations.
+
+## Relationship to Other Modules
+
+- **Feedback**: Consumes PR outcome data.
+- **Health**: Consumes health snapshots.
+- **Reputation**: Consumes reputation scores.
+- **Memory**: Stores and retrieves improvement history.
+- **Work Tasks**: Can create work tasks for recommended improvements.
+- **Process Manager**: Spawns agent sessions for analysis.

--- a/specs/lib/context.md
+++ b/specs/lib/context.md
@@ -1,0 +1,23 @@
+# Lib (Agent Utils) — Context
+
+## Why This Module Exists
+
+Several infrastructure concerns don't belong to any specific feature module but are needed across the system: model tier definitions, message delivery tracking, GitHub token validation, and project directory resolution. The lib module provides these shared utilities.
+
+## Architectural Role
+
+Lib is **shared infrastructure** — low-level utilities that other modules depend on. It has no business logic, just plumbing.
+
+## Key Design Decisions
+
+- **Agent tiers**: Maps models to capability levels (iteration limits, rate caps, council participation eligibility). This is how the system knows what a Haiku agent can vs. can't do compared to an Opus agent.
+- **Delivery tracker**: Tracks outbound message delivery across bridges with retry logic and per-platform metrics. This ensures messages aren't silently lost.
+- **Project directory strategies**: Supports persistent, clone-on-demand, ephemeral, and worktree strategies for agent working directories. Worktree mode is used for isolated work tasks.
+- **GitHub token validation**: Checks OAuth scopes at startup to catch misconfigured tokens early.
+
+## Relationship to Other Modules
+
+- **Every bridge module**: Uses the delivery tracker.
+- **Process Manager**: Uses agent tier definitions for session limits.
+- **Work Tasks**: Uses project directory resolution for worktree-based isolation.
+- **Config**: Consumes configuration values.

--- a/specs/lib/schemas/context.md
+++ b/specs/lib/schemas/context.md
@@ -1,0 +1,21 @@
+# Lib Schemas — Context
+
+## Why This Module Exists
+
+REST API routes need consistent request/response validation. The schemas module provides Zod schemas for API payloads — marketplace listings, agent configurations, and other structured inputs. Centralizing schemas here keeps validation consistent and enables automatic OpenAPI type generation.
+
+## Architectural Role
+
+Schemas is a **validation layer** — it defines the shape of data at API boundaries. Route handlers use these schemas to validate incoming requests before processing.
+
+## Key Design Decisions
+
+- **Zod-based**: Uses Zod for runtime validation with TypeScript type inference. This avoids maintaining separate type definitions and validation logic.
+- **Co-located with lib**: Schemas live under `lib/` because they're shared infrastructure used by multiple route handlers, not specific to any one feature.
+- **OpenAPI integration**: Zod schemas can be converted to JSON Schema for OpenAPI documentation, bridging validation and documentation.
+
+## Relationship to Other Modules
+
+- **Routes**: Route handlers import schemas for request validation.
+- **OpenAPI**: Schemas contribute to the generated API specification.
+- **Marketplace**: Marketplace-specific schemas define listing and transaction payloads.

--- a/specs/marketplace/context.md
+++ b/specs/marketplace/context.md
@@ -1,0 +1,22 @@
+# Marketplace — Context
+
+## Why This Module Exists
+
+As the platform grows beyond a single team, agents may offer services to each other — code review, research, analysis. The marketplace escrow system provides credit-based payments with trust guarantees: buyer credits are held in escrow until delivery is confirmed, preventing fraud in both directions.
+
+## Architectural Role
+
+Marketplace is a **transaction layer** — it sits between the credit system and agent-to-agent service interactions, providing payment safety.
+
+## Key Design Decisions
+
+- **Credit-based, not crypto**: Uses platform credits rather than on-chain tokens for payments. This simplifies the UX and avoids blockchain transaction fees for every trade.
+- **Escrow pattern**: Credits are locked when a task is accepted and released only on delivery confirmation. This protects both parties.
+- **72-hour auto-release**: If the buyer doesn't dispute within 72 hours, credits auto-release to the seller. This prevents indefinite holds.
+- **Dispute support**: Either party can raise a dispute, which pauses the auto-release and flags for human review.
+
+## Relationship to Other Modules
+
+- **Credits (DB)**: Reads and modifies credit balances.
+- **Billing**: Credits are purchased through the billing system.
+- **Flock Directory**: Agents advertise services via the flock directory; marketplace handles the payment side.

--- a/specs/mcp/context.md
+++ b/specs/mcp/context.md
@@ -1,0 +1,23 @@
+# MCP (Coding Tools) — Context
+
+## Why This Module Exists
+
+Agents need to interact with the filesystem, run shell commands, and search code. The MCP module provides these capabilities as tool definitions that LLM providers can call. It also assembles the complete tool catalog (MCP-based tools + direct coding tools) into a filtered, permission-aware set for each agent session.
+
+## Architectural Role
+
+MCP is the **tool layer** — it defines what agents can *do*, not what they *know*. Every agent capability that involves side effects (file writes, command execution, API calls) is exposed through MCP tools.
+
+## Key Design Decisions
+
+- **Direct execution engine for Ollama**: Ollama agents can't use MCP natively, so the coding tools module provides equivalent functionality via a direct tool definition format.
+- **Permission filtering**: Tools are filtered per-agent based on permissions. Not all agents get all tools.
+- **Tool categories**: Tools are organized into categories (coding, memory, communication, etc.) for UI display and permission grouping.
+
+## Relationship to Other Modules
+
+- **Process Manager**: Tools are registered per session.
+- **Permissions**: Tool access is gated by the permission broker.
+- **AST**: Code navigation tools delegate to the AST service.
+- **Memory**: Memory tools (`corvid_save_memory`, `corvid_recall_memory`) are MCP tools.
+- **Browser**: The `corvid_browser` tool delegates to the browser service.

--- a/specs/memory/context.md
+++ b/specs/memory/context.md
@@ -1,0 +1,26 @@
+# Memory — Context
+
+## Why This Module Exists
+
+Agents need persistent knowledge that survives across sessions and restarts. The memory module provides a two-tier system: short-term memories in SQLite (fast, mutable) and long-term memories as ARC-69 ASAs on the Algorand localnet (tamper-evident, verifiable). It also provides the shared library (CRVLIB) for team-wide knowledge sharing.
+
+## Architectural Role
+
+Memory is a **core data service** — it's how agents remember things. It sits alongside the database module as one of the two primary persistence mechanisms (DB for operational state, memory for agent knowledge).
+
+## Key Design Decisions
+
+- **Two-tier architecture**: SQLite for speed and mutability, blockchain for permanence and verifiability. Memories graduate from short-term to long-term based on access frequency.
+- **ARC-69 format**: Uses Algorand's ARC-69 standard for metadata, making memories queryable by blockchain indexers.
+- **Encryption for private memories (CRVMEM)**: Private memories are encrypted with the agent's AlgoChat PSK, readable only by the authoring agent.
+- **Plaintext shared library (CRVLIB)**: Team knowledge is stored unencrypted so any agent can read it. Organized by category (standards, references, guides, decisions, runbooks).
+- **Book chaining**: Content exceeding the 1024-byte note limit is split into linked pages, forming a "book" that can be read sequentially.
+- **Memory decay**: Memories that aren't accessed decay over time, automatically cleaning up stale knowledge.
+
+## Relationship to Other Modules
+
+- **DB**: The `agent_memories` and `agent_library` tables are the SQLite tier.
+- **AlgoChat**: Uses the same Algorand localnet for on-chain storage.
+- **Dashboard**: The memory brain viewer reads from both tiers.
+- **Improvement**: Stores and retrieves improvement history as memories.
+- **MCP**: Memory tools are exposed as MCP tools for agent use.

--- a/specs/middleware/context.md
+++ b/specs/middleware/context.md
@@ -1,0 +1,23 @@
+# Middleware — Context
+
+## Why This Module Exists
+
+Every HTTP request and WebSocket connection needs authentication, CORS handling, and security validation. The middleware module provides these cross-cutting concerns in one place, ensuring consistent security enforcement across all endpoints.
+
+## Architectural Role
+
+Middleware is a **security boundary** — it sits between the network and all route handlers, enforcing authentication and CORS before any business logic runs.
+
+## Key Design Decisions
+
+- **API key required for non-localhost**: Any deployment accessible from the network must have an API key configured. This prevents accidental exposure.
+- **Timing-safe comparison**: API key validation uses timing-safe comparison to prevent timing attacks.
+- **CORS origin reflection**: Reflects the request origin in CORS headers rather than using a wildcard. This is more secure while still supporting cross-origin access from the dashboard.
+- **Startup validation**: Checks security configuration at boot time and fails fast if the deployment is insecure.
+
+## Relationship to Other Modules
+
+- **Routes**: All route handlers run after middleware authentication.
+- **WebSocket**: WebSocket connections are authenticated through the same middleware.
+- **Config**: Reads API key and security settings from configuration.
+- **Health**: The health monitor checks middleware pipeline status.

--- a/specs/notifications/context.md
+++ b/specs/notifications/context.md
@@ -1,0 +1,23 @@
+# Notifications — Context
+
+## Why This Module Exists
+
+Agents need to reach operators across multiple channels — WebSocket for the dashboard, Discord for team chat, Telegram for mobile, AlgoChat for on-chain, GitHub for PR-related items, and more. The notification service provides a unified dispatch layer that routes notifications to the right channel(s) based on operator preferences.
+
+## Architectural Role
+
+Notifications is a **multi-channel dispatch service** — it takes a notification intent and delivers it through one or more channels. It also handles the question/response pattern (agent asks operator, operator responds).
+
+## Key Design Decisions
+
+- **Channel-agnostic dispatch**: Notifications are created without specifying a channel; the service routes based on configuration and availability.
+- **Question dispatcher**: Supports structured questions (yes/no, multiple choice) that can be answered via any channel.
+- **Response poller**: For channels that don't support real-time responses, a poller checks for answers.
+- **Per-channel implementations**: Each channel (WebSocket, Discord, Telegram, GitHub, AlgoChat, WhatsApp, Signal, Slack) has its own delivery adapter.
+
+## Relationship to Other Modules
+
+- **Channels**: Uses channel adapters for delivery.
+- **Health**: Receives health degradation alerts.
+- **Process Manager**: Agent sessions can trigger notifications.
+- **Approval Manager**: Owner approval questions route through notifications.

--- a/specs/observability/context.md
+++ b/specs/observability/context.md
@@ -1,0 +1,22 @@
+# Observability — Context
+
+## Why This Module Exists
+
+Debugging distributed agent systems requires understanding what happened, when, and in what order. The observability module provides structured tracing, metrics, and event correlation across all entry points — web requests, AlgoChat messages, scheduled tasks, webhooks, workflows, and councils.
+
+## Architectural Role
+
+Observability is **cross-cutting infrastructure** — it instruments every entry point and propagates trace context through the entire request lifecycle using AsyncLocalStorage.
+
+## Key Design Decisions
+
+- **OpenTelemetry-compatible**: Uses OpenTelemetry standards for distributed tracing, making it compatible with external observability platforms.
+- **AsyncLocalStorage for context**: Trace context propagates automatically through async call chains without manual threading.
+- **Prometheus-compatible metrics**: In-memory metrics that can be scraped by Prometheus for alerting and dashboards.
+- **Event correlation**: Every significant event includes a trace ID, enabling correlation across modules.
+
+## Relationship to Other Modules
+
+- **Every module**: Observability instruments all entry points and can trace requests through any module.
+- **Health**: Health checks may use observability metrics.
+- **Performance**: Overlaps with performance metrics but at a finer granularity (per-request vs. periodic snapshots).

--- a/specs/openapi/context.md
+++ b/specs/openapi/context.md
@@ -1,0 +1,21 @@
+# OpenAPI — Context
+
+## Why This Module Exists
+
+The corvid-agent REST API needs machine-readable documentation for client generation, testing tools, and developer onboarding. The OpenAPI module generates a complete OpenAPI 3.1 specification from the route registry, with per-domain route files that document each API area.
+
+## Architectural Role
+
+OpenAPI is a **documentation generation module** — it introspects the codebase to produce an API specification. The `docs` module serves this spec via Swagger UI.
+
+## Key Design Decisions
+
+- **Per-domain route files**: Route documentation is split by domain (agents, algochat, billing, councils, etc.) rather than one giant file. This keeps each file focused and maintainable.
+- **Registry-driven**: Route definitions are registered in a central registry, and the OpenAPI generator reads from it. This ensures the spec matches the actual implementation.
+- **OpenAPI 3.1**: Uses the latest OpenAPI version for JSON Schema compatibility.
+
+## Relationship to Other Modules
+
+- **Routes**: Reads route definitions from the registry.
+- **Docs**: The docs module serves the generated spec via Swagger UI.
+- **Middleware**: Documents authentication requirements in the spec.

--- a/specs/performance/context.md
+++ b/specs/performance/context.md
@@ -1,0 +1,21 @@
+# Performance — Context
+
+## Why This Module Exists
+
+Long-running agent servers need performance trending to detect regressions and resource leaks. The performance module periodically samples system metrics (memory, database health, disk usage, uptime) and persists them for analysis.
+
+## Architectural Role
+
+Performance is a **monitoring service** — it collects and stores metrics on a timer for retrospective analysis. Unlike health (which monitors "is it working?"), performance focuses on "how well is it working?"
+
+## Key Design Decisions
+
+- **Periodic sampling**: Collects metrics at regular intervals rather than on every request. This keeps overhead low.
+- **Database-stored**: Metrics are persisted to SQLite for local trend analysis without requiring external monitoring infrastructure.
+- **System-level focus**: Tracks OS-level metrics (memory, disk) rather than application-level metrics (request latency). Application metrics are handled by observability.
+
+## Relationship to Other Modules
+
+- **Health**: Complementary — health checks system status, performance tracks system trends.
+- **Improvement**: Performance data can inform improvement recommendations.
+- **DB**: Stores snapshots in the `performance_metrics` table.

--- a/specs/permissions/context.md
+++ b/specs/permissions/context.md
@@ -1,0 +1,22 @@
+# Permissions — Context
+
+## Why This Module Exists
+
+Not all agents should be able to do everything. The permission broker provides fine-grained access control — which agents can use which tools, access which resources, and perform which operations. This is especially important in a multi-agent system where junior agents should have restricted capabilities compared to senior ones.
+
+## Architectural Role
+
+Permissions is a **security layer** that sits between tool invocations and their execution. Every tool call passes through the permission broker before running.
+
+## Key Design Decisions
+
+- **Governance tiers**: Permissions are categorized by governance tier. Some changes (Layer 1) require council votes; others can be granted by the owner directly.
+- **Grant-based model**: Permissions are explicitly granted, not role-based. This provides fine-grained control.
+- **Audit trail**: All permission checks are logged in the `permission_checks` table for security auditing.
+
+## Relationship to Other Modules
+
+- **MCP**: Tool access is filtered by permissions.
+- **Councils**: Governance tier changes require council votes.
+- **DB**: Grants and checks are stored in `permission_grants` and `permission_checks`.
+- **Agent Tiers (Lib)**: Tier definitions influence default permission sets.

--- a/specs/plugins/context.md
+++ b/specs/plugins/context.md
@@ -1,0 +1,22 @@
+# Plugins — Context
+
+## Why This Module Exists
+
+The platform needs to be extensible without modifying core code. The plugin system allows loading external modules that register new capabilities (tools, routes, event handlers) at runtime. This enables third-party extensions and keeps optional features out of the core.
+
+## Architectural Role
+
+Plugins is an **extension framework** — it provides the loader, registry, and permission model for external code.
+
+## Key Design Decisions
+
+- **Capability-based permissions**: Plugins declare what capabilities they need; the system grants them explicitly. Plugins can't access anything they haven't been granted.
+- **Registry pattern**: Plugins register themselves with a central registry, making discovery and lifecycle management uniform.
+- **Database-tracked**: Plugin state (installed, enabled, version) is tracked in SQLite for persistence across restarts.
+
+## Relationship to Other Modules
+
+- **MCP**: Plugins can register new MCP tools.
+- **Routes**: Plugins can register new API routes.
+- **Permissions**: Plugin capabilities are gated by the permission system.
+- **DB**: Plugin metadata stored in `plugins` and `plugin_capabilities` tables.

--- a/specs/polling/context.md
+++ b/specs/polling/context.md
@@ -1,0 +1,22 @@
+# Polling (Auto-Merge) — Context
+
+## Why This Module Exists
+
+Agents create PRs that need to be merged once CI passes. The auto-merge poller watches for agent-authored PRs with passing CI and squash-merges them automatically. This removes the bottleneck of human merge approval for routine agent work.
+
+## Architectural Role
+
+Polling is an **automation service** — it runs on a timer, scanning GitHub for PRs that are ready to merge.
+
+## Key Design Decisions
+
+- **Security scan before merge**: Every PR diff is scanned for security issues (protected file modifications, unapproved external fetches, malicious patterns) before merging. Flagged PRs get a comment and are left for human review.
+- **2-minute interval**: Checks every 2 minutes, balancing responsiveness with GitHub API rate limits.
+- **Squash-merge only**: All auto-merges use squash to keep the commit history clean.
+- **Config-driven repos**: Only scans repos that have active polling configs, not all repos.
+
+## Relationship to Other Modules
+
+- **GitHub**: Uses GitHub operations for PR status checks and merging.
+- **DB**: Polling configs stored in `mention_polling_configs`.
+- **Work Tasks**: Auto-merged PRs may correspond to completed work tasks.

--- a/specs/process/context.md
+++ b/specs/process/context.md
@@ -1,0 +1,23 @@
+# Process (Approval) — Context
+
+## Why This Module Exists
+
+Some agent actions require human approval — destructive operations, expensive API calls, or irreversible changes. The approval manager provides a structured way for agents to request and receive owner approval, with the question manager handling more complex multi-option queries.
+
+## Architectural Role
+
+The process module broadly manages agent session lifecycle. The approval sub-module specifically handles the **human-in-the-loop pattern** — pausing agent execution until an owner responds.
+
+## Key Design Decisions
+
+- **Escalation queue**: Approval requests are stored in a database queue (`escalation_queue`) so they survive server restarts and can be answered asynchronously.
+- **Multi-channel delivery**: Approval requests are sent via notifications to whichever channel the owner is active on (Discord, AlgoChat, etc.).
+- **Owner questions**: For more complex interactions ("which of these 3 approaches should I take?"), the question manager presents numbered options.
+- **Fail-closed**: If approval can't be obtained (timeout, error), the action is denied. Never defaults to allowing.
+
+## Relationship to Other Modules
+
+- **Notifications**: Approval requests are delivered via the notification service.
+- **AlgoChat**: Approval responses can come via on-chain messages.
+- **DB**: Requests stored in `escalation_queue` and `owner_questions`.
+- **Process Manager**: Agent sessions block on approval and resume when answered.

--- a/specs/providers/context.md
+++ b/specs/providers/context.md
@@ -1,0 +1,23 @@
+# Providers — Context
+
+## Why This Module Exists
+
+corvid-agent supports multiple LLM providers — Anthropic (Claude), OpenAI, Ollama, and others. The provider system normalizes their APIs behind a common interface so the rest of the system can request completions without knowing which provider is being used.
+
+## Architectural Role
+
+Providers is the **LLM abstraction layer** — it sits between agent sessions and AI APIs, normalizing requests and responses.
+
+## Key Design Decisions
+
+- **Claude-first**: Anthropic Claude is the primary provider. Opus for councils/synthesis, Sonnet for execution, Haiku for routing and triage.
+- **BaseLlmProvider pattern**: All providers extend a base class that handles common concerns (retry, rate limiting, token counting), with provider-specific subclasses for API differences.
+- **Normalized results**: All providers return `LlmCompletionResult` regardless of their native response format.
+- **Model dispatch**: The model dispatch system routes requests to the right provider based on the requested model.
+
+## Relationship to Other Modules
+
+- **Process Manager**: Agent sessions use providers for LLM completions.
+- **Councils**: Different council stages use different model tiers.
+- **Health**: Provider availability is part of health monitoring.
+- **Agent Tiers (Lib)**: Tier definitions map to specific models and providers.

--- a/specs/reputation/context.md
+++ b/specs/reputation/context.md
@@ -1,0 +1,22 @@
+# Reputation — Context
+
+## Why This Module Exists
+
+In a multi-agent system, you need to know which agents are reliable. The reputation system tracks agent performance through multiple signals — PR outcomes, response feedback (thumbs up/down), task completion rates — and produces composite scores that influence task routing and trust decisions.
+
+## Architectural Role
+
+Reputation is a **scoring service** — it aggregates signals from multiple sources into a single reputation score per agent. This score is consumed by the flock directory's capability router for task delegation.
+
+## Key Design Decisions
+
+- **Multi-signal scoring**: Combines peer feedback, PR outcomes, task completion, and other events. No single signal dominates.
+- **Event-driven**: Reputation changes are driven by events (`feedback_received`, `pr_merged`, `task_completed`), not periodic recalculation.
+- **User feedback integration**: Thumbs-up/thumbs-down on agent responses directly influences reputation, giving operators a simple way to shape agent behavior.
+
+## Relationship to Other Modules
+
+- **Flock Directory**: Reputation scores influence task routing decisions.
+- **Feedback**: PR outcomes feed into reputation.
+- **DB**: Reputation events stored in `reputation_events`, feedback in `response_feedback`.
+- **Attestations**: Reputation can be published as on-chain attestations.

--- a/specs/routes/context.md
+++ b/specs/routes/context.md
@@ -1,0 +1,22 @@
+# Routes — Context
+
+## Why This Module Exists
+
+The corvid-agent server exposes a REST API for the dashboard, CLI, and external integrations. The routes module defines all API endpoints, organized by domain (agents, sessions, memories, schedules, etc.), with consistent patterns for authentication, pagination, and error handling.
+
+## Architectural Role
+
+Routes is the **HTTP interface layer** — it sits between middleware (auth, CORS) and business logic (services, DB). Each route handler validates input, calls the appropriate service, and formats the response.
+
+## Key Design Decisions
+
+- **Domain-organized**: Routes are grouped by domain (brain-viewer, dashboard, library, etc.) rather than by HTTP method. This keeps related endpoints together.
+- **Dashboard auth guard**: Dashboard endpoints use a separate auth guard from API endpoints, supporting different authentication flows.
+- **Read-only dashboard**: Dashboard routes are read-only (GET) by design. Mutations go through the main API endpoints.
+
+## Relationship to Other Modules
+
+- **Middleware**: All routes run after authentication middleware.
+- **OpenAPI**: Routes are registered in the route registry for documentation generation.
+- **Client**: The Angular frontend consumes these endpoints.
+- **DB/Services**: Routes delegate to service modules and DB functions.

--- a/specs/sandbox/context.md
+++ b/specs/sandbox/context.md
@@ -1,0 +1,21 @@
+# Sandbox — Context
+
+## Why This Module Exists
+
+Running untrusted code (from agents or plugins) on the host system is dangerous. The sandbox module provides container-based isolation — executing code in controlled environments with resource limits, network restrictions, and filesystem constraints.
+
+## Architectural Role
+
+Sandbox is a **security infrastructure** — it wraps command execution in containers with configurable policies. It's used when agents need to run code they've written or when plugins execute untrusted logic.
+
+## Key Design Decisions
+
+- **Container-based**: Uses Docker/Podman containers for strong isolation rather than lighter mechanisms (chroot, seccomp). This provides filesystem, network, and process isolation.
+- **Policy-driven**: Each sandbox has a policy defining resource limits (CPU, memory, time), allowed network access, and filesystem mounts.
+- **Lifecycle adapter**: The sandbox integrates with the process manager via a lifecycle adapter, so sandboxed processes are managed like regular processes.
+
+## Relationship to Other Modules
+
+- **Process Manager**: Sandboxed processes use the lifecycle adapter for management.
+- **Work Tasks**: Work task execution can use sandboxed environments for safety.
+- **Plugins**: Plugin execution can be sandboxed.

--- a/specs/scheduler/context.md
+++ b/specs/scheduler/context.md
@@ -1,0 +1,23 @@
+# Scheduler — Context
+
+## Why This Module Exists
+
+Agents need to perform recurring tasks — daily reviews, periodic health checks, scheduled reports, polling external services. The scheduler provides cron-based task scheduling with health-aware execution (tasks can be gated or boosted based on system health).
+
+## Architectural Role
+
+Scheduler is a **time-based orchestration service** — it manages when tasks run, using cron expressions with preset aliases for common patterns.
+
+## Key Design Decisions
+
+- **Cron expressions with presets**: Supports standard cron syntax plus aliases like `@daily`, `@hourly` for common patterns.
+- **Health-aware scheduling**: Priority rules can gate scheduled actions when the system is unhealthy (e.g., skip heavy analysis if memory is low) or boost them when healthy.
+- **System state detection**: Detects current system state (healthy, degraded, critical) to inform scheduling decisions.
+- **Human-readable descriptions**: Cron expressions are converted to human-readable strings for display in the dashboard.
+
+## Relationship to Other Modules
+
+- **Health**: Uses health data for scheduling decisions.
+- **Process Manager**: Scheduled tasks create agent sessions.
+- **Events**: Schedule executions emit events for real-time dashboard updates.
+- **Usage**: Tracks schedule execution history.

--- a/specs/selftest/context.md
+++ b/specs/selftest/context.md
@@ -1,0 +1,21 @@
+# Self-Test — Context
+
+## Why This Module Exists
+
+The platform needs to be able to test itself — not just unit tests, but spawning a real agent session to run the test suite and optionally auto-fix failures. Self-test provides this self-healing capability.
+
+## Architectural Role
+
+Self-test is a **quality assurance tool** — simpler than the full exam module, focused specifically on running the project's test suite via an agent session.
+
+## Key Design Decisions
+
+- **Dedicated test agent**: Creates a separate project and agent for test runs to avoid polluting production data.
+- **Auto-fix capability**: When tests fail, the spawned agent can attempt to fix them, creating a feedback loop.
+- **Configurable scope**: Can run unit tests, e2e tests, or both.
+
+## Relationship to Other Modules
+
+- **Process Manager**: Creates agent sessions for test execution.
+- **DB**: Uses project, agent, and session tables.
+- **Exam**: Exam is the more comprehensive testing framework; self-test is the quick version.

--- a/specs/shared/context.md
+++ b/specs/shared/context.md
@@ -1,0 +1,20 @@
+# Shared (Client Components) — Context
+
+## Why This Module Exists
+
+The Angular client has reusable components that are used across multiple features. The shared module contains these components — like the cron editor, which provides a user-friendly interface for editing cron expressions with presets and validation.
+
+## Architectural Role
+
+Shared is a **component library** for the Angular frontend — standalone components that features import as needed.
+
+## Key Design Decisions
+
+- **Standalone components**: All shared components are Angular standalone components, avoiding NgModule boilerplate and enabling tree-shaking.
+- **Cron editor as representative**: The cron editor exemplifies the shared pattern — reusable, self-contained, with its own validation and display logic.
+- **Shared types**: TypeScript types used by both server and client live in the top-level `shared/` directory (not this spec's scope), while client-only components live here.
+
+## Relationship to Other Modules
+
+- **Client**: Shared components are consumed by feature components across the dashboard.
+- **Scheduler**: The cron editor uses the cron-human pipe for display, which corresponds to the server-side cron parser.

--- a/specs/slack/context.md
+++ b/specs/slack/context.md
@@ -1,0 +1,23 @@
+# Slack Bridge — Context
+
+## Why This Module Exists
+
+Teams using Slack can interact with corvid-agent directly from their Slack workspace. The Slack bridge receives messages via webhook (Events API), routes them to agent sessions, and responds via the Slack Web API. This brings agent capabilities into an existing team communication workflow.
+
+## Architectural Role
+
+Slack is a **channel bridge** — it implements the `ChannelAdapter` interface and translates between Slack's Events API and corvid-agent's session model.
+
+## Key Design Decisions
+
+- **Webhook-based (Events API)**: Uses Slack's Events API rather than the older RTM API. This works behind firewalls and doesn't require a persistent WebSocket connection.
+- **Request signature verification**: All incoming webhooks are verified using Slack's signing secret to prevent spoofing.
+- **Thread-based conversations**: Slack threads map to agent sessions, keeping conversations organized.
+- **Per-user rate limiting**: Prevents abuse by rate-limiting requests per Slack user.
+- **Message chunking**: Long responses are split into multiple Slack messages to respect the 4000-character limit.
+
+## Relationship to Other Modules
+
+- **Channels**: Implements `ChannelAdapter`.
+- **Process Manager**: Creates agent sessions for Slack interactions.
+- **DB**: Uses sessions and session_messages tables.

--- a/specs/telegram/context.md
+++ b/specs/telegram/context.md
@@ -1,0 +1,22 @@
+# Telegram Bridge — Context
+
+## Why This Module Exists
+
+Telegram is a popular messaging platform, especially for mobile. The Telegram bridge enables operators to chat with agents via Telegram, with support for text, voice messages (via the voice module's STT), and bot commands.
+
+## Architectural Role
+
+Telegram is a **channel bridge** — it implements the `ChannelAdapter` interface and translates between Telegram's Bot API and corvid-agent's session model.
+
+## Key Design Decisions
+
+- **Bot API**: Uses Telegram's Bot API with webhooks for receiving messages and REST calls for sending.
+- **Voice support**: Telegram voice messages are transcribed using the voice module's speech-to-text capability, enabling hands-free interaction.
+- **Session management**: Each Telegram chat maps to an agent session.
+
+## Relationship to Other Modules
+
+- **Channels**: Implements `ChannelAdapter`.
+- **Voice**: Uses STT for voice message transcription.
+- **Process Manager**: Creates agent sessions.
+- **DB**: Uses sessions and session_messages tables.

--- a/specs/tenant/context.md
+++ b/specs/tenant/context.md
@@ -1,0 +1,21 @@
+# Tenant — Context
+
+## Why This Module Exists
+
+The platform is being prepared for multi-tenant operation — multiple organizations sharing a single deployment. The tenant module provides resolution helpers that map entities (agents, councils) to tenant IDs for scoping.
+
+## Architectural Role
+
+Tenant is a **scoping layer** — it ensures that data and events are properly isolated between tenants. Currently, most deployments are single-tenant, so the module returns `undefined` (unscoped) as the default.
+
+## Key Design Decisions
+
+- **Graceful single-tenant default**: When multi-tenant mode is off, tenant resolution returns `undefined`, allowing callers to use flat (unscoped) topics. No code changes needed for single-tenant deployments.
+- **Entity-to-tenant mapping**: Converts agent IDs and council launch IDs to tenant IDs, centralizing the scoping logic.
+- **WebSocket topic scoping**: The primary consumer is the event broadcasting module, which uses tenant IDs to scope WebSocket topics.
+
+## Relationship to Other Modules
+
+- **Events**: Event broadcasting uses tenant resolution for topic scoping.
+- **DB**: Looks up agent/entity records to determine tenant affiliation.
+- **WebSocket**: Tenant-scoped topics are broadcast via WebSocket.

--- a/specs/usage/context.md
+++ b/specs/usage/context.md
@@ -1,0 +1,22 @@
+# Usage — Context
+
+## Why This Module Exists
+
+Operators need visibility into how much agents are being used — session counts, schedule executions, resource consumption. The usage monitor tracks these metrics and alerts operators when usage approaches limits or exhibits unusual patterns.
+
+## Architectural Role
+
+Usage is a **monitoring and alerting service** — it watches usage patterns and notifies operators of anomalies or approaching limits.
+
+## Key Design Decisions
+
+- **Schedule execution tracking**: Tracks which schedules have run and their outcomes.
+- **Session monitoring**: Monitors active and historical session counts.
+- **Alert integration**: Unusual usage patterns trigger notifications to operators.
+
+## Relationship to Other Modules
+
+- **Scheduler**: Tracks schedule execution history.
+- **Process Manager**: Monitors session counts and durations.
+- **Notifications**: Sends usage alerts.
+- **DB**: Reads from `schedule_executions`, `sessions`, `agent_schedules` tables.

--- a/specs/voice/context.md
+++ b/specs/voice/context.md
@@ -1,0 +1,21 @@
+# Voice — Context
+
+## Why This Module Exists
+
+Some operators prefer voice interaction — speaking commands rather than typing, or having agent responses read aloud. The voice module provides speech-to-text (STT) and text-to-speech (TTS) capabilities using OpenAI's Whisper and Speech APIs.
+
+## Architectural Role
+
+Voice is a **media processing service** — it converts between audio and text, enabling voice-based interaction through channels that support audio (Telegram, potentially future voice assistants).
+
+## Key Design Decisions
+
+- **OpenAI APIs**: Uses Whisper for STT and Speech API for TTS. This provides high-quality voice processing without running local models.
+- **TTS caching**: TTS results are cached using SHA-256 content hashing with LRU eviction. This avoids re-synthesizing the same text and reduces API costs.
+- **SQLite cache**: Cache is stored in a `voice_cache` database table rather than filesystem, keeping it managed and evictable.
+
+## Relationship to Other Modules
+
+- **Telegram**: Voice messages from Telegram are transcribed using STT.
+- **DB**: TTS cache stored in `voice_cache` table.
+- **Config**: Requires `OPENAI_API_KEY` configuration.

--- a/specs/webhooks/context.md
+++ b/specs/webhooks/context.md
@@ -1,0 +1,24 @@
+# Webhooks — Context
+
+## Why This Module Exists
+
+External services need to trigger agent actions — GitHub push events, CI completion, monitoring alerts, custom integrations. The webhooks module receives HTTP webhook deliveries, validates their authenticity, and routes them to appropriate handlers (agent sessions, work tasks, or schedules).
+
+## Architectural Role
+
+Webhooks is an **inbound integration layer** — it sits at the HTTP boundary, receiving events from external services and translating them into internal actions.
+
+## Key Design Decisions
+
+- **Registration-based**: Webhooks are explicitly registered with expected source, secret, and event types. Unregistered webhooks are rejected.
+- **Delivery tracking**: Every webhook delivery is recorded in `webhook_deliveries` with status and response, enabling debugging and replay.
+- **Security validation**: Each delivery is verified against the registered secret (HMAC signature or equivalent).
+- **Multi-handler routing**: A single webhook can trigger multiple actions — creating a work task, resuming a schedule, or starting a new agent session.
+
+## Relationship to Other Modules
+
+- **Work Tasks**: Webhooks can create or update work tasks.
+- **Scheduler**: Webhook deliveries can trigger scheduled actions.
+- **Process Manager**: Can spawn agent sessions in response to webhooks.
+- **GitHub**: GitHub webhooks (push, PR, issue events) are a primary webhook source.
+- **DB**: Registrations in `webhook_registrations`, deliveries in `webhook_deliveries`.

--- a/specs/work/context.md
+++ b/specs/work/context.md
@@ -1,0 +1,24 @@
+# Work Tasks — Context
+
+## Why This Module Exists
+
+Work tasks are the unit of agent work output — each task represents a discrete code change, research task, or operational action. The work task system manages the full lifecycle: creation, assignment, execution in isolated git worktrees, PR creation, and completion tracking. The chain continuation sub-module specifically handles model tier escalation when a lower-tier model stalls.
+
+## Architectural Role
+
+Work is the **task execution engine** — it orchestrates how agents do concrete work. Git worktree isolation ensures each task gets a clean working directory, preventing cross-task contamination.
+
+## Key Design Decisions
+
+- **Worktree isolation**: Each work task runs in its own git worktree with a dedicated branch. This prevents tasks from interfering with each other and makes cleanup easy.
+- **Auto-PR**: Completed work tasks automatically create pull requests for review.
+- **Chain continuation**: When a lower-tier model (e.g., Haiku) stalls mid-task (no tool calls in consecutive turns), the system detects this and signals for escalation to a higher-tier model. This optimizes cost while ensuring task completion.
+- **Stall detection**: A configurable threshold of consecutive stalled steps (turns with no tool use) triggers escalation.
+
+## Relationship to Other Modules
+
+- **Process Manager**: Work tasks create agent sessions.
+- **Flock Directory**: The capability router assigns tasks to agents.
+- **GitHub**: Completed tasks create PRs.
+- **Providers**: Chain continuation involves switching between model tiers.
+- **Lib**: Uses project directory resolution for worktree management.

--- a/specs/workflow/context.md
+++ b/specs/workflow/context.md
@@ -1,0 +1,23 @@
+# Workflow — Context
+
+## Why This Module Exists
+
+Some tasks are multi-step pipelines — run tests, then if they pass, create a PR, then notify the team. The workflow module provides a DAG-based execution engine where nodes represent actions and edges represent dependencies/conditions. This enables complex automation without custom scripting.
+
+## Architectural Role
+
+Workflow is a **pipeline orchestration engine** — it manages multi-step processes with conditional branching, parallel execution, and failure handling.
+
+## Key Design Decisions
+
+- **DAG execution**: Workflows are directed acyclic graphs, not linear sequences. Nodes can run in parallel when their dependencies are met.
+- **Node-level tracking**: Each node run is tracked individually (`workflow_node_runs`), enabling granular retry and debugging.
+- **Work task integration**: Individual workflow nodes can create work tasks, bridging orchestration with execution.
+- **Process manager integration**: Nodes that require agent interaction spawn sessions through the process manager.
+
+## Relationship to Other Modules
+
+- **Work Tasks**: Workflow nodes can create and monitor work tasks.
+- **Process Manager**: Agent sessions are spawned for nodes that need AI.
+- **Events**: Workflow progress is broadcast for real-time dashboard updates.
+- **DB**: State tracked in `workflows`, `workflow_runs`, `workflow_node_runs`.

--- a/specs/ws/context.md
+++ b/specs/ws/context.md
@@ -1,0 +1,24 @@
+# WebSocket — Context
+
+## Why This Module Exists
+
+The web dashboard and CLI need real-time bidirectional communication with the server — streaming agent responses, live council updates, notification delivery, and interactive commands. The WebSocket handler manages all real-time connections, multiplexing many concerns over a single connection per client.
+
+## Architectural Role
+
+WebSocket is the **real-time communication layer** — it's the alternative to REST for interactions that need streaming or push delivery. It handles both client→server commands and server→client events.
+
+## Key Design Decisions
+
+- **Multi-purpose protocol**: A single WebSocket connection handles chat, session subscriptions, approvals, work tasks, agent invocations, rewards, schedule approvals, and owner questions. This avoids connection proliferation.
+- **Shared protocol definition**: The wire protocol (`ws-protocol.ts`) is in the `shared/` directory, ensuring type safety between client and server.
+- **Authentication at connect**: WebSocket connections are authenticated during the upgrade handshake, not per-message. This keeps per-message overhead low.
+- **Tenant-scoped broadcast**: Messages are broadcast to tenant-scoped topics via the event broadcasting module.
+
+## Relationship to Other Modules
+
+- **Events**: Receives events to broadcast to connected clients.
+- **Middleware**: Uses auth middleware for connection authentication.
+- **Process Manager**: Routes chat messages to agent sessions.
+- **Client**: The Angular frontend connects via WebSocket for real-time updates.
+- **Shared**: Wire protocol types are shared between client and server.


### PR DESCRIPTION
## Summary
- Adds `context.md` files to all 52 spec directories (including `lib/schemas`)
- Each file explains **why** the module exists, its architectural role, key design decisions, and relationships to other modules
- Fills the gap between `requirements.md` (what it must do) and `*.spec.md` (how it works) — gives agents the "why" they need when working on unfamiliar modules

## Test plan
- [ ] Verify all 52 context.md files are present
- [ ] Spot-check a few for accuracy against actual code
- [ ] Confirm spec:check still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6