### PR TITLE
docs: v0.60.0 changelog, releases page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.60.0] - 2026-03-30
+
+### Added
+- **Memory: short-term default** — all new saves go to SQLite with explicit promote to on-chain (#1741)
+- **Memory: decay & cleanup** — TTL-based expiry, access-count retention, auto-cleanup (#1760, #1722)
+- **Memory: conversation summaries** — save conversation summaries as observations on context reset (#1753)
+- **Discord: thread-session persistence** — persist thread-session mappings to SQLite for restart recovery (#1754)
+- **Discord: mention-session persistence** — persist and recover mention sessions across restarts (#1752)
+- **UI: mobile search button** — add Search button to mobile bottom nav for command palette discovery (#1739)
+- **Ollama/Cursor: cloud model support** — improve cloud model support and Cursor CLI agent (#1738)
+- **Benchmark: Ollama cloud** — Ollama cloud model AlgoChat reliability benchmark (#1744)
+- **Docs: GitHub Pages workflow** — automated GitHub Pages deployment (#1726, #1736, #1737)
+- **Specs: context.md** — add context.md to all 52 spec directories with architectural rationale and design decisions (#1762)
+- **Specs: requirements.md** — fill all 52 requirements.md with user stories, acceptance criteria, constraints (#1761)
+- **Specs: spec-sync v3.2.0** — upgrade from v2.1.0 with stricter parser (#1761)
+- **Specs: DB schema validation** — column validation script for spec-to-schema drift (#1709)
+- **Specs: DB coverage** — add DB specs for 9 uncovered tables (#1708)
+
+### Fixed
+- **Ollama: tool parsing** — XML and ReAct tool call parsing for junior agents (#1748, #1747, #1743)
+- **Agent Messenger: reliability** — inter-agent response reliability improvements (#1715, #1713)
+- **Health: auth config** — wire getAuthConfig into health check deps (#1703, #1704)
+- **Lint: Biome warnings** — clean up Biome lint warnings in scripts and shared code (#1758)
+- **Specs: schema drift** — resolve DB schema drift across 15 spec files (#1699)
+- **Specs: agent-memories** — update agent-memories spec for short_term default (#1756)
+- **Frontend: routing** — move comms to /observe/comms, fix cache-busting regex (#1725)
+
+### Security
+- **path-to-regexp ReDoS** — fix ReDoS vulnerability (#1714)
+- **TOCTOU race conditions** — fix time-of-check/time-of-use races (#1710)
+- **Secure temp dirs** — use secure temporary directories (#1707)
+
+### Dependencies
+- TypeScript 5.9.3 → 6.0.2
+- OpenTelemetry SDK/exporters → 0.214.0
+- Cosign installer → 4.1.1
+- spec-sync → v3.2.0
+
+### CI
+- Exclude build artifacts from CodeQL scanning (#1745)
+- Bump GitHub Actions (cosign, gh-release, spec-sync)
+
 ## [0.59.1] - 2026-03-29
 
 ### Fixed

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>CorvidAgent — Release Retrospective: v0.1.0 → v0.59.1</title>
+<title>CorvidAgent — Release Retrospective: v0.1.0 → v0.60.0</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap');
 
@@ -473,24 +473,24 @@
 
   <!-- Hero -->
   <section class="hero">
-    <div class="hero-badge">52 days · 59 releases · 1090 commits</div>
+    <div class="hero-badge">53 days · 60 releases · 1100+ commits</div>
     <h1>CorvidAgent<br>Release Retrospective</h1>
     <p>From a prototype CLI to a full autonomous AI agent platform with on-chain memory, multi-model orchestration, and cross-platform bridges.</p>
     <div class="hero-version-range">
       <span class="version">v0.1.0</span>
       <span class="arrow">→</span>
-      <span class="version">v0.59.1</span>
+      <span class="version">v0.60.0</span>
     </div>
   </section>
 
   <!-- Stats bar -->
   <section class="stats-bar">
     <div class="stat-card">
-      <div class="stat-number">59</div>
+      <div class="stat-number">60</div>
       <div class="stat-label">Releases</div>
     </div>
     <div class="stat-card">
-      <div class="stat-number">1090</div>
+      <div class="stat-number">1100+</div>
       <div class="stat-label">Commits</div>
     </div>
     <div class="stat-card">
@@ -948,9 +948,9 @@
         <div class="era-icon">&#x1F680;</div>
         <div>
           <div class="era-title">Scale — Provider Parity & Agent Observatory</div>
-          <div class="era-date">Mar 21 – Mar 29, 2026</div>
+          <div class="era-date">Mar 21 – Mar 30, 2026</div>
         </div>
-        <div class="era-versions">v0.42.0 – v0.59.1</div>
+        <div class="era-versions">v0.42.0 – v0.60.0</div>
       </div>
       <div class="era-body">
         <div class="release-card">
@@ -994,6 +994,21 @@
             <li><span class="tag tag-feat">feat</span> <strong>Shared agent library (CRVLIB)</strong> — ARC-69 reusable on-chain agent components</li>
             <li><span class="tag tag-test">test</span> <strong>Flock e2e: 45 tests</strong> — comprehensive e2e suite with inner transaction fee fix for AVM fee-pooling</li>
             <li><span class="tag tag-fix">fix</span> MCP tool permissions, scheduler tenant fallback, Ollama readiness probe</li>
+          </ul>
+        </div>
+        <div class="release-card" style="border-color: rgba(74,222,128,0.3); background: rgba(74,222,128,0.05);">
+          <div class="release-header">
+            <span class="release-version">v0.60.0</span>
+            <span class="release-date">Mar 30</span>
+          </div>
+          <ul class="release-highlights">
+            <li><span class="tag tag-feat">feat</span> <strong>Memory overhaul</strong> — short-term default (SQLite), TTL-based decay &amp; cleanup, conversation summary observations</li>
+            <li><span class="tag tag-feat">feat</span> <strong>Discord persistence</strong> — thread-session and mention-session recovery across restarts</li>
+            <li><span class="tag tag-feat">feat</span> <strong>Spec completeness</strong> — context.md added to all 52 specs, all 52 requirements.md filled, spec-sync v3.2.0</li>
+            <li><span class="tag tag-feat">feat</span> <strong>UI &amp; tooling</strong> — mobile search button, Ollama cloud benchmark, GitHub Pages deployment workflow</li>
+            <li><span class="tag tag-fix">fix</span> <strong>Ollama tool parsing</strong> — XML and ReAct tool call parsing for junior agents</li>
+            <li><span class="tag tag-sec">sec</span> ReDoS fix (path-to-regexp), TOCTOU race conditions, secure temp dirs</li>
+            <li><span class="tag tag-chore">deps</span> TypeScript 5.9.3 → 6.0.2, OpenTelemetry → 0.214.0, spec-sync → v3.2.0</li>
           </ul>
         </div>
         <div class="release-card" style="border-color: rgba(0,229,255,0.3); background: rgba(0,229,255,0.05);">


### PR DESCRIPTION
## Summary
- Add v0.60.0 entry to CHANGELOG.md
- Update docs/releases.html with v0.60.0 release card, bump stats (60 releases, 1100+ commits)
- Update hero version range to v0.60.0

## Test plan
- [x] CHANGELOG follows existing format
- [x] releases.html renders correctly (HTML valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6