### PR TITLE
fix(docs): correct project field name in testnet-onboarding

### DIFF
--- a/docs/testnet-onboarding.md
+++ b/docs/testnet-onboarding.md
@@ -397,7 +397,7 @@ PROJECT=$(curl -s -X POST https://your-corvid-instance.example.com/api/projects 
   -H "Content-Type: application/json" \
   -d '{
     "name": "my-app",
-    "path": "/home/user/projects/my-app"
+    "directory": "/home/user/projects/my-app"
   }')
 
 PROJECT_ID=$(echo "$PROJECT" | jq -r '.id')


### PR DESCRIPTION
## Summary

Fixes a critical bug in the testnet-onboarding guide where the project creation curl example used the wrong field name.

## Details

The example on line 400 was:
```json
{"path": "/home/user/projects/my-app"}
```

But the `/api/projects` endpoint expects:
```json
{"directory": "/home/user/projects/my-app"}
```

This would cause the curl command to fail with a field validation error when users followed the guide.

## Impact

Users following the testnet-onboarding guide would encounter an immediate failure when creating their first project, blocking the entire workflow.

## Test Plan

- [x] Verify the corrected field name matches the actual API specification in `api-reference.md`
- [x] Confirm no other instances of this error exist in the documentation
- [x] @0xLeif review