### PR TITLE
fix(flock): add scheduled flock reputation refresh

### DIFF
--- a/server/scheduler/execution.ts
+++ b/server/scheduler/execution.ts
@@ -34,6 +34,7 @@ import {
     execImprovementLoop,
     execMemoryMaintenance,
     execReputationAttestation,
+    execFlockReputationRefresh,
     execOutcomeAnalysis,
     execDailyReview,
     execStatusCheckin,
@@ -72,8 +73,9 @@ async function dispatchAction(
         case 'dependency_audit':       await execDependencyAudit(hctx, executionId, schedule, action); break;
         case 'improvement_loop':       await execImprovementLoop(hctx, executionId, schedule, action); break;
         case 'memory_maintenance':     await execMemoryMaintenance(hctx, executionId, schedule); break;
-        case 'reputation_attestation': await execReputationAttestation(hctx, executionId, schedule); break;
-        case 'outcome_analysis':       await execOutcomeAnalysis(hctx, executionId, schedule); break;
+        case 'reputation_attestation':      await execReputationAttestation(hctx, executionId, schedule); break;
+        case 'flock_reputation_refresh':    await execFlockReputationRefresh(hctx, executionId, schedule); break;
+        case 'outcome_analysis':            await execOutcomeAnalysis(hctx, executionId, schedule); break;
         case 'daily_review':           await execDailyReview(hctx, executionId, schedule); break;
         case 'status_checkin':         await execStatusCheckin(hctx, executionId, schedule); break;
         case 'marketplace_billing':    execMarketplaceBilling(hctx, executionId); break;

--- a/server/scheduler/handlers/index.ts
+++ b/server/scheduler/handlers/index.ts
@@ -9,6 +9,7 @@ export { execImprovementLoop } from './improvement';
 export {
     execMemoryMaintenance,
     execReputationAttestation,
+    execFlockReputationRefresh,
     execOutcomeAnalysis,
     execDailyReview,
     execStatusCheckin,

--- a/server/scheduler/handlers/maintenance.ts
+++ b/server/scheduler/handlers/maintenance.ts
@@ -7,6 +7,7 @@ import { updateExecutionStatus } from '../../db/schedules';
 import { getAgent } from '../../db/agents';
 import { createSession } from '../../db/sessions';
 import { summarizeOldMemories } from '../../memory/summarizer';
+import { FlockDirectoryService } from '../../flock-directory/service';
 import type { HandlerContext } from './types';
 import { resolveProjectId } from './utils';
 
@@ -174,6 +175,23 @@ export async function execStatusCheckin(
         }
 
         updateExecutionStatus(ctx.db, executionId, 'completed', { result: summary });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        updateExecutionStatus(ctx.db, executionId, 'failed', { result: message });
+    }
+}
+
+export async function execFlockReputationRefresh(
+    ctx: HandlerContext,
+    executionId: string,
+    _schedule: AgentSchedule,
+): Promise<void> {
+    try {
+        const flockService = new FlockDirectoryService(ctx.db);
+        const updated = flockService.recomputeAllReputations();
+        updateExecutionStatus(ctx.db, executionId, 'completed', {
+            result: `Flock reputation refresh completed: ${updated} agents updated.`,
+        });
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         updateExecutionStatus(ctx.db, executionId, 'failed', { result: message });

--- a/server/scheduler/priority-rules.ts
+++ b/server/scheduler/priority-rules.ts
@@ -25,6 +25,7 @@ const ACTION_CATEGORY_MAP: Record<ScheduleActionType, ActionCategory> = {
     star_repo: 'lightweight',
     marketplace_billing: 'maintenance',
     flock_testing: 'maintenance',
+    flock_reputation_refresh: 'lightweight',
     discord_post: 'lightweight',
     custom: 'feature_work',
 };

--- a/shared/types/schedules.ts
+++ b/shared/types/schedules.ts
@@ -18,6 +18,7 @@ export type ScheduleActionType =
     | 'status_checkin'
     | 'marketplace_billing'
     | 'flock_testing'
+    | 'flock_reputation_refresh'
     | 'discord_post'
     | 'custom';
 

--- a/specs/scheduler/handlers.spec.md
+++ b/specs/scheduler/handlers.spec.md
@@ -109,6 +109,7 @@ All functions and the `HandlerContext` type listed below are re-exported from `i
 |----------|-----------|---------|-------------|
 | `execMemoryMaintenance` | `(ctx: HandlerContext, executionId: string, schedule: AgentSchedule)` | `Promise<void>` | Archives and summarizes old memories via `summarizeOldMemories` (30-day threshold) |
 | `execReputationAttestation` | `(ctx: HandlerContext, executionId: string, schedule: AgentSchedule)` | `Promise<void>` | Computes reputation score, creates attestation hash, optionally publishes on-chain via AlgoChat |
+| `execFlockReputationRefresh` | `(ctx: HandlerContext, executionId: string, schedule: AgentSchedule)` | `Promise<void>` | Recomputes flock directory reputation scores for all non-deregistered agents |
 | `execOutcomeAnalysis` | `(ctx: HandlerContext, executionId: string, schedule: AgentSchedule)` | `Promise<void>` | Checks open PRs, runs weekly analysis, saves insights to memory |
 | `execDailyReview` | `(ctx: HandlerContext, executionId: string, schedule: AgentSchedule)` | `void` | Generates daily activity summary (executions, PRs, health, observations) |
 | `execStatusCheckin` | `(ctx: HandlerContext, executionId: string, schedule: AgentSchedule)` | `Promise<void>` | Evaluates system state, broadcasts `[STATUS_CHECKIN]` summary to AlgoChat |
@@ -128,6 +129,7 @@ All functions and the `HandlerContext` type listed below are re-exported from `i
 10. `execSendMessage` requires `ctx.agentMessenger` to be non-null.
 11. `execFlockTesting` requires `ctx.agentMessenger` to be non-null; fails with "Agent messenger not configured" otherwise. Tests use hardcoded config `{ mode: 'full', decayPerDay: 0.02 }`.
 12. `execFlockTesting` skips testing the schedule's own agent (self-test prevention via wallet address comparison).
+12a. `execFlockReputationRefresh` instantiates `FlockDirectoryService` directly (no context dependency) and calls `recomputeAllReputations()`. No service null-check needed.
 13. `execCouncilLaunch` requires `councilId`, `projectId`, and `description` in the action; fails if any is missing.
 14. `execStarRepos` and `execForkRepos` require `action.repos` to be non-empty. Repos are starred/forked sequentially, not in parallel.
 15. `execSendMessage` requires `toAgentId` and `message` in the action.
@@ -241,3 +243,4 @@ All functions and the `HandlerContext` type listed below are re-exported from `i
 | 2026-03-13 | corvid-agent | Initial spec |
 | 2026-03-17 | corvid-agent | Added `execFlockTesting` handler for automated Flock Directory agent testing |
 | 2026-03-23 | corvid-agent | Added `execDiscordPost` handler for direct Discord channel posting |
+| 2026-03-31 | corvid-agent | Added `execFlockReputationRefresh` handler for automatic flock reputation refresh |

--- a/specs/scheduler/scheduler-service.spec.md
+++ b/specs/scheduler/scheduler-service.spec.md
@@ -227,6 +227,7 @@ See ADR-001 (`docs/decisions/001-autonomous-scheduler.md`) for full architectura
 | `outcome_analysis` | Analyze PR outcomes and schedule effectiveness | (none) |
 | `daily_review` | Generate daily activity summary (PRs, executions, health) | (none) |
 | `status_checkin` | Evaluates system state and broadcasts agent status summary to AlgoChat | (none) |
+| `flock_reputation_refresh` | Recompute flock directory reputation scores for all agents | (none) |
 | `custom` | Freeform prompt (owner-only creation) | `prompt` |
 
 ## Change Log


### PR DESCRIPTION
## Summary
- Adds `flock_reputation_refresh` as a new scheduler action type
- Wires `FlockDirectoryService.recomputeAllReputations()` into the scheduler handler system
- Flock directory reputation scores were going stale because the method existed but was never called on a schedule — now it can be scheduled like any other maintenance task

## Changes
- `shared/types/schedules.ts` — added `flock_reputation_refresh` to `ScheduleActionType`
- `server/scheduler/handlers/maintenance.ts` — new `execFlockReputationRefresh` handler
- `server/scheduler/handlers/index.ts` — barrel export
- `server/scheduler/execution.ts` — dispatch case
- `server/scheduler/priority-rules.ts` — category mapping (lightweight)
- `specs/scheduler/handlers.spec.md` — spec update
- `specs/scheduler/scheduler-service.spec.md` — action type table

## Test plan
- [x] `bun x tsc --noEmit --skipLibCheck` passes
- [x] `bun run spec:check` passes (205/205, 100% coverage)
- [ ] Create a schedule with `flock_reputation_refresh` action and verify it runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)