### PR TITLE
feat(memory): add confirmation gate for permanent plain-txn writes (#1721)

### DIFF
--- a/server/__tests__/tool-handlers.test.ts
+++ b/server/__tests__/tool-handlers.test.ts
@@ -63,7 +63,7 @@ import {
 import { buildDirectTools } from '../mcp/direct-tools';
 import { getSchedule } from '../db/schedules';
 import { grantCredits } from '../db/credits';
-import { saveMemory, updateMemoryTxid } from '../db/agent-memories';
+import { saveMemory, recallMemory, updateMemoryTxid } from '../db/agent-memories';
 const OWNER_WALLET = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ';
 
 /** Set the agent's wallet address in the DB. */
@@ -1182,11 +1182,26 @@ describe('handlePromoteMemory', () => {
         expect(text).toContain('ARC-69 write error');
     });
 
-    test('queues promotion on testnet', async () => {
+    test('returns confirmation warning on testnet without confirmed flag', async () => {
         const ctx = createMockContext({ network: 'testnet', serverMnemonic: 'test mnemonic words here' });
         saveMemory(db, { agentId, key: 'promote-testnet', content: 'data' });
 
         const result = await handlePromoteMemory(ctx, { key: 'promote-testnet' });
+        expect(result.isError).toBeFalsy();
+        const text = (result.content[0] as { text: string }).text;
+        expect(text).toContain('WARNING');
+        expect(text).toContain('immutable');
+        expect(text).toContain('confirmed: true');
+        // Must NOT write to chain yet
+        const memory = recallMemory(db, agentId, 'promote-testnet');
+        expect(memory?.status).toBe('short_term');
+    });
+
+    test('queues promotion on testnet when confirmed: true', async () => {
+        const ctx = createMockContext({ network: 'testnet', serverMnemonic: 'test mnemonic words here' });
+        saveMemory(db, { agentId, key: 'promote-testnet-confirmed', content: 'data' });
+
+        const result = await handlePromoteMemory(ctx, { key: 'promote-testnet-confirmed', confirmed: true });
         expect(result.isError).toBeFalsy();
         const text = (result.content[0] as { text: string }).text;
         expect(text).toContain('queued for promotion');

--- a/server/lib/validation.ts
+++ b/server/lib/validation.ts
@@ -414,6 +414,7 @@ export const McpDeleteMemorySchema = z.object({
 export const McpPromoteMemorySchema = z.object({
     agentId: z.string().min(1, 'agentId is required'),
     key: z.string().min(1, 'key is required'),
+    confirmed: z.boolean().optional(),
 });
 
 // ─── Observation routes ──────────────────────────────────────────────────────

--- a/server/mcp/direct-tools.ts
+++ b/server/mcp/direct-tools.ts
@@ -235,18 +235,19 @@ export function buildDirectTools(ctx: McpToolContext | null, codingCtx?: CodingT
         },
         {
             name: 'corvid_promote_memory',
-            description: 'Promote a short-term (SQLite) memory to long-term on-chain storage (ARC-69 ASA). Use after corvid_save_memory to make a memory permanent.',
+            description: 'Promote a short-term (SQLite) memory to long-term on-chain storage (ARC-69 ASA). Use after corvid_save_memory to make a memory permanent. On testnet/mainnet, plain-transaction writes are immutable forever — you will be prompted to confirm before the write executes.',
             parameters: {
                 type: 'object',
                 properties: {
                     key: { type: 'string', description: 'Memory key to promote to long-term on-chain storage' },
+                    confirmed: { type: 'boolean', description: 'Set to true to confirm a permanent plain-transaction write on testnet/mainnet.' },
                 },
                 required: ['key'],
             },
             handler: async (args) => {
                 const err = validateRequired('corvid_promote_memory', args, ['key']);
                 if (err) return err;
-                return unwrapResult(await handlePromoteMemory(ctx, args as { key: string }));
+                return unwrapResult(await handlePromoteMemory(ctx, args as { key: string; confirmed?: boolean }));
             },
         },
         // ── Shared Library (CRVLIB) ──────────────────────────────────────

--- a/server/mcp/http-transport.ts
+++ b/server/mcp/http-transport.ts
@@ -204,11 +204,12 @@ function createMcpServer(baseUrl: string, agentId: string): McpServer {
         } catch (err) { return handleError(err); }
     });
 
-    server.tool('corvid_promote_memory', 'Promote a short-term (SQLite) memory to long-term on-chain storage (ARC-69 ASA).', {
+    server.tool('corvid_promote_memory', 'Promote a short-term (SQLite) memory to long-term on-chain storage (ARC-69 ASA). On testnet/mainnet, plain-transaction writes are immutable forever — you will be prompted to confirm before the write executes.', {
         key: z.string().describe('Memory key to promote to long-term on-chain storage'),
-    }, async ({ key }) => {
+        confirmed: z.boolean().optional().describe('Set to true to confirm a permanent plain-transaction write on testnet/mainnet.'),
+    }, async ({ key, confirmed }) => {
         try {
-            const data = await callApi(baseUrl, '/api/mcp/promote-memory', { agentId, key });
+            const data = await callApi(baseUrl, '/api/mcp/promote-memory', { agentId, key, confirmed });
             return { content: [{ type: 'text' as const, text: data.response }], isError: data.isError };
         } catch (err) { return handleError(err); }
     });

--- a/server/mcp/sdk-tools.ts
+++ b/server/mcp/sdk-tools.ts
@@ -90,9 +90,11 @@ export function createCorvidMcpServer(ctx: McpToolContext, pluginTools?: ReturnT
             'corvid_promote_memory',
             'Promote a short-term (SQLite) memory to long-term on-chain storage (ARC-69 ASA). ' +
             'After promotion the memory is durable, encrypted, and stored on the Algorand blockchain. ' +
-            'Use this after corvid_save_memory when you want to make a memory permanent.',
+            'Use this after corvid_save_memory when you want to make a memory permanent. ' +
+            'On testnet/mainnet, plain-transaction writes are immutable forever — you will be prompted to confirm before the write executes.',
             {
                 key: z.string().describe('Memory key to promote to long-term on-chain storage'),
+                confirmed: z.boolean().optional().describe('Set to true to confirm a permanent plain-transaction write on testnet/mainnet. Required when the previous call returned a confirmation warning.'),
             },
             async (args) => handlePromoteMemory(ctx, args),
         ),

--- a/server/mcp/stdio-server.ts
+++ b/server/mcp/stdio-server.ts
@@ -190,14 +190,17 @@ server.tool(
 server.tool(
     'corvid_promote_memory',
     'Promote a short-term (SQLite) memory to long-term on-chain storage (ARC-69 ASA). ' +
-    'Use after corvid_save_memory when you want to make a memory permanent.',
+    'Use after corvid_save_memory when you want to make a memory permanent. ' +
+    'On testnet/mainnet, plain-transaction writes are immutable forever — you will be prompted to confirm before the write executes.',
     {
         key: z.string().describe('Memory key to promote to long-term on-chain storage'),
+        confirmed: z.boolean().optional().describe('Set to true to confirm a permanent plain-transaction write on testnet/mainnet.'),
     },
     async (args) => {
         const data = await callApi('/api/mcp/promote-memory', {
             agentId,
             key: args.key,
+            confirmed: args.confirmed,
         });
         return {
             content: [{ type: 'text' as const, text: data.response }],

--- a/server/mcp/tool-handlers/memory.ts
+++ b/server/mcp/tool-handlers/memory.ts
@@ -90,9 +90,16 @@ export async function handleSaveMemory(
     }
 }
 
+const PERMANENT_WRITE_WARNING =
+    'WARNING: This will write a permanent, immutable record to the Algorand blockchain ' +
+    'that can NEVER be modified or deleted. ' +
+    'Permanent plain-transaction memories are reserved for attestations, verified facts, ' +
+    'signed commitments, and audit-trail entries — not for general memories. ' +
+    'To proceed, call corvid_promote_memory again with confirmed: true.';
+
 export async function handlePromoteMemory(
     ctx: McpToolContext,
-    args: { key: string },
+    args: { key: string; confirmed?: boolean },
 ): Promise<CallToolResult> {
     try {
         const memory = recallMemory(ctx.db, ctx.agentId, args.key);
@@ -137,7 +144,13 @@ export async function handlePromoteMemory(
                 return errorResult(`Failed to promote memory to ARC-69: ${message}`);
             }
         } else {
-            // Testnet/mainnet: fire-and-forget (costs ALGO, may be slow)
+            // Testnet/mainnet: plain txn (immutable). Require explicit confirmation.
+            if (!args.confirmed) {
+                log.warn('Permanent memory write blocked — confirmation required', { key: args.key, agentId: ctx.agentId });
+                return textResult(PERMANENT_WRITE_WARNING);
+            }
+
+            // fire-and-forget (costs ALGO, may be slow)
             updateMemoryStatus(ctx.db, memory.id, 'pending');
             encryptMemoryContent(memory.content, ctx.serverMnemonic, ctx.network).then((encrypted) => {
                 return ctx.agentMessenger.sendOnChainToSelf(

--- a/server/routes/mcp-api.ts
+++ b/server/routes/mcp-api.ts
@@ -181,7 +181,7 @@ async function handlePromoteMemoryRoute(req: Request, deps: McpApiDeps): Promise
         const data = await parseBodyOrThrow(req, McpPromoteMemorySchema);
 
         const ctx = buildContext(deps, data.agentId);
-        const result = await handlePromoteMemory(ctx, { key: data.key });
+        const result = await handlePromoteMemory(ctx, { key: data.key, confirmed: data.confirmed });
         return json({ response: extractResultText(result), isError: result.isError ?? false });
     } catch (err) {
         return handleRouteError(err);

--- a/specs/memory/memory.spec.md
+++ b/specs/memory/memory.spec.md
@@ -136,6 +136,7 @@ Provides automatic categorization, TF-IDF embedding generation, LRU caching, dua
 23. **Access-based decay resistance**: `recallMemory()` increments `access_count` for `short_term` memories. When `access_count` reaches 3, the TTL is extended to `max(expires_at, datetime('now', '+14 days'))`, resisting automatic expiry.
 24. **Automatic expiry**: `expireShortTermMemories()` archives (`archived=1`) all `short_term` memories where `expires_at < datetime('now')`. Only `short_term` status memories are affected — promoted memories are never auto-archived.
 25. **Purge after retention**: `purgeOldArchivedMemories()` deletes archived `short_term` memories whose `updated_at` is older than 30 days (configurable). Archived promoted memories are excluded.
+26. **Permanent write gate**: On testnet/mainnet, `corvid_promote_memory` writes plain self-to-self Algorand transactions which are immutable forever. If `confirmed` is not explicitly `true`, the handler returns a warning message and does NOT execute the write. The agent must call again with `confirmed: true` to proceed. This gate does not apply on localnet (uses mutable ARC-69 ASAs instead).
 
 ## Behavioral Examples
 


### PR DESCRIPTION
## Summary

- Closes #1721
- On testnet/mainnet, `corvid_promote_memory` writes plain self-to-self Algorand transactions that are **immutable forever** — previously no safeguard existed
- Added `confirmed: boolean` optional param: if not `true` on testnet/mainnet, the tool returns a clear warning and does NOT execute the write
- Gate is skipped on localnet (which uses mutable ARC-69 ASAs instead)
- Updated all four tool transports (SDK, HTTP, direct, stdio), HTTP route validator, and memory spec (new invariant 26)

## Test plan

- [x] `bun test server/__tests__/tool-handlers.test.ts --grep handlePromoteMemory` — 9 tests pass, including new warning-path and confirmed-path tests
- [x] `bun test` — 9631 pass, 0 fail
- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun run spec:check` — 205/205 specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)