### PR TITLE
fix: pin spec-sync action to SHA digest

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Spec validation (strict + 100% coverage)
         # https://github.com/marketplace/actions/spec-sync
-        uses: CorvidLabs/spec-sync@v3.2.0
+        uses: CorvidLabs/spec-sync@07a5ceb395a0a085b30284fc25a077d3edd06647  # v3.2.0
         with:
           version: '3.2.0'
           strict: 'true'


### PR DESCRIPTION
## Summary

Pins `CorvidLabs/spec-sync@v3.2.0` to its full commit SHA in `.github/workflows/checks.yml`.

This addresses a missed action from the recent supply-chain fixes (#1770, #1774). Tag references are mutable — anyone with push access can silently redirect them to malicious code. SHA digests are immutable and cryptographically verified.

## Changes

- `.github/workflows/checks.yml:44` — replaced `uses: CorvidLabs/spec-sync@v3.2.0` with `uses: CorvidLabs/spec-sync@07a5ceb395a0a085b30284fc25a077d3edd06647  # v3.2.0`

## Verification

- SHA verified via `gh api repos/CorvidLabs/spec-sync/git/ref/tags/v3.2.0`
- YAML syntax valid
- No other changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)