### PR TITLE
fix(ollama): apply OLLAMA_USE_CLAUDE_PROXY to explicit Ollama agents

### DIFF
--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -377,8 +377,26 @@ export class ProcessManager {
 
         // Route: direct providers (cursor, ollama) go through startDirectProcessWrapped;
         // cursor no longer has a special case — it flows through the standard path.
-        if (provider && provider.executionMode === 'direct') {
+        // Check if Ollama should use Claude Code proxy even when explicitly configured
+        const ollamaProxyEnabled = process.env.OLLAMA_USE_CLAUDE_PROXY === 'true';
+        const isOllamaProvider = provider?.type === 'ollama';
+        if (provider && provider.executionMode === 'direct' && !(isOllamaProvider && ollamaProxyEnabled)) {
             this.startDirectProcessWrapped(session, effectiveProject, effectiveAgent, resolvedPrompt, provider, options?.depth, options?.schedulerMode, options?.schedulerActionType, options?.conversationOnly, options?.toolAllowList, options?.mcpToolAllowList);
+        } else if (isOllamaProvider && ollamaProxyEnabled) {
+            // Ollama via Claude Code proxy
+            log.info(`Routing explicit Ollama agent through Claude Code proxy for session ${session.id}`, {
+                model: effectiveAgent?.model,
+            });
+            const proxyUrl = process.env.OLLAMA_CLAUDE_PROXY_URL ?? `http://localhost:${process.env.PORT ?? '3000'}/api/ollama/claude-proxy`;
+            const projectWithProxy = {
+                ...effectiveProject,
+                envVars: {
+                    ...(effectiveProject.envVars ?? {}),
+                    ANTHROPIC_BASE_URL: proxyUrl,
+                    ANTHROPIC_API_KEY: 'ollama-proxy',
+                },
+            };
+            this.startSdkProcessWrapped(session, projectWithProxy, effectiveAgent, resolvedPrompt, options?.depth, options?.schedulerMode, options?.schedulerActionType, options?.conversationOnly, options?.toolAllowList, options?.mcpToolAllowList);
         } else {
             this.startSdkProcessWrapped(session, effectiveProject, effectiveAgent, resolvedPrompt, options?.depth, options?.schedulerMode, options?.schedulerActionType, options?.conversationOnly, options?.toolAllowList, options?.mcpToolAllowList);
         }


### PR DESCRIPTION
## Summary

Fixes the OLLAMA_USE_CLAUDE_PROXY env var to work with agents that have `provider: 'ollama'` explicitly configured.

## Problem

Previously, the env var only worked for agents with no explicit provider (fallback mode). Agents explicitly configured with `provider: 'ollama'` would bypass the proxy and use direct Ollama execution.

## Solution

Check for `OLLAMA_USE_CLAUDE_PROXY=true` in the routing logic, even when the provider is explicitly set to 'ollama'. When enabled, route these agents through `startSdkProcessWrapped` (Claude Code) instead of `startDirectProcessWrapped`.

## Testing

- All specs pass (208/208)
- TypeScript compiles

## Related

Follow-up to PR #1790