### PR TITLE
fix(memory): add confirmation gate for permanent on-chain writes and tier labels

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,12 @@ permissions:
 
 # E2E tests temporarily disabled to conserve CI minutes.
 # Uncomment the job below when GitHub Actions credits are replenished.
-jobs: {}
+jobs:
+  skip:
+    name: E2E (skipped)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "E2E tests temporarily disabled — see #1436"
   # e2e:
   #   name: E2E Tests
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds an explicit confirmation gate for permanent (plain-txn) memory writes on testnet/mainnet — these are immutable forever, so \`corvid_promote_memory\` now returns a warning and requires \`confirmed: true\` before writing
- Exposes the new \`confirmed\` optional parameter through all four MCP transport layers (sdk-tools, direct-tools, http-transport, stdio-server)
- Updates tier labels in \`handleRecallMemory\` to show \`short-term\`, \`long-term\`, or \`permanent\` instead of the old generic \`on-chain\` label
- Adds structured \`log.info\` tier-transition entries on every successful promote path
- Fixes CI: replaces empty \`jobs: {}\` in \`.github/workflows/e2e.yml\` with a lightweight \`skip\` placeholder (was causing GitHub Actions parse errors)

## Governance Note

This PR modifies Layer 1 (Structural) MCP paths — flagged by the automated governance tier check:

- \`server/mcp/direct-tools.ts\`
- \`server/mcp/http-transport.ts\`
- \`server/mcp/sdk-tools.ts\`
- \`server/mcp/stdio-server.ts\`
- \`server/mcp/tool-handlers/memory.ts\`

These changes are **necessary**: the \`confirmed\` parameter must be wired through every transport layer or callers cannot bypass the confirmation gate. No Layer 1 change is gratuitous. **Requires manual reviewer approval.**

## Test plan
- [x] \`bun x tsc --noEmit --skipLibCheck\` — clean
- [x] \`bun test\` — 9644 pass, 0 fail
- [ ] Reviewer approves Layer 1 modifications

🤖 Generated with [Claude Code](https://claude.ai/claude-code)