### PR TITLE
fix(discord): skip stale autocomplete responses past 3-second deadline

### DIFF
--- a/server/__tests__/discord-command-handlers.test.ts
+++ b/server/__tests__/discord-command-handlers.test.ts
@@ -456,6 +456,54 @@ describe('handleAutocomplete', () => {
     expect(choices).toHaveLength(1);
     expect(choices[0].value).toBe('Friendly Helper');
   });
+
+  // ── Timing guard (deadline exceeded) ───────────────────────────────────
+
+  test('skips response when receivedAt exceeds 2500ms deadline', async () => {
+    const ctx = createTestContext();
+    createAgent(db, { name: 'LateBotAgent', model: 'test-model' });
+
+    const interaction = {
+      ...makeAutocompleteInteraction('session', [{ name: 'agent', value: '', focused: true }]),
+      receivedAt: Date.now() - 3000, // 3 seconds ago — past the 2500ms deadline
+    } as DiscordInteractionData;
+
+    await handleAutocomplete(ctx, interaction);
+
+    // Response should NOT have been sent — capturedResponse stays null
+    expect(capturedResponse).toBeNull();
+  });
+
+  test('sends response when receivedAt is within 2500ms deadline', async () => {
+    const ctx = createTestContext();
+    createAgent(db, { name: 'FastBotAgent', model: 'test-model' });
+
+    const interaction = {
+      ...makeAutocompleteInteraction('session', [{ name: 'agent', value: '', focused: true }]),
+      receivedAt: Date.now() - 100, // 100ms ago — well within deadline
+    } as DiscordInteractionData;
+
+    await handleAutocomplete(ctx, interaction);
+
+    // Response should have been sent normally
+    expect(capturedResponse).not.toBeNull();
+    const choices = (capturedResponse!.data as { choices: Array<{ name: string; value: string }> }).choices;
+    expect(choices.some((c) => c.value === 'FastBotAgent')).toBe(true);
+  });
+
+  test('sends response when receivedAt is absent (guard skipped)', async () => {
+    const ctx = createTestContext();
+    createAgent(db, { name: 'NoTimestampAgent', model: 'test-model' });
+
+    // No receivedAt field — interactions injected without timestamp should pass through
+    const interaction = makeAutocompleteInteraction('session', [{ name: 'agent', value: '', focused: true }]);
+
+    await handleAutocomplete(ctx, interaction);
+
+    expect(capturedResponse).not.toBeNull();
+    const choices = (capturedResponse!.data as { choices: Array<{ name: string; value: string }> }).choices;
+    expect(choices.some((c) => c.value === 'NoTimestampAgent')).toBe(true);
+  });
 });
 
 // ── Component (Button) Handlers ─────────────────────────────────────

--- a/server/discord/command-handlers/autocomplete-handler.ts
+++ b/server/discord/command-handlers/autocomplete-handler.ts
@@ -18,6 +18,14 @@ import { InteractionCallbackType } from '../types';
 
 const log = createLogger('DiscordCommands');
 
+/**
+ * Discord requires autocomplete responses within 3 seconds of the interaction being created.
+ * If we exceed this deadline (e.g. due to event-loop backlog), posting the callback returns
+ * a "Unknown interaction" 404. A skipped response is silent on the user side — far better than
+ * a logged error for a stale interaction that Discord has already discarded.
+ */
+const AUTOCOMPLETE_DEADLINE_MS = 2500;
+
 /* ---------- lightweight TTL cache for autocomplete results ---------- */
 const CACHE_TTL_MS = 5_000; // 5 seconds — long enough to absorb keystrokes, short enough to stay fresh
 
@@ -134,6 +142,16 @@ export async function handleAutocomplete(ctx: InteractionContext, interaction: D
       error: err instanceof Error ? err.message : String(err),
     });
     choices = [];
+  }
+
+  // Guard: skip the response if we're past Discord's 3-second interaction deadline.
+  // Sending a stale response results in a 404 "Unknown interaction" error — silence is better.
+  if (interaction.receivedAt !== undefined && Date.now() - interaction.receivedAt >= AUTOCOMPLETE_DEADLINE_MS) {
+    log.warn('Autocomplete: skipping stale interaction (deadline exceeded)', {
+      command: interaction.data?.name,
+      elapsedMs: Date.now() - interaction.receivedAt,
+    });
+    return;
   }
 
   const response = await discordFetch(

--- a/server/discord/gateway.ts
+++ b/server/discord/gateway.ts
@@ -124,7 +124,11 @@ export class DiscordGateway {
         this.client.on('interactionCreate', (interaction: BaseInteraction) => {
             if (!this._running) return;
             const data = mapInteraction(interaction);
-            if (data) this.handlers.onInteraction(data);
+            if (data) {
+                // Stamp the receive time for deadline-sensitive handlers (e.g. autocomplete).
+                data.receivedAt = Date.now();
+                this.handlers.onInteraction(data);
+            }
         });
 
         this.client.on('messageReactionAdd', (reaction: MessageReaction | PartialMessageReaction, user: User | PartialUser) => {

--- a/server/discord/types.ts
+++ b/server/discord/types.ts
@@ -80,6 +80,12 @@ export interface DiscordInteractionData {
     token: string; // interaction token for responding
     /** The message the component was attached to (for component interactions) */
     message?: { id: string; channel_id: string };
+    /**
+     * Timestamp (ms since epoch) set by the gateway when the INTERACTION_CREATE event
+     * is received. Used to enforce Discord's 3-second interaction response deadline —
+     * stale autocomplete responses are skipped rather than sending a guaranteed 404.
+     */
+    receivedAt?: number;
 }
 
 // Interaction types

--- a/specs/discord/bridge.spec.md
+++ b/specs/discord/bridge.spec.md
@@ -1,6 +1,6 @@
 ---
 module: discord-bridge
-version: 21
+version: 22
 status: active
 files:
   - server/discord/bridge.ts
@@ -476,6 +476,7 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 39. **Text commands deprecated**: Text commands (messages starting with `/`) are no longer parsed from regular channel messages. All commands use Discord's slash command system (requires `appId`)
 40. **Work intake mode**: When `mode='work_intake'`, @mentions and thread messages create async work tasks via `WorkTaskService` instead of chat sessions. Embeds are used for task status feedback
 41. **`/admin` command**: Admin-only configuration management with subcommand groups. All changes persist to `discord_config` DB table and hot-reload within 30s. Subcommands: `channels add/remove/list` (manage monitored channels via #channel mentions), `users add/remove/list` (manage allowed users via @user mentions), `roles set/remove/list` (manage role→permission mappings via @role mentions with level dropdown), `mode` (set bridge mode), `public` (toggle public mode), `show` (display full config summary). Every mutation is audit-logged. Responses use rich embeds with clear confirmation/status
+42. **Autocomplete deadline guard**: The gateway stamps `receivedAt = Date.now()` on every `INTERACTION_CREATE` payload. In `handleAutocomplete`, if `Date.now() - receivedAt >= 2500ms` before posting the callback, the response is silently skipped. Discord rejects autocomplete responses arriving after its 3-second window with "Unknown interaction" (404); a skipped response is silent on the user side and avoids false-positive error logs. If `receivedAt` is absent (e.g. tests injecting interactions without the field), the guard is skipped
 
 ## Behavioral Examples
 
@@ -673,3 +674,4 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | 2026-04-04 | corvid-agent | v19 (Phase 2): Replaced custom WebSocket gateway (`DiscordGateway`) with discord.js `Client`. Gateway now uses `GatewayIntentBits`, `Client` events (`messageCreate`, `interactionCreate`, `messageReactionAdd`, `ready`), and discord.js built-in reconnection/heartbeat. Removed raw protocol types `DiscordGatewayPayload`, `DiscordHelloData`, `DiscordReadyData`, `GatewayOp`, `GatewayIntent` — these were gateway internals now handled by discord.js. Public interface (`GatewayDispatchHandlers`, `DiscordGateway.start/stop/updatePresence/running/botToken`) is unchanged. Discord message/interaction/reaction types are mapped to existing internal types for downstream compatibility. Closes #1792 |
 | 2026-04-04 | corvid-agent | v20 (Phase 3 Part 1): Migrated slash command registration from raw JSON objects to `SlashCommandBuilder` from `@discordjs/builders`. Replaced `discordFetch` PUT call with `DiscordRestClient.putCommands()`. Added `putCommands(appId, guildId, commands)` method to `DiscordRestClient`. All 18 commands re-expressed as type-safe builder chains: options use explicit type methods (`addStringOption`, `addIntegerOption`, `addBooleanOption`, `addUserOption`, `addChannelOption`, `addRoleOption`), permissions use `PermissionFlagsBits.Administrator` instead of hardcoded `'8'`. Test updated to mock `DiscordRestClient` via `_setRestClientForTesting`. Part of #1793 |
 | 2026-04-04 | corvid-agent | v21: Declarative permission middleware — `COMMAND_HANDLERS` map entries now declare `minPermission`. Dispatcher enforces it before calling handlers. Per-handler redundant permission checks removed. Closes #1581 |
+| 2026-04-04 | corvid-agent | v22: Autocomplete deadline guard — `handleAutocomplete` skips stale responses (≥2500ms elapsed since `receivedAt`) to avoid Discord "Unknown interaction" 404 errors. Added invariant #42. Refs #1800 |


### PR DESCRIPTION
## Summary

- Gateway stamps `receivedAt = Date.now()` on every `INTERACTION_CREATE` payload
- `handleAutocomplete` skips the API callback if ≥2500ms have elapsed since receipt
- Discord rejects stale autocomplete responses (after 3s) with \"Unknown interaction\" (404); silence is better
- Guard is skipped when `receivedAt` is absent (backward-compatible with tests injecting interactions without the field)
- Adds spec invariant #42 and changelog entry v20 to `bridge.spec.md`

## Root cause

From #1800: autocomplete timeout errors occur when the event loop is busy — by the time `handleAutocomplete` runs, Discord has already discarded the interaction. The existing `discordFetch` rate-limit bypass only helps for API-side delays; this guard handles event-loop backlog.

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 9687 pass, 0 fail
- [x] `bun run spec:check` — 209/209 specs pass
- [x] 3 new tests: deadline exceeded (skips), within deadline (sends), absent timestamp (sends)

Refs #1800

🤖 Agent: Jackdaw | Model: Sonnet 4.6 | CorvidLabs Team Alpha