### PR TITLE
fix(auth): replace hardcoded identity in device authorize verify page

### DIFF
--- a/server/__tests__/routes-auth-flow.test.ts
+++ b/server/__tests__/routes-auth-flow.test.ts
@@ -97,7 +97,7 @@ describe('Auth Flow Routes', () => {
         expect(data.email).toBe('test@example.com');
     });
 
-    it('GET /api/auth/verify returns HTML page', async () => {
+    it('GET /api/auth/verify returns HTML page with email input', async () => {
         const { req, url } = fakeReq('GET', '/api/auth/verify?code=ABCD1234');
         const res = await Promise.resolve(handleAuthFlowRoutes(req, url, db));
         expect(res).not.toBeNull();
@@ -106,6 +106,71 @@ describe('Auth Flow Routes', () => {
         const html = await res!.text();
         expect(html).toContain('ABCD1234');
         expect(html).toContain('Device Authorization');
+        // Email input must be present (not hardcoded)
+        expect(html).toContain('email-input');
+        expect(html).toContain('type="email"');
+        // Hardcoded owner@localhost must not appear
+        expect(html).not.toContain('owner@localhost');
+    });
+
+    it('GET /api/auth/verify pre-populates email from X-Forwarded-Email when TRUST_PROXY=1', async () => {
+        const originalTrustProxy = process.env.TRUST_PROXY;
+        process.env.TRUST_PROXY = '1';
+        try {
+            const url = new URL('http://localhost:3000/api/auth/verify?code=EFGH5678');
+            const req = new Request(url.toString(), {
+                method: 'GET',
+                headers: { 'x-forwarded-email': 'alice@example.com' },
+            });
+            const res = await Promise.resolve(handleAuthFlowRoutes(req, url, db));
+            expect(res).not.toBeNull();
+            const html = await res!.text();
+            expect(html).toContain('alice@example.com');
+            expect(html).toContain('readonly');
+            expect(html).toContain('Identity confirmed by your login provider');
+        } finally {
+            if (originalTrustProxy === undefined) delete process.env.TRUST_PROXY;
+            else process.env.TRUST_PROXY = originalTrustProxy;
+        }
+    });
+
+    it('GET /api/auth/verify ignores X-Forwarded-Email without TRUST_PROXY', async () => {
+        const originalTrustProxy = process.env.TRUST_PROXY;
+        delete process.env.TRUST_PROXY;
+        try {
+            const url = new URL('http://localhost:3000/api/auth/verify?code=IJKL9012');
+            const req = new Request(url.toString(), {
+                method: 'GET',
+                headers: { 'x-forwarded-email': 'attacker@evil.com' },
+            });
+            const res = await Promise.resolve(handleAuthFlowRoutes(req, url, db));
+            expect(res).not.toBeNull();
+            const html = await res!.text();
+            // Proxy email must NOT appear when TRUST_PROXY is off
+            expect(html).not.toContain('attacker@evil.com');
+        } finally {
+            if (originalTrustProxy === undefined) delete process.env.TRUST_PROXY;
+            else process.env.TRUST_PROXY = originalTrustProxy;
+        }
+    });
+
+    it('GET /api/auth/verify rejects malformed X-Forwarded-Email even with TRUST_PROXY=1', async () => {
+        const originalTrustProxy = process.env.TRUST_PROXY;
+        process.env.TRUST_PROXY = '1';
+        try {
+            const url = new URL('http://localhost:3000/api/auth/verify?code=MNOP3456');
+            const req = new Request(url.toString(), {
+                method: 'GET',
+                headers: { 'x-forwarded-email': 'not-an-email' },
+            });
+            const res = await Promise.resolve(handleAuthFlowRoutes(req, url, db));
+            expect(res).not.toBeNull();
+            const html = await res!.text();
+            expect(html).not.toContain('not-an-email');
+        } finally {
+            if (originalTrustProxy === undefined) delete process.env.TRUST_PROXY;
+            else process.env.TRUST_PROXY = originalTrustProxy;
+        }
     });
 
     it('returns null for unmatched paths', async () => {

--- a/server/routes/auth-flow.ts
+++ b/server/routes/auth-flow.ts
@@ -81,7 +81,7 @@ export function handleAuthFlowRoutes(
 
     // Verify page (shows user code input)
     if (path === '/api/auth/verify' && method === 'GET') {
-        return handleVerifyPage(url, context?.tenantId ?? 'default');
+        return handleVerifyPage(req, url, context?.tenantId ?? 'default');
     }
 
     return null;
@@ -215,12 +215,40 @@ function escapeHtml(str: string): string {
         .replace(/'/g, '&#39;');
 }
 
-function handleVerifyPage(url: URL, tenantId: string): Response {
+/** Runtime check — evaluated on each request so tests can toggle via process.env. */
+function isTrustProxy(): boolean {
+    return process.env.TRUST_PROXY === '1' || process.env.TRUST_PROXY === 'true';
+}
+
+/** Basic email format check — must contain exactly one @ with non-empty local and domain parts. */
+function isValidEmail(value: string): boolean {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function handleVerifyPage(req: Request, url: URL, tenantId: string): Response {
     const rawCode = url.searchParams.get('code') ?? '';
     // Validate: user codes are uppercase alphanumeric only
     const code = /^[A-Z0-9]{0,16}$/.test(rawCode) ? rawCode : '';
     const safeCode = escapeHtml(code);
     const safeTenantId = JSON.stringify(tenantId);
+
+    // When behind a trusted proxy, read the email the OAuth provider resolved.
+    // Otherwise leave empty — the user fills it in on the form.
+    let proxyEmail = '';
+    if (isTrustProxy()) {
+        const forwarded = req.headers.get('x-forwarded-email') ?? '';
+        if (isValidEmail(forwarded)) {
+            proxyEmail = forwarded;
+        }
+    }
+    const safeProxyEmail = escapeHtml(proxyEmail);
+
+    // Whether email is locked (proxy-supplied) or editable (manual entry)
+    const emailReadonly = proxyEmail ? 'readonly' : '';
+    const emailPlaceholder = proxyEmail ? '' : 'your@email.com';
+    const proxyNote = proxyEmail
+        ? '<p class="info">Identity confirmed by your login provider.</p>'
+        : '<p class="info">Enter your email to identify yourself for this authorization.</p>';
 
     const html = `<!DOCTYPE html>
 <html><head><title>CorvidAgent - Device Authorization</title>
@@ -230,22 +258,32 @@ function handleVerifyPage(url: URL, tenantId: string): Response {
   .code { font-size: 2rem; font-weight: bold; letter-spacing: 0.3em; text-align: center;
           padding: 20px; background: #f5f5f5; border-radius: 8px; margin: 20px 0; }
   .info { color: #666; font-size: 0.9rem; }
+  input[type=email] { width:100%;padding:10px;font-size:1rem;margin:8px 0 16px;
+                      border:1px solid #ccc;border-radius:6px;box-sizing:border-box; }
+  input[readonly] { background:#f5f5f5;color:#555; }
 </style>
 </head><body>
 <h1>Device Authorization</h1>
 <p>Confirm this code matches what's shown in your terminal:</p>
 <div class="code">${safeCode || '--------'}</div>
-<p class="info">If this code matches, click Authorize below to grant access to the CLI.</p>
+${proxyNote}
+<label for="email-input" style="font-size:0.9rem;font-weight:600;">Email</label>
+<input id="email-input" type="email" value="${safeProxyEmail}" placeholder="${emailPlaceholder}" ${emailReadonly} />
 <button onclick="authorize()" style="width:100%;padding:12px;font-size:1rem;cursor:pointer;
   background:#2563eb;color:white;border:none;border-radius:6px;">Authorize</button>
 <script>
 async function authorize() {
   const code = document.querySelector('.code').textContent.trim();
   if (!code || code === '--------') return;
+  const email = document.getElementById('email-input').value.trim();
+  if (!email || !email.includes('@')) {
+    alert('Please enter a valid email address.');
+    return;
+  }
   const resp = await fetch('/api/auth/device/authorize', {
     method: 'POST',
     headers: {'Content-Type':'application/json'},
-    body: JSON.stringify({userCode:code,tenantId:${safeTenantId},email:'owner@localhost',approve:true})
+    body: JSON.stringify({userCode:code,tenantId:${safeTenantId},email:email,approve:true})
   });
   if (resp.ok) { document.body.innerHTML = '<h1>Authorized!</h1><p>You can close this window.</p>'; }
   else { document.body.innerHTML = '<h1>Error</h1><p>Authorization failed.</p>'; }


### PR DESCRIPTION
## Summary

- Removes hardcoded `email:'owner@localhost'` from the `/api/auth/verify` page
- Adds an email input field so users explicitly identify themselves at authorization time
- When `TRUST_PROXY=1`, reads `X-Forwarded-Email` from the upstream OAuth2 proxy (oauth2-proxy/Caddy) and pre-fills + locks the email field — supports Phase 2 of #1549
- `X-Forwarded-Email` is ignored without `TRUST_PROXY` (prevents header spoofing attacks)
- Rejects malformed email values from `X-Forwarded-Email` even with `TRUST_PROXY=1`
- Client-side validation ensures an email is entered before submission

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 9687 pass, 0 fail
- [x] `bun run spec:check` — 209/209 specs pass
- [x] 4 new tests: email input present (no hardcoded owner@localhost), proxy pre-population with readonly, spoofing blocked without TRUST_PROXY, malformed email rejected

## Context

This is **item 1 of Phase 2** from the Rook security architecture comment on #1549. Described as a standalone correctness fix that should ship independently before the broader proxy/OAuth work.

Part of #1549

🤖 Agent: Jackdaw | Model: Sonnet 4.6 | CorvidLabs Team Alpha