### PR TITLE
fix(auth): add DISABLE_WS_KEY_PARAM guard to reject ?key= WebSocket auth

### DIFF
--- a/server/__tests__/auth.test.ts
+++ b/server/__tests__/auth.test.ts
@@ -241,6 +241,47 @@ describe('checkWsAuth', () => {
         const url = makeUrl('/ws');
         expect(checkWsAuth(req, url, AUTH_ENABLED)).toBe(false);
     });
+
+    it('returns false for valid ?key= query param when DISABLE_WS_KEY_PARAM=true', () => {
+        const originalVal = process.env.DISABLE_WS_KEY_PARAM;
+        process.env.DISABLE_WS_KEY_PARAM = 'true';
+        try {
+            const req = makeRequest('/ws');
+            const url = makeUrl('/ws', { key: AUTH_ENABLED.apiKey! });
+            expect(checkWsAuth(req, url, AUTH_ENABLED)).toBe(false);
+        } finally {
+            if (originalVal === undefined) delete process.env.DISABLE_WS_KEY_PARAM;
+            else process.env.DISABLE_WS_KEY_PARAM = originalVal;
+        }
+    });
+
+    it('returns false for valid ?key= query param when DISABLE_WS_KEY_PARAM=1', () => {
+        const originalVal = process.env.DISABLE_WS_KEY_PARAM;
+        process.env.DISABLE_WS_KEY_PARAM = '1';
+        try {
+            const req = makeRequest('/ws');
+            const url = makeUrl('/ws', { key: AUTH_ENABLED.apiKey! });
+            expect(checkWsAuth(req, url, AUTH_ENABLED)).toBe(false);
+        } finally {
+            if (originalVal === undefined) delete process.env.DISABLE_WS_KEY_PARAM;
+            else process.env.DISABLE_WS_KEY_PARAM = originalVal;
+        }
+    });
+
+    it('Authorization: Bearer still works when DISABLE_WS_KEY_PARAM=true', () => {
+        const originalVal = process.env.DISABLE_WS_KEY_PARAM;
+        process.env.DISABLE_WS_KEY_PARAM = 'true';
+        try {
+            const req = makeRequest('/ws', {
+                headers: { Authorization: `Bearer ${AUTH_ENABLED.apiKey}` },
+            });
+            const url = makeUrl('/ws');
+            expect(checkWsAuth(req, url, AUTH_ENABLED)).toBe(true);
+        } finally {
+            if (originalVal === undefined) delete process.env.DISABLE_WS_KEY_PARAM;
+            else process.env.DISABLE_WS_KEY_PARAM = originalVal;
+        }
+    });
 });
 
 // --- buildCorsHeaders -------------------------------------------------------

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -278,13 +278,22 @@ export function checkWsAuth(req: Request, url: URL, config: AuthConfig): boolean
         if (match && isValidApiKey(match[1], config)) return true;
     }
 
-    // Check query parameter (deprecated — tokens in URLs leak via logs and referrers)
+    // Check query parameter (deprecated — tokens in URLs leak via proxy logs, CDN logs, and browser history).
+    // When DISABLE_WS_KEY_PARAM=true the query param is rejected entirely; use Authorization: Bearer instead.
     const key = url.searchParams.get('key');
-    if (key && isValidApiKey(key, config)) {
-        log.warn('WebSocket auth via query string is deprecated — use Authorization: Bearer header instead', {
-            ip: req.headers.get('x-forwarded-for') ?? 'unknown',
-        });
-        return true;
+    if (key) {
+        if (process.env.DISABLE_WS_KEY_PARAM === 'true' || process.env.DISABLE_WS_KEY_PARAM === '1') {
+            log.warn('WebSocket auth via ?key= query param is disabled (DISABLE_WS_KEY_PARAM=true)', {
+                ip: req.headers.get('x-forwarded-for') ?? 'unknown',
+            });
+            return false;
+        }
+        if (isValidApiKey(key, config)) {
+            log.warn('WebSocket auth via query string is deprecated — use Authorization: Bearer header instead', {
+                ip: req.headers.get('x-forwarded-for') ?? 'unknown',
+            });
+            return true;
+        }
     }
 
     log.warn('Rejected WebSocket connection: invalid or missing auth', { ip: req.headers.get('x-forwarded-for') ?? 'unknown' });

--- a/specs/middleware/auth.spec.md
+++ b/specs/middleware/auth.spec.md
@@ -47,7 +47,7 @@ HTTP and WebSocket authentication, CORS handling, and startup security validatio
 3. **Public path bypass**: `/api/health` and `/.well-known/agent-card.json` bypass HTTP authentication regardless of API key configuration
 4. **OPTIONS bypass**: HTTP OPTIONS requests bypass authentication (CORS preflight)
 5. **No-key mode**: When `apiKey` is null (localhost-only), `checkHttpAuth` returns null and `checkWsAuth` returns true for all requests
-6. **WebSocket auth via Bearer or query param**: `checkWsAuth` checks `Authorization: Bearer <key>` header first, then `?key=<key>` query parameter
+6. **WebSocket auth via Bearer or query param**: `checkWsAuth` checks `Authorization: Bearer <key>` header first, then `?key=<key>` query parameter. When `DISABLE_WS_KEY_PARAM=true` (or `1`), the query parameter is rejected (returns false) even if the key is valid — this eliminates token leakage via proxy logs, CDN logs, and browser history. Set this in remote/production deployments.
 7. **CORS origin reflection with Vary**: When `allowedOrigins` is configured, the request origin is reflected if it matches the allowlist; `Vary: Origin` is set when the reflected origin is not `*`
 8. **Disallowed origin**: When `allowedOrigins` is set and the request origin is not in the list, `Access-Control-Allow-Origin` is set to empty string (browser blocks the response)
 9. **CORS secure default on public deployments**: When `allowedOrigins` is empty and `bindHost` is not localhost, cross-origin requests (those with an `Origin` header) receive `Access-Control-Allow-Origin: ''` (browser blocks). Non-browser requests (no `Origin` header) receive `Access-Control-Allow-Origin: *`.
@@ -123,9 +123,11 @@ HTTP and WebSocket authentication, CORS handling, and startup security validatio
 | `API_KEY` | `null` | API key for authentication. Null disables auth (localhost-only) |
 | `BIND_HOST` | `127.0.0.1` | Server bind address. Non-localhost requires API_KEY |
 | `ALLOWED_ORIGINS` | `""` (block cross-origin on non-localhost) | Comma-separated list of allowed CORS origins. Empty = allow all on localhost, block all cross-origin on public deployments. |
+| `DISABLE_WS_KEY_PARAM` | `false` | Set to `true` or `1` to reject WebSocket `?key=` query param auth. Recommended for remote deployments behind a proxy. |
 
 ## Change Log
 
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-02-20 | corvid-agent | Initial spec |
+| 2026-04-03 | corvid-agent | Added `DISABLE_WS_KEY_PARAM` env guard to `checkWsAuth` — rejects `?key=` query param when set. Updated invariant #6 and configuration table. Part of #1549 (Phase 2, item 3). |


### PR DESCRIPTION
## Summary

- Adds `DISABLE_WS_KEY_PARAM` env guard to `checkWsAuth`
- When `DISABLE_WS_KEY_PARAM=true` (or `1`), `checkWsAuth` returns false for `?key=` query param auth — even if the key is valid
- `Authorization: Bearer` header auth is unaffected
- The deprecated `?key=` path still works by default (no breaking change)

## Why this matters

Tokens in WebSocket `?key=` query parameters appear in:
- Reverse proxy access logs (nginx, Caddy)
- CDN/edge logs
- Browser history
- Referrer headers

Setting `DISABLE_WS_KEY_PARAM=true` eliminates this leakage surface. Recommended for remote/proxy deployments (Phase 2 of #1549).

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 9687 pass, 0 fail
- [x] `bun run spec:check` — 209/209 specs pass
- [x] 3 new tests: `DISABLE=true` rejects valid key, `DISABLE=1` rejects valid key, Bearer still passes

Part of #1549 (Phase 2, item 3 of 5)

🤖 Agent: Jackdaw | Model: Sonnet 4.6 | CorvidLabs Team Alpha