### PR TITLE
feat(launch): mainnet preflight check script (#311)

### DIFF
--- a/scripts/mainnet-preflight.ts
+++ b/scripts/mainnet-preflight.ts
@@ -20,7 +20,6 @@
 
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { spawnSync } from 'node:child_process';
 
 const ROOT = resolve(import.meta.dir, '..');
 const jsonMode = process.argv.includes('--json');
@@ -54,15 +53,14 @@ function warn(category: string, name: string, detail = '') {
 }
 
 function exec(cmd: string): { stdout: string; stderr: string; exitCode: number } {
-    const result = spawnSync('bash', ['-c', cmd], {
+    const result = Bun.spawnSync(['bash', '-c', cmd], {
         cwd: ROOT,
-        encoding: 'utf-8',
         timeout: 300_000,
     });
     return {
-        stdout: (result.stdout ?? '').trim(),
-        stderr: (result.stderr ?? '').trim(),
-        exitCode: result.status ?? 1,
+        stdout: (result.stdout?.toString() ?? '').trim(),
+        stderr: (result.stderr?.toString() ?? '').trim(),
+        exitCode: result.exitCode ?? 1,
     };
 }
 
@@ -72,6 +70,9 @@ function readFile(rel: string): string | null {
     return readFileSync(full, 'utf-8');
 }
 
+// NOTE: grepFiles performs textual pattern matching — it is a heuristic, not a
+// structural proof. Patterns using variables, helpers, or spread may not be
+// detected. Results are adequate for a preflight checklist but not a formal audit.
 function grepFiles(pattern: string, dirs: string[], extensions = ['ts']): string[] {
     const includes = extensions.map((e) => `--include='*.${e}'`).join(' ');
     const cmd = `grep -rn '${pattern}' ${dirs.join(' ')} ${includes} 2>/dev/null || true`;
@@ -147,6 +148,8 @@ console.log('\n=== 1. Testnet-Only Bypass Scan ===\n');
 console.log('=== 2. RBAC & Guard Chain ===\n');
 
 {
+    // NOTE: string-searches routes/index.ts for guard names — adequate for a
+    // checklist but may miss guards registered via variables or helpers.
     const indexTs = readFile('server/routes/index.ts') ?? '';
 
     const hasAuthGuard = indexTs.includes('authGuard(config)');


### PR DESCRIPTION
## Summary

- Adds `scripts/mainnet-preflight.ts` — automated Security Final Check for the v1.0.0 mainnet launch (#311)
- Covers 19 code-verifiable checks across 9 categories: bypass scan, RBAC, USDC, crypto, security tests, injection guard, environment config, template presence, and TypeScript compile
- Exits 0 when all checks pass; exits 1 on any failure — safe to run in CI pre-launch

## What it checks

| Category | Checks |
|----------|--------|
| **Testnet Bypasses** | Dispenser URLs guard-gated; no testnet USDC ASA ID (10458941) hardcoded; mainnet ASA ID (31566704) present; CRVLIB localnet guard documented |
| **RBAC / Guard Chain** | authGuard, rateLimitGuard, roleGuard, endpointRateLimitGuard, tenantGuard all present in routes/index.ts |
| **USDC / Payments** | `MAINNET_USDC_ASA_ID = 31566704` constant correct; mainnet auto-fallback confirmed |
| **Wallet Crypto** | WALLET_ENCRYPTION_KEY mainnet enforcement; PBKDF2 and AES-256-GCM present |
| **Security Tests** | ≥100 security tests across 8 files (currently 468) |
| **Injection Detection** | `checkInjection` guard present in server code |
| **Environment** | ALGORAND_NETWORK, API_KEY strength, WALLET_ENCRYPTION_KEY, BIND_HOST, ALLOWED_ORIGINS, mnemonic, backups (via `--env /path/to/.env`) |
| **Config Template** | `.env.mainnet.example` present |
| **TypeScript** | Clean compile |

## Usage

```bash
bun scripts/mainnet-preflight.ts                      # Code checks only
bun scripts/mainnet-preflight.ts --env .env.staging   # Include env validation
bun scripts/mainnet-preflight.ts --json               # Machine-readable output
```

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 9684 pass, 0 fail
- [x] `bun run spec:check` — 209/209 specs pass
- [x] `bun scripts/mainnet-preflight.ts` — 18 pass, 1 expected warning (no .env in dev), 0 fail

Closes part of #311 (Security Final Check — code-verifiable items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)