### PR TITLE
feat(discord): [Phase 2] replace custom WebSocket gateway with discord.js Client

### DIFF
--- a/server/__tests__/discord-bridge.test.ts
+++ b/server/__tests__/discord-bridge.test.ts
@@ -12,7 +12,6 @@ mock.module('../lib/worktree', () => ({
 import { Database } from 'bun:sqlite';
 import { runMigrations } from '../db/schema';
 import { DiscordBridge } from '../discord/bridge';
-import { GatewayOp } from '../discord/types';
 import type { DiscordBridgeConfig } from '../discord/types';
 import { createAgent } from '../db/agents';
 import { createProject } from '../db/projects';
@@ -104,14 +103,6 @@ describe('DiscordBridge', () => {
         };
         const bridge = new DiscordBridge(db, pm, config);
         expect(bridge).toBeDefined();
-    });
-
-    test('gateway opcodes are correct', () => {
-        expect(GatewayOp.DISPATCH).toBe(0);
-        expect(GatewayOp.HEARTBEAT).toBe(1);
-        expect(GatewayOp.IDENTIFY).toBe(2);
-        expect(GatewayOp.HELLO).toBe(10);
-        expect(GatewayOp.HEARTBEAT_ACK).toBe(11);
     });
 
     test('ignores bot messages', async () => {

--- a/server/discord/bridge.ts
+++ b/server/discord/bridge.ts
@@ -1,16 +1,9 @@
 /**
- * Bidirectional Discord bridge using raw WebSocket gateway.
- * No external Discord library dependencies.
+ * Bidirectional Discord bridge backed by discord.js Client (Phase 2).
  *
  * Supports two modes:
  * - `chat` (default): Messages route to persistent agent sessions.
  * - `work_intake`: Messages create async work tasks via WorkTaskService.
- *
- * Security note: This bridge authenticates via the Discord Gateway WebSocket API
- * using a bot token — it does NOT use the HTTP-based Interactions endpoint.
- * Therefore, Ed25519 request signature validation (X-Signature-Ed25519) is not
- * applicable here. If Discord Interactions support is added in the future,
- * Ed25519 verification must be implemented for that endpoint.
  *
  * This file is a thin orchestration layer. Domain logic is in:
  * - commands.ts — slash command registration & handling
@@ -19,6 +12,8 @@
  * - message-handler.ts — message routing & dispatch
  * - permissions.ts — role-based access control
  * - thread-manager.ts — thread lifecycle & streaming
+ * - gateway.ts — discord.js Client wrapper (WebSocket, heartbeat, reconnect)
+ * - rest-client.ts — discord.js REST adapter (Phase 1)
  */
 
 import type { Database } from 'bun:sqlite';

--- a/server/discord/gateway.ts
+++ b/server/discord/gateway.ts
@@ -1,388 +1,369 @@
+/**
+ * Discord Gateway — Discord.js Client wrapper.
+ *
+ * Replaces the custom WebSocket gateway implementation with discord.js Client,
+ * which handles the WebSocket lifecycle, heartbeat, identify/resume, and
+ * reconnection internally.
+ *
+ * Public interface is unchanged: GatewayDispatchHandlers + DiscordGateway class
+ * with start(), stop(), running, botToken, and updatePresence().
+ * Downstream modules (bridge.ts, commands.ts, etc.) are unaffected.
+ *
+ * Phase 2 of the discord.js migration (#1792).
+ * Phase 1 (REST API layer) lives in rest-client.ts.
+ */
+
+import {
+    ActivityType,
+    Client,
+    GatewayIntentBits,
+    PresenceUpdateStatus,
+    type BaseInteraction,
+    type Message,
+    type MessageReaction,
+    type PartialMessageReaction,
+    type PartialUser,
+    type User,
+} from 'discord.js';
 import { createLogger } from '../lib/logger';
 import type {
-  DiscordBridgeConfig,
-  DiscordGatewayPayload,
-  DiscordHelloData,
-  DiscordInteractionData,
-  DiscordMessageData,
-  DiscordReactionData,
-  DiscordReadyData,
+    DiscordAttachment,
+    DiscordAuthor,
+    DiscordBridgeConfig,
+    DiscordInteractionData,
+    DiscordInteractionOption,
+    DiscordMessageData,
+    DiscordReactionData,
 } from './types';
-import { GatewayIntent, GatewayOp } from './types';
 
 const log = createLogger('DiscordGateway');
-
-const GATEWAY_URL = 'wss://gateway.discord.gg/?v=10&encoding=json';
 
 /**
  * Callbacks the gateway fires when it receives dispatch events
  * that the bridge layer needs to handle.
  */
 export interface GatewayDispatchHandlers {
-  onMessage(data: DiscordMessageData): void;
-  onInteraction(data: DiscordInteractionData): void;
-  onReady(sessionId: string, botUserId: string | null): void;
-  onReactionAdd?(data: DiscordReactionData): void;
+    onMessage(data: DiscordMessageData): void;
+    onInteraction(data: DiscordInteractionData): void;
+    onReady(sessionId: string, botUserId: string | null): void;
+    onReactionAdd?(data: DiscordReactionData): void;
 }
 
 /**
- * Manages the Discord Gateway WebSocket connection, heartbeat,
- * identify/resume lifecycle, and reconnection logic.
+ * Discord.js Client wrapper that provides the same dispatch interface
+ * as the former raw WebSocket gateway.
  *
- * Dispatch events (MESSAGE_CREATE, INTERACTION_CREATE, READY) are
- * forwarded to the bridge via the {@link GatewayDispatchHandlers} callbacks.
+ * Discord.js handles: WebSocket lifecycle, heartbeat, identify/resume,
+ * session management, and exponential-backoff reconnection automatically.
  */
 export class DiscordGateway {
-  private config: DiscordBridgeConfig;
-  private handlers: GatewayDispatchHandlers;
+    private config: DiscordBridgeConfig;
+    private handlers: GatewayDispatchHandlers;
+    private client: Client | null = null;
+    private _running = false;
 
-  private ws: WebSocket | null = null;
-  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
-  private heartbeatAcked = true;
-  private sequence: number | null = null;
-  private sessionId: string | null = null;
-  // Note: resume_gateway_url from Discord READY is intentionally not stored
-  // to avoid SSRF risk. We always reconnect via the hardcoded gateway URL.
-  private _running = false;
-  private reconnectAttempts = 0;
-  private maxReconnectAttempts = 10;
-
-  constructor(config: DiscordBridgeConfig, handlers: GatewayDispatchHandlers) {
-    this.config = config;
-    this.handlers = handlers;
-  }
-
-  get running(): boolean {
-    return this._running;
-  }
-
-  /** Open the gateway connection. No-op if already running. */
-  start(): void {
-    if (this._running) return;
-    this._running = true;
-    this.connect();
-  }
-
-  /** Close the gateway connection and stop heartbeat. */
-  stop(): void {
-    this._running = false;
-    if (this.heartbeatTimer) {
-      clearInterval(this.heartbeatTimer);
-      this.heartbeatTimer = null;
-    }
-    if (this.ws) {
-      this.ws.close(1000, 'Shutting down');
-      this.ws = null;
-    }
-  }
-
-  /** Expose the bot token for REST API calls made by the bridge. */
-  get botToken(): string {
-    return this.config.botToken;
-  }
-
-  /** Send a PRESENCE_UPDATE over the live gateway connection. */
-  updatePresence(statusText?: string, activityType?: number): void {
-    this.send({
-      op: GatewayOp.PRESENCE_UPDATE,
-      d: {
-        status: 'online',
-        activities: [
-          {
-            name: statusText ?? process.env.DISCORD_STATUS ?? 'corvid-agent',
-            type: activityType ?? parseInt(process.env.DISCORD_ACTIVITY_TYPE ?? '3', 10),
-          },
-        ],
-        since: null,
-        afk: false,
-      },
-      s: null,
-      t: null,
-    });
-  }
-
-  // ── Connection ────────────────────────────────────────────────────────
-
-  private connect(): void {
-    // Always use the hardcoded gateway URL to prevent SSRF.
-    // Discord handles re-identification when we don't use the resume URL.
-    log.info('Connecting to Discord gateway');
-
-    this.ws = new WebSocket(GATEWAY_URL);
-
-    this.ws.onopen = () => {
-      log.info('Discord gateway connected');
-      this.reconnectAttempts = 0;
-    };
-
-    this.ws.onmessage = (event) => {
-      try {
-        const payload = JSON.parse(String(event.data)) as DiscordGatewayPayload;
-        this.handleGatewayMessage(payload);
-      } catch (err) {
-        log.error('Failed to parse gateway message', { error: err instanceof Error ? err.message : String(err) });
-      }
-    };
-
-    this.ws.onclose = (event) => {
-      log.warn('Discord gateway disconnected', { code: event.code, reason: event.reason });
-      if (this.heartbeatTimer) {
-        clearInterval(this.heartbeatTimer);
-        this.heartbeatTimer = null;
-      }
-
-      // 4003/4007/4009: session is invalid — clear it so we IDENTIFY fresh
-      // 4004/4010-4014: fatal config errors — stop reconnecting
-      const code = event.code;
-      if (code === 4003 || code === 4007 || code === 4009) {
-        this.sessionId = null;
-        this.sequence = null;
-      } else if (code === 4004 || (code >= 4010 && code <= 4014)) {
-        log.error('Discord gateway fatal close code, not reconnecting', { code });
-        this._running = false;
-        return;
-      }
-
-      if (this._running) {
-        this.scheduleReconnect();
-      }
-    };
-
-    this.ws.onerror = (event) => {
-      log.error('Discord gateway error', { error: String(event) });
-    };
-  }
-
-  // ── Gateway Message Handling ──────────────────────────────────────────
-
-  private handleGatewayMessage(payload: DiscordGatewayPayload): void {
-    // Update sequence number
-    if (payload.s !== null) {
-      this.sequence = payload.s;
+    constructor(config: DiscordBridgeConfig, handlers: GatewayDispatchHandlers) {
+        this.config = config;
+        this.handlers = handlers;
     }
 
-    switch (payload.op) {
-      case GatewayOp.HELLO: {
-        const data = payload.d as DiscordHelloData;
-        this.startHeartbeat(data.heartbeat_interval);
-        // If we have a session, try to resume; otherwise identify
-        if (this.sessionId) {
-          this.resume();
-        } else {
-          this.identify();
+    get running(): boolean {
+        return this._running;
+    }
+
+    /** Expose the bot token for REST API calls made by the bridge. */
+    get botToken(): string {
+        return this.config.botToken;
+    }
+
+    /** Open the gateway connection. No-op if already running. */
+    start(): void {
+        if (this._running) return;
+        this._running = true;
+
+        const intents: GatewayIntentBits[] = [
+            GatewayIntentBits.Guilds,
+            GatewayIntentBits.GuildMessages,
+            GatewayIntentBits.GuildMessageReactions,
+            GatewayIntentBits.MessageContent,
+        ];
+        if (this.config.publicMode) {
+            intents.push(GatewayIntentBits.GuildMembers);
         }
-        break;
-      }
 
-      case GatewayOp.HEARTBEAT_ACK:
-        this.heartbeatAcked = true;
-        log.debug('Heartbeat ACK received');
-        break;
+        this.client = new Client({ intents });
 
-      case GatewayOp.DISPATCH:
-        this.handleDispatch(payload);
-        break;
-
-      case GatewayOp.RECONNECT:
-        log.info('Discord requested reconnect');
-        this.ws?.close(4000, 'Reconnect requested');
-        break;
-
-      case GatewayOp.INVALID_SESSION: {
-        const resumable = payload.d as boolean;
-        log.warn('Discord invalid session', { resumable });
-        if (!resumable) {
-          this.sessionId = null;
-        }
-        // Wait 1-5 seconds before re-identifying
-        setTimeout(
-          () => {
-            if (this.sessionId) {
-              this.resume();
-            } else {
-              this.identify();
-            }
-          },
-          1000 + Math.random() * 4000,
-        );
-        break;
-      }
-    }
-  }
-
-  private handleDispatch(payload: DiscordGatewayPayload): void {
-    switch (payload.t) {
-      case 'READY': {
-        const data = payload.d as DiscordReadyData;
-        this.sessionId = data.session_id;
-        // resume_gateway_url intentionally not stored (SSRF prevention)
-        const botUserId = data.user?.id ?? null;
-        log.info('Discord gateway ready', { sessionId: this.sessionId, botUserId });
-        this.handlers.onReady(this.sessionId, botUserId);
-        break;
-      }
-
-      case 'RESUMED':
-        log.info('Discord session resumed');
-        break;
-
-      case 'MESSAGE_CREATE': {
-        const data = payload.d as DiscordMessageData;
-        log.debug('MESSAGE_CREATE dispatch', {
-          channelId: data.channel_id,
-          username: data.author?.username,
-          isBot: data.author?.bot,
-          mentionCount: data.mentions?.length ?? 0,
-          mentionRoleCount: data.mention_roles?.length ?? 0,
-          attachmentCount: data.attachments?.length ?? 0,
-          attachments: data.attachments?.map((a) => ({
-            filename: a.filename,
-            content_type: a.content_type,
-            size: a.size,
-            hasUrl: !!a.url,
-            hasProxyUrl: !!a.proxy_url,
-          })),
+        this.client.on('ready', (readyClient) => {
+            // Discord.js manages session state internally; we surface the
+            // bot user ID which is what bridge.ts actually uses.
+            const botUserId = readyClient.user.id;
+            log.info('Discord gateway ready', { botUserId });
+            this.handlers.onReady(botUserId, botUserId);
         });
-        this.handlers.onMessage(data);
-        break;
-      }
 
-      case 'INTERACTION_CREATE': {
-        const data = payload.d as DiscordInteractionData;
-        this.handlers.onInteraction(data);
-        break;
-      }
+        this.client.on('messageCreate', (message: Message) => {
+            if (!this._running) return;
+            log.debug('MESSAGE_CREATE dispatch', {
+                channelId: message.channelId,
+                username: message.author.username,
+                isBot: message.author.bot,
+                mentionCount: message.mentions.users.size,
+                mentionRoleCount: message.mentions.roles.size,
+                attachmentCount: message.attachments.size,
+                attachments: [...message.attachments.values()].map((a) => ({
+                    filename: a.name,
+                    content_type: a.contentType,
+                    size: a.size,
+                    hasUrl: !!a.url,
+                    hasProxyUrl: !!a.proxyURL,
+                })),
+            });
+            this.handlers.onMessage(mapMessage(message));
+        });
 
-      case 'MESSAGE_REACTION_ADD': {
-        const data = payload.d as DiscordReactionData;
-        this.handlers.onReactionAdd?.(data);
-        break;
-      }
+        this.client.on('interactionCreate', (interaction: BaseInteraction) => {
+            if (!this._running) return;
+            const data = mapInteraction(interaction);
+            if (data) this.handlers.onInteraction(data);
+        });
+
+        this.client.on('messageReactionAdd', (reaction: MessageReaction | PartialMessageReaction, user: User | PartialUser) => {
+            if (!this._running || !this.handlers.onReactionAdd) return;
+            const data = mapReaction(reaction, user);
+            if (data) this.handlers.onReactionAdd(data);
+        });
+
+        this.client.on('error', (err) => {
+            log.error('Discord gateway error', { error: err.message });
+        });
+
+        this.client.login(this.config.botToken).catch((err: unknown) => {
+            log.error('Discord gateway login failed', {
+                error: err instanceof Error ? err.message : String(err),
+            });
+            this._running = false;
+        });
+
+        // Set initial presence from env after login
+        const statusText = process.env.DISCORD_STATUS ?? 'corvid-agent';
+        const activityType = parseInt(process.env.DISCORD_ACTIVITY_TYPE ?? '3', 10);
+        this.client.once('ready', () => {
+            this.updatePresence(statusText, activityType);
+        });
     }
-  }
 
-  // ── Identify / Resume ─────────────────────────────────────────────────
-
-  private identify(): void {
-    // GUILDS is always needed for the bot to receive guild dispatch events.
-    // GUILD_MEMBERS is added when public mode is enabled (for role data).
-    let intents =
-      GatewayIntent.GUILDS |
-      GatewayIntent.GUILD_MESSAGES |
-      GatewayIntent.GUILD_MESSAGE_REACTIONS |
-      GatewayIntent.MESSAGE_CONTENT;
-    if (this.config.publicMode) {
-      intents |= GatewayIntent.GUILD_MEMBERS;
+    /** Close the gateway connection. */
+    stop(): void {
+        this._running = false;
+        if (this.client) {
+            this.client.destroy();
+            this.client = null;
+        }
     }
-    this.send({
-      op: GatewayOp.IDENTIFY,
-      d: {
-        token: this.config.botToken,
-        intents,
-        properties: {
-          os: 'linux',
-          browser: 'corvid-agent',
-          device: 'corvid-agent',
-        },
-        presence: this.buildPresence(),
-      },
-      s: null,
-      t: null,
-    });
-  }
 
-  /**
-   * Build the presence payload from DISCORD_STATUS and DISCORD_ACTIVITY_TYPE env vars.
-   * Activity types: 0=Playing, 1=Streaming, 2=Listening, 3=Watching, 5=Competing
-   */
-  private buildPresence(): Record<string, unknown> {
-    const statusText = process.env.DISCORD_STATUS ?? 'corvid-agent';
-    const activityType = parseInt(process.env.DISCORD_ACTIVITY_TYPE ?? '3', 10); // default: Watching
+    /** Update the bot's presence via the live Discord.js client. */
+    updatePresence(statusText?: string, activityType?: number): void {
+        if (!this.client?.isReady()) return;
+        this.client.user.setPresence({
+            status: PresenceUpdateStatus.Online,
+            activities: [
+                {
+                    name: statusText ?? process.env.DISCORD_STATUS ?? 'corvid-agent',
+                    type: (activityType ?? parseInt(process.env.DISCORD_ACTIVITY_TYPE ?? '3', 10)) as ActivityType,
+                },
+            ],
+        });
+    }
+}
+
+// ─── Type mapping helpers ─────────────────────────────────────────────────────
+
+function mapAuthor(user: { id: string; username: string; bot?: boolean }): DiscordAuthor {
     return {
-      status: 'online',
-      activities: [
-        {
-          name: statusText,
-          type: activityType,
-        },
-      ],
-      since: null,
-      afk: false,
+        id: user.id,
+        username: user.username,
+        bot: user.bot ?? false,
     };
-  }
+}
 
-  private resume(): void {
-    this.send({
-      op: GatewayOp.RESUME,
-      d: {
-        token: this.config.botToken,
-        session_id: this.sessionId,
-        seq: this.sequence,
-      },
-      s: null,
-      t: null,
-    });
-  }
+function mapAttachment(a: {
+    id: string;
+    name: string;
+    contentType: string | null;
+    size: number;
+    url: string;
+    proxyURL: string;
+    width: number | null;
+    height: number | null;
+}): DiscordAttachment {
+    return {
+        id: a.id,
+        filename: a.name,
+        content_type: a.contentType ?? undefined,
+        size: a.size,
+        url: a.url,
+        proxy_url: a.proxyURL,
+        width: a.width ?? undefined,
+        height: a.height ?? undefined,
+    };
+}
 
-  // ── Heartbeat ─────────────────────────────────────────────────────────
-
-  private startHeartbeat(intervalMs: number): void {
-    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
-
-    // Use a fixed heartbeat interval (41.25s, Discord's typical default).
-    // The server-provided value is validated but we use a constant to prevent
-    // resource exhaustion from malicious/malformed gateway payloads.
-    const HEARTBEAT_MS = 41_250;
-    if (intervalMs < 10_000 || intervalMs > 120_000) {
-      log.warn('Discord heartbeat interval out of range, using default', { received: intervalMs });
+function mapMessage(message: Message): DiscordMessageData {
+    // Resolve referenced message from the client cache when available.
+    // Discord.js does not embed it automatically (unlike the raw gateway),
+    // so we use the cache for best-effort mapping.
+    let referencedMessage: DiscordMessageData['referenced_message'] = null;
+    if (message.reference?.messageId) {
+        const cached = message.channel.messages?.cache.get(message.reference.messageId);
+        if (cached) {
+            referencedMessage = {
+                id: cached.id,
+                content: cached.content,
+                author: mapAuthor(cached.author),
+            };
+        }
     }
 
-    // Send first heartbeat after jitter
-    setTimeout(() => this.heartbeat(), Math.random() * HEARTBEAT_MS);
+    return {
+        id: message.id,
+        channel_id: message.channelId,
+        author: mapAuthor(message.author),
+        content: message.content,
+        timestamp: message.createdAt.toISOString(),
+        thread: message.channel.isThread() ? { id: message.channelId } : undefined,
+        mentions: [...message.mentions.users.values()].map(mapAuthor),
+        mention_roles: [...message.mentions.roles.keys()],
+        member: message.member
+            ? { roles: [...message.member.roles.cache.keys()] }
+            : undefined,
+        message_reference: message.reference?.messageId
+            ? {
+                message_id: message.reference.messageId,
+                channel_id: message.reference.channelId ?? undefined,
+                guild_id: message.reference.guildId ?? undefined,
+            }
+            : undefined,
+        referenced_message: referencedMessage,
+        attachments: [...message.attachments.values()].map(mapAttachment),
+    };
+}
 
-    this.heartbeatTimer = setInterval(() => {
-      if (!this.heartbeatAcked) {
-        log.warn('Discord heartbeat not acknowledged, reconnecting');
-        this.ws?.close(4000, 'Heartbeat timeout');
-        return;
-      }
-      this.heartbeat();
-    }, HEARTBEAT_MS);
-  }
+function mapOption(opt: {
+    name: string;
+    type: number;
+    value?: string | number | boolean;
+    focused?: boolean;
+    options?: typeof opt[];
+}): DiscordInteractionOption {
+    return {
+        name: opt.name,
+        type: opt.type,
+        value: opt.value,
+        focused: opt.focused,
+        options: opt.options?.map(mapOption),
+    };
+}
 
-  private heartbeat(): void {
-    this.heartbeatAcked = false;
-    this.send({
-      op: GatewayOp.HEARTBEAT,
-      d: this.sequence,
-      s: null,
-      t: null,
-    });
-  }
+function mapInteraction(interaction: BaseInteraction): DiscordInteractionData | null {
+    if (!interaction.channelId) return null;
 
-  // ── Send / Reconnect ──────────────────────────────────────────────────
+    const base = {
+        id: interaction.id,
+        type: interaction.type as number,
+        channel_id: interaction.channelId,
+        guild_id: interaction.guildId ?? undefined,
+        token: interaction.token,
+    };
 
-  private send(payload: DiscordGatewayPayload): void {
-    if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify(payload));
+    // Member context (guild interactions)
+    let member: DiscordInteractionData['member'];
+    if (interaction.member) {
+        const m = interaction.member;
+        // GuildMember has .user and .roles.cache; API member has .user and .roles (string[])
+        const user = 'user' in m && m.user ? m.user : null;
+        const roles = 'roles' in m
+            ? (m.roles instanceof Map || (typeof m.roles === 'object' && 'cache' in m.roles)
+                // GuildMember — roles is a GuildMemberRoleManager
+                ? [...(m.roles as { cache: Map<string, unknown> }).cache.keys()]
+                // APIInteractionGuildMember — roles is string[]
+                : m.roles as string[])
+            : [];
+        if (user && typeof user === 'object' && 'id' in user && 'username' in user) {
+            member = {
+                user: {
+                    id: user.id as string,
+                    username: user.username as string,
+                    bot: (user as { bot?: boolean }).bot ?? false,
+                },
+                roles,
+            };
+        }
     }
-  }
 
-  private scheduleReconnect(): void {
-    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-      log.error('Max Discord reconnect attempts reached, giving up');
-      this._running = false;
-      return;
+    // User context (DM interactions)
+    const user: DiscordAuthor | undefined = interaction.user
+        ? mapAuthor(interaction.user)
+        : undefined;
+
+    // Slash command / autocomplete
+    if (interaction.isChatInputCommand() || interaction.isAutocomplete()) {
+        const opts = interaction.options.data as unknown as {
+            name: string;
+            type: number;
+            value?: string | number | boolean;
+            focused?: boolean;
+            options?: unknown[];
+        }[];
+        return {
+            ...base,
+            member,
+            user,
+            data: {
+                name: interaction.commandName,
+                options: opts.map(mapOption as (o: typeof opts[0]) => DiscordInteractionOption),
+            },
+        };
     }
 
-    const delay = Math.min(1000 * 2 ** this.reconnectAttempts, 60000);
-    this.reconnectAttempts++;
-    log.info(`Reconnecting to Discord in ${delay}ms (attempt ${this.reconnectAttempts})`);
+    // Button / select component
+    if (interaction.isMessageComponent()) {
+        return {
+            ...base,
+            member,
+            user,
+            data: {
+                name: '',
+                custom_id: interaction.customId,
+                component_type: interaction.componentType as number,
+            },
+            message: {
+                id: interaction.message.id,
+                channel_id: interaction.message.channelId,
+            },
+        };
+    }
 
-    setTimeout(() => {
-      if (this._running) {
-        this.connect();
-      }
-    }, delay);
-  }
+    // Ping — no data needed
+    if (interaction.type === 1 /* InteractionType.Ping */) {
+        return { ...base, member, user };
+    }
+
+    return null;
+}
+
+function mapReaction(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
+): DiscordReactionData | null {
+    if (!user.id) return null;
+    return {
+        user_id: user.id,
+        channel_id: reaction.message.channelId,
+        message_id: reaction.message.id,
+        guild_id: reaction.message.guildId ?? undefined,
+        emoji: {
+            id: reaction.emoji.id,
+            name: reaction.emoji.name ?? '',
+        },
+    };
 }

--- a/server/discord/types.ts
+++ b/server/discord/types.ts
@@ -127,23 +127,6 @@ export interface DiscordActionRow {
     components: DiscordButton[];
 }
 
-export interface DiscordGatewayPayload {
-    op: number;
-    d: unknown;
-    s: number | null;
-    t: string | null;
-}
-
-export interface DiscordHelloData {
-    heartbeat_interval: number;
-}
-
-export interface DiscordReadyData {
-    session_id: string;
-    resume_gateway_url: string;
-    user?: { id: string; username: string };
-}
-
 /** A file attached to a Discord message. */
 export interface DiscordAttachment {
     id: string;
@@ -202,28 +185,6 @@ export interface DiscordAuthor {
     username: string;
     bot?: boolean;
 }
-
-// Gateway opcodes
-export const GatewayOp = {
-    DISPATCH: 0,
-    HEARTBEAT: 1,
-    IDENTIFY: 2,
-    PRESENCE_UPDATE: 3,
-    RESUME: 6,
-    RECONNECT: 7,
-    INVALID_SESSION: 9,
-    HELLO: 10,
-    HEARTBEAT_ACK: 11,
-} as const;
-
-// Gateway intents
-export const GatewayIntent = {
-    GUILDS: 1 << 0,
-    GUILD_MEMBERS: 1 << 1,
-    GUILD_MESSAGES: 1 << 9,
-    GUILD_MESSAGE_REACTIONS: 1 << 10,
-    MESSAGE_CONTENT: 1 << 15,
-} as const;
 
 /** Payload received from Discord MESSAGE_REACTION_ADD dispatch event. */
 export interface DiscordReactionData {

--- a/specs/discord/bridge.spec.md
+++ b/specs/discord/bridge.spec.md
@@ -268,7 +268,7 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | Export | Kind | Description |
 |--------|------|-------------|
 | `GatewayDispatchHandlers` | Interface | Callbacks for gateway dispatch events: `onMessage`, `onInteraction`, `onReady`, `onReactionAdd?` |
-| `DiscordGateway` | Class | Manages the Discord Gateway WebSocket connection, heartbeat, identify/resume lifecycle, and reconnection. Dispatch events are forwarded to the bridge via `GatewayDispatchHandlers` |
+| `DiscordGateway` | Class | Discord.js Client wrapper. Handles WebSocket lifecycle, heartbeat, identify/resume, and reconnection internally via discord.js. Dispatches events to bridge via `GatewayDispatchHandlers`. (Phase 2 migration — formerly custom WebSocket implementation) |
 
 #### DiscordGateway Constructor
 
@@ -389,17 +389,12 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 |------|-------------|
 | `DiscordBridgeMode` | `'chat' \| 'work_intake'` — operational mode for the bridge |
 | `DiscordBridgeConfig` | `{ botToken, channelId, additionalChannelIds?, allowedUserIds, mode?, defaultAgentId?, appId?, guildId?, botRoleId?, publicMode?, rolePermissions?, defaultPermissionLevel?, rateLimitByLevel? }` |
-| `DiscordGatewayPayload` | `{ op: number; d: unknown; s: number \| null; t: string \| null }` |
-| `DiscordHelloData` | `{ heartbeat_interval: number }` |
-| `DiscordReadyData` | `{ session_id: string; resume_gateway_url: string }` |
 | `DiscordMessageData` | `{ id, channel_id, author, content, timestamp, mentions?: DiscordAuthor[], mention_roles?: string[], member?: { roles: string[] }, message_reference?, referenced_message?, attachments?: DiscordAttachment[] }` |
 | `DiscordAttachment` | `{ id, filename, content_type?, size, url, proxy_url, width?, height? }` — file attached to a Discord message |
 | `DiscordAuthor` | `{ id: string; username: string; bot?: boolean }` |
 | `DiscordInteractionOption` | `{ name, type, value?, options?: DiscordInteractionOption[] }` — recursive option type for subcommands and subcommand groups |
 | `DiscordInteractionData` | Slash command interaction payload from gateway |
-| `GatewayOp` | Constants for gateway opcodes (DISPATCH=0, HEARTBEAT=1, IDENTIFY=2, PRESENCE_UPDATE=3, RESUME=6, RECONNECT=7, INVALID_SESSION=9, HELLO=10, HEARTBEAT_ACK=11) |
-| `GatewayIntent` | Bit flags: `GUILDS` (1<<0), `GUILD_MEMBERS` (1<<1), `GUILD_MESSAGES` (1<<9), `GUILD_MESSAGE_REACTIONS` (1<<10), `MESSAGE_CONTENT` (1<<15) |
-| `DiscordReactionData` | `{ user_id, channel_id, message_id, guild_id?, emoji: { id, name } }` — payload from MESSAGE_REACTION_ADD |
+| `DiscordReactionData` | `{ user_id, channel_id, message_id, guild_id?, emoji: { id, name } }` — payload from messageReactionAdd event |
 | `PermissionLevel` | Constants: `BLOCKED=0, BASIC=1, STANDARD=2, ADMIN=3` |
 | `ComponentType` | Constants for Discord component types: `ACTION_ROW=1, BUTTON=2` |
 | `ButtonStyle` | Constants for Discord button styles: `PRIMARY=1, SECONDARY=2, SUCCESS=3, DANGER=4` |
@@ -675,3 +670,4 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | 2026-03-18 | corvid-agent | v15: Added `extractMentionsFromEmbed` — extracts Discord mentions from embed descriptions into top-level `content` field so mentions trigger notifications. Applied to `sendEmbed`, `sendReplyEmbed`, and `editEmbed` |
 | 2026-03-20 | corvid-agent | v16: File attachment support via `sendEmbedWithFiles` and `sendMessageWithFiles` (multipart/form-data, 25MB limit). Simplified embed footer to `agentName · status`. Added `image` and `thumbnail` fields to `DiscordEmbed`. `DiscordFileAttachment` interface |
 | 2026-03-23 | corvid-agent | v17: Renamed `extractMentionsFromEmbed` → `extractContentFromEmbed`. v18: Discord won't auto-unfurl URLs in `content` when rich embeds are present — URLs are now stripped from embed description via `stripUrlsFromEmbed` and sent as a separate follow-up message (no embeds) so Discord renders link previews. Added `extractUrlsFromEmbed` and `stripUrlsFromEmbed` helpers |
+| 2026-04-04 | corvid-agent | v19 (Phase 2): Replaced custom WebSocket gateway (`DiscordGateway`) with discord.js `Client`. Gateway now uses `GatewayIntentBits`, `Client` events (`messageCreate`, `interactionCreate`, `messageReactionAdd`, `ready`), and discord.js built-in reconnection/heartbeat. Removed raw protocol types `DiscordGatewayPayload`, `DiscordHelloData`, `DiscordReadyData`, `GatewayOp`, `GatewayIntent` — these were gateway internals now handled by discord.js. Public interface (`GatewayDispatchHandlers`, `DiscordGateway.start/stop/updatePresence/running/botToken`) is unchanged. Discord message/interaction/reaction types are mapped to existing internal types for downstream compatibility. Closes #1792 |


### PR DESCRIPTION
## Summary

Phase 2 of the discord.js migration (#1792). Replaces the 388-line hand-rolled WebSocket gateway with `discord.js Client`, eliminating ~350 lines of low-level protocol code.

- **gateway.ts** — full rewrite using `discord.js Client` with `GatewayIntentBits`; adapter functions map discord.js events to existing `DiscordMessageData` / `DiscordInteractionData` / `DiscordReactionData` types so all downstream code is unchanged
- **types.ts** — remove raw protocol types (`DiscordGatewayPayload`, `DiscordHelloData`, `DiscordReadyData`, `GatewayOp`, `GatewayIntent`) now handled internally by discord.js
- **bridge.ts** — doc comment updated to reflect Phase 2
- **discord-bridge.test.ts** — remove `GatewayOp` import and opcode test (no longer applicable)
- **bridge.spec.md** — remove deleted type exports, update `DiscordGateway` description, add v19 Change Log entry

### What discord.js now handles for us
- WebSocket connection lifecycle
- Heartbeat send/ACK tracking
- Identify and resume payloads
- Exponential backoff reconnection
- Session state and sequence numbers

### Public interface unchanged
`GatewayDispatchHandlers`, `DiscordGateway.start()`, `.stop()`, `.running`, `.botToken`, `.updatePresence()` — bridge.ts is unaffected.

## Test plan
- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 9717 pass, 0 fail
- [x] `bun run spec:check` — 210/210 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)