### PR TITLE
fix(test): use empty string instead of delete for env var isolation in Bun

### DIFF
--- a/server/__tests__/provider-routing.test.ts
+++ b/server/__tests__/provider-routing.test.ts
@@ -207,15 +207,12 @@ describe('resolveProviderRouting', () => {
 
         beforeEach(() => {
             savedOllamaProxyEnv = process.env.OLLAMA_USE_CLAUDE_PROXY;
-            delete process.env.OLLAMA_USE_CLAUDE_PROXY;
+            // Use '' not delete — Bun ignores delete for .env-loaded vars
+            process.env.OLLAMA_USE_CLAUDE_PROXY = '';
         });
 
         afterEach(() => {
-            if (savedOllamaProxyEnv !== undefined) {
-                process.env.OLLAMA_USE_CLAUDE_PROXY = savedOllamaProxyEnv;
-            } else {
-                delete process.env.OLLAMA_USE_CLAUDE_PROXY;
-            }
+            process.env.OLLAMA_USE_CLAUDE_PROXY = savedOllamaProxyEnv ?? '';
         });
 
         test('falls back to Ollama when no cloud access and Ollama available', () => {


### PR DESCRIPTION
## Summary

- Fixes `delete process.env.OLLAMA_USE_CLAUDE_PROXY` → `process.env.OLLAMA_USE_CLAUDE_PROXY = ''` in provider-routing test `beforeEach`/`afterEach`
- In Bun, `delete process.env.X` is a no-op for vars loaded from `.env` at startup — the var remains `'true'` causing the routing function to return `sdk` instead of `ollama`
- PR #1806 attempted the same fix with `delete`, which failed for the same reason

## Root cause

`resolveProviderRouting()` checks `process.env.OLLAMA_USE_CLAUDE_PROXY === 'true'`. The `.env` file sets this to `'true'`. Bun's test runner loads `.env` once at startup and `delete` on `process.env` is silently ignored — the variable stays set throughout the test run. Setting to `''` works because `'' !== 'true'`.

## Test plan

- [x] `bun test server/__tests__/provider-routing.test.ts` — 25 pass, 0 fail
- [x] No modifications to protected `server/process/manager.ts`
- [x] `bun x tsc --noEmit --skipLibCheck` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)