### PR TITLE
fix(security): add @anthropic-ai/sdk override to exclude GHSA-5474-4w2j-mq4c vulnerable range

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
     },
   },
   "overrides": {
+    "@anthropic-ai/sdk": ">=0.81.0",
     "@hono/node-server": ">=1.19.10",
     "ajv": ">=8.18.0",
     "express-rate-limit": ">=8.2.2",
@@ -678,8 +679,6 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
-
-    "@anthropic-ai/claude-agent-sdk/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.80.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g=="],
 
     "@types/bunyan/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "hono": ">=4.12.7",
     "@hono/node-server": ">=1.19.10",
     "express-rate-limit": ">=8.2.2",
-    "path-to-regexp": ">=8.4.0"
+    "path-to-regexp": ">=8.4.0",
+    "@anthropic-ai/sdk": ">=0.81.0"
   }
 }


### PR DESCRIPTION
## Summary

Closes the `bun audit` vulnerability introduced by `@anthropic-ai/claude-agent-sdk@0.2.92` declaring `@anthropic-ai/sdk: ^0.80.0`.

- **CVE:** GHSA-5474-4w2j-mq4c (moderate) — Memory Tool Path Validation Allows Sandbox Escape
- **Root cause:** The caret range `^0.80.0` allows 0.80.0 (vulnerable). The already-resolved version is 0.82.0 (safe), but `bun audit` checks declared ranges, not resolved versions.
- **Fix:** Add `"@anthropic-ai/sdk": ">=0.81.0"` to `package.json` overrides. This excludes the vulnerable 0.80.0 and forces all resolution paths to safe versions.

Supersedes #1831 (which only committed a markdown TODO instead of the actual fix).

## Test plan

- [x] `bun install` — lockfile updated cleanly
- [x] `bun audit` — 0 vulnerabilities
- [x] `bun x tsc --noEmit --skipLibCheck` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)