### PR TITLE
test(a2a): add SSRF blocking coverage for invokeRemoteAgent and fetchAgentCard

### DIFF
--- a/server/__tests__/a2a-invoke.test.ts
+++ b/server/__tests__/a2a-invoke.test.ts
@@ -2,10 +2,10 @@
  * Tests for A2A remote agent invocation client.
  *
  * Validates invokeRemoteAgent: task submission, polling, success/failure
- * handling, taskId propagation, and timeout behaviour.
+ * handling, taskId propagation, timeout behaviour, and SSRF blocking.
  */
 import { describe, it, expect, mock, afterEach } from 'bun:test';
-import { invokeRemoteAgent } from '../a2a/client';
+import { invokeRemoteAgent, fetchAgentCard } from '../a2a/client';
 
 const BASE_URL = 'https://remote-agent.example.com';
 const originalFetch = globalThis.fetch;
@@ -162,5 +162,71 @@ describe('invokeRemoteAgent', () => {
         expect(result.responseText).toBeNull();
         expect(result.error).toContain('Timed out');
         expect(result.error).toContain('100');
+    });
+});
+
+// ─── SSRF blocking ───────────────────────────────────────────────────────────
+
+describe('invokeRemoteAgent SSRF blocking', () => {
+    it('throws ValidationError for localhost URL', async () => {
+        await expect(
+            invokeRemoteAgent('http://localhost/agent', 'hello'),
+        ).rejects.toThrow(/Blocked URL/);
+    });
+
+    it('throws ValidationError for 127.0.0.1', async () => {
+        await expect(
+            invokeRemoteAgent('http://127.0.0.1:3000', 'hello'),
+        ).rejects.toThrow(/Blocked URL/);
+    });
+
+    it('throws ValidationError for 10.x private IP', async () => {
+        await expect(
+            invokeRemoteAgent('http://10.0.0.1/agent', 'hello'),
+        ).rejects.toThrow(/Blocked URL/);
+    });
+
+    it('throws ValidationError for 192.168.x.x private IP', async () => {
+        await expect(
+            invokeRemoteAgent('http://192.168.1.1/agent', 'hello'),
+        ).rejects.toThrow(/Blocked URL/);
+    });
+
+    it('throws ValidationError for non-http scheme', async () => {
+        await expect(
+            invokeRemoteAgent('ftp://remote-agent.example.com', 'hello'),
+        ).rejects.toThrow(/Blocked URL scheme/);
+    });
+
+    it('throws ValidationError for malformed URL', async () => {
+        await expect(
+            invokeRemoteAgent('not-a-url', 'hello'),
+        ).rejects.toThrow(/Invalid URL/);
+    });
+});
+
+describe('fetchAgentCard SSRF blocking', () => {
+    it('throws ValidationError for localhost URL', async () => {
+        await expect(
+            fetchAgentCard('http://localhost'),
+        ).rejects.toThrow(/Blocked URL/);
+    });
+
+    it('throws ValidationError for 172.16.x.x private IP', async () => {
+        await expect(
+            fetchAgentCard('https://172.16.0.1'),
+        ).rejects.toThrow(/Blocked URL/);
+    });
+
+    it('throws ValidationError for .local hostname', async () => {
+        await expect(
+            fetchAgentCard('http://my-server.local'),
+        ).rejects.toThrow(/Blocked URL/);
+    });
+
+    it('throws ValidationError for non-http scheme', async () => {
+        await expect(
+            fetchAgentCard('file:///etc/passwd'),
+        ).rejects.toThrow(/Blocked URL scheme/);
     });
 });


### PR DESCRIPTION
## Summary

- Both `invokeRemoteAgent` and `fetchAgentCard` call `validateUrl()` before any network I/O, but existing tests only exercised the happy path with a safe public URL — the SSRF guard was untested
- Add 10 new tests covering all major block categories: private IPs (127.0.0.1, 10.x, 192.168.x, 172.16.x), localhost, `.local` hostnames, non-http schemes (ftp://, file://), and malformed URLs
- Also imports and tests `fetchAgentCard` SSRF path, which had zero test coverage

## Test results

```
15 pass (was 5), 0 fail — bun test server/__tests__/a2a-invoke.test.ts
9850 pass (was 9840), 0 fail — full suite
```

TypeScript clean, spec:check 100%.

## Why this matters

The SSRF guard on the A2A client was introduced in #1817 (replacing the weak federation validator). Without these tests, a future refactor could silently remove the `validateUrl()` call and open a SSRF vector with no test failure to catch it.