### PR TITLE
release: v0.61.0 — bump version, update README, changelog, and releases page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to this project will be documented in this file.
 ## [0.61.0] - 2026-04-05
 
 ### Added
-- **Discord: Phase 3 SlashCommandBuilder migration** — migrate command registration to SlashCommandBuilder (#1822)
-- **Discord: Phase 2 discord.js integration** — replace custom WebSocket gateway with discord.js Client (#1818)
-- **Auth: proxy trust mode** — oauth2-proxy email-based tenant authentication via TRUST_PROXY (#1813)
+- **Discord: complete REST client migration (Phases 1–5)** — replace all raw `fetch()` calls with discord.js REST client: foundation (#1825), gateway (#1818), SlashCommandBuilder (#1822), interaction passthrough (#1823), thread lifecycle (#1826), embeds (#1855)
+- **Auth: proxy trust mode** — oauth2-proxy email-based tenant authentication via TRUST_PROXY (#1813, #1836)
+- **Work: reputation-gated creation** — require minimum reputation for work task creation (#1842)
+- **Analytics: weekly activity recap** — add weekly activity recap endpoint (#1835)
 - **Mainnet: preflight checks** — mainnet launch readiness validation script (#1816)
 - **Discord: permission middleware** — declarative permission enforcement for command dispatcher (#1808)
 - **Ollama: Claude Code proxy** — add Claude Code proxy for Ollama cloud models (#1787)
@@ -32,6 +33,9 @@ All notable changes to this project will be documented in this file.
 - **Work: governance validator** — resolve false positives blocking legitimate work tasks (#1775)
 - **Work: TSC validation** — skip TypeScript check for projects without tsconfig.json (#1768)
 - **Work: worktree cleanup** — clean stale state and block creation on lingering worktrees (#1803, #1769)
+- **Security: input validation** — add max-length constraints to agent and session validation schemas (#1827)
+- **Work: queued inserts** — use non-atomic insert for queued work tasks (#1844)
+- **Work: origin remote** — ensure origin remote before fallback PR creation (#1830)
 - **Tests: env isolation** — use empty string instead of delete for Bun env var isolation (#1820)
 - **Tests: coverage** — add coverage for discord guild-api, contact-linker, memory-sync, session-heartbeat (#1821)
 - **Docs: testnet-onboarding** — correct project field name in onboarding guide (#1771)
@@ -55,10 +59,18 @@ All notable changes to this project will be documented in this file.
 - **Memory: deepSearch** — add coverage for deepSearch, search dispatch, LibrarySyncService (#1807)
 - **Scheduler: flock_reputation_refresh** — add coverage for flock reputation refresh action (#1778)
 - **Session: audit logging** — audit logging, tier transitions, and state machine tests (#1797, #1783)
+- **A2A: SSRF blocking** — add SSRF blocking coverage for invokeRemoteAgent and fetchAgentCard (#1837)
+- **Routes: untested handlers** — add route tests for 10 untested handlers (#1854, #1853)
+- **Discord: edge cases** — discord-permissions and priority-rules edge case tests (#1833)
+- **OpenRouter** — unit tests for OpenRouter routes (#1851)
+- **Billing** — tests for UsageMeter and db/usdc-revenue (#1850)
+- **Library/Contacts** — unit tests for library, contacts, and buddy routes (#1840)
 
 ### Dependencies
 - @anthropic-ai/claude-agent-sdk → 0.2.92
+- @anthropic-ai/sdk ≥ 0.82.0 (pinned for GHSA-5474-4w2j-mq4c) (#1841)
 - spec-sync → v3.2.0 (with stricter validation)
+- docker/login-action → 4.1.0, actions/checkout → 6.0.2, actions/upload-pages-artifact → 4.0.0
 
 ## [0.60.0] - 2026-03-30
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.59.1-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.61.0-blue" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>
@@ -124,7 +124,7 @@ skills/
 
 ## Tech stack
 
-Bun + Angular 21 + SQLite + Claude Agent SDK + Algorand (on-chain identity). 65 MCP tools, ~380 API endpoints, 1,268 test files, 211 module specs.
+Bun + Angular 21 + SQLite + Claude Agent SDK + Algorand (on-chain identity). 65 MCP tools, ~380 API endpoints, 1,300+ test files, 323 module specs.
 
 **[Architecture →](docs/how-it-works.md)** | **[Security →](SECURITY.md)** | **[Deployment →](docs/self-hosting.md)**
 

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>CorvidAgent — Release Retrospective: v0.1.0 → v0.60.0</title>
+<title>CorvidAgent — Release Retrospective: v0.1.0 → v0.61.0</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap');
 
@@ -473,28 +473,28 @@
 
   <!-- Hero -->
   <section class="hero">
-    <div class="hero-badge">53 days · 60 releases · 1100+ commits</div>
+    <div class="hero-badge">60 days · 61 releases · 1200+ commits</div>
     <h1>CorvidAgent<br>Release Retrospective</h1>
     <p>From a prototype CLI to a full autonomous AI agent platform with on-chain memory, multi-model orchestration, and cross-platform bridges.</p>
     <div class="hero-version-range">
       <span class="version">v0.1.0</span>
       <span class="arrow">→</span>
-      <span class="version">v0.60.0</span>
+      <span class="version">v0.61.0</span>
     </div>
   </section>
 
   <!-- Stats bar -->
   <section class="stats-bar">
     <div class="stat-card">
-      <div class="stat-number">60</div>
+      <div class="stat-number">61</div>
       <div class="stat-label">Releases</div>
     </div>
     <div class="stat-card">
-      <div class="stat-number">1100+</div>
+      <div class="stat-number">1200+</div>
       <div class="stat-label">Commits</div>
     </div>
     <div class="stat-card">
-      <div class="stat-number">10,500+</div>
+      <div class="stat-number">11,000+</div>
       <div class="stat-label">Unit Tests</div>
     </div>
     <div class="stat-card">
@@ -577,8 +577,16 @@
         <div class="growth-label">0.29</div>
       </div>
       <div class="growth-bar-wrapper">
-        <div class="growth-bar" style="height: 100%; background: linear-gradient(180deg, var(--green), var(--accent));" title="v0.41.0: 7,000+ tests"></div>
+        <div class="growth-bar" style="height: 100%" title="v0.41.0: 7,000+ tests"></div>
         <div class="growth-label">0.41</div>
+      </div>
+      <div class="growth-bar-wrapper">
+        <div class="growth-bar" style="height: 150%" title="v0.60.0: 10,500+ tests"></div>
+        <div class="growth-label">0.60</div>
+      </div>
+      <div class="growth-bar-wrapper">
+        <div class="growth-bar" style="height: 157%; background: linear-gradient(180deg, var(--green), var(--accent));" title="v0.61.0: 11,000+ tests"></div>
+        <div class="growth-label">0.61</div>
       </div>
     </div>
   </section>
@@ -950,7 +958,7 @@
           <div class="era-title">Scale — Provider Parity & Agent Observatory</div>
           <div class="era-date">Mar 21 – Mar 30, 2026</div>
         </div>
-        <div class="era-versions">v0.42.0 – v0.60.0</div>
+        <div class="era-versions">v0.42.0 – v0.61.0</div>
       </div>
       <div class="era-body">
         <div class="release-card">
@@ -994,6 +1002,22 @@
             <li><span class="tag tag-feat">feat</span> <strong>Shared agent library (CRVLIB)</strong> — ARC-69 reusable on-chain agent components</li>
             <li><span class="tag tag-test">test</span> <strong>Flock e2e: 45 tests</strong> — comprehensive e2e suite with inner transaction fee fix for AVM fee-pooling</li>
             <li><span class="tag tag-fix">fix</span> MCP tool permissions, scheduler tenant fallback, Ollama readiness probe</li>
+          </ul>
+        </div>
+        <div class="release-card" style="border-color: rgba(251,146,60,0.3); background: rgba(251,146,60,0.05);">
+          <div class="release-header">
+            <span class="release-version">v0.61.0</span>
+            <span class="release-date">Apr 5</span>
+          </div>
+          <ul class="release-highlights">
+            <li><span class="tag tag-feat">feat</span> <strong>Discord REST migration (5 phases)</strong> — replace all raw fetch() with discord.js REST client: foundation, gateway, slash commands, threads, embeds</li>
+            <li><span class="tag tag-feat">feat</span> <strong>Auth: proxy trust + hardening</strong> — oauth2-proxy email-based tenant auth, input validation, WS auth guard</li>
+            <li><span class="tag tag-feat">feat</span> <strong>Reputation-gated work</strong> — require minimum reputation for work task creation</li>
+            <li><span class="tag tag-feat">feat</span> <strong>Weekly activity recap</strong> — analytics endpoint for weekly activity summaries</li>
+            <li><span class="tag tag-feat">feat</span> <strong>Mainnet preflight</strong> — launch readiness validation script</li>
+            <li><span class="tag tag-sec">sec</span> SSRF guard, SDK pin (GHSA-5474-4w2j-mq4c), max-length validation, scope enforcement</li>
+            <li><span class="tag tag-test">test</span> <strong>Test coverage surge</strong> — 10+ test PRs covering routes, billing, OpenRouter, discord, A2A SSRF</li>
+            <li><span class="tag tag-chore">deps</span> actions/checkout → 6.0.2, docker/login-action → 4.1.0, @anthropic-ai/sdk ≥ 0.82.0</li>
           </ul>
         </div>
         <div class="release-card" style="border-color: rgba(74,222,128,0.3); background: rgba(74,222,128,0.05);">
@@ -1093,8 +1117,8 @@
   <!-- Footer -->
   <footer class="footer">
     <div class="footer-logo">CorvidAgent</div>
-    <p>Built by <a href="https://github.com/CorvidLabs">CorvidLabs</a> · Feb 6 – Mar 29, 2026</p>
-    <p style="margin-top: 8px;">52 days from zero to a full autonomous AI agent platform.</p>
+    <p>Built by <a href="https://github.com/CorvidLabs">CorvidLabs</a> · Feb 6 – Apr 5, 2026</p>
+    <p style="margin-top: 8px;">59 days from zero to a full autonomous AI agent platform.</p>
   </footer>
 
 </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary\n\n- Bump version to 0.61.0 in package.json\n- Update README badge (0.59.1 → 0.61.0), test files (1,268 → 1,300+), specs (211 → 323)\n- Add merged PRs to CHANGELOG (Discord Phases 3–5, auth hardening, security fixes, test coverage, CI bumps)\n- Add v0.61.0 release card to docs/releases.html, update hero stats and growth chart\n\n## Highlights for v0.61.0\n\n- **Discord REST Migration** — all 5 phases complete, raw fetch() fully eliminated\n- **Auth Phase 2** — proxy trust hardening, reputation-gated work tasks\n- **Security** — input validation, SSRF blocking, queued DB inserts, origin remote checks\n- **Testing** — 11,000+ unit tests, new coverage for A2A, routes, OpenRouter, billing, Discord edge cases\n- **CI** — dependency bumps, SDK pin\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)