### PR TITLE
fix(security): resolve 10 CodeQL alerts

### DIFF
--- a/cli/commands/doctor.ts
+++ b/cli/commands/doctor.ts
@@ -148,16 +148,26 @@ function checkProviders(envOverrides: Record<string, string>): CheckResult[] {
 async function checkPort(serverUrl: string): Promise<CheckResult> {
     // Extract port from configured server URL
     let port = 3000;
+    let parsedUrl: URL;
     try {
-        const url = new URL(serverUrl);
-        port = url.port ? parseInt(url.port, 10) : (url.protocol === 'https:' ? 443 : 80);
-    } catch { /* use default */ }
+        parsedUrl = new URL(serverUrl);
+        port = parsedUrl.port ? parseInt(parsedUrl.port, 10) : (parsedUrl.protocol === 'https:' ? 443 : 80);
+    } catch {
+        return fail(`Port ${port}`, 'invalid server URL', 'Check SERVER_URL in your config');
+    }
+
+    // Validate: only connect to localhost or known local addresses
+    const host = parsedUrl.hostname;
+    if (host !== 'localhost' && host !== '127.0.0.1' && host !== '::1' && !host.endsWith('.local')) {
+        return fail(`Port ${port}`, 'server URL is not a local address', 'Doctor only checks local server instances');
+    }
 
     // Try to connect to the server — if it responds, the server is already running (good)
+    const healthUrl = `${parsedUrl.origin}/api/health`;
     try {
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), 2000);
-        const res = await fetch(`${serverUrl}/api/health`, { signal: controller.signal });
+        const res = await fetch(healthUrl, { signal: controller.signal });
         clearTimeout(timer);
         if (res.ok) {
             return pass(`Port ${port}`, 'server already running');
@@ -181,12 +191,29 @@ async function checkAlgoChat(envOverrides: Record<string, string>): Promise<Chec
 
     if (network === 'localnet') {
         const algodUrl = getEnv('LOCALNET_ALGOD_URL', envOverrides) ?? 'http://localhost:4001';
+
+        // Validate algod URL is a local address before connecting
+        let parsedAlgod: URL;
+        try {
+            parsedAlgod = new URL(algodUrl);
+        } catch {
+            results.push(fail('Algorand localnet', 'invalid LOCALNET_ALGOD_URL', 'Check LOCALNET_ALGOD_URL in .env'));
+            return results;
+        }
+        const algodHost = parsedAlgod.hostname;
+        if (algodHost !== 'localhost' && algodHost !== '127.0.0.1' && algodHost !== '::1') {
+            results.push(fail('Algorand localnet', 'LOCALNET_ALGOD_URL is not a local address', 'Localnet algod should be on localhost'));
+            return results;
+        }
+
+        const algodToken = getEnv('ALGOD_TOKEN', envOverrides) ?? 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
         try {
             const controller = new AbortController();
             const timer = setTimeout(() => controller.abort(), 3000);
-            const res = await fetch(`${algodUrl}/v2/status`, {
+            const statusUrl = `${parsedAlgod.origin}/v2/status`;
+            const res = await fetch(statusUrl, {
                 signal: controller.signal,
-                headers: { 'X-Algo-API-Token': getEnv('ALGOD_TOKEN', envOverrides) ?? 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+                headers: { 'X-Algo-API-Token': algodToken },
             });
             clearTimeout(timer);
             if (res.ok) {

--- a/scripts/benchmark-system.ts
+++ b/scripts/benchmark-system.ts
@@ -17,7 +17,7 @@
  * @see https://github.com/CorvidLabs/corvid-agent/issues/747
  */
 
-import { existsSync, statSync, readdirSync } from "fs";
+import { existsSync, statSync } from "fs";
 import { join } from "path";
 
 // ─── Types ──────────────────────────────────────────────────────────────────

--- a/scripts/mainnet-preflight.ts
+++ b/scripts/mainnet-preflight.ts
@@ -18,7 +18,7 @@
  * Related: #311 (v1.0.0 — Mainnet Launch)
  */
 
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 const ROOT = resolve(import.meta.dir, '..');
@@ -317,7 +317,7 @@ if (existsSync(envPath)) {
     } else if (!network) {
         warn('env', 'ALGORAND_NETWORK not set in .env', 'Defaults to localnet — set to mainnet for production');
     } else {
-        fail('env', `ALGORAND_NETWORK=${network}`, 'Must be "mainnet" for production launch');
+        fail('env', 'ALGORAND_NETWORK is not set to mainnet', 'Must be "mainnet" for production launch');
     }
 
     // Check API_KEY
@@ -357,7 +357,7 @@ if (existsSync(envPath)) {
     } else if (!bindHost) {
         warn('env', 'BIND_HOST not set', 'Defaults to localhost — set to 0.0.0.0 for production with reverse proxy');
     } else {
-        warn('env', `BIND_HOST=${bindHost}`, 'Ensure this is correct for your production deployment');
+        warn('env', 'BIND_HOST is set (verify it matches your production deployment)');
     }
 
     // Check ALLOWED_ORIGINS
@@ -365,9 +365,9 @@ if (existsSync(envPath)) {
     if (!origins) {
         warn('env', 'ALLOWED_ORIGINS not set', 'Recommend restricting to production domain');
     } else if (origins.includes('localhost') || origins.includes('127.0.0.1')) {
-        warn('env', `ALLOWED_ORIGINS includes localhost: ${origins}`, 'Should be production domain only on mainnet');
+        warn('env', 'ALLOWED_ORIGINS includes localhost references', 'Should be production domain only on mainnet');
     } else {
-        pass('env', `ALLOWED_ORIGINS set: ${origins}`);
+        pass('env', 'ALLOWED_ORIGINS configured');
     }
 
     // Check ALGOCHAT_MNEMONIC
@@ -386,7 +386,7 @@ if (existsSync(envPath)) {
     // Check BACKUP_DIR
     const backupDir = envVars['BACKUP_DIR'];
     if (backupDir) {
-        pass('env', `BACKUP_DIR configured: ${backupDir}`);
+        pass('env', 'BACKUP_DIR configured');
     } else {
         warn('env', 'BACKUP_DIR not set', 'Required for daily database backups');
     }

--- a/scripts/rc-checklist.ts
+++ b/scripts/rc-checklist.ts
@@ -12,7 +12,7 @@
  * Related: #310 (v1.0.0-rc — Release Candidate)
  */
 
-import { execSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 


### PR DESCRIPTION
## Summary

Resolves CodeQL alerts #334-339, #359-362:

- **High (#359-361)**: `mainnet-preflight.ts` was logging raw env-derived values (network name, bind host, allowed origins, backup dir path) to console. Replaced with sanitized descriptions that don't leak config values.
- **Medium (#334-337)**: `doctor.ts` was sending env-sourced data in fetch requests without URL validation. Added localhost validation for `serverUrl` and `algodUrl` before sending any credentials — doctor only checks local server instances.
- **Note (#338-339, #362)**: Removed unused imports — `readdirSync` from mainnet-preflight and benchmark-system, `execSync` from rc-checklist.

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` passes (verified)
- [x] `bun scripts/mainnet-preflight.ts` still runs and shows sanitized output
- [x] `corvid doctor` still works for local server checks
- [x] CodeQL re-scan clears the 10 alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6