### PR TITLE
chore: update specsync from v3.2.0 to v3.3.0

### DIFF
--- a/scripts/specsync.sh
+++ b/scripts/specsync.sh
@@ -3,7 +3,7 @@
 # Downloads the correct binary from CorvidLabs/spec-sync releases on first use.
 set -euo pipefail
 
-SPECSYNC_VERSION="${SPECSYNC_VERSION:-v3.2.0}"
+SPECSYNC_VERSION="${SPECSYNC_VERSION:-v3.3.0}"
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/specsync"
 BINARY="$CACHE_DIR/$SPECSYNC_VERSION/specsync"
 


### PR DESCRIPTION
## Summary
- Bump default specsync version in `scripts/specsync.sh` from v3.2.0 to v3.3.0
- All 211 specs pass, 100% file and LOC coverage

## Test plan
- [x] `bun run spec:check` passes with v3.3.0
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)