### PR TITLE
fix: queue work tasks on concurrency race instead of rejecting

### DIFF
--- a/server/work/service.ts
+++ b/server/work/service.ts
@@ -713,6 +713,34 @@ export class WorkTaskService {
             tenantId,
         });
         if (!task) {
+            // Race condition: another task became active between getActiveTaskForProject
+            // and the atomic insert. Queue behind it instead of rejecting.
+            const raceActiveTask = getActiveTaskForProject(this.db, projectId);
+            if (raceActiveTask) {
+                const queued = createWorkTask(this.db, {
+                    agentId: input.agentId,
+                    projectId,
+                    description: input.description,
+                    source: input.source,
+                    sourceId: input.sourceId,
+                    requesterInfo: input.requesterInfo,
+                    priority,
+                    tenantId,
+                });
+                updateWorkTaskStatus(this.db, queued.id, 'queued');
+                this.setTaskPriority(queued, priority);
+                this.storeTierOverride(queued.id, input.modelTier);
+                this.storeBuddyConfig(queued.id, input);
+                log.info('Work task queued (race condition recovery)', {
+                    taskId: queued.id,
+                    activeTaskId: raceActiveTask.id,
+                    priority,
+                });
+                this.emitCreationNotifications(queued, input);
+                const enriched = getWorkTask(this.db, queued.id) ?? queued;
+                return this.enrichTask(enriched);
+            }
+            // Truly unexpected — no active task found but atomic insert still failed
             throw new ConflictError('Another task is already active on project', { projectId });
         }
 


### PR DESCRIPTION
## Summary

- When `createWorkTaskAtomic` fails due to a race condition (another task activated between the active-task check and the atomic INSERT), the code now falls back to **queuing** the task instead of throwing a `ConflictError`
- This prevents scheduled tasks like "Daily Issue Triage" from failing when they collide with already-running tasks

## Root Cause

The `create()` method in `WorkTaskService` has three paths: queue (Path A), preempt (Path B), and run immediately (Path C). Path C uses an atomic INSERT with a `WHERE NOT EXISTS` guard. When a task starts between `getActiveTaskForProject()` and the atomic INSERT, Path C throws `ConflictError` — but should queue instead, since queuing infrastructure already exists.

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` passes
- [x] Verify scheduled triage no longer fails on active task collision
- [x] Confirm queued tasks execute after active task completes

Fixes #1864

🤖 Generated with [Claude Code](https://claude.com/claude-code)