### PR TITLE
fix(test): prevent mock.module contamination of discord-bridge tests

### DIFF
--- a/server/__tests__/discord-tool-handlers.test.ts
+++ b/server/__tests__/discord-tool-handlers.test.ts
@@ -4,18 +4,18 @@ import { runMigrations } from '../db/schema';
 import type { McpToolContext } from '../mcp/tool-handlers/types';
 import { mockDiscordRest } from './helpers/mock-discord-rest';
 
-// Create controllable mocks for embeds functions. This is necessary because
+// Create controllable mock for sendMessageWithFiles. This is necessary because
 // routes-discord-image.test.ts uses mock.module to replace sendMessageWithFiles,
 // which persists in Bun's module cache and would bypass _setRestClientForTesting.
-// By owning the mock here, we can control return values per-test.
+// NOTE: We intentionally do NOT mock sendDiscordMessage here — doing so would
+// contaminate the module cache for discord-bridge.test.ts and other files that
+// rely on the real sendDiscordMessage calling through to the REST client.
 const mockSendMessageWithFiles = mock((..._args: unknown[]) => Promise.resolve('mock-msg-1' as string | null));
-const mockSendDiscordMessage = mock((..._args: unknown[]) => Promise.resolve());
 
 const realEmbeds = await import('../discord/embeds');
 mock.module('../discord/embeds', () => ({
     ...realEmbeds,
     sendMessageWithFiles: mockSendMessageWithFiles,
-    sendDiscordMessage: mockSendDiscordMessage,
 }));
 
 const { handleDiscordSendMessage, handleDiscordSendImage } = await import('../mcp/tool-handlers/discord');
@@ -42,9 +42,8 @@ beforeEach(() => {
     process.env.DISCORD_BOT_TOKEN = 'test-token';
     const { cleanup } = mockDiscordRest();
     restCleanup = cleanup;
-    // Reset mocks to default success behavior
+    // Reset mock to default success behavior
     mockSendMessageWithFiles.mockImplementation((..._args: unknown[]) => Promise.resolve('mock-msg-1'));
-    mockSendDiscordMessage.mockImplementation((..._args: unknown[]) => Promise.resolve());
 });
 
 afterEach(() => {

--- a/server/__tests__/thread-lifecycle.test.ts
+++ b/server/__tests__/thread-lifecycle.test.ts
@@ -6,8 +6,12 @@
  */
 import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 
-// Mock embeds module — we only need buildActionRow and assertSnowflake.
+// Preserve real embeds exports so we don't strip sendDiscordMessage etc. from the
+// module cache (which would break discord-bridge.test.ts if it runs after this file).
+const realEmbeds = await import('../discord/embeds');
+
 mock.module('../discord/embeds', () => ({
+    ...realEmbeds,
     buildActionRow: mock((..._args: unknown[]) => ({ type: 1, components: [] })),
     assertSnowflake: (value: string, label: string) => {
         if (!/^\d{17,20}$/.test(value)) {


### PR DESCRIPTION
## Summary
- **discord-tool-handlers**: Stop mocking `sendDiscordMessage` — only `sendMessageWithFiles` needs mocking. The `sendDiscordMessage` mock persisted in Bun's module cache and caused discord-bridge tests to get a no-op stub instead of the real function.
- **thread-lifecycle**: Spread `realEmbeds` before overriding `buildActionRow` and `assertSnowflake` so `sendDiscordMessage` stays in the module cache.

Fixes 3 CI test failures introduced by mock.module cache contamination across test files:
- `sendMessage splits long messages`
- `@mention with Ollama agent sends complexity warning`
- `work_intake mode errors without WorkTaskService`

## Test plan
- [x] `bun test server/__tests__/discord-tool-handlers.test.ts server/__tests__/discord-bridge.test.ts` — 46 pass, 0 fail
- [x] All 4 Discord test files together — 71 pass, 0 fail
- [x] Full test suite — 10108 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6