### PR TITLE
fix(memory): prevent upsert from demoting confirmed memories

### DIFF
--- a/server/__tests__/agent-memories.test.ts
+++ b/server/__tests__/agent-memories.test.ts
@@ -72,19 +72,21 @@ describe('Save and Recall', () => {
     expect(all).toHaveLength(1);
   });
 
-  test('upsert resets txid to null', () => {
+  test('upsert preserves confirmed status and txid', () => {
     const mem = saveMemory(db, { agentId, key: 'sync', content: 'original' });
     updateMemoryTxid(db, mem.id, 'TX_CONFIRMED');
+    updateMemoryStatus(db, mem.id, 'confirmed');
 
     const confirmed = recallMemory(db, agentId, 'sync');
     expect(confirmed!.txid).toBe('TX_CONFIRMED');
     expect(confirmed!.status).toBe('confirmed');
 
-    // Upsert should reset txid
+    // Upsert should preserve confirmed status and txid (no demotion)
     saveMemory(db, { agentId, key: 'sync', content: 'updated' });
     const after = recallMemory(db, agentId, 'sync');
-    expect(after!.txid).toBeNull();
-    expect(after!.status).toBe('short_term');
+    expect(after!.txid).toBe('TX_CONFIRMED');
+    expect(after!.status).toBe('confirmed');
+    expect(after!.content).toBe('updated');
   });
 });
 
@@ -258,13 +260,13 @@ describe('List Memories', () => {
 // ─── Status & Txid Updates ───────────────────────────────────────────────────
 
 describe('Status and Txid Updates', () => {
-  test('updateMemoryTxid sets txid and confirms', () => {
+  test('updateMemoryTxid sets txid without changing status', () => {
     const mem = saveMemory(db, { agentId, key: 'tx-test', content: 'data' });
     updateMemoryTxid(db, mem.id, 'TXID_ABC123');
 
     const updated = recallMemory(db, agentId, 'tx-test');
     expect(updated!.txid).toBe('TXID_ABC123');
-    expect(updated!.status).toBe('confirmed');
+    expect(updated!.status).toBe('short_term'); // txid update alone doesn't change status
   });
 
   test('updateMemoryStatus changes status', () => {
@@ -276,19 +278,21 @@ describe('Status and Txid Updates', () => {
     expect(found!.status).toBe('failed');
   });
 
-  test('status transition: short_term → confirmed → short_term (on re-save)', () => {
+  test('status transition: short_term → confirmed preserves on re-save', () => {
     const mem = saveMemory(db, { agentId, key: 'lifecycle', content: 'v1' });
     expect(mem.status).toBe('short_term');
     updateMemoryTxid(db, mem.id, 'TX1');
+    updateMemoryStatus(db, mem.id, 'confirmed');
 
     const confirmed = recallMemory(db, agentId, 'lifecycle');
     expect(confirmed!.status).toBe('confirmed');
 
-    // Re-save with new content resets to short_term (needs re-promotion)
+    // Re-save with new content preserves confirmed status (no demotion)
     saveMemory(db, { agentId, key: 'lifecycle', content: 'v2' });
     const afterUpdate = recallMemory(db, agentId, 'lifecycle');
-    expect(afterUpdate!.status).toBe('short_term');
-    expect(afterUpdate!.txid).toBeNull();
+    expect(afterUpdate!.status).toBe('confirmed');
+    expect(afterUpdate!.txid).toBe('TX1');
+    expect(afterUpdate!.content).toBe('v2');
   });
 });
 
@@ -347,8 +351,9 @@ describe('Pending Memories', () => {
     updateMemoryStatus(db, mb.id, 'pending');
     expect(countPendingMemories(db)).toBe(2);
 
-    // Confirm one
+    // Confirm one (requires explicit status update, txid alone doesn't change status)
     updateMemoryTxid(db, ma.id, 'TX1');
+    updateMemoryStatus(db, ma.id, 'confirmed');
     expect(countPendingMemories(db)).toBe(1);
   });
 

--- a/server/__tests__/memory-sync.test.ts
+++ b/server/__tests__/memory-sync.test.ts
@@ -189,6 +189,7 @@ describe('MemorySyncService tick', () => {
     expect(mockEncryptMemoryContent).toHaveBeenCalledTimes(1);
     expect(messenger.sendOnChainToSelf).toHaveBeenCalledTimes(1);
     expect(mockUpdateMemoryTxid).toHaveBeenCalledWith(db, 'mem-1', 'txid-xyz');
+    expect(mockUpdateMemoryStatus).toHaveBeenCalledWith(db, 'mem-1', 'confirmed');
   });
 
   test('tick skips failed memory within backoff window', async () => {
@@ -205,6 +206,23 @@ describe('MemorySyncService tick', () => {
 
     expect(mockUpdateMemoryTxid).not.toHaveBeenCalled();
     expect(mockUpdateMemoryStatus).not.toHaveBeenCalled();
+  });
+
+  test('tick marks memory as failed when localnet ARC-69 is unavailable', async () => {
+    const messenger = makeMockMessenger();
+    const walletService = {
+      checkAndRefill: mock(async () => {}),
+      getAlgoChatService: () => ({ algodClient: {}, indexerClient: null }),
+      getAgentChatAccount: mock(async () => null),
+    } as unknown as import('../algochat/agent-wallet').AgentWalletService;
+    service.setServices(messenger, undefined, 'localnet');
+    service.setWalletService(walletService);
+    mockGetPendingMemories.mockImplementation(() => [makeMemory()]);
+
+    await service.tick();
+
+    expect(mockUpdateMemoryStatus).toHaveBeenCalledWith(db, 'mem-1', 'failed');
+    expect(mockUpdateMemoryTxid).not.toHaveBeenCalled();
   });
 
   test('tick retries failed memory outside backoff window (non-localnet)', async () => {

--- a/server/__tests__/tool-handlers.test.ts
+++ b/server/__tests__/tool-handlers.test.ts
@@ -45,7 +45,7 @@ mock.module('../algochat/config', () => ({
   _resetConfigCache: () => {},
 }));
 
-import { saveMemory, updateMemoryStatus, updateMemoryTxid } from '../db/agent-memories';
+import { recallMemory, saveMemory, updateMemoryStatus, updateMemoryTxid } from '../db/agent-memories';
 import { grantCredits } from '../db/credits';
 import { getSchedule } from '../db/schedules';
 import { buildDirectTools } from '../mcp/direct-tools';
@@ -64,6 +64,7 @@ import {
   handleRecallMemory,
   handleSaveMemory,
   handleSendMessage,
+  handleSyncOnChainMemories,
   type McpToolContext,
 } from '../mcp/tool-handlers';
 
@@ -1256,6 +1257,61 @@ describe('handlePromoteMemory', () => {
     const promTool = tools.find((t) => t.name === 'corvid_promote_memory');
     expect(promTool).toBeDefined();
     expect(promTool!.parameters.required).toContain('key');
+  });
+});
+
+// ─── handleSyncOnChainMemories ───────────────────────────────────────────────
+
+describe('handleSyncOnChainMemories', () => {
+  test('syncs plain transaction memories and marks as confirmed', async () => {
+    const ctx = createMockContext({
+      agentMessenger: {
+        readOnChainMemories: mock(() =>
+          Promise.resolve([
+            { key: 'chain-key-1', content: 'chain content 1', txid: 'TX_CHAIN_1' },
+            { key: 'chain-key-2', content: 'chain content 2', txid: 'TX_CHAIN_2' },
+          ]),
+        ),
+      } as unknown as McpToolContext['agentMessenger'],
+      agentWalletService: {} as McpToolContext['agentWalletService'],
+    });
+
+    const result = await handleSyncOnChainMemories(ctx, {});
+    expect(result.isError).toBeFalsy();
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('restored/updated');
+
+    // Verify both memories were saved and confirmed
+    const mem1 = recallMemory(db, agentId, 'chain-key-1');
+    expect(mem1).toBeDefined();
+    expect(mem1!.status).toBe('confirmed');
+    expect(mem1!.txid).toBe('TX_CHAIN_1');
+
+    const mem2 = recallMemory(db, agentId, 'chain-key-2');
+    expect(mem2).toBeDefined();
+    expect(mem2!.status).toBe('confirmed');
+    expect(mem2!.txid).toBe('TX_CHAIN_2');
+  });
+
+  test('upgrades existing non-confirmed memory to confirmed on sync', async () => {
+    // Pre-save a memory locally (short_term, no txid)
+    saveMemory(db, { agentId, key: 'existing-sync', content: 'local content' });
+
+    const ctx = createMockContext({
+      agentMessenger: {
+        readOnChainMemories: mock(() =>
+          Promise.resolve([{ key: 'existing-sync', content: 'chain content', txid: 'TX_UPGRADE' }]),
+        ),
+      } as unknown as McpToolContext['agentMessenger'],
+      agentWalletService: {} as McpToolContext['agentWalletService'],
+    });
+
+    const result = await handleSyncOnChainMemories(ctx, {});
+    expect(result.isError).toBeFalsy();
+
+    const mem = recallMemory(db, agentId, 'existing-sync');
+    expect(mem!.status).toBe('confirmed');
+    expect(mem!.txid).toBe('TX_UPGRADE');
   });
 });
 

--- a/server/__tests__/tool-handlers.test.ts
+++ b/server/__tests__/tool-handlers.test.ts
@@ -45,7 +45,7 @@ mock.module('../algochat/config', () => ({
   _resetConfigCache: () => {},
 }));
 
-import { saveMemory, updateMemoryTxid } from '../db/agent-memories';
+import { saveMemory, updateMemoryStatus, updateMemoryTxid } from '../db/agent-memories';
 import { grantCredits } from '../db/credits';
 import { getSchedule } from '../db/schedules';
 import { buildDirectTools } from '../mcp/direct-tools';
@@ -1077,6 +1077,7 @@ describe('handleRecallMemory', () => {
   test('recall by key shows full txid when confirmed', async () => {
     const mem = saveMemory(db, { agentId, key: 'full-txid-key', content: 'txid-content' });
     updateMemoryTxid(db, mem.id, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789012345678901234');
+    updateMemoryStatus(db, mem.id, 'confirmed');
     const ctx = createMockContext();
     const result = await handleRecallMemory(ctx, { key: 'full-txid-key' });
     const text = (result.content[0] as { text: string }).text;
@@ -1139,6 +1140,7 @@ describe('handleRecallMemory', () => {
   test('search results include txid when confirmed', async () => {
     const mem = saveMemory(db, { agentId, key: 'search-txid', content: 'searchable content' });
     updateMemoryTxid(db, mem.id, 'FULLTXIDINSEARCH');
+    updateMemoryStatus(db, mem.id, 'confirmed');
     const ctx = createMockContext();
     const result = await handleRecallMemory(ctx, { query: 'searchable' });
     const text = (result.content[0] as { text: string }).text;

--- a/server/db/agent-memories.ts
+++ b/server/db/agent-memories.ts
@@ -43,9 +43,23 @@ export function saveMemory(
          VALUES (?, ?, ?, ?, 'short_term', datetime('now', ?))
          ON CONFLICT(agent_id, key) DO UPDATE SET
              content = excluded.content,
-             status = 'short_term',
-             txid = NULL,
-             expires_at = datetime('now', ?),
+             -- Preserve on-chain status: only reset to short_term if not already promoted
+             status = CASE
+                 WHEN agent_memories.status IN ('confirmed', 'pending')
+                 THEN agent_memories.status
+                 ELSE 'short_term'
+             END,
+             -- Preserve txid/asa_id for promoted memories
+             txid = CASE
+                 WHEN agent_memories.status IN ('confirmed', 'pending')
+                 THEN agent_memories.txid
+                 ELSE NULL
+             END,
+             expires_at = CASE
+                 WHEN agent_memories.status IN ('confirmed', 'pending')
+                 THEN NULL
+                 ELSE datetime('now', ?)
+             END,
              access_count = 0,
              updated_at = datetime('now')`,
   ).run(id, params.agentId, params.key, params.content, `+${ttl} days`, `+${ttl} days`);
@@ -173,7 +187,7 @@ export function listMemories(db: Database, agentId: string): AgentMemory[] {
 }
 
 export function updateMemoryTxid(db: Database, id: string, txid: string): void {
-  db.query("UPDATE agent_memories SET txid = ?, status = 'confirmed' WHERE id = ?").run(txid, id);
+  db.query("UPDATE agent_memories SET txid = ?, updated_at = datetime('now') WHERE id = ?").run(txid, id);
 }
 
 export function updateMemoryStatus(db: Database, id: string, status: MemoryStatus): void {

--- a/server/db/memory-sync.ts
+++ b/server/db/memory-sync.ts
@@ -114,11 +114,12 @@ export class MemorySyncService {
                 continue;
               }
               // syncViaArc69 returned false — ARC-69 infra unavailable (no indexer, no chat account)
-              log.warn('ARC-69 unavailable on localnet, memory stays pending', {
+              log.warn('ARC-69 unavailable on localnet, marking memory as failed for retry', {
                 key: memory.key,
                 agentId: memory.agentId,
               });
-              skipped++;
+              updateMemoryStatus(this.db, memory.id, 'failed');
+              failed++;
               continue;
             } catch (err) {
               log.warn('ARC-69 sync failed on localnet, marking failed for retry', {
@@ -140,6 +141,7 @@ export class MemorySyncService {
 
           if (txid) {
             updateMemoryTxid(this.db, memory.id, txid);
+            updateMemoryStatus(this.db, memory.id, 'confirmed');
             synced++;
           } else {
             // sendOnChainToSelf returned null — no wallet, stay pending
@@ -196,10 +198,12 @@ export class MemorySyncService {
     if (existingAsaId) {
       const { txid } = await updateMemoryAsa(ctx, existingAsaId, memory.key, memory.content);
       updateMemoryTxid(this.db, memory.id, txid);
+      updateMemoryStatus(this.db, memory.id, 'confirmed');
     } else {
       const { asaId, txid } = await createMemoryAsa(ctx, memory.key, memory.content);
       updateMemoryTxid(this.db, memory.id, txid);
       updateMemoryAsaId(this.db, memory.id, asaId);
+      updateMemoryStatus(this.db, memory.id, 'confirmed');
     }
 
     return true;

--- a/server/mcp/tool-handlers/memory.ts
+++ b/server/mcp/tool-handlers/memory.ts
@@ -137,6 +137,7 @@ export async function handlePromoteMemory(ctx: McpToolContext, args: { key: stri
           if (txid) {
             try {
               updateMemoryTxid(ctx.db, memory.id, txid);
+              updateMemoryStatus(ctx.db, memory.id, 'confirmed');
             } catch {
               // DB may be closed during test teardown — safe to ignore
             }
@@ -389,6 +390,7 @@ export async function handleSyncOnChainMemories(
                 // Local row exists but doesn't know about its ASA — update it
                 updateMemoryAsaId(ctx.db, existing.id, m.asaId);
                 updateMemoryTxid(ctx.db, existing.id, m.txid);
+                updateMemoryStatus(ctx.db, existing.id, 'confirmed');
                 asaSynced++;
               } else {
                 skipped++;
@@ -402,6 +404,7 @@ export async function handleSyncOnChainMemories(
               });
               updateMemoryTxid(ctx.db, saved.id, m.txid);
               updateMemoryAsaId(ctx.db, saved.id, m.asaId);
+              updateMemoryStatus(ctx.db, saved.id, 'confirmed');
               asaSynced++;
             }
           }
@@ -423,6 +426,7 @@ export async function handleSyncOnChainMemories(
       if (existing) {
         if (existing.status !== 'confirmed' && m.txid) {
           updateMemoryTxid(ctx.db, existing.id, m.txid);
+          updateMemoryStatus(ctx.db, existing.id, 'confirmed');
           synced++;
         } else {
           skipped++;
@@ -434,6 +438,7 @@ export async function handleSyncOnChainMemories(
           content: m.content,
         });
         updateMemoryTxid(ctx.db, saved.id, m.txid);
+        updateMemoryStatus(ctx.db, saved.id, 'confirmed');
         synced++;
       }
     }


### PR DESCRIPTION
## Summary

- **Upsert demotion fix**: `saveMemory()` ON CONFLICT clause was unconditionally resetting `status` to `short_term` and clearing `txid` — updating content of a confirmed memory wiped its on-chain status. Now preserves confirmed/pending status, txid, and asaId.
- **Decoupled status from txid update**: `updateMemoryTxid()` silently set status to `confirmed` before ASA ID was persisted. Callers now set status explicitly after both txid and asaId are saved.
- **Infrastructure failure visibility**: Memory sync silently skipped when ARC-69 infra was unavailable, leaving memories stuck in `pending` forever. Now marks them as `failed` so the UI shows "sync-failed — will retry" and backoff logic handles retries.

## Files changed
- `server/db/agent-memories.ts` — upsert preservation + txid decoupling
- `server/db/memory-sync.ts` — explicit status setting + failure marking
- `server/mcp/tool-handlers/memory.ts` — explicit status setting after sync restore

## Test plan
- [x] TSC passes (`bun x tsc --noEmit --skipLibCheck`)
- [x] No lint issues in changed files
- [x] 10173 tests pass (6 pre-existing failures unrelated to memory)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6