### PR TITLE
feat(library): enforce librarian permission model on corvid_library_write

### DIFF
--- a/server/__tests__/library-tool-handler.test.ts
+++ b/server/__tests__/library-tool-handler.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for corvid_library_write librarian permission model.
+ *
+ * Only agents in LIBRARIAN_AGENT_IDS may write to the shared library.
+ * All other agents receive an error.
+ */
+import { Database } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { runMigrations } from '../db/schema';
+import { handleLibraryWrite } from '../mcp/tool-handlers/library';
+import type { McpToolContext } from '../mcp/tool-handlers/types';
+
+// CorvidAgent — the default librarian
+const CORVID_AGENT_ID = '90cf34fa-1478-454c-a789-1c87cbb0d552';
+const OTHER_AGENT_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+let db: Database;
+
+function createMockContext(agentId: string): McpToolContext {
+  return {
+    agentId,
+    db,
+    agentMessenger: {} as McpToolContext['agentMessenger'],
+    agentDirectory: {} as McpToolContext['agentDirectory'],
+    agentWalletService: {
+      getAlgoChatService: () => ({ indexerClient: null }),
+    } as unknown as McpToolContext['agentWalletService'],
+    network: 'localnet',
+  };
+}
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  runMigrations(db);
+  db.query('INSERT INTO agents (id, name) VALUES (?, ?)').run(CORVID_AGENT_ID, 'CorvidAgent');
+  db.query('INSERT INTO agents (id, name) VALUES (?, ?)').run(OTHER_AGENT_ID, 'OtherAgent');
+});
+
+afterEach(() => db.close());
+
+describe('handleLibraryWrite — librarian permission model', () => {
+  it('allows CorvidAgent (librarian) to write', async () => {
+    const ctx = createMockContext(CORVID_AGENT_ID);
+    const result = await handleLibraryWrite(ctx, {
+      key: 'test-entry',
+      content: 'Hello library',
+      category: 'reference',
+    });
+    // Should save to local cache successfully (no wallet = local-only)
+    expect(result.isError).toBeUndefined();
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toContain('test-entry');
+    expect(text).toContain('local cache');
+  });
+
+  it('denies non-librarian agents', async () => {
+    const ctx = createMockContext(OTHER_AGENT_ID);
+    const result = await handleLibraryWrite(ctx, {
+      key: 'test-entry',
+      content: 'Should be rejected',
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toBe('Only agents with librarian role can write to the shared library');
+  });
+
+  it('returns error for invalid category even for librarian', async () => {
+    const ctx = createMockContext(CORVID_AGENT_ID);
+    const result = await handleLibraryWrite(ctx, {
+      key: 'test-entry',
+      content: 'Content',
+      category: 'bogus',
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toContain('Invalid category');
+  });
+
+  it('non-librarian cannot write regardless of category', async () => {
+    const ctx = createMockContext(OTHER_AGENT_ID);
+    for (const category of ['guide', 'reference', 'decision', 'standard', 'runbook']) {
+      const result = await handleLibraryWrite(ctx, {
+        key: `test-${category}`,
+        content: 'Content',
+        category,
+      });
+      expect(result.isError).toBe(true);
+    }
+  });
+});

--- a/server/mcp/tool-handlers/library.ts
+++ b/server/mcp/tool-handlers/library.ts
@@ -28,6 +28,14 @@ const log = createLogger('McpLibraryHandlers');
 const VALID_CATEGORIES: LibraryCategory[] = ['guide', 'reference', 'decision', 'standard', 'runbook'];
 
 /**
+ * Agents permitted to write to the shared library.
+ * All other callers receive an error. CorvidAgent is the default librarian.
+ */
+const LIBRARIAN_AGENT_IDS: ReadonlySet<string> = new Set([
+  '90cf34fa-1478-454c-a789-1c87cbb0d552', // CorvidAgent — default librarian
+]);
+
+/**
  * Build a LibraryContext from the MCP tool context.
  * Returns null if any required component is unavailable.
  */
@@ -152,6 +160,10 @@ export async function handleLibraryWrite(
   },
 ): Promise<CallToolResult> {
   try {
+    if (!LIBRARIAN_AGENT_IDS.has(ctx.agentId)) {
+      return errorResult('Only agents with librarian role can write to the shared library');
+    }
+
     const category = (args.category as LibraryCategory) ?? 'reference';
     if (!VALID_CATEGORIES.includes(category)) {
       return errorResult(`Invalid category "${args.category}". Valid: ${VALID_CATEGORIES.join(', ')}`);


### PR DESCRIPTION
## Summary

- Add `LIBRARIAN_AGENT_IDS` constant to `server/mcp/tool-handlers/library.ts` with CorvidAgent as the default librarian
- Enforce the check at the top of `handleLibraryWrite` — non-librarian agents receive `"Only agents with librarian role can write to the shared library"`
- Add 4 tests in `server/__tests__/library-tool-handler.test.ts` covering allow/deny paths

## Motivation

The librarian permission model was fully specified in `specs/memory/arc69-library.spec.md` (Librarian Permission Model section) but was never implemented in the handler. Any agent could call `corvid_library_write` and mutate shared knowledge — this fix closes that gap.

## Test plan

- [x] `bun test server/__tests__/library-tool-handler.test.ts` — 4/4 pass
- [x] `bun test` (all library tests) — 79/79 pass
- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun run spec:check --force` — `arc69-library` spec: 37/37 exports, all invariants satisfied
- [x] `biome check` on changed files — clean

Closes #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)