### PR TITLE
fix(shared): convert bracket notation to dot notation in ws-protocol type guard

### DIFF
--- a/server/__tests__/library-tool-handler.test.ts
+++ b/server/__tests__/library-tool-handler.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for corvid_library_write librarian permission model.
+ *
+ * Only agents in LIBRARIAN_AGENT_IDS may write to the shared library.
+ * All other agents receive an error.
+ */
+import { Database } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { runMigrations } from '../db/schema';
+import { handleLibraryWrite } from '../mcp/tool-handlers/library';
+import type { McpToolContext } from '../mcp/tool-handlers/types';
+
+// CorvidAgent — the default librarian
+const CORVID_AGENT_ID = '90cf34fa-1478-454c-a789-1c87cbb0d552';
+const OTHER_AGENT_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+let db: Database;
+
+function createMockContext(agentId: string): McpToolContext {
+  return {
+    agentId,
+    db,
+    agentMessenger: {} as McpToolContext['agentMessenger'],
+    agentDirectory: {} as McpToolContext['agentDirectory'],
+    agentWalletService: {
+      getAlgoChatService: () => ({ indexerClient: null }),
+    } as unknown as McpToolContext['agentWalletService'],
+    network: 'localnet',
+  };
+}
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  runMigrations(db);
+  db.query('INSERT INTO agents (id, name) VALUES (?, ?)').run(CORVID_AGENT_ID, 'CorvidAgent');
+  db.query('INSERT INTO agents (id, name) VALUES (?, ?)').run(OTHER_AGENT_ID, 'OtherAgent');
+});
+
+afterEach(() => db.close());
+
+describe('handleLibraryWrite — librarian permission model', () => {
+  it('allows CorvidAgent (librarian) to write', async () => {
+    const ctx = createMockContext(CORVID_AGENT_ID);
+    const result = await handleLibraryWrite(ctx, {
+      key: 'test-entry',
+      content: 'Hello library',
+      category: 'reference',
+    });
+    // Should save to local cache successfully (no wallet = local-only)
+    expect(result.isError).toBeUndefined();
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toContain('test-entry');
+    expect(text).toContain('local cache');
+  });
+
+  it('denies non-librarian agents', async () => {
+    const ctx = createMockContext(OTHER_AGENT_ID);
+    const result = await handleLibraryWrite(ctx, {
+      key: 'test-entry',
+      content: 'Should be rejected',
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toBe('Only agents with librarian role can write to the shared library');
+  });
+
+  it('returns error for invalid category even for librarian', async () => {
+    const ctx = createMockContext(CORVID_AGENT_ID);
+    const result = await handleLibraryWrite(ctx, {
+      key: 'test-entry',
+      content: 'Content',
+      category: 'bogus',
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toContain('Invalid category');
+  });
+
+  it('non-librarian cannot write regardless of category', async () => {
+    const ctx = createMockContext(OTHER_AGENT_ID);
+    for (const category of ['guide', 'reference', 'decision', 'standard', 'runbook']) {
+      const result = await handleLibraryWrite(ctx, {
+        key: `test-${category}`,
+        content: 'Content',
+        category,
+      });
+      expect(result.isError).toBe(true);
+    }
+  });
+});

--- a/server/__tests__/scheduler-github-comment-monitor.test.ts
+++ b/server/__tests__/scheduler-github-comment-monitor.test.ts
@@ -1,71 +1,73 @@
 /**
  * Tests for the github_comment_monitor schedule handler.
  */
-import { test, expect, describe, beforeEach, afterEach, mock } from 'bun:test';
+
 import { Database } from 'bun:sqlite';
-import { runMigrations } from '../db/schema';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { AgentSchedule, ScheduleAction } from '../../shared/types';
 import { addToGitHubAllowlist } from '../db/github-allowlist';
+import { runMigrations } from '../db/schema';
 import { execGitHubCommentMonitor } from '../scheduler/handlers/github-comment-monitor';
 import type { HandlerContext } from '../scheduler/handlers/types';
-import type { AgentSchedule, ScheduleAction } from '../../shared/types';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function createMockCtx(db: Database): HandlerContext {
-    return {
-        db,
-        processManager: {} as any,
-        workTaskService: null,
-        agentMessenger: null,
-        improvementLoopService: null,
-        reputationScorer: null,
-        reputationAttestation: null,
-        outcomeTrackerService: null,
-        dailyReviewService: null,
-        systemStateDetector: {} as any,
-        runningExecutions: new Set(),
-        resolveScheduleTenantId: () => 'default',
-    };
+  return {
+    db,
+    processManager: {} as any,
+    workTaskService: null,
+    agentMessenger: null,
+    improvementLoopService: null,
+    reputationScorer: null,
+    reputationAttestation: null,
+    outcomeTrackerService: null,
+    dailyReviewService: null,
+    systemStateDetector: {} as any,
+    runningExecutions: new Set(),
+    resolveScheduleTenantId: () => 'default',
+  };
 }
 
 function createMockSchedule(): AgentSchedule {
-    return {
-        id: 'sched-1',
-        agentId: 'agent-1',
-        name: 'GitHub Comment Monitor Test',
-        description: 'Test schedule',
-        cronExpression: '0 0 * * *',
-        intervalMs: null,
-        actions: [{ type: 'github_comment_monitor' }],
-        approvalPolicy: 'auto',
-        status: 'active',
-        maxExecutions: null,
-        executionCount: 0,
-        maxBudgetPerRun: null,
-        notifyAddress: null,
-        triggerEvents: null,
-        outputDestinations: null,
-        executionMode: 'independent',
-        pipelineSteps: null,
-        lastRunAt: null,
-        nextRunAt: null,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-    };
+  return {
+    id: 'sched-1',
+    agentId: 'agent-1',
+    name: 'GitHub Comment Monitor Test',
+    description: 'Test schedule',
+    cronExpression: '0 0 * * *',
+    intervalMs: null,
+    actions: [{ type: 'github_comment_monitor' }],
+    approvalPolicy: 'auto',
+    status: 'active',
+    maxExecutions: null,
+    executionCount: 0,
+    maxBudgetPerRun: null,
+    notifyAddress: null,
+    triggerEvents: null,
+    outputDestinations: null,
+    executionMode: 'independent',
+    pipelineSteps: null,
+    lastRunAt: null,
+    nextRunAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
 }
 
 function insertExecution(db: Database, id: string): void {
-    db.query(`
+  db.query(`
         INSERT INTO schedule_executions (id, schedule_id, agent_id, status, action_type, action_input, cost_usd, started_at)
         VALUES (?, 'sched-1', 'agent-1', 'running', 'github_comment_monitor', '{}', 0, datetime('now'))
     `).run(id);
 }
 
 function getExecutionResult(db: Database, id: string): { status: string; result: string | null } {
-    return db.query('SELECT status, result FROM schedule_executions WHERE id = ?').get(id) as any;
+  return db.query('SELECT status, result FROM schedule_executions WHERE id = ?').get(id) as any;
 }
 
-function makeComment(overrides: Partial<{
+function makeComment(
+  overrides: Partial<{
     id: number;
     login: string;
     body: string;
@@ -74,17 +76,18 @@ function makeComment(overrides: Partial<{
     html_url: string;
     created_at: string;
     updated_at: string;
-}> = {}): any {
-    return {
-        id: overrides.id ?? 1,
-        html_url: overrides.html_url ?? 'https://github.com/CorvidLabs/corvid-agent/issues/1#issuecomment-1',
-        body: overrides.body ?? 'Great work!',
-        created_at: overrides.created_at ?? '2026-04-09T10:00:00Z',
-        updated_at: overrides.updated_at ?? '2026-04-09T10:00:00Z',
-        user: { login: overrides.login ?? 'external-user' },
-        issue_url: overrides.issue_url,
-        pull_request_url: overrides.pull_request_url,
-    };
+  }> = {},
+): any {
+  return {
+    id: overrides.id ?? 1,
+    html_url: overrides.html_url ?? 'https://github.com/CorvidLabs/corvid-agent/issues/1#issuecomment-1',
+    body: overrides.body ?? 'Great work!',
+    created_at: overrides.created_at ?? '2026-04-09T10:00:00Z',
+    updated_at: overrides.updated_at ?? '2026-04-09T10:00:00Z',
+    user: { login: overrides.login ?? 'external-user' },
+    issue_url: overrides.issue_url,
+    pull_request_url: overrides.pull_request_url,
+  };
 }
 
 let db: Database;
@@ -93,302 +96,309 @@ let originalDiscordToken: string | undefined;
 let originalFetch: typeof globalThis.fetch;
 
 beforeEach(() => {
-    db = new Database(':memory:');
-    runMigrations(db);
-    originalGhToken = process.env.GITHUB_TOKEN;
-    originalDiscordToken = process.env.DISCORD_BOT_TOKEN;
-    originalFetch = globalThis.fetch;
+  db = new Database(':memory:');
+  runMigrations(db);
+  originalGhToken = process.env.GITHUB_TOKEN;
+  originalDiscordToken = process.env.DISCORD_BOT_TOKEN;
+  originalFetch = globalThis.fetch;
 });
 
 afterEach(() => {
-    if (originalGhToken !== undefined) {
-        process.env.GITHUB_TOKEN = originalGhToken;
-    } else {
-        delete process.env.GITHUB_TOKEN;
-    }
-    if (originalDiscordToken !== undefined) {
-        process.env.DISCORD_BOT_TOKEN = originalDiscordToken;
-    } else {
-        delete process.env.DISCORD_BOT_TOKEN;
-    }
-    globalThis.fetch = originalFetch;
-    db.close();
+  if (originalGhToken !== undefined) {
+    process.env.GITHUB_TOKEN = originalGhToken;
+  } else {
+    delete process.env.GITHUB_TOKEN;
+  }
+  if (originalDiscordToken !== undefined) {
+    process.env.DISCORD_BOT_TOKEN = originalDiscordToken;
+  } else {
+    delete process.env.DISCORD_BOT_TOKEN;
+  }
+  globalThis.fetch = originalFetch;
+  db.close();
 });
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('execGitHubCommentMonitor', () => {
-    test('fails when GITHUB_TOKEN not set', async () => {
-        delete process.env.GITHUB_TOKEN;
-        const ctx = createMockCtx(db);
-        const schedule = createMockSchedule();
-        const action: ScheduleAction = { type: 'github_comment_monitor', repos: ['CorvidLabs/corvid-agent'] };
-        const execId = crypto.randomUUID();
-        insertExecution(db, execId);
+  test('fails when GITHUB_TOKEN not set', async () => {
+    delete process.env.GITHUB_TOKEN;
+    const ctx = createMockCtx(db);
+    const schedule = createMockSchedule();
+    const action: ScheduleAction = { type: 'github_comment_monitor', repos: ['CorvidLabs/corvid-agent'] };
+    const execId = crypto.randomUUID();
+    insertExecution(db, execId);
 
-        await execGitHubCommentMonitor(ctx, execId, schedule, action);
+    await execGitHubCommentMonitor(ctx, execId, schedule, action);
 
-        const result = getExecutionResult(db, execId);
-        expect(result?.status).toBe('failed');
-        expect(result?.result).toContain('GITHUB_TOKEN not configured');
-    });
+    const result = getExecutionResult(db, execId);
+    expect(result?.status).toBe('failed');
+    expect(result?.result).toContain('GITHUB_TOKEN not configured');
+  });
 
-    test('fails with invalid repo format', async () => {
-        process.env.GITHUB_TOKEN = 'test-token';
-        const ctx = createMockCtx(db);
-        const schedule = createMockSchedule();
-        const action: ScheduleAction = { type: 'github_comment_monitor', repos: ['bad-repo-no-slash'] };
-        const execId = crypto.randomUUID();
-        insertExecution(db, execId);
+  test('fails with invalid repo format', async () => {
+    process.env.GITHUB_TOKEN = 'test-token';
+    const ctx = createMockCtx(db);
+    const schedule = createMockSchedule();
+    const action: ScheduleAction = { type: 'github_comment_monitor', repos: ['bad-repo-no-slash'] };
+    const execId = crypto.randomUUID();
+    insertExecution(db, execId);
 
-        await execGitHubCommentMonitor(ctx, execId, schedule, action);
+    await execGitHubCommentMonitor(ctx, execId, schedule, action);
 
-        const result = getExecutionResult(db, execId);
-        expect(result?.status).toBe('failed');
-        expect(result?.result).toContain('Invalid repo format');
-    });
+    const result = getExecutionResult(db, execId);
+    expect(result?.status).toBe('failed');
+    expect(result?.result).toContain('Invalid repo format');
+  });
 
-    test('completes with no external comments', async () => {
-        process.env.GITHUB_TOKEN = 'test-token';
-        // Add a team member to the allowlist
-        addToGitHubAllowlist(db, 'team-member', 'Team');
+  test('completes with no external comments', async () => {
+    process.env.GITHUB_TOKEN = 'test-token';
+    // Add a team member to the allowlist
+    addToGitHubAllowlist(db, 'team-member', 'Team');
 
-        // Mock GitHub API — only team member comments
-        globalThis.fetch = mock(async () => {
-            const teamComment = makeComment({ login: 'team-member', issue_url: 'https://api.github.com/repos/CorvidLabs/corvid-agent/issues/1' });
-            return new Response(JSON.stringify([teamComment]), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-            });
-        }) as any;
+    // Mock GitHub API — only team member comments
+    globalThis.fetch = mock(async () => {
+      const teamComment = makeComment({
+        login: 'team-member',
+        issue_url: 'https://api.github.com/repos/CorvidLabs/corvid-agent/issues/1',
+      });
+      return new Response(JSON.stringify([teamComment]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as any;
 
-        const ctx = createMockCtx(db);
-        const schedule = createMockSchedule();
-        const action: ScheduleAction = { type: 'github_comment_monitor', repos: ['CorvidLabs/corvid-agent'] };
-        const execId = crypto.randomUUID();
-        insertExecution(db, execId);
+    const ctx = createMockCtx(db);
+    const schedule = createMockSchedule();
+    const action: ScheduleAction = { type: 'github_comment_monitor', repos: ['CorvidLabs/corvid-agent'] };
+    const execId = crypto.randomUUID();
+    insertExecution(db, execId);
 
-        await execGitHubCommentMonitor(ctx, execId, schedule, action);
+    await execGitHubCommentMonitor(ctx, execId, schedule, action);
 
-        const result = getExecutionResult(db, execId);
-        expect(result?.status).toBe('completed');
-        expect(result?.result).toContain('No external comments');
-    });
+    const result = getExecutionResult(db, execId);
+    expect(result?.status).toBe('completed');
+    expect(result?.result).toContain('No external comments');
+  });
 
-    test('filters out bot accounts', async () => {
-        process.env.GITHUB_TOKEN = 'test-token';
+  test('filters out bot accounts', async () => {
+    process.env.GITHUB_TOKEN = 'test-token';
 
-        globalThis.fetch = mock(async () => {
-            const botComment = makeComment({ login: 'dependabot[bot]', issue_url: 'https://api.github.com/repos/CorvidLabs/corvid-agent/issues/1' });
-            return new Response(JSON.stringify([botComment]), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-            });
-        }) as any;
+    globalThis.fetch = mock(async () => {
+      const botComment = makeComment({
+        login: 'dependabot[bot]',
+        issue_url: 'https://api.github.com/repos/CorvidLabs/corvid-agent/issues/1',
+      });
+      return new Response(JSON.stringify([botComment]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as any;
 
-        const ctx = createMockCtx(db);
-        const schedule = createMockSchedule();
-        const action: ScheduleAction = { type: 'github_comment_monitor', repos: ['CorvidLabs/corvid-agent'] };
-        const execId = crypto.randomUUID();
-        insertExecution(db, execId);
+    const ctx = createMockCtx(db);
+    const schedule = createMockSchedule();
+    const action: ScheduleAction = { type: 'github_comment_monitor', repos: ['CorvidLabs/corvid-agent'] };
+    const execId = crypto.randomUUID();
+    insertExecution(db, execId);
 
-        await execGitHubCommentMonitor(ctx, execId, schedule, action);
+    await execGitHubCommentMonitor(ctx, execId, schedule, action);
 
-        const result = getExecutionResult(db, execId);
-        expect(result?.status).toBe('completed');
-        expect(result?.result).toContain('No external comments');
-    });
+    const result = getExecutionResult(db, execId);
+    expect(result?.status).toBe('completed');
+    expect(result?.result).toContain('No external comments');
+  });
 
-    test('detects external comments and posts Discord digest', async () => {
-        process.env.GITHUB_TOKEN = 'test-token';
-        process.env.DISCORD_BOT_TOKEN = 'discord-token';
-        addToGitHubAllowlist(db, 'team-member', 'Team');
+  test('detects external comments and posts Discord digest', async () => {
+    process.env.GITHUB_TOKEN = 'test-token';
+    process.env.DISCORD_BOT_TOKEN = 'discord-token';
+    addToGitHubAllowlist(db, 'team-member', 'Team');
 
-        let discordCalled = false;
-        let discordBody: any = null;
-        let callCount = 0;
+    let discordCalled = false;
+    let discordBody: any = null;
 
-        globalThis.fetch = mock(async (url: any, init?: any) => {
-            const urlStr = typeof url === 'string' ? url : url.toString();
+    globalThis.fetch = mock(async (url: any, init?: any) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
 
-            // GitHub API calls
-            if (urlStr.includes('api.github.com')) {
-                callCount++;
-                const externalComment = makeComment({
-                    id: 10,
-                    login: 'external-contributor',
-                    body: 'Found a bug in the scheduler',
-                    issue_url: 'https://api.github.com/repos/CorvidLabs/corvid-agent/issues/42',
-                    html_url: 'https://github.com/CorvidLabs/corvid-agent/issues/42#issuecomment-10',
-                });
-                const teamComment = makeComment({ login: 'team-member', issue_url: 'https://api.github.com/repos/CorvidLabs/corvid-agent/issues/1' });
-                return new Response(JSON.stringify([externalComment, teamComment]), {
-                    status: 200,
-                    headers: { 'Content-Type': 'application/json' },
-                });
-            }
+      // GitHub API calls
+      if (urlStr.includes('api.github.com')) {
+        const externalComment = makeComment({
+          id: 10,
+          login: 'external-contributor',
+          body: 'Found a bug in the scheduler',
+          issue_url: 'https://api.github.com/repos/CorvidLabs/corvid-agent/issues/42',
+          html_url: 'https://github.com/CorvidLabs/corvid-agent/issues/42#issuecomment-10',
+        });
+        const teamComment = makeComment({
+          login: 'team-member',
+          issue_url: 'https://api.github.com/repos/CorvidLabs/corvid-agent/issues/1',
+        });
+        return new Response(JSON.stringify([externalComment, teamComment]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
 
-            // Discord API call
-            if (urlStr.includes('discord.com')) {
-                discordCalled = true;
-                discordBody = JSON.parse(init.body);
-                return new Response(JSON.stringify({ id: 'msg-1' }), {
-                    status: 200,
-                    headers: { 'Content-Type': 'application/json' },
-                });
-            }
+      // Discord API call
+      if (urlStr.includes('discord.com')) {
+        discordCalled = true;
+        discordBody = JSON.parse(init.body);
+        return new Response(JSON.stringify({ id: 'msg-1' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
 
-            return new Response('Not found', { status: 404 });
-        }) as any;
+      return new Response('Not found', { status: 404 });
+    }) as any;
 
-        const ctx = createMockCtx(db);
-        const schedule = createMockSchedule();
-        const action: ScheduleAction = {
-            type: 'github_comment_monitor',
-            repos: ['CorvidLabs/corvid-agent'],
-            channelId: '123456',
-        };
-        const execId = crypto.randomUUID();
-        insertExecution(db, execId);
+    const ctx = createMockCtx(db);
+    const schedule = createMockSchedule();
+    const action: ScheduleAction = {
+      type: 'github_comment_monitor',
+      repos: ['CorvidLabs/corvid-agent'],
+      channelId: '123456',
+    };
+    const execId = crypto.randomUUID();
+    insertExecution(db, execId);
 
-        await execGitHubCommentMonitor(ctx, execId, schedule, action);
+    await execGitHubCommentMonitor(ctx, execId, schedule, action);
 
-        const result = getExecutionResult(db, execId);
-        expect(result?.status).toBe('completed');
-        expect(result?.result).toContain('2 external comment');
-        expect(discordCalled).toBe(true);
-        expect(discordBody.embeds).toHaveLength(1);
-        expect(discordBody.embeds[0].title).toContain('External Comment');
-        expect(discordBody.embeds[0].description).toContain('external-contributor');
-    });
+    const result = getExecutionResult(db, execId);
+    expect(result?.status).toBe('completed');
+    expect(result?.result).toContain('2 external comment');
+    expect(discordCalled).toBe(true);
+    expect(discordBody.embeds).toHaveLength(1);
+    expect(discordBody.embeds[0].title).toContain('External Comment');
+    expect(discordBody.embeds[0].description).toContain('external-contributor');
+  });
 
-    test('skips Discord notification when no channelId', async () => {
-        process.env.GITHUB_TOKEN = 'test-token';
-        process.env.DISCORD_BOT_TOKEN = 'discord-token';
+  test('skips Discord notification when no channelId', async () => {
+    process.env.GITHUB_TOKEN = 'test-token';
+    process.env.DISCORD_BOT_TOKEN = 'discord-token';
 
-        let discordCalled = false;
+    let discordCalled = false;
 
-        globalThis.fetch = mock(async (url: any) => {
-            const fetchUrl = typeof url === 'string' ? url : url.toString();
-            if (fetchUrl.includes('discord.com')) {
-                discordCalled = true;
-            }
-            const externalComment = makeComment({
-                login: 'outsider',
-                issue_url: 'https://api.github.com/repos/CorvidLabs/corvid-agent/issues/5',
-            });
-            return new Response(JSON.stringify([externalComment]), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-            });
-        }) as any;
+    globalThis.fetch = mock(async (url: any) => {
+      const fetchUrl = typeof url === 'string' ? url : url.toString();
+      if (fetchUrl.includes('discord.com')) {
+        discordCalled = true;
+      }
+      const externalComment = makeComment({
+        login: 'outsider',
+        issue_url: 'https://api.github.com/repos/CorvidLabs/corvid-agent/issues/5',
+      });
+      return new Response(JSON.stringify([externalComment]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as any;
 
-        const ctx = createMockCtx(db);
-        const schedule = createMockSchedule();
-        const action: ScheduleAction = { type: 'github_comment_monitor', repos: ['CorvidLabs/corvid-agent'] };
-        const execId = crypto.randomUUID();
-        insertExecution(db, execId);
+    const ctx = createMockCtx(db);
+    const schedule = createMockSchedule();
+    const action: ScheduleAction = { type: 'github_comment_monitor', repos: ['CorvidLabs/corvid-agent'] };
+    const execId = crypto.randomUUID();
+    insertExecution(db, execId);
 
-        await execGitHubCommentMonitor(ctx, execId, schedule, action);
+    await execGitHubCommentMonitor(ctx, execId, schedule, action);
 
-        const result = getExecutionResult(db, execId);
-        expect(result?.status).toBe('completed');
-        expect(discordCalled).toBe(false);
-    });
+    const result = getExecutionResult(db, execId);
+    expect(result?.status).toBe('completed');
+    expect(discordCalled).toBe(false);
+  });
 
-    test('uses default repo when none specified', async () => {
-        process.env.GITHUB_TOKEN = 'test-token';
+  test('uses default repo when none specified', async () => {
+    process.env.GITHUB_TOKEN = 'test-token';
 
-        let capturedUrls: string[] = [];
-        globalThis.fetch = mock(async (url: any) => {
-            capturedUrls.push(typeof url === 'string' ? url : url.toString());
-            return new Response(JSON.stringify([]), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-            });
-        }) as any;
+    const capturedUrls: string[] = [];
+    globalThis.fetch = mock(async (url: any) => {
+      capturedUrls.push(typeof url === 'string' ? url : url.toString());
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as any;
 
-        const ctx = createMockCtx(db);
-        const schedule = createMockSchedule();
-        const action: ScheduleAction = { type: 'github_comment_monitor' };
-        const execId = crypto.randomUUID();
-        insertExecution(db, execId);
+    const ctx = createMockCtx(db);
+    const schedule = createMockSchedule();
+    const action: ScheduleAction = { type: 'github_comment_monitor' };
+    const execId = crypto.randomUUID();
+    insertExecution(db, execId);
 
-        await execGitHubCommentMonitor(ctx, execId, schedule, action);
+    await execGitHubCommentMonitor(ctx, execId, schedule, action);
 
-        expect(capturedUrls.some((u) => u.includes('CorvidLabs/corvid-agent'))).toBe(true);
-        const result = getExecutionResult(db, execId);
-        expect(result?.status).toBe('completed');
-    });
+    expect(capturedUrls.some((u) => u.includes('CorvidLabs/corvid-agent'))).toBe(true);
+    const result = getExecutionResult(db, execId);
+    expect(result?.status).toBe('completed');
+  });
 
-    test('handles GitHub API error', async () => {
-        process.env.GITHUB_TOKEN = 'test-token';
+  test('handles GitHub API error', async () => {
+    process.env.GITHUB_TOKEN = 'test-token';
 
-        globalThis.fetch = mock(async () => {
-            return new Response('{"message": "rate limit exceeded"}', {
-                status: 403,
-                headers: { 'Content-Type': 'application/json' },
-            });
-        }) as any;
+    globalThis.fetch = mock(async () => {
+      return new Response('{"message": "rate limit exceeded"}', {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as any;
 
-        const ctx = createMockCtx(db);
-        const schedule = createMockSchedule();
-        const action: ScheduleAction = { type: 'github_comment_monitor', repos: ['CorvidLabs/corvid-agent'] };
-        const execId = crypto.randomUUID();
-        insertExecution(db, execId);
+    const ctx = createMockCtx(db);
+    const schedule = createMockSchedule();
+    const action: ScheduleAction = { type: 'github_comment_monitor', repos: ['CorvidLabs/corvid-agent'] };
+    const execId = crypto.randomUUID();
+    insertExecution(db, execId);
 
-        await execGitHubCommentMonitor(ctx, execId, schedule, action);
+    await execGitHubCommentMonitor(ctx, execId, schedule, action);
 
-        const result = getExecutionResult(db, execId);
-        expect(result?.status).toBe('failed');
-        expect(result?.result).toContain('403');
-    });
+    const result = getExecutionResult(db, execId);
+    expect(result?.status).toBe('failed');
+    expect(result?.result).toContain('403');
+  });
 
-    test('handles fetch exception', async () => {
-        process.env.GITHUB_TOKEN = 'test-token';
+  test('handles fetch exception', async () => {
+    process.env.GITHUB_TOKEN = 'test-token';
 
-        globalThis.fetch = mock(async () => {
-            throw new Error('Network timeout');
-        }) as any;
+    globalThis.fetch = mock(async () => {
+      throw new Error('Network timeout');
+    }) as any;
 
-        const ctx = createMockCtx(db);
-        const schedule = createMockSchedule();
-        const action: ScheduleAction = { type: 'github_comment_monitor', repos: ['CorvidLabs/corvid-agent'] };
-        const execId = crypto.randomUUID();
-        insertExecution(db, execId);
+    const ctx = createMockCtx(db);
+    const schedule = createMockSchedule();
+    const action: ScheduleAction = { type: 'github_comment_monitor', repos: ['CorvidLabs/corvid-agent'] };
+    const execId = crypto.randomUUID();
+    insertExecution(db, execId);
 
-        await execGitHubCommentMonitor(ctx, execId, schedule, action);
+    await execGitHubCommentMonitor(ctx, execId, schedule, action);
 
-        const result = getExecutionResult(db, execId);
-        expect(result?.status).toBe('failed');
-        expect(result?.result).toContain('Network timeout');
-    });
+    const result = getExecutionResult(db, execId);
+    expect(result?.status).toBe('failed');
+    expect(result?.result).toContain('Network timeout');
+  });
 
-    test('uses since from action.description for continuity', async () => {
-        process.env.GITHUB_TOKEN = 'test-token';
-        const customSince = '2026-04-08T12:00:00Z';
+  test('uses since from action.description for continuity', async () => {
+    process.env.GITHUB_TOKEN = 'test-token';
+    const customSince = '2026-04-08T12:00:00Z';
 
-        let capturedUrls: string[] = [];
-        globalThis.fetch = mock(async (url: any) => {
-            capturedUrls.push(typeof url === 'string' ? url : url.toString());
-            return new Response(JSON.stringify([]), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-            });
-        }) as any;
+    const capturedUrls: string[] = [];
+    globalThis.fetch = mock(async (url: any) => {
+      capturedUrls.push(typeof url === 'string' ? url : url.toString());
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as any;
 
-        const ctx = createMockCtx(db);
-        const schedule = createMockSchedule();
-        const action: ScheduleAction = {
-            type: 'github_comment_monitor',
-            repos: ['CorvidLabs/corvid-agent'],
-            description: customSince,
-        };
-        const execId = crypto.randomUUID();
-        insertExecution(db, execId);
+    const ctx = createMockCtx(db);
+    const schedule = createMockSchedule();
+    const action: ScheduleAction = {
+      type: 'github_comment_monitor',
+      repos: ['CorvidLabs/corvid-agent'],
+      description: customSince,
+    };
+    const execId = crypto.randomUUID();
+    insertExecution(db, execId);
 
-        await execGitHubCommentMonitor(ctx, execId, schedule, action);
+    await execGitHubCommentMonitor(ctx, execId, schedule, action);
 
-        expect(capturedUrls.some((u) => u.includes(encodeURIComponent(customSince)))).toBe(true);
-    });
+    expect(capturedUrls.some((u) => u.includes(encodeURIComponent(customSince)))).toBe(true);
+  });
 });

--- a/server/__tests__/subscriptions.test.ts
+++ b/server/__tests__/subscriptions.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { Database } from 'bun:sqlite';
-import { beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { getBalance, grantCredits } from '../db/credits';
 import { runMigrations } from '../db/schema';
 import { GRACE_PERIOD_HOURS, SubscriptionService } from '../marketplace/subscriptions';
@@ -23,6 +23,10 @@ function setupDb(): Database {
   runMigrations(d);
   return d;
 }
+
+afterEach(() => {
+  db.close();
+});
 
 function fundSubscriber(credits: number): void {
   grantCredits(db, SUBSCRIBER, credits, 'test_setup');

--- a/server/mcp/tool-handlers/library.ts
+++ b/server/mcp/tool-handlers/library.ts
@@ -28,6 +28,14 @@ const log = createLogger('McpLibraryHandlers');
 const VALID_CATEGORIES: LibraryCategory[] = ['guide', 'reference', 'decision', 'standard', 'runbook'];
 
 /**
+ * Agents permitted to write to the shared library.
+ * All other callers receive an error. CorvidAgent is the default librarian.
+ */
+const LIBRARIAN_AGENT_IDS: ReadonlySet<string> = new Set([
+  '90cf34fa-1478-454c-a789-1c87cbb0d552', // CorvidAgent — default librarian
+]);
+
+/**
  * Build a LibraryContext from the MCP tool context.
  * Returns null if any required component is unavailable.
  */
@@ -152,6 +160,10 @@ export async function handleLibraryWrite(
   },
 ): Promise<CallToolResult> {
   try {
+    if (!LIBRARIAN_AGENT_IDS.has(ctx.agentId)) {
+      return errorResult('Only agents with librarian role can write to the shared library');
+    }
+
     const category = (args.category as LibraryCategory) ?? 'reference';
     if (!VALID_CATEGORIES.includes(category)) {
       return errorResult(`Invalid category "${args.category}". Valid: ${VALID_CATEGORIES.join(', ')}`);

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -451,43 +451,43 @@ export type StreamEventType = StreamEvent['eventType'];
 export function isClientMessage(data: unknown): data is ClientMessage {
   if (typeof data !== 'object' || data === null) return false;
   const msg = data as Record<string, unknown>;
-  if (typeof msg['type'] !== 'string') return false;
+  if (typeof msg.type !== 'string') return false;
 
-  switch (msg['type']) {
+  switch (msg.type) {
     case 'auth':
-      return typeof msg['key'] === 'string';
+      return typeof msg.key === 'string';
     case 'subscribe':
     case 'unsubscribe':
-      return typeof msg['sessionId'] === 'string';
+      return typeof msg.sessionId === 'string';
     case 'send_message':
-      return typeof msg['sessionId'] === 'string' && typeof msg['content'] === 'string';
+      return typeof msg.sessionId === 'string' && typeof msg.content === 'string';
     case 'chat_send':
       return (
-        typeof msg['agentId'] === 'string' &&
-        typeof msg['content'] === 'string' &&
-        (msg['projectId'] === undefined || typeof msg['projectId'] === 'string') &&
-        (msg['tools'] === undefined || Array.isArray(msg['tools']))
+        typeof msg.agentId === 'string' &&
+        typeof msg.content === 'string' &&
+        (msg.projectId === undefined || typeof msg.projectId === 'string') &&
+        (msg.tools === undefined || Array.isArray(msg.tools))
       );
     case 'agent_reward':
-      return typeof msg['agentId'] === 'string' && typeof msg['microAlgos'] === 'number';
+      return typeof msg.agentId === 'string' && typeof msg.microAlgos === 'number';
     case 'agent_invoke':
       return (
-        typeof msg['fromAgentId'] === 'string' && typeof msg['toAgentId'] === 'string' && typeof msg['content'] === 'string'
+        typeof msg.fromAgentId === 'string' && typeof msg.toAgentId === 'string' && typeof msg.content === 'string'
       );
     case 'approval_response':
-      return typeof msg['requestId'] === 'string' && (msg['behavior'] === 'allow' || msg['behavior'] === 'deny');
+      return typeof msg.requestId === 'string' && (msg.behavior === 'allow' || msg.behavior === 'deny');
     case 'create_work_task':
       return (
-        typeof msg['agentId'] === 'string' &&
-        typeof msg['description'] === 'string' &&
-        (msg['projectId'] === undefined || typeof msg['projectId'] === 'string')
+        typeof msg.agentId === 'string' &&
+        typeof msg.description === 'string' &&
+        (msg.projectId === undefined || typeof msg.projectId === 'string')
       );
     case 'schedule_approval':
-      return typeof msg['executionId'] === 'string' && typeof msg['approved'] === 'boolean';
+      return typeof msg.executionId === 'string' && typeof msg.approved === 'boolean';
     case 'pong':
       return true;
     case 'question_response':
-      return typeof msg['questionId'] === 'string' && typeof msg['answer'] === 'string';
+      return typeof msg.questionId === 'string' && typeof msg.answer === 'string';
     default:
       return false;
   }

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -472,7 +472,9 @@ export function isClientMessage(data: unknown): data is ClientMessage {
       return typeof msg['agentId'] === 'string' && typeof msg['microAlgos'] === 'number';
     case 'agent_invoke':
       return (
-        typeof msg['fromAgentId'] === 'string' && typeof msg['toAgentId'] === 'string' && typeof msg['content'] === 'string'
+        typeof msg['fromAgentId'] === 'string' &&
+        typeof msg['toAgentId'] === 'string' &&
+        typeof msg['content'] === 'string'
       );
     case 'approval_response':
       return typeof msg['requestId'] === 'string' && (msg['behavior'] === 'allow' || msg['behavior'] === 'deny');

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -451,43 +451,43 @@ export type StreamEventType = StreamEvent['eventType'];
 export function isClientMessage(data: unknown): data is ClientMessage {
   if (typeof data !== 'object' || data === null) return false;
   const msg = data as Record<string, unknown>;
-  if (typeof msg.type !== 'string') return false;
+  if (typeof msg['type'] !== 'string') return false;
 
-  switch (msg.type) {
+  switch (msg['type']) {
     case 'auth':
-      return typeof msg.key === 'string';
+      return typeof msg['key'] === 'string';
     case 'subscribe':
     case 'unsubscribe':
-      return typeof msg.sessionId === 'string';
+      return typeof msg['sessionId'] === 'string';
     case 'send_message':
-      return typeof msg.sessionId === 'string' && typeof msg.content === 'string';
+      return typeof msg['sessionId'] === 'string' && typeof msg['content'] === 'string';
     case 'chat_send':
       return (
-        typeof msg.agentId === 'string' &&
-        typeof msg.content === 'string' &&
-        (msg.projectId === undefined || typeof msg.projectId === 'string') &&
-        (msg.tools === undefined || Array.isArray(msg.tools))
+        typeof msg['agentId'] === 'string' &&
+        typeof msg['content'] === 'string' &&
+        (msg['projectId'] === undefined || typeof msg['projectId'] === 'string') &&
+        (msg['tools'] === undefined || Array.isArray(msg['tools']))
       );
     case 'agent_reward':
-      return typeof msg.agentId === 'string' && typeof msg.microAlgos === 'number';
+      return typeof msg['agentId'] === 'string' && typeof msg['microAlgos'] === 'number';
     case 'agent_invoke':
       return (
-        typeof msg.fromAgentId === 'string' && typeof msg.toAgentId === 'string' && typeof msg.content === 'string'
+        typeof msg['fromAgentId'] === 'string' && typeof msg['toAgentId'] === 'string' && typeof msg['content'] === 'string'
       );
     case 'approval_response':
-      return typeof msg.requestId === 'string' && (msg.behavior === 'allow' || msg.behavior === 'deny');
+      return typeof msg['requestId'] === 'string' && (msg['behavior'] === 'allow' || msg['behavior'] === 'deny');
     case 'create_work_task':
       return (
-        typeof msg.agentId === 'string' &&
-        typeof msg.description === 'string' &&
-        (msg.projectId === undefined || typeof msg.projectId === 'string')
+        typeof msg['agentId'] === 'string' &&
+        typeof msg['description'] === 'string' &&
+        (msg['projectId'] === undefined || typeof msg['projectId'] === 'string')
       );
     case 'schedule_approval':
-      return typeof msg.executionId === 'string' && typeof msg.approved === 'boolean';
+      return typeof msg['executionId'] === 'string' && typeof msg['approved'] === 'boolean';
     case 'pong':
       return true;
     case 'question_response':
-      return typeof msg.questionId === 'string' && typeof msg.answer === 'string';
+      return typeof msg['questionId'] === 'string' && typeof msg['answer'] === 'string';
     default:
       return false;
   }


### PR DESCRIPTION
## Summary
- Replace all useLiteralKeys violations in the isClientMessage() type guard function
- Convert bracket notation (e.g., msg['key']) to dot notation (e.g., msg.key) throughout the function
- Improves code readability and passes Biome lint checks

## Changes
- Modified shared/ws-protocol.ts to use literal key access instead of computed property access
- 17 bracket notation references converted to dot notation