### PR TITLE
fix(discord): preserve conversation context across thread session restarts

### DIFF
--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -38,7 +38,7 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Server modules | 47 |
 | API routes | 51 modules (~300 endpoints) |
 | Database tables | 110 |
-| Database migrations | 39 (squashed baseline) |
+| Database migrations | 40 (squashed baseline) |
 | MCP tools | 56 corvid_* handlers |
 | Unit tests | 4,242 test files |
 | E2E tests | 360 across 33 Playwright specs |

--- a/server/db/discord-thread-sessions.ts
+++ b/server/db/discord-thread-sessions.ts
@@ -16,6 +16,7 @@ interface ThreadSessionRow {
   buddy_agent_id: string | null;
   buddy_agent_name: string | null;
   buddy_max_rounds: number | null;
+  last_summary: string | null;
   last_activity_at: string;
   created_at: string;
 }
@@ -97,6 +98,36 @@ export function getRecentThreadSessions(
  */
 export function deleteThreadSession(db: Database, threadId: string): void {
   db.query('DELETE FROM discord_thread_sessions WHERE thread_id = ?').run(threadId);
+}
+
+/**
+ * Update the conversation summary stored on a thread session.
+ * Called on process exit so context survives even if the session record is later deleted.
+ */
+export function updateThreadSessionSummary(db: Database, threadId: string, summary: string): void {
+  db.query(`UPDATE discord_thread_sessions SET last_summary = ? WHERE thread_id = ?`).run(summary, threadId);
+}
+
+/**
+ * Get the durable conversation summary from a thread session mapping.
+ * Falls back to null if the thread has no stored summary.
+ */
+export function getThreadSessionSummary(db: Database, threadId: string): string | null {
+  const row = db
+    .query(`SELECT last_summary FROM discord_thread_sessions WHERE thread_id = ?`)
+    .get(threadId) as { last_summary: string | null } | null;
+  return row?.last_summary ?? null;
+}
+
+/**
+ * Look up the thread ID for a given session ID (reverse lookup).
+ * Used to persist conversation summaries to thread sessions on process exit.
+ */
+export function getThreadIdForSession(db: Database, sessionId: string): string | null {
+  const row = db
+    .query(`SELECT thread_id FROM discord_thread_sessions WHERE session_id = ?`)
+    .get(sessionId) as { thread_id: string } | null;
+  return row?.thread_id ?? null;
 }
 
 /**

--- a/server/db/migrations/117_thread_session_summary.ts
+++ b/server/db/migrations/117_thread_session_summary.ts
@@ -1,0 +1,19 @@
+import type { Database } from 'bun:sqlite';
+
+export function up(db: Database): void {
+  // Store conversation summary on thread session for durable context carry-over.
+  // Survives session deletion — the thread mapping outlives individual sessions.
+  db.run(`ALTER TABLE discord_thread_sessions ADD COLUMN last_summary TEXT DEFAULT NULL`);
+}
+
+export function down(db: Database): void {
+  // SQLite doesn't support DROP COLUMN before 3.35 — recreate the table without it
+  db.run(`CREATE TABLE discord_thread_sessions_backup AS SELECT
+    thread_id, session_id, agent_name, agent_model, owner_user_id, topic, project_name,
+    display_color, display_icon, avatar_url, creator_perm_level,
+    buddy_agent_id, buddy_agent_name, buddy_max_rounds,
+    last_activity_at, created_at
+    FROM discord_thread_sessions`);
+  db.run(`DROP TABLE discord_thread_sessions`);
+  db.run(`ALTER TABLE discord_thread_sessions_backup RENAME TO discord_thread_sessions`);
+}

--- a/server/db/migrations/117_thread_session_summary.ts
+++ b/server/db/migrations/117_thread_session_summary.ts
@@ -3,7 +3,11 @@ import type { Database } from 'bun:sqlite';
 export function up(db: Database): void {
   // Store conversation summary on thread session for durable context carry-over.
   // Survives session deletion — the thread mapping outlives individual sessions.
-  db.run(`ALTER TABLE discord_thread_sessions ADD COLUMN last_summary TEXT DEFAULT NULL`);
+  // Guard: column may already exist via legacy schema (schema/discord.ts).
+  const cols = db.prepare(`PRAGMA table_info(discord_thread_sessions)`).all() as { name: string }[];
+  if (!cols.some((c) => c.name === 'last_summary')) {
+    db.run(`ALTER TABLE discord_thread_sessions ADD COLUMN last_summary TEXT DEFAULT NULL`);
+  }
 }
 
 export function down(db: Database): void {

--- a/server/db/schema/discord.ts
+++ b/server/db/schema/discord.ts
@@ -45,6 +45,7 @@ export const tables: string[] = [
         buddy_agent_id     TEXT,
         buddy_agent_name   TEXT,
         buddy_max_rounds   INTEGER,
+        last_summary       TEXT,
         last_activity_at   TEXT NOT NULL DEFAULT (datetime('now')),
         created_at         TEXT NOT NULL DEFAULT (datetime('now'))
     )`,

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -67,7 +67,7 @@ type Domain = {
 
 // ── Schema version (bump when adding new migrations) ────────────────
 
-const SCHEMA_VERSION = 116;
+const SCHEMA_VERSION = 117;
 
 // ── Build MIGRATIONS dict ───────────────────────────────────────────
 
@@ -234,6 +234,10 @@ const MIGRATIONS: Record<number, string[]> = {
     `ALTER TABLE governance_proposals ADD COLUMN voting_deadline TEXT DEFAULT NULL`,
     ...councils.tables.filter((s) => s.includes('proposal_vetoes')),
     ...councils.indexes.filter((s) => s.includes('proposal_vetoes')),
+  ],
+  117: [
+    // Durable conversation summary on thread sessions for context carry-over
+    `ALTER TABLE discord_thread_sessions ADD COLUMN last_summary TEXT DEFAULT NULL`,
   ],
 };
 

--- a/server/discord/message-handler.ts
+++ b/server/discord/message-handler.ts
@@ -11,9 +11,14 @@ import { listAgents } from '../db/agents';
 import { recordAudit } from '../db/audit';
 import { updateDiscordConfig } from '../db/discord-config';
 import { getMentionSession, saveMentionSession, updateMentionSessionActivity } from '../db/discord-mention-sessions';
-import { deleteThreadSession, saveThreadSession, updateThreadSessionActivity } from '../db/discord-thread-sessions';
+import {
+  deleteThreadSession,
+  getThreadSessionSummary,
+  saveThreadSession,
+  updateThreadSessionActivity,
+} from '../db/discord-thread-sessions';
 import { listProjects } from '../db/projects';
-import { createSession, getPreviousThreadSessionSummary, getSession } from '../db/sessions';
+import { createSession, getPreviousThreadSessionSummary, getSession, getSessionMessages } from '../db/sessions';
 import type { DeliveryTracker } from '../lib/delivery-tracker';
 import { createLogger } from '../lib/logger';
 import { buildOllamaComplexityWarning } from '../lib/ollama-complexity-warning';
@@ -837,6 +842,48 @@ async function handleMentionReplyResume(
 }
 
 /**
+ * Build structured conversation context from a previous thread session.
+ * Tries three sources in order: actual messages (richest), thread summary, session summary.
+ * Call BEFORE deleting the thread session or session record.
+ */
+function buildPreviousThreadContext(db: Database, threadId: string, previousSessionId: string): string {
+  // 1. Try to load actual messages from the previous session (richest context)
+  const messages = getSessionMessages(db, previousSessionId);
+  const conversational = messages
+    .filter((m) => m.role === 'user' || m.role === 'assistant')
+    .slice(-20);
+
+  if (conversational.length > 0) {
+    const historyLines = conversational.map((m) => {
+      const role = m.role === 'user' ? 'User' : 'Assistant';
+      const text = m.content.length > 2000 ? `${m.content.slice(0, 2000)}...` : m.content;
+      return `[${role}]: ${text}`;
+    });
+    return [
+      '<conversation_history>',
+      'The following is the conversation history from this session. Use it for context when responding to the new message.',
+      '',
+      ...historyLines,
+      '</conversation_history>',
+    ].join('\n');
+  }
+
+  // 2. Fall back to durable thread session summary (survives session deletion)
+  const threadSummary = getThreadSessionSummary(db, threadId);
+  if (threadSummary) {
+    return `<conversation_history>\nThe following is a summary of the previous session in this thread. Use it for context when responding to the new message.\n\n[Context Summary]\n${threadSummary}\n</conversation_history>`;
+  }
+
+  // 3. Fall back to session-level conversation summary
+  const sessionSummary = getPreviousThreadSessionSummary(db, threadId);
+  if (sessionSummary) {
+    return `<conversation_history>\nThe following is a summary of the previous session in this thread. Use it for context when responding to the new message.\n\n[Context Summary]\n${sessionSummary}\n</conversation_history>`;
+  }
+
+  return '';
+}
+
+/**
  * Create a new session in a thread whose previous session expired or was deleted.
  * Reuses the original agent when possible, falls back to the default agent.
  * Returns true if the session was successfully created and the message dispatched.
@@ -856,6 +903,7 @@ async function resumeExpiredThreadSession(
   authorId?: string,
   authorUsername?: string,
   attachments?: DiscordAttachment[],
+  previousContext?: string,
 ): Promise<boolean> {
   const agents = listAgents(ctx.db);
   const agent = agents.find((a) => a.name === previousInfo.agentName) ?? resolveDefaultAgent(ctx.db, ctx.config);
@@ -915,11 +963,9 @@ async function resumeExpiredThreadSession(
   ctx.threadLastActivity.set(threadId, Date.now());
   saveThreadSession(ctx.db, threadId, threadInfo);
 
-  // Carry over context from the previous session in this thread (if any)
-  const previousSummary = getPreviousThreadSessionSummary(ctx.db, threadId);
-  const contextPrefix = previousSummary
-    ? `[Previous session context — the session was resumed, here is what was discussed before]\n${previousSummary}\n\n[New message from user]\n`
-    : '';
+  // Carry over context from the previous session in this thread.
+  // Uses pre-captured context (actual messages or durable summary) passed from the caller.
+  const contextPrefix = previousContext ? `${previousContext}\n\n` : '';
 
   // Start the process with the user's message (include attachment URLs in text so
   // the agent sees them even though startProcess only accepts strings).
@@ -943,7 +989,7 @@ async function resumeExpiredThreadSession(
   );
 
   // Brief non-blocking notification
-  const resumeDesc = previousSummary
+  const resumeDesc = previousContext
     ? `Session resumed with **${agent.name}** (previous context carried over).`
     : `Session resumed with **${agent.name}**.`;
   sendEmbed(ctx.delivery, ctx.config.botToken, threadId, {
@@ -1014,6 +1060,8 @@ async function routeToThread(
 
   const session = getSession(ctx.db, sessionId);
   if (!session) {
+    // Capture context BEFORE deleting — thread summary survives session deletion
+    const previousContext = buildPreviousThreadContext(ctx.db, threadId, sessionId);
     ctx.threadSessions.delete(threadId);
     deleteThreadSession(ctx.db, threadId);
     // Automatically resume: create a new session in the same thread
@@ -1025,6 +1073,7 @@ async function routeToThread(
       authorId,
       authorUsername,
       attachments,
+      previousContext,
     );
     if (!resumed) {
       await sendEmbedWithButtons(
@@ -1068,6 +1117,8 @@ async function routeToThread(
     // sending a false "session ended unexpectedly" crash embed.
     if (!ctx.processManager.isRunning(sessionId)) {
       log.warn('resumeProcess did not start — creating fresh session in thread', { sessionId, threadId });
+      // Capture context BEFORE deleting
+      const previousContext = buildPreviousThreadContext(ctx.db, threadId, sessionId);
       // Clear stale mapping and create a brand new session, same as expired sessions
       ctx.threadSessions.delete(threadId);
       deleteThreadSession(ctx.db, threadId);
@@ -1079,6 +1130,7 @@ async function routeToThread(
         authorId,
         authorUsername,
         attachments,
+        previousContext,
       );
       if (!resumed) {
         await sendEmbed(ctx.delivery, ctx.config.botToken, threadId, {

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -18,6 +18,7 @@ import {
   updateSessionStatus,
   updateSessionSummary,
 } from '../db/sessions';
+import { getThreadIdForSession, updateThreadSessionSummary } from '../db/discord-thread-sessions';
 import { recordApiCost } from '../db/spending';
 import { createLogger } from '../lib/logger';
 import { cleanupEphemeralDir, type ResolvedDir, resolveProjectDir } from '../lib/project-dir';
@@ -1825,7 +1826,14 @@ export class ProcessManager {
 
       const summary = summarizeConversation(conversational.map((m) => ({ role: m.role, content: m.content })));
       updateSessionSummary(this.db, sessionId, summary);
-      log.debug('Persisted conversation summary to session', { sessionId });
+
+      // Also persist to the thread session mapping (durable — survives session deletion)
+      const threadId = getThreadIdForSession(this.db, sessionId);
+      if (threadId) {
+        updateThreadSessionSummary(this.db, threadId, summary);
+      }
+
+      log.debug('Persisted conversation summary to session', { sessionId, threadId: threadId ?? 'none' });
     } catch (err) {
       log.warn('Failed to persist conversation summary', {
         sessionId,

--- a/specs/db/sessions/discord-thread-sessions.spec.md
+++ b/specs/db/sessions/discord-thread-sessions.spec.md
@@ -5,6 +5,7 @@ status: active
 files:
   - server/db/discord-thread-sessions.ts
   - server/db/migrations/112_discord_thread_sessions.ts
+  - server/db/migrations/117_thread_session_summary.ts
 db_tables:
   - discord_thread_sessions
 depends_on:
@@ -29,6 +30,16 @@ Persists Discord thread-to-session mappings in SQLite so that active conversatio
 | `getRecentThreadSessions` | `(db: Database, maxAgeHours?: number)` | `Array<{ threadId, info, lastActivityAt }>` | Bulk-load recent thread sessions for startup recovery (default: 48 hours) |
 | `deleteThreadSession` | `(db: Database, threadId: string)` | `void` | Delete a thread session (e.g. on thread archival) |
 | `pruneOldThreadSessions` | `(db: Database, maxAgeDays?: number)` | `number` | Remove thread sessions older than specified age (default: 14 days); returns count of deleted rows |
+| `updateThreadSessionSummary` | `(db: Database, threadId: string, summary: string)` | `void` | Update the durable conversation summary on a thread session (survives session deletion) |
+| `getThreadSessionSummary` | `(db: Database, threadId: string)` | `string \| null` | Get the durable conversation summary for a thread; returns null if none stored |
+| `getThreadIdForSession` | `(db: Database, sessionId: string)` | `string \| null` | Reverse lookup of thread ID by session ID (used to persist summaries on process exit) |
+
+### Exported Migration Functions (117_thread_session_summary.ts)
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `up` | `(db: Database)` | `void` | Adds `last_summary TEXT` column to `discord_thread_sessions` for durable conversation context |
+| `down` | `(db: Database)` | `void` | Removes `last_summary` column by recreating the table without it |
 
 ### Exported Migration Functions (112_discord_thread_sessions.ts)
 
@@ -116,6 +127,7 @@ Persists Discord thread-to-session mappings in SQLite so that active conversatio
 | buddy_agent_id | TEXT | nullable | Buddy agent ID for paired sessions |
 | buddy_agent_name | TEXT | nullable | Buddy agent name |
 | buddy_max_rounds | INTEGER | nullable | Max buddy conversation rounds |
+| last_summary | TEXT | nullable | Durable conversation summary that survives session deletion |
 | last_activity_at | TEXT | NOT NULL DEFAULT datetime('now') | Last activity timestamp |
 | created_at | TEXT | NOT NULL DEFAULT datetime('now') | Creation timestamp |
 

--- a/specs/discord/thread-session-map.spec.md
+++ b/specs/discord/thread-session-map.spec.md
@@ -43,6 +43,9 @@ Owns the in-memory state types for thread-based Discord conversations and the DB
 | `getRecentThreadSessions` | `(db: Database, maxAgeHours?: number)` | `Array<{ threadId, info, lastActivityAt }>` | Bulk-loads recent thread sessions for startup recovery (default: 48 hours). |
 | `deleteThreadSession` | `(db: Database, threadId: string)` | `void` | Deletes a thread session (e.g. on archival). |
 | `pruneOldThreadSessions` | `(db: Database, maxAgeDays?: number)` | `number` | Removes thread session entries older than the specified age (default: 14 days). Returns count of deleted rows. |
+| `updateThreadSessionSummary` | `(db: Database, threadId: string, summary: string)` | `void` | Updates the durable conversation summary on a thread session (survives session deletion). |
+| `getThreadSessionSummary` | `(db: Database, threadId: string)` | `string \| null` | Retrieves the durable conversation summary for a thread. Returns null if none stored. |
+| `getThreadIdForSession` | `(db: Database, sessionId: string)` | `string \| null` | Reverse lookup of thread ID by session ID. Used to persist summaries on process exit. |
 
 ## Invariants
 
@@ -85,6 +88,7 @@ Owns the in-memory state types for thread-based Discord conversations and the DB
 | buddy_agent_id | TEXT | | Buddy agent ID (if buddy mode) |
 | buddy_agent_name | TEXT | | Buddy agent name |
 | buddy_max_rounds | INTEGER | | Max buddy interaction rounds |
+| last_summary | TEXT | nullable | Durable conversation summary that survives session deletion |
 | last_activity_at | TEXT | NOT NULL DEFAULT datetime('now') | Last activity timestamp |
 | created_at | TEXT | NOT NULL DEFAULT datetime('now') | Creation timestamp |
 


### PR DESCRIPTION
## Summary

When a Discord thread session expired and restarted, the new session only received a lossy `conversation_summary` (truncated, plain text). This meant the agent lost most conversational context on resume.

**Three-tier context resolution:**
1. **Actual messages** (richest) — loads up to 20 previous user/assistant messages from the DB, formatted as structured `<conversation_history>` XML
2. **Thread-level summary** (new, durable) — `last_summary` column on `discord_thread_sessions` that survives session deletion
3. **Session-level summary** (existing fallback) — queries sessions by thread name

**Key changes:**
- **Migration 117**: Adds `last_summary TEXT` column to `discord_thread_sessions`
- **`updateThreadSessionSummary`** / **`getThreadSessionSummary`**: New DB helpers for durable thread summaries
- **`buildPreviousThreadContext()`**: New helper that tries messages → thread summary → session summary
- **`resumeExpiredThreadSession`**: Uses structured `<conversation_history>` format instead of plain text prefix
- **`persistConversationSummary`**: Now also writes to the thread session mapping (survives session deletion)
- Both call sites in `routeToThread` capture context BEFORE deleting the thread session

## Test plan
- [x] Verify thread session resume carries over conversation context
- [x] Verify context survives session record deletion (falls back to thread summary)
- [x] Verify `bun run lint` and `bun x tsc --noEmit --skipLibCheck` pass

---
🤖 Agent: CorvidAgent | Model: Opus 4.6