### PR TITLE
fix(scheduler): distinguish permanent vs transient conflicts in work task handler

### DIFF
--- a/server/__tests__/scheduler-work-task-handler.test.ts
+++ b/server/__tests__/scheduler-work-task-handler.test.ts
@@ -113,7 +113,7 @@ describe('execWorkTask', () => {
     expect(mockUpdateStatus.mock.calls[0][3]?.result).toContain('queued behind active task');
   });
 
-  it('retries on ConflictError and succeeds on second attempt', async () => {
+  it('retries on transient ConflictError and succeeds on second attempt', async () => {
     const svc = {
       create: mock()
         .mockRejectedValueOnce(new ConflictError('Another task is already active on project'))
@@ -136,18 +136,45 @@ describe('execWorkTask', () => {
     expect(mockUpdateStatus.mock.calls[0][2]).toBe('completed');
   });
 
-  it('fails after exhausting all retry attempts on conflict', async () => {
+  it('marks permanent skip conflicts as completed instead of retrying', async () => {
+    const svc = {
+      create: mock().mockRejectedValueOnce(
+        new ConflictError('An active work task already addresses issue #42. Skipping.'),
+      ),
+    };
+    await execWorkTask(makeCtx(svc), 'exec-1', makeSchedule(), makeAction());
+    // Should NOT retry — permanent skip
+    expect(svc.create).toHaveBeenCalledTimes(1);
+    expect(mockUpdateStatus).toHaveBeenCalledTimes(1);
+    expect(mockUpdateStatus.mock.calls[0][2]).toBe('completed');
+    expect(mockUpdateStatus.mock.calls[0][3]?.result).toContain('Skipped:');
+  });
+
+  it('marks flock conflict as completed skip', async () => {
+    const svc = {
+      create: mock().mockRejectedValueOnce(
+        new ConflictError('Another agent (Jackdaw) is already working on this issue. Skipping to avoid duplicate work.'),
+      ),
+    };
+    await execWorkTask(makeCtx(svc), 'exec-1', makeSchedule(), makeAction());
+    expect(svc.create).toHaveBeenCalledTimes(1);
+    expect(mockUpdateStatus.mock.calls[0][2]).toBe('completed');
+    expect(mockUpdateStatus.mock.calls[0][3]?.result).toContain('Skipped:');
+  });
+
+  it('fails after exhausting all retry attempts on transient conflict', async () => {
     const conflictErr = new ConflictError('Another task is already active on project');
     const svc = {
       create: mock()
         .mockRejectedValueOnce(conflictErr)
         .mockRejectedValueOnce(conflictErr)
         .mockRejectedValueOnce(conflictErr)
+        .mockRejectedValueOnce(conflictErr)
         .mockRejectedValueOnce(conflictErr),
     };
     await execWorkTask(makeCtx(svc), 'exec-1', makeSchedule(), makeAction());
-    // MAX_ATTEMPTS = 4 (RETRY_DELAYS.length + 1)
-    expect(svc.create).toHaveBeenCalledTimes(4);
+    // MAX_ATTEMPTS = 5 (RETRY_DELAYS.length + 1)
+    expect(svc.create).toHaveBeenCalledTimes(5);
     expect(mockUpdateStatus).toHaveBeenCalledTimes(1);
     expect(mockUpdateStatus.mock.calls[0][2]).toBe('failed');
   });

--- a/server/scheduler/handlers/work-task.ts
+++ b/server/scheduler/handlers/work-task.ts
@@ -1,7 +1,15 @@
 /**
  * Work task schedule action handler.
- * Retries on conflict errors (e.g. another task active on the same project)
- * with exponential backoff to avoid daily triage failures from transient collisions.
+ *
+ * Handles two kinds of conflict from WorkTaskService.create():
+ *
+ * 1. **Permanent (skip)** — dedup/flock checks determined the work is already
+ *    covered (e.g. "An active work task already addresses issue #X. Skipping.").
+ *    These are marked as 'completed' so they don't trigger the consecutive-
+ *    failure auto-pause and correctly reflect that no action was needed.
+ *
+ * 2. **Transient** — a generic concurrency collision ("already active") that
+ *    may clear up after backoff. Retried with exponential delays.
  */
 import type { AgentSchedule, ScheduleAction } from '../../../shared/types';
 import { updateExecutionStatus } from '../../db/schedules';
@@ -11,9 +19,24 @@ import type { HandlerContext } from './types';
 
 const log = createLogger('SchedulerWorkTask');
 
-/** Retry delays in ms: 30s, 2min, 5min */
-const RETRY_DELAYS = [30_000, 120_000, 300_000];
+/** Retry delays in ms: 30s, 2min, 5min, 10min */
+const RETRY_DELAYS = [30_000, 120_000, 300_000, 600_000];
 const MAX_ATTEMPTS = RETRY_DELAYS.length + 1;
+
+/**
+ * Permanent skip conflicts are intentional dedup/flock rejections where the
+ * work is already being handled. Retrying them is pointless.
+ */
+function isPermanentSkip(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message;
+  return msg.includes('Skipping') || msg.includes('already addresses') || msg.includes('already working');
+}
+
+function isTransientConflict(err: unknown): boolean {
+  if (isPermanentSkip(err)) return false;
+  return err instanceof ConflictError || (err instanceof Error && err.message.includes('already active'));
+}
 
 export async function execWorkTask(
   ctx: HandlerContext,
@@ -48,10 +71,18 @@ export async function execWorkTask(
       });
       return;
     } catch (err) {
-      const isConflict =
-        err instanceof ConflictError || (err instanceof Error && err.message.includes('already active'));
+      // Permanent skip: work is already covered — mark completed, don't retry.
+      if (isPermanentSkip(err)) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.info('Work task skipped — already covered', { executionId, reason: message });
+        updateExecutionStatus(ctx.db, executionId, 'completed', {
+          result: `Skipped: ${message}`,
+        });
+        return;
+      }
 
-      if (isConflict && attempt < MAX_ATTEMPTS) {
+      // Transient conflict: retry with backoff.
+      if (isTransientConflict(err) && attempt < MAX_ATTEMPTS) {
         const delay = RETRY_DELAYS[attempt - 1];
         log.info('Work task conflict — retrying after backoff', {
           executionId,


### PR DESCRIPTION
## Summary

- **Permanent skip conflicts** (dedup/flock: "Skipping" in message) are now marked as `completed` instead of retried-then-`failed`. This prevents the consecutive-failure auto-pause from disabling scheduled tasks like Daily Issue Triage when the work is already covered.
- **Transient conflicts** ("already active") still retry with backoff, now extended to 4 retries (30s → 2m → 5m → 10m) for better coverage of longer-running tasks.
- Added tests for permanent skip handling (dedup and flock conflict scenarios).

## Test plan

- [x] All 11 existing + new tests pass (`bun test server/__tests__/scheduler-work-task-handler.test.ts`)
- [x] TypeScript type check passes
- [x] Verify Daily Issue Triage schedule no longer auto-pauses after dedup skips

Fixes #1943

🤖 Generated with [Claude Code](https://claude.com/claude-code)