### PR TITLE
fix: correct API endpoint counter and update stats

### DIFF
--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -38,12 +38,12 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Server modules | 47 |
 | API routes | 51 modules (~300 endpoints) |
 | Database tables | 110 |
-| Database migrations | 40 (squashed baseline) |
+| Database migrations | 41 (squashed baseline) |
 | MCP tools | 56 corvid_* handlers |
 | Unit tests | 4,242 test files |
 | E2E tests | 360 across 33 Playwright specs |
 | Security tests | 232 dedicated |
-| Module specs | 210 .spec.md files |
+| Module specs | 211 .spec.md files |
 | Test:code ratio | 1.14x (more test than production) |
 | Dependencies | 17 direct |
 | Version | 0.51.0 |

--- a/scripts/collect-stats.ts
+++ b/scripts/collect-stats.ts
@@ -50,8 +50,20 @@ function countRouteModules(): number {
 }
 
 function countApiEndpoints(): number {
-  const registry = readFileSync(join(ROOT, 'server/openapi/route-registry.ts'), 'utf-8');
-  return (registry.match(/method:/g) || []).length;
+  // Count method: definitions across all route files in the routes directory
+  const routesDir = join(ROOT, 'server/openapi/routes');
+  let count = 0;
+  try {
+    for (const file of readdirSync(routesDir)) {
+      if (file.endsWith('.ts') && file !== 'types.ts' && file !== 'index.ts') {
+        const content = readFileSync(join(routesDir, file), 'utf-8');
+        count += (content.match(/method:/g) || []).length;
+      }
+    }
+  } catch {
+    /* directory may not exist */
+  }
+  return count;
 }
 
 function countDbTables(): number {


### PR DESCRIPTION
## Summary
- Fix `countApiEndpoints()` to read `method:` definitions from individual route files instead of route-registry.ts
- Update docs/deep-dive.md stats: 211 specs (was 210), 41 migrations (was 40)
- API endpoint count now correctly reports 214 (was 0 due to wrong file)

## Impact
This fixes stats:check failures on PRs that trigger the Stats workflow. The endpoint counter was reading the wrong file and getting 0 results, causing CI failures on feature PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)