### PR TITLE
fix(specs): document getLatestMentionSessionByChannel export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.63.1] - 2026-04-11
+
+### Fixed
+- **Discord: mention session context** — add channel-based session fallback and conversation history carryover for mention sessions (#1968). Users can now reply without Discord's reply feature and still route to the correct session. When a mention session expires, new sessions inherit the previous conversation context.
+
 ## [0.63.0] - 2026-04-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.63.0-4a90d9" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.63.1-4a90d9" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corvid-agent",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "description": "AI agent framework with on-chain identity and messaging via AlgoChat on Algorand",
   "repository": {
     "type": "git",

--- a/specs/db/sessions/discord-mention-sessions.spec.md
+++ b/specs/db/sessions/discord-mention-sessions.spec.md
@@ -28,6 +28,7 @@ Persists Discord mention-reply session mappings so they survive server restarts.
 | `getRecentMentionSessions` | `db: Database, maxAgeHours?: number` | `Array<{ botMessageId, info, createdAt }>` | Returns all mention sessions created within the last N hours (default 24), joined with agent display metadata |
 | `updateMentionSessionActivity` | `db: Database, botMessageId: string` | `void` | Updates the `last_activity_at` timestamp for a mention session |
 | `pruneOldMentionSessions` | `db: Database, maxAgeDays?: number` | `number` | Deletes rows older than the specified age (default 7 days); returns the number of deleted rows |
+| `getLatestMentionSessionByChannel` | `db: Database, channelId: string, maxAgeMinutes?: number` | `MentionSessionInfo \| null` | Finds the most recently active mention session in a channel (default 15-minute window); used as fallback when no direct message-reply match exists |
 
 ## Invariants
 


### PR DESCRIPTION
## Summary
- Adds missing `getLatestMentionSessionByChannel` export to `discord-mention-sessions.spec.md`
- This was added in #1968 but the spec wasn't updated, causing `specsync check --strict` to fail in CI with 2 warnings

## Test plan
- [x] `bun run spec:check` passes locally with 0 warnings
- CI Checks workflow should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)