### PR TITLE
fix: update work-task-service spec to reflect queuing behavior

### DIFF
--- a/specs/work/work-task-service.spec.md
+++ b/specs/work/work-task-service.spec.md
@@ -278,7 +278,9 @@ The optional `agent_id` parameter on `corvid_create_work_task` allows the callin
 | No project ID (none provided, agent has no default) | Throws `Error("No projectId provided and agent has no defaultProjectId")` |
 | Project not found | Throws `Error("Project {id} not found")` |
 | Project has no workingDir | Throws `Error("Project {id} has no workingDir")` |
-| Another active task on same project | Throws `Error("Another task is already active on project {id}")` |
+| Another active task on same project (equal/higher priority) | New task is queued with status `'queued'` behind the active task |
+| Another active task on same project (lower priority) | Active task is paused and preempted; new task runs immediately |
+| Atomic insert race condition | New task is queued as fallback (never rejected) |
 | Git worktree creation fails | Task status set to `failed` with error message, task returned |
 | `cancelTask` with nonexistent ID | Returns `null` |
 


### PR DESCRIPTION
## Summary

- Updates the work-task-service spec error cases table to match current code behavior
- The spec still documented that an active task throws `Error("Another task is already active on project {id}")`, but the code was updated in PRs #1865, #1891, and #1945 to queue tasks behind active ones instead
- Adds documentation for queuing (equal/higher priority), preemption (lower priority active task), and race-condition fallback behaviors

Fixes #1978

## Test plan

- [x] `bun run spec:check` passes (verified via pre-commit hook)
- [x] Verify spec text matches actual `WorkTaskService.create()` behavior in `server/work/service.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)