### PR TITLE
fix: add startup timeout for sessions stuck on slow model endpoints

### DIFF
--- a/server/__tests__/process-manager-startup-timeout.test.ts
+++ b/server/__tests__/process-manager-startup-timeout.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for the startup timeout in ProcessManager.
+ *
+ * When a session starts but receives no events within the startup window,
+ * the timer fires and kills the session (e.g., hung Ollama proxy, dead endpoint).
+ */
+
+import { mock, spyOn } from 'bun:test';
+
+// Must mock sdk-process before ProcessManager import
+mock.module('../process/sdk-process', () => ({
+  startSdkProcess: () => ({ pid: 999, sendMessage: () => true, kill: () => {} }),
+}));
+
+import { Database } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { runMigrations } from '../db/schema';
+import { createSession, getSession } from '../db/sessions';
+import { ProcessManager } from '../process/manager';
+import type { SessionTimerManager } from '../process/session-timer-manager';
+import type { ClaudeStreamEvent } from '../process/types';
+
+const AGENT_ID = 'agent-startup-timeout-1';
+const PROJECT_ID = 'proj-startup-timeout-1';
+
+let db: Database;
+let pm: ProcessManager;
+let sessionId: string;
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  runMigrations(db);
+
+  db.query(
+    `INSERT INTO agents (id, name, model, system_prompt) VALUES (?, 'TestAgent', 'claude-haiku-4-5-20251001', 'test')`,
+  ).run(AGENT_ID);
+  db.query(`INSERT INTO projects (id, name, working_dir) VALUES (?, 'TestProject', '/tmp/test')`).run(PROJECT_ID);
+
+  const session = createSession(db, { projectId: PROJECT_ID, agentId: AGENT_ID, name: 'StartupTimeoutTest' });
+  sessionId = session.id;
+
+  pm = new ProcessManager(db);
+});
+
+afterEach(() => {
+  pm.shutdown();
+  db.close();
+});
+
+describe('startup timeout', () => {
+  test('onStartupTimeout callback stops session and adds system message', () => {
+    // Access the timerManager's callbacks by triggering the startup timeout directly
+    // We spy on stopProcess-related DB calls to verify the callback wiring
+    const session = getSession(db, sessionId)!;
+    pm.resumeProcess(session);
+
+    // Directly invoke the startup timeout callback via the timer manager
+    // by getting the callback from the ProcessManager's timerManager
+    const timerManager = (pm as unknown as { timerManager: SessionTimerManager }).timerManager;
+    const callbacks = (timerManager as unknown as { callbacks: { onStartupTimeout: (id: string) => void } }).callbacks;
+
+    // Call the callback directly to test the wiring
+    callbacks.onStartupTimeout(sessionId);
+
+    // Session should be stopped
+    const updated = getSession(db, sessionId)!;
+    expect(updated.status).toBe('stopped');
+
+    // Should have a system message about the timeout
+    const messages = db
+      .query('SELECT content FROM session_messages WHERE session_id = ? AND role = ?')
+      .all(sessionId, 'system') as { content: string }[];
+    const timeoutMsg = messages.find((m) => m.content.includes('timed out waiting for the model'));
+    expect(timeoutMsg).toBeDefined();
+  });
+
+  test('clearStartupTimeout is called on handleEvent', () => {
+    const timerManager = (pm as unknown as { timerManager: SessionTimerManager }).timerManager;
+    const spy = spyOn(timerManager, 'clearStartupTimeout');
+
+    const session = getSession(db, sessionId)!;
+    pm.resumeProcess(session);
+    spy.mockClear(); // clear calls from setup
+
+    // Trigger handleEvent via the private method through the event callback
+    const handleEvent = (pm as unknown as { handleEvent: (id: string, e: ClaudeStreamEvent) => void }).handleEvent;
+    handleEvent.call(pm, sessionId, { type: 'assistant', session_id: sessionId } as ClaudeStreamEvent);
+
+    expect(spy).toHaveBeenCalledWith(sessionId);
+    spy.mockRestore();
+  });
+});

--- a/server/__tests__/session-timer-manager.test.ts
+++ b/server/__tests__/session-timer-manager.test.ts
@@ -34,6 +34,7 @@ describe('SessionTimerManager', () => {
       const stats = manager.getStats();
       expect(stats.sessionTimeouts).toBe(0);
       expect(stats.stableTimers).toBe(0);
+      expect(stats.startupTimeouts).toBe(0);
     });
 
     it('accepts custom config', () => {
@@ -191,18 +192,90 @@ describe('SessionTimerManager', () => {
     });
   });
 
+  describe('startStartupTimeout / clearStartupTimeout', () => {
+    it('fires onStartupTimeout when no events arrive within the window', async () => {
+      const startupTimeouts: string[] = [];
+      callbacks.onStartupTimeout = (sessionId) => startupTimeouts.push(sessionId);
+      runningSessions.add('s1');
+      manager = new SessionTimerManager(callbacks, { startupTimeoutMs: 50 });
+
+      manager.startStartupTimeout('s1');
+      expect(manager.getStats().startupTimeouts).toBe(1);
+
+      await new Promise((r) => setTimeout(r, 100));
+      expect(startupTimeouts).toContain('s1');
+      expect(manager.getStats().startupTimeouts).toBe(0);
+    });
+
+    it('does not fire if cleared before timeout', async () => {
+      const startupTimeouts: string[] = [];
+      callbacks.onStartupTimeout = (sessionId) => startupTimeouts.push(sessionId);
+      runningSessions.add('s1');
+      manager = new SessionTimerManager(callbacks, { startupTimeoutMs: 50 });
+
+      manager.startStartupTimeout('s1');
+      manager.clearStartupTimeout('s1');
+
+      await new Promise((r) => setTimeout(r, 100));
+      expect(startupTimeouts).toHaveLength(0);
+      expect(manager.getStats().startupTimeouts).toBe(0);
+    });
+
+    it('does not fire if session stopped running before timeout', async () => {
+      const startupTimeouts: string[] = [];
+      callbacks.onStartupTimeout = (sessionId) => startupTimeouts.push(sessionId);
+      runningSessions.add('s1');
+      manager = new SessionTimerManager(callbacks, { startupTimeoutMs: 50 });
+
+      manager.startStartupTimeout('s1');
+      runningSessions.delete('s1');
+
+      await new Promise((r) => setTimeout(r, 100));
+      expect(startupTimeouts).toHaveLength(0);
+    });
+
+    it('clearStartupTimeout is idempotent', () => {
+      manager = new SessionTimerManager(callbacks);
+      manager.clearStartupTimeout('nonexistent');
+      expect(manager.getStats().startupTimeouts).toBe(0);
+    });
+
+    it('startStartupTimeout resets existing timer', async () => {
+      const startupTimeouts: string[] = [];
+      callbacks.onStartupTimeout = (sessionId) => startupTimeouts.push(sessionId);
+      runningSessions.add('s1');
+      manager = new SessionTimerManager(callbacks, { startupTimeoutMs: 80 });
+
+      manager.startStartupTimeout('s1');
+      await new Promise((r) => setTimeout(r, 50));
+      manager.startStartupTimeout('s1');
+      expect(manager.getStats().startupTimeouts).toBe(1);
+
+      // Original timer would have fired at 80ms, but we reset at 50ms
+      await new Promise((r) => setTimeout(r, 50));
+      expect(startupTimeouts).toHaveLength(0);
+
+      // Reset timer fires at 130ms total
+      await new Promise((r) => setTimeout(r, 50));
+      expect(startupTimeouts).toContain('s1');
+    });
+  });
+
   describe('cleanupSession', () => {
-    it('clears both stable timer and session timeout', () => {
-      manager = new SessionTimerManager(callbacks, { stablePeriodMs: 10000, agentTimeoutMs: 10000 });
+    it('clears all timers including startup timeout', () => {
+      manager = new SessionTimerManager(callbacks, { stablePeriodMs: 10000, agentTimeoutMs: 10000, startupTimeoutMs: 10000 });
       runningSessions.add('s1');
       manager.startStableTimer('s1');
       manager.startSessionTimeout('s1');
+      manager.startStartupTimeout('s1');
       expect(manager.getStats().stableTimers).toBe(1);
       expect(manager.getStats().sessionTimeouts).toBe(1);
+      expect(manager.getStats().startupTimeouts).toBe(1);
 
       manager.cleanupSession('s1');
       expect(manager.getStats().stableTimers).toBe(0);
       expect(manager.getStats().sessionTimeouts).toBe(0);
+      expect(manager.getStats().startupTimeouts).toBe(0);
     });
   });
 

--- a/server/__tests__/session-timer-manager.test.ts
+++ b/server/__tests__/session-timer-manager.test.ts
@@ -18,6 +18,7 @@ describe('SessionTimerManager', () => {
     callbacks = {
       onTimeout: (sessionId) => timeoutSessions.push(sessionId),
       onStablePeriod: (sessionId) => stableSessions.push(sessionId),
+      onStartupTimeout: (sessionId) => timeoutSessions.push(sessionId),
       isRunning: (sessionId) => runningSessions.has(sessionId),
       getLastActivityAt: (sessionId) => activityMap.get(sessionId),
     };

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -202,6 +202,22 @@ export class ProcessManager {
           meta.restartCount = 0;
         }
       },
+      onStartupTimeout: (sessionId) => {
+        const session = getSession(this.db, sessionId);
+        const meta = this.sessionMeta.get(sessionId);
+        log.error(`Session ${sessionId} startup timeout — no events received, killing session`, {
+          name: session?.name,
+          agentId: session?.agentId,
+          source: meta?.source ?? session?.source,
+        });
+        addSessionMessage(
+          this.db,
+          sessionId,
+          'system',
+          'Session timed out waiting for the model to respond. The model endpoint may be down or overloaded. Try again or use a different agent.',
+        );
+        this.stopProcess(sessionId, 'startup_timeout');
+      },
       isRunning: (sessionId) => this.processes.has(sessionId),
       getLastActivityAt: (sessionId) => this.sessionMeta.get(sessionId)?.lastActivityAt,
     });
@@ -827,6 +843,7 @@ export class ProcessManager {
 
     this.timerManager.startStableTimer(session.id);
     this.timerManager.startSessionTimeout(session.id);
+    this.timerManager.startStartupTimeout(session.id);
 
     log.info(`Started process for session ${session.id}`, { pid: process.pid });
 
@@ -1552,6 +1569,8 @@ export class ProcessManager {
     if (meta) {
       meta.lastActivityAt = Date.now();
       this.timerManager.startSessionTimeout(sessionId);
+      // First event received — clear the startup timeout
+      this.timerManager.clearStartupTimeout(sessionId);
     }
 
     // Cursor (and similar): per-turn cost/metrics without broadcasting `result`

--- a/server/process/session-timer-manager.ts
+++ b/server/process/session-timer-manager.ts
@@ -17,6 +17,8 @@ export interface SessionTimerCallbacks {
   onTimeout: (sessionId: string) => void;
   /** Called when a session has been stable long enough to reset its restart counter. */
   onStablePeriod: (sessionId: string) => void;
+  /** Called when a session produces no events within the startup window. */
+  onStartupTimeout: (sessionId: string) => void;
   /** Check whether a session has an active process. */
   isRunning: (sessionId: string) => boolean;
   /** Get the last activity timestamp for a session (epoch ms), or undefined if not tracked. */
@@ -30,12 +32,15 @@ export interface SessionTimerConfig {
   stablePeriodMs: number;
   /** Interval for the fallback timeout checker. Default: 60s. */
   timeoutCheckIntervalMs: number;
+  /** Max time (ms) to wait for the first event after process registration. Default: 90s. */
+  startupTimeoutMs: number;
 }
 
 const DEFAULT_CONFIG: SessionTimerConfig = {
   agentTimeoutMs: parseInt(process.env.AGENT_TIMEOUT_MS ?? String(30 * 60 * 1000), 10),
   stablePeriodMs: 10 * 60 * 1000,
   timeoutCheckIntervalMs: 60_000,
+  startupTimeoutMs: parseInt(process.env.STARTUP_TIMEOUT_MS ?? '90000', 10),
 };
 
 export class SessionTimerManager {
@@ -44,6 +49,7 @@ export class SessionTimerManager {
 
   private stableTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
   private sessionTimeouts: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  private startupTimeouts: Map<string, ReturnType<typeof setTimeout>> = new Map();
   private timeoutTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(callbacks: SessionTimerCallbacks, config: Partial<SessionTimerConfig> = {}) {
@@ -69,6 +75,32 @@ export class SessionTimerManager {
     if (timer) {
       clearTimeout(timer);
       this.stableTimers.delete(sessionId);
+    }
+  }
+
+  /**
+   * Start a startup timeout — fires if no events arrive within the startup window.
+   * Catches hung Ollama proxy requests, dead model endpoints, etc.
+   * Cleared automatically on the first event via clearStartupTimeout().
+   */
+  startStartupTimeout(sessionId: string): void {
+    this.clearStartupTimeout(sessionId);
+    const timer = setTimeout(() => {
+      this.startupTimeouts.delete(sessionId);
+      if (!this.callbacks.isRunning(sessionId)) return;
+      log.warn(`Session ${sessionId} produced no events within startup window`, {
+        timeoutMs: this.config.startupTimeoutMs,
+      });
+      this.callbacks.onStartupTimeout(sessionId);
+    }, this.config.startupTimeoutMs);
+    this.startupTimeouts.set(sessionId, timer);
+  }
+
+  clearStartupTimeout(sessionId: string): void {
+    const timer = this.startupTimeouts.get(sessionId);
+    if (timer) {
+      clearTimeout(timer);
+      this.startupTimeouts.delete(sessionId);
     }
   }
 
@@ -154,14 +186,16 @@ export class SessionTimerManager {
   cleanupSession(sessionId: string): void {
     this.clearStableTimer(sessionId);
     this.clearSessionTimeout(sessionId);
+    this.clearStartupTimeout(sessionId);
   }
 
   /**
    * Get the count of active timers for monitoring.
    */
-  getStats(): { sessionTimeouts: number; stableTimers: number } {
+  getStats(): { sessionTimeouts: number; stableTimers: number; startupTimeouts: number } {
     return {
       sessionTimeouts: this.sessionTimeouts.size,
+      startupTimeouts: this.startupTimeouts.size,
       stableTimers: this.stableTimers.size,
     };
   }


### PR DESCRIPTION
## Summary

- Adds a **90-second startup timeout** that kills sessions producing zero events after process registration
- Catches hung Ollama proxy requests, dead model endpoints, and similar hangs
- Writes a user-visible system message ("model endpoint may be down") before killing the session
- Configurable via `STARTUP_TIMEOUT_MS` env var

## Problem

Sessions using slow model endpoints (e.g. Starling via Ollama cloud proxy) could hang indefinitely — the typing indicator kept refreshing every 8s while the 30-min inactivity timeout slowly counted down. No feedback was given to the user.

## Changes

- `server/process/session-timer-manager.ts` — new `startStartupTimeout()` / `clearStartupTimeout()` methods, added to `cleanupSession()` and `getStats()`
- `server/process/manager.ts` — starts startup timeout on `registerProcess()`, clears on first event, kills session with descriptive message on timeout
- `server/__tests__/session-timer-manager.test.ts` — full test coverage for startup timeout lifecycle

## Test plan

- [x] All tests pass (`bun test`)
- [x] TypeScript compiles clean (`bun x tsc --noEmit --skipLibCheck`)
- [x] Lint passes (`bun run lint`)
- [x] Spec check passes (`bun run spec:check`)
- [x] Startup timeout fires correctly when no events arrive (unit tested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6