### PR TITLE
fix: prevent duplicate PR comments from cross-config polling

### DIFF
--- a/server/__tests__/polling-service-core.test.ts
+++ b/server/__tests__/polling-service-core.test.ts
@@ -12,7 +12,9 @@ import { createAgent } from '../db/agents';
 import { createMentionPollingConfig } from '../db/mention-polling';
 import { createProject } from '../db/projects';
 import { runMigrations } from '../db/schema';
+import { DedupService } from '../lib/dedup';
 import type { DetectedMention } from '../polling/github-searcher';
+
 import { MentionPollingService } from '../polling/service';
 
 // ─── Test Setup ─────────────────────────────────────────────────────────────
@@ -20,6 +22,7 @@ import { MentionPollingService } from '../polling/service';
 let db: Database;
 let agentId: string;
 let projectId: string;
+let savedGhToken: string | undefined;
 
 const mockStartProcess = mock(() => {});
 
@@ -44,10 +47,21 @@ beforeEach(() => {
   projectId = project.id;
 
   mockStartProcess.mockReset();
+  DedupService.resetGlobal();
+
+  // Prevent real GitHub API calls from ack/completion comments.
+  // Saving and restoring GH_TOKEN so the test's mocked runGh can run
+  // without the github/operations module's addIssueComment hitting the real API.
+  savedGhToken = process.env.GH_TOKEN;
+  delete process.env.GH_TOKEN;
 });
 
 afterEach(() => {
   db.close();
+  // Restore GH_TOKEN after each test
+  if (savedGhToken !== undefined) {
+    process.env.GH_TOKEN = savedGhToken;
+  }
 });
 
 function createTestConfig(overrides?: Record<string, unknown>) {
@@ -427,6 +441,41 @@ describe('processMention', () => {
     // Should proceed past the assignee guard since it's an assignment type
     expect(result).toBe(true);
     expect(mockStartProcess).toHaveBeenCalledTimes(1);
+  });
+
+  test('cross-config session dedup prevents duplicate sessions for same PR', async () => {
+    const config1 = createTestConfig({ repo: 'CorvidLabs/spec-sync' });
+    const config2 = createTestConfig({ repo: 'CorvidLabs/spec-sync' });
+    const mention = makeMention({ id: 'review-999', number: 226 });
+
+    const service = new MentionPollingService(db, mockProcessManager);
+    const priv = getPrivate(service);
+
+    priv.runGh = mock(async (args: string[]) => {
+      if (args.some((a) => a.includes('.body'))) {
+        return { ok: true, stdout: 'PR body', stderr: '' };
+      }
+      if (args.some((a) => a.includes('[.assignees'))) {
+        return { ok: true, stdout: JSON.stringify([]), stderr: '' };
+      }
+      return { ok: true, stdout: '', stderr: '' };
+    });
+
+    // First config triggers successfully
+    const result1 = await priv.processMention(config1, mention);
+    expect(result1).toBe(true);
+    expect(mockStartProcess).toHaveBeenCalledTimes(1);
+
+    // Second config for the same repo#number is deduped
+    const result2 = await priv.processMention(config2, { ...mention, id: 'review-1000' });
+    expect(result2).toBe(false);
+    expect(mockStartProcess).toHaveBeenCalledTimes(1); // still 1
+
+    // Different PR number should still work
+    const differentMention = makeMention({ id: 'review-1001', number: 227 });
+    const result3 = await priv.processMention(config2, differentMention);
+    expect(result3).toBe(true);
+    expect(mockStartProcess).toHaveBeenCalledTimes(2);
   });
 
   test('creates session and calls startProcess on successful trigger', async () => {

--- a/server/polling/service.ts
+++ b/server/polling/service.ts
@@ -46,6 +46,7 @@ import { type DetectedMention, filterNewMentions, GitHubSearcher, resolveFullRep
 const log = createLogger('MentionPoller');
 const TRIGGER_DEDUP_NS = 'polling:triggers';
 const ACK_DEDUP_NS = 'polling:ack-comments';
+const SESSION_DEDUP_NS = 'polling:session-dedup';
 
 /** How often we check which configs are due (main loop interval). */
 const POLL_LOOP_INTERVAL_MS = 15_000; // 15 seconds
@@ -90,6 +91,8 @@ export class MentionPollingService {
     this.dedup.register(TRIGGER_DEDUP_NS, { maxSize: 500, ttlMs: MIN_TRIGGER_GAP_MS });
     // Cross-config dedup for ack comments: same repo#number only gets one "looking into this"
     this.dedup.register(ACK_DEDUP_NS, { maxSize: 500, ttlMs: 5 * 60 * 1000 });
+    // Cross-config dedup for sessions: same repo#number only gets one session across all configs
+    this.dedup.register(SESSION_DEDUP_NS, { maxSize: 500, ttlMs: 5 * 60 * 1000 });
     this.searcher = new GitHubSearcher((args) => this.runGh(args));
 
     // Initialize sub-services
@@ -427,6 +430,20 @@ export class MentionPollingService {
       return false;
     }
 
+    // Cross-config dedup: if another config already triggered a session for the
+    // same repo#number within the TTL window, skip. This prevents multiple
+    // polling configs from independently reacting to the same PR review/comment.
+    const sessionDedupKey = `${fullRepo}#${mention.number}`;
+    if (this.dedup.has(SESSION_DEDUP_NS, sessionDedupKey)) {
+      log.debug('Skipping mention — cross-config session dedup', {
+        configId: config.id,
+        mentionId: mention.id,
+        number: mention.number,
+        repo: fullRepo,
+      });
+      return false;
+    }
+
     // Dependency check: skip if the issue has open blockers.
     // Returning false keeps the mention unprocessed so it retries next cycle.
     const openBlockers = await this.checkDependencies(fullRepo, mention);
@@ -479,6 +496,7 @@ export class MentionPollingService {
     const prompt = this.buildPrompt(config, mention);
 
     this.dedup.markSeen(TRIGGER_DEDUP_NS, rateLimitKey);
+    this.dedup.markSeen(SESSION_DEDUP_NS, sessionDedupKey);
 
     try {
       const session = createSession(this.db, {

--- a/specs/polling/mention-polling-service.spec.md
+++ b/specs/polling/mention-polling-service.spec.md
@@ -64,6 +64,7 @@ Initializes `DedupService` (namespace `polling:triggers`, maxSize 500, TTL 60s),
 15. **Completion tracking**: The service subscribes to session end events; on error or manual stop, a follow-up comment is posted to ensure the issue does not go silent after acknowledgment
 16. **Event-based schedule triggering**: After successful triggers, matching event-based schedules (type `github_poll`, action `mention`) are fired via the `SchedulerService`
 17. **Observability context**: Each poll config execution runs inside an event context via `runWithEventContext` for tracing
+18. **Cross-config session dedup**: When multiple polling configs detect the same repo#number, only the first config triggers a session. Managed by `DedupService` namespace `polling:session-dedup` (maxSize 500, TTL 5 minutes). Prevents duplicate agent responses when multiple configs overlap on the same repository
 
 ## Behavioral Examples
 
@@ -90,6 +91,12 @@ Initializes `DedupService` (namespace `polling:triggers`, maxSize 500, TTL 60s),
 - **Given** a PR authored by `agent-user` with a review also by `agent-user`
 - **When** the poll fetches PR reviews
 - **Then** the self-review is skipped (reviewer username matches mentionUsername)
+
+### Scenario: Cross-config session dedup prevents duplicate responses
+
+- **Given** two polling configs (A and B) both covering `owner/repo`
+- **When** a reviewer approves PR #226, detected by both configs
+- **Then** config A triggers a session; config B is skipped because `polling:session-dedup` already has the key `owner/repo#226`
 
 ### Scenario: Multiple mentions for same issue collapse
 


### PR DESCRIPTION
## Summary

- **Cross-config session dedup**: Adds `polling:session-dedup` DedupService namespace (5-min TTL) that prevents multiple polling configs from independently spawning sessions for the same `repo#number`. This was the root cause of duplicate ack comments and near-identical "thanks for approval" replies on PRs like CorvidLabs/spec-sync#226 (4 comments when there should have been 1).
- **Test leak fix**: `polling-service-core.test.ts` was calling `processMention` without mocking `addIssueComment`, causing real GitHub comments (signed "TestAgent") to appear on production PRs during test runs. Fixed by clearing `GH_TOKEN` during tests so the `hasGhToken()` guard prevents real API calls.
- **Test isolation**: Added `DedupService.resetGlobal()` to `beforeEach` so dedup state doesn't leak between tests.

## Root Cause

When a PR gets approved, `searchGlobalAuthoredPRReviews` detects the review. If multiple polling configs cover the same repo (e.g. org-level `CorvidLabs` + repo-level), each config independently passes the per-config dedup (`processedIds`, `TRIGGER_DEDUP_NS`) and spawns its own agent session. Each session then posts its own "thanks for approval" comment.

The ack comment dedup (`ACK_DEDUP_NS`) already prevented duplicate "looking into this" messages across configs, but there was no equivalent for session creation itself.

## Test plan

- [x] All 10,284 tests pass
- [x] Type check clean
- [x] Deleted spurious "TestAgent" comments from CorvidLabs/spec-sync#227
- [ ] Verify next PR approval only produces one session and one reply

---
🤖 Agent: CorvidAgent | Model: Opus 4.6