### PR TITLE
fix: Phase 1C audit — add missing automate/schedules redirect + lint fix

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -262,6 +262,7 @@ export const routes: Routes = [
 
     // Old automate paths -> settings/*
     { path: 'automate', redirectTo: 'settings/automation', pathMatch: 'full' },
+    { path: 'automate/schedules', redirectTo: 'settings/automation', pathMatch: 'full' },
     { path: 'automate/workflows', redirectTo: 'settings/automation', pathMatch: 'full' },
     { path: 'automate/webhooks', redirectTo: 'settings/automation', pathMatch: 'full' },
     { path: 'automate/mention-polling', redirectTo: 'settings/automation', pathMatch: 'full' },

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -11,12 +11,8 @@ import {
   updateDiscordConfigBatch,
   VALID_DISCORD_CONFIG_KEYS,
 } from '../db/discord-config';
-import {
-  getTelegramConfigRaw,
-  updateTelegramConfigBatch,
-  VALID_TELEGRAM_CONFIG_KEYS,
-} from '../db/telegram-config';
 import { purgeTestData } from '../db/purge-test-data';
+import { getTelegramConfigRaw, updateTelegramConfigBatch, VALID_TELEGRAM_CONFIG_KEYS } from '../db/telegram-config';
 import { loadGuildCache } from '../discord/guild-api';
 import { json } from '../lib/response';
 import { parseBodyOrThrow, UpdateCreditConfigSchema, ValidationError } from '../lib/validation';


### PR DESCRIPTION
## Phase 1C Audit: Automation/Integration Feature Directories

### Summary

Audited all 6 candidate feature directories for safe removal. **None can be safely deleted** — all have active non-redirect imports from the consolidated settings pages.

### Grep Proof Per Directory

| Directory | Imported By | Safe to Delete? |
|-----------|-------------|-----------------|
| `features/mention-polling/` | `settings-automation/settings-automation.component.ts:9` | ❌ No |
| `features/webhooks/` | `settings-automation/settings-automation.component.ts:8` | ❌ No |
| `features/schedules/` | `settings-automation/settings-automation.component.ts:6` | ❌ No |
| `features/workflows/` | `settings-automation/settings-automation.component.ts:7` | ❌ No |
| `features/marketplace/` | `settings-integrations/settings-integrations.component.ts:8` | ❌ No |
| `features/mcp-servers/` | `settings-integrations/settings-integrations.component.ts:6` | ❌ No |

The "consolidation" embeds the old components via Angular imports — `settings-automation` renders `<app-schedule-list />`, `<app-workflow-list />`, `<app-webhook-list />`, `<app-mention-polling-list />` and `settings-integrations` renders `<app-mcp-server-list />` and `<app-marketplace />`. Deleting these directories would break the consolidated pages.

### Route Status

All routes are already redirect-only — no lazy-loaded routes exist for the old feature paths. Route cleanup from prior phases is complete.

### Changes in This PR

1. **Added missing `automate/schedules` redirect** — `automate/workflows`, `automate/webhooks`, `automate/mention-polling`, and `automate/mcp-servers` all had redirects; `automate/schedules` was the only sibling missing one.

2. **Fixed pre-existing import sort order** in `server/routes/settings.ts` (Biome lint: `purge-test-data` must come before `telegram-config` alphabetically).

### What Would Enable Future Directory Removal

To safely remove these directories in a future phase, the component code would need to be either:
- Inlined directly into `settings-automation.component.ts` / `settings-integrations.component.ts`, or
- Moved into the settings feature directories with updated import paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)