### PR TITLE
fix: add missing automate/schedules redirect and fix import ordering

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -264,6 +264,7 @@ export const routes: Routes = [
     { path: 'automate', redirectTo: 'settings/automation', pathMatch: 'full' },
     { path: 'automate/workflows', redirectTo: 'settings/automation', pathMatch: 'full' },
     { path: 'automate/webhooks', redirectTo: 'settings/automation', pathMatch: 'full' },
+    { path: 'automate/schedules', redirectTo: 'settings/automation', pathMatch: 'full' },
     { path: 'automate/mention-polling', redirectTo: 'settings/automation', pathMatch: 'full' },
     { path: 'automate/mcp-servers', redirectTo: 'settings/integrations', pathMatch: 'full' },
     { path: 'schedules', redirectTo: 'settings/automation', pathMatch: 'full' },

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -11,12 +11,8 @@ import {
   updateDiscordConfigBatch,
   VALID_DISCORD_CONFIG_KEYS,
 } from '../db/discord-config';
-import {
-  getTelegramConfigRaw,
-  updateTelegramConfigBatch,
-  VALID_TELEGRAM_CONFIG_KEYS,
-} from '../db/telegram-config';
 import { purgeTestData } from '../db/purge-test-data';
+import { getTelegramConfigRaw, updateTelegramConfigBatch, VALID_TELEGRAM_CONFIG_KEYS } from '../db/telegram-config';
 import { loadGuildCache } from '../discord/guild-api';
 import { json } from '../lib/response';
 import { parseBodyOrThrow, UpdateCreditConfigSchema, ValidationError } from '../lib/validation';


### PR DESCRIPTION
## Summary

Audit follow-up for the settings consolidation refactor. Two minor fixes:

1. **Missing redirect**: Added redirect for `/automate/schedules` → `/settings/automation`. This was overlooked during the initial consolidation and users navigating to the old schedules path would have gotten a 404.

2. **Import ordering**: Fixed alphabetical ordering in `server/routes/settings.ts` — `purge-test-data` now comes before `telegram-config` as per lint standards.

## Test Plan

- [x] Lint passes (`bun run lint`)
- [x] Type check passes (`bun x tsc --noEmit --skipLibCheck`)
- [x] Spec validation passes (`bun run spec:check`)
- [x] All redirects verified in `app.routes.ts`