### PR TITLE
fix: resolve e2e test failures (issue #1988)

### DIFF
--- a/client/src/app/core/services/chat-tabs.service.ts
+++ b/client/src/app/core/services/chat-tabs.service.ts
@@ -20,7 +20,7 @@ export class ChatTabsService {
         return this.tabs().find((t) => t.sessionId === id) ?? null;
     });
 
-    openTab(sessionId: string, label: string, status = 'idle', agentName?: string): void {
+    openTab(sessionId: string, label: string, status = 'idle', agentName?: string, setActive = true): void {
         this.tabs.update((tabs) => {
             const existing = tabs.find((t) => t.sessionId === sessionId);
             if (existing) {
@@ -33,7 +33,9 @@ export class ChatTabsService {
             if (newTabs.length > MAX_TABS) newTabs.shift();
             return newTabs;
         });
-        this.activeSessionId.set(sessionId);
+        if (setActive) {
+            this.activeSessionId.set(sessionId);
+        }
         this.saveTabs();
     }
 

--- a/client/src/app/features/sessions/session-view.component.ts
+++ b/client/src/app/features/sessions/session-view.component.ts
@@ -363,12 +363,16 @@ export class SessionViewComponent implements OnInit, OnDestroy {
         this.session.set(session);
         this.messages.set(messages);
 
-        // Register tab
+        // Register tab — if we've already navigated away, register passively (don't hijack active session)
         const tabLabel = session.name || session.initialPrompt?.slice(0, 40) || session.id.slice(0, 8);
-        this.chatTabs.openTab(session.id, tabLabel, session.status);
+        const isCurrentSession = this.sessionId === sid;
+        this.chatTabs.openTab(session.id, tabLabel, session.status, undefined, isCurrentSession);
 
         if (session.agentId) {
             this.agentService.getAgent(session.agentId).then((agent) => {
+                // Guard against stale callbacks: if we've navigated to a different session,
+                // don't re-add this session's tab (fixes race where getAgent resolves after tab close)
+                if (this.sessionId !== sid) return;
                 this.agentName.set(agent.name);
                 this.chatTabs.openTab(session.id, tabLabel, session.status, agent.name);
             }).catch(() => {});

--- a/client/src/app/shared/components/chat-tab-bar.component.ts
+++ b/client/src/app/shared/components/chat-tab-bar.component.ts
@@ -254,12 +254,14 @@ export class ChatTabBarComponent {
     protected closeTab(sessionId: string, event: Event): void {
         event.preventDefault();
         event.stopPropagation();
+        const wasActive = this.tabsService.activeSessionId() === sessionId;
         const nextId = this.tabsService.closeTab(sessionId);
         if (nextId) {
             this.router.navigate(['/sessions', nextId]);
-        } else {
+        } else if (wasActive) {
             this.router.navigate(['/chat']);
         }
+        // Non-active tab closed — stay on current page
     }
 
     protected newChat(): void {

--- a/e2e/agents.spec.ts
+++ b/e2e/agents.spec.ts
@@ -7,8 +7,8 @@ test.describe('Agents', () => {
         const agentName = `Playwright Agent ${Date.now()}`;
         await gotoWithRetry(page, '/agents');
 
-        // Click "New Agent" link (header button, not the empty-state CTA)
-        await page.locator('.page__header a[href="/agents/new"]').click();
+        // Click "New Agent" link (rendered in .page-shell__actions, not .page__header)
+        await page.locator('a[href="/agents/new"]').first().click();
         await page.waitForURL('/agents/new');
 
         // Fill in the agent form
@@ -71,8 +71,9 @@ test.describe('Agents', () => {
 
         await gotoWithRetry(page, `/agents/${agent.id}`);
 
-        // Verify tabs are present
+        // Verify tabs are present (wait for async render)
         const tabs = page.locator('.tab');
+        await expect(tabs.first()).toBeVisible({ timeout: 10000 });
         expect(await tabs.count()).toBeGreaterThanOrEqual(2);
 
         // First tab should be active (overview)

--- a/e2e/allowlist.spec.ts
+++ b/e2e/allowlist.spec.ts
@@ -24,11 +24,11 @@ test.describe('Allowlist', () => {
     test('shows empty state or list', async ({ page }) => {
         await gotoWithRetry(page, '/allowlist', { isRendered: async (p) => (await p.locator('h2').count()) > 0 || (await p.locator('.page__header').count()) > 0 });
 
-        // Should show either the list with items or the empty state
-        const list = page.locator('.list');
-        const empty = page.locator('.empty');
-        const hasList = await list.count() > 0;
-        const hasEmpty = await empty.count() > 0;
+        // Wait for async data load (skeleton → content)
+        await page.waitForSelector('.list, .empty-state', { timeout: 10000 });
+
+        const hasList = await page.locator('.list').count() > 0;
+        const hasEmpty = await page.locator('.empty-state').count() > 0;
         expect(hasList || hasEmpty).toBe(true);
     });
 

--- a/e2e/chat-tabs.spec.ts
+++ b/e2e/chat-tabs.spec.ts
@@ -34,7 +34,7 @@ test.describe('Chat Tabs', () => {
         // Click Tab A — should switch back
         await tabAAfter.click();
         await page.waitForURL(`**/sessions/${sessionA.id}**`);
-        await expect(page.locator('.session-view')).toBeVisible({ timeout: 10_000 });
+        await expect(page.locator('.session-view').first()).toBeVisible({ timeout: 10_000 });
         await expect(page.locator('.tab', { hasText: 'Session Alpha' })).toHaveClass(/tab--active/);
     });
 
@@ -57,13 +57,15 @@ test.describe('Chat Tabs', () => {
         await page.waitForURL(`**/sessions/${sessionA.id}**`);
         await expect(page.locator('.tab', { hasText: 'Stay Session' })).toHaveClass(/tab--active/);
 
-        // Close session B (non-active tab)
-        const closeBtn = page.locator('.tab', { hasText: 'Close Session' }).locator('.tab__close');
-        await closeBtn.click({ force: true });
+        // Close session B (non-active tab) — hover to reveal the button, then click
+        const closeBtnTab = page.locator('.tab', { hasText: 'Close Session' });
+        await closeBtnTab.hover();
+        const closeBtn = closeBtnTab.locator('.tab__close');
+        await closeBtn.click();
 
         // Should still be on session A
         await expect(page).toHaveURL(new RegExp(`sessions/${sessionA.id}`));
-        await expect(page.locator('.session-view')).toBeVisible();
+        await expect(page.locator('.session-view').first()).toBeVisible();
         await expect(page.locator('.tab', { hasText: 'Stay Session' })).toHaveClass(/tab--active/);
 
         // Closed tab should be gone
@@ -84,9 +86,11 @@ test.describe('Chat Tabs', () => {
             isRendered: async (p) => (await p.locator('.session-view').count()) > 0,
         });
 
-        // Close the active tab (session B)
-        const closeBtn = page.locator('.tab--active .tab__close');
-        await closeBtn.click({ force: true });
+        // Close the active tab (session B) — hover to reveal button, then click
+        const closeBtnTab = page.locator('.tab--active');
+        await closeBtnTab.hover();
+        const closeBtn = closeBtnTab.locator('.tab__close');
+        await closeBtn.click();
 
         // Should switch to session A
         await page.waitForURL(`**/sessions/${sessionA.id}**`);
@@ -102,9 +106,11 @@ test.describe('Chat Tabs', () => {
             isRendered: async (p) => (await p.locator('.session-view').count()) > 0,
         });
 
-        // Close the only tab
-        const closeBtn = page.locator('.tab--active .tab__close');
-        await closeBtn.click({ force: true });
+        // Close the only tab — hover to reveal button, then click
+        const closeBtnTab = page.locator('.tab--active');
+        await closeBtnTab.hover();
+        const closeBtn = closeBtnTab.locator('.tab__close');
+        await closeBtn.click();
 
         // Should navigate to /chat
         await page.waitForURL('**/chat**');

--- a/e2e/skill-bundles.spec.ts
+++ b/e2e/skill-bundles.spec.ts
@@ -71,6 +71,8 @@ test.describe('Skill Bundles', () => {
         await api.seedSkillBundle({ name: deleteName });
         await gotoWithRetry(page, '/skill-bundles');
 
+        // Accept the browser confirm() dialog that fires on delete
+        page.on('dialog', (dialog) => dialog.accept());
         await page.locator(`text=${deleteName}`).first().click();
         await page.locator('button:text("Delete")').first().click();
         await expect(page.locator('text=Bundle deleted').first()).toBeVisible({ timeout: 5000 });
@@ -137,6 +139,8 @@ test.describe('Skill Bundles', () => {
         await gotoWithRetry(page, '/skill-bundles');
 
         const tabs = page.locator('.filter-tab');
+        // Wait for async render before counting
+        await expect(tabs.first()).toBeVisible({ timeout: 10000 });
         expect(await tabs.count()).toBe(3); // All, Preset, Custom
 
         // First tab (All) should be active

--- a/e2e/system-logs.spec.ts
+++ b/e2e/system-logs.spec.ts
@@ -20,7 +20,7 @@ test.describe('System Logs', () => {
         await gotoWithRetry(page, '/logs', { isRendered: async (p) => (await p.locator('h2').count()) > 0 });
 
         const hasList = await page.locator('.log-list').count() > 0;
-        const hasEmpty = await page.locator('.empty').count() > 0;
+        const hasEmpty = await page.locator('.empty-state').count() > 0;
         expect(hasList || hasEmpty).toBe(true);
 
         if (hasList) {

--- a/e2e/work-tasks.spec.ts
+++ b/e2e/work-tasks.spec.ts
@@ -81,8 +81,8 @@ test.describe('Work Tasks', () => {
         await expect(page.locator('.form-select')).toBeVisible();
         await expect(page.locator('.form-textarea')).toBeVisible();
 
-        // Cancel hides form
-        await page.locator('button:text("Cancel")').click();
+        // Cancel hides form — the toggle button (.create-btn) changes text to "Cancel" when form is open
+        await page.locator('button.create-btn').click();
         await expect(page.locator('.create-form')).not.toBeVisible({ timeout: 5000 });
     });
 


### PR DESCRIPTION
Closes #1988

## Summary

- **agents**: correct new-agent button selector (`.page-shell__actions`)
- **allowlist / system-logs**: use `.empty-state` selector instead of `.empty`
- **chat-tabs**: switch from `click({ force: true })` to hover-then-click for `.tab__close` buttons (hidden inside `<a routerLink>`); fix stale async race condition where `loadSession(A)` callback hijacked active session after navigation to B; fix non-active tab close incorrectly navigating to `/chat`
- **skill-bundles**: handle `confirm()` dialog; fix filter tab count assertion
- **work-tasks**: use `.create-btn` toggle pattern

### Root cause details

Two Angular bugs fixed alongside the test selector updates:

1. **`chat-tab-bar.component.ts`** — `closeTab()` always called `router.navigate(['/chat'])` when `nextId` was null, even for non-active tabs. Added `wasActive` guard.

2. **`session-view.component.ts`** — `openTab()` was called unconditionally with `setActive = true` in a `Promise.all` callback, so a slow `loadSession(A)` completing after the user navigated to B would reset `activeSessionId` back to A. Fixed by passing `setActive = isCurrentSession`. Also added `sessionId !== sid` guard in `getAgent` callback to prevent re-adding a closed tab.

## Test plan

- [x] `bun run test:e2e -- --grep "Chat Tabs"` — all 4 tests pass
- [x] `bun run test:e2e -- --grep "Agents"` — passes
- [x] `bun run test:e2e -- --grep "Allowlist"` — passes
- [x] `bun run test:e2e -- --grep "Skill Bundles"` — passes
- [x] `bun run test:e2e -- --grep "System Logs"` — passes
- [x] `bun run test:e2e -- --grep "Work Tasks"` — passes
- [x] All 49 targeted e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)