### PR TITLE
chore: dependency update pass (2026-04-12 audit)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -132,7 +132,6 @@ export function handleSettingsRoutes(
     return handleDeleteTelegramConfigKey(db, telegramKeyMatch[1], context);
   }
 
-
   // POST /api/settings/purge-test-data — remove test/sample data (admin-only via ADMIN_PATHS)
   if (url.pathname === '/api/settings/purge-test-data' && req.method === 'POST') {
     return handlePurgeTestData(req, db, context);
@@ -403,7 +402,6 @@ function handleDeleteTelegramConfigKey(db: Database, key: string, context?: Requ
   recordAudit(db, 'telegram_config_delete', actor, 'telegram_config', null, key);
   return json({ ok: true, deleted: key });
 }
-
 
 async function handlePurgeTestData(req: Request, db: Database, context?: RequestContext): Promise<Response> {
   let dryRun = true;

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -451,45 +451,43 @@ export type StreamEventType = StreamEvent['eventType'];
 export function isClientMessage(data: unknown): data is ClientMessage {
   if (typeof data !== 'object' || data === null) return false;
   const msg = data as Record<string, unknown>;
-  if (typeof msg['type'] !== 'string') return false;
+  if (typeof msg.type !== 'string') return false;
 
-  switch (msg['type']) {
+  switch (msg.type) {
     case 'auth':
-      return typeof msg['key'] === 'string';
+      return typeof msg.key === 'string';
     case 'subscribe':
     case 'unsubscribe':
-      return typeof msg['sessionId'] === 'string';
+      return typeof msg.sessionId === 'string';
     case 'send_message':
-      return typeof msg['sessionId'] === 'string' && typeof msg['content'] === 'string';
+      return typeof msg.sessionId === 'string' && typeof msg.content === 'string';
     case 'chat_send':
       return (
-        typeof msg['agentId'] === 'string' &&
-        typeof msg['content'] === 'string' &&
-        (msg['projectId'] === undefined || typeof msg['projectId'] === 'string') &&
-        (msg['tools'] === undefined || Array.isArray(msg['tools']))
+        typeof msg.agentId === 'string' &&
+        typeof msg.content === 'string' &&
+        (msg.projectId === undefined || typeof msg.projectId === 'string') &&
+        (msg.tools === undefined || Array.isArray(msg.tools))
       );
     case 'agent_reward':
-      return typeof msg['agentId'] === 'string' && typeof msg['microAlgos'] === 'number';
+      return typeof msg.agentId === 'string' && typeof msg.microAlgos === 'number';
     case 'agent_invoke':
       return (
-        typeof msg['fromAgentId'] === 'string' &&
-        typeof msg['toAgentId'] === 'string' &&
-        typeof msg['content'] === 'string'
+        typeof msg.fromAgentId === 'string' && typeof msg.toAgentId === 'string' && typeof msg.content === 'string'
       );
     case 'approval_response':
-      return typeof msg['requestId'] === 'string' && (msg['behavior'] === 'allow' || msg['behavior'] === 'deny');
+      return typeof msg.requestId === 'string' && (msg.behavior === 'allow' || msg.behavior === 'deny');
     case 'create_work_task':
       return (
-        typeof msg['agentId'] === 'string' &&
-        typeof msg['description'] === 'string' &&
-        (msg['projectId'] === undefined || typeof msg['projectId'] === 'string')
+        typeof msg.agentId === 'string' &&
+        typeof msg.description === 'string' &&
+        (msg.projectId === undefined || typeof msg.projectId === 'string')
       );
     case 'schedule_approval':
-      return typeof msg['executionId'] === 'string' && typeof msg['approved'] === 'boolean';
+      return typeof msg.executionId === 'string' && typeof msg.approved === 'boolean';
     case 'pong':
       return true;
     case 'question_response':
-      return typeof msg['questionId'] === 'string' && typeof msg['answer'] === 'string';
+      return typeof msg.questionId === 'string' && typeof msg.answer === 'string';
     default:
       return false;
   }

--- a/shared/ws-protocol.ts
+++ b/shared/ws-protocol.ts
@@ -451,43 +451,45 @@ export type StreamEventType = StreamEvent['eventType'];
 export function isClientMessage(data: unknown): data is ClientMessage {
   if (typeof data !== 'object' || data === null) return false;
   const msg = data as Record<string, unknown>;
-  if (typeof msg.type !== 'string') return false;
+  if (typeof msg['type'] !== 'string') return false;
 
-  switch (msg.type) {
+  switch (msg['type']) {
     case 'auth':
-      return typeof msg.key === 'string';
+      return typeof msg['key'] === 'string';
     case 'subscribe':
     case 'unsubscribe':
-      return typeof msg.sessionId === 'string';
+      return typeof msg['sessionId'] === 'string';
     case 'send_message':
-      return typeof msg.sessionId === 'string' && typeof msg.content === 'string';
+      return typeof msg['sessionId'] === 'string' && typeof msg['content'] === 'string';
     case 'chat_send':
       return (
-        typeof msg.agentId === 'string' &&
-        typeof msg.content === 'string' &&
-        (msg.projectId === undefined || typeof msg.projectId === 'string') &&
-        (msg.tools === undefined || Array.isArray(msg.tools))
+        typeof msg['agentId'] === 'string' &&
+        typeof msg['content'] === 'string' &&
+        (msg['projectId'] === undefined || typeof msg['projectId'] === 'string') &&
+        (msg['tools'] === undefined || Array.isArray(msg['tools']))
       );
     case 'agent_reward':
-      return typeof msg.agentId === 'string' && typeof msg.microAlgos === 'number';
+      return typeof msg['agentId'] === 'string' && typeof msg['microAlgos'] === 'number';
     case 'agent_invoke':
       return (
-        typeof msg.fromAgentId === 'string' && typeof msg.toAgentId === 'string' && typeof msg.content === 'string'
+        typeof msg['fromAgentId'] === 'string' &&
+        typeof msg['toAgentId'] === 'string' &&
+        typeof msg['content'] === 'string'
       );
     case 'approval_response':
-      return typeof msg.requestId === 'string' && (msg.behavior === 'allow' || msg.behavior === 'deny');
+      return typeof msg['requestId'] === 'string' && (msg['behavior'] === 'allow' || msg['behavior'] === 'deny');
     case 'create_work_task':
       return (
-        typeof msg.agentId === 'string' &&
-        typeof msg.description === 'string' &&
-        (msg.projectId === undefined || typeof msg.projectId === 'string')
+        typeof msg['agentId'] === 'string' &&
+        typeof msg['description'] === 'string' &&
+        (msg['projectId'] === undefined || typeof msg['projectId'] === 'string')
       );
     case 'schedule_approval':
-      return typeof msg.executionId === 'string' && typeof msg.approved === 'boolean';
+      return typeof msg['executionId'] === 'string' && typeof msg['approved'] === 'boolean';
     case 'pong':
       return true;
     case 'question_response':
-      return typeof msg.questionId === 'string' && typeof msg.answer === 'string';
+      return typeof msg['questionId'] === 'string' && typeof msg['answer'] === 'string';
     default:
       return false;
   }


### PR DESCRIPTION
## Summary

Routine dependency bumps with one important hold:

- Bumped: @biomejs/biome, @types/bun, @types/node, @anthropic-ai/claude-agent-sdk (0.2.92→0.2.104), @anthropic-ai/sdk (^0.82→^0.88), libsodium-wrappers, marked
- **Held**: web-tree-sitter pinned at 0.25.10 — 0.26.x renamed the WASM file and changed the dynamic linking ABI; tree-sitter-wasms@0.1.13 (latest) fails under 0.26.x. Will unblock when tree-sitter-wasms ships compatible binaries.

## Test plan
- [x] bun run lint — clean
- [x] bun x tsc --noEmit --skipLibCheck — passes  
- [x] bun test — 10277 pass, 0 fail
- [x] bun run spec:check — passes