### PR TITLE
feat: runtime config visibility in dashboard settings (#1490)

### DIFF
--- a/client/src/app/features/settings/environment-settings.component.ts
+++ b/client/src/app/features/settings/environment-settings.component.ts
@@ -1,5 +1,43 @@
-import { Component, ChangeDetectionStrategy, Input, signal } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, signal, OnInit } from '@angular/core';
+import { ApiService } from '../../core/services/api.service';
+import { firstValueFrom } from 'rxjs';
 import { SECTION_STYLES } from './settings-shared.styles';
+
+interface RuntimeConfig {
+    agent: {
+        name: string;
+        description: string | null;
+        defaultModel: string;
+        defaultProvider: string;
+    };
+    server: {
+        port: number;
+        bindHost: string;
+        logLevel: string;
+        logFormat: string;
+        apiKeyConfigured: boolean;
+        adminApiKeyConfigured: boolean;
+        allowedOrigins: string | null;
+        publicUrl: string | null;
+    };
+    database: {
+        path: string;
+    };
+    providers: {
+        enabled: string[];
+        anthropicConfigured: boolean;
+        ollamaHost: string;
+        openrouterConfigured: boolean;
+        councilModel: string | null;
+    };
+    integrations: {
+        discord: { enabled: boolean; tokenConfigured: boolean; channelConfigured: boolean };
+        telegram: { enabled: boolean; tokenConfigured: boolean; chatIdConfigured: boolean };
+        algochat: { enabled: boolean; mnemonicConfigured: boolean; network: string };
+        github: { tokenConfigured: boolean; owner: string | null; repo: string | null };
+        slack: { enabled: boolean; tokenConfigured: boolean };
+    };
+}
 
 @Component({
     selector: 'app-environment-settings',
@@ -9,57 +47,206 @@ import { SECTION_STYLES } from './settings-shared.styles';
         <div class="settings__section">
             <h3 class="section-toggle" (click)="toggleSection()">
                 <span class="section-chevron" [class.section-chevron--open]="!collapsed()">&#9654;</span>
-                Environment
+                Runtime Configuration
             </h3>
             @if (!collapsed()) {
-                <div class="env-grid section-collapse">
-                    <div class="env-item">
-                        <span class="env-key">ANTHROPIC_API_KEY</span>
-                        <span class="env-value env-value--set">Configured</span>
+                @if (loading()) {
+                    <p class="muted">Loading configuration...</p>
+                } @else if (!config()) {
+                    <p class="muted">Unable to load runtime configuration.</p>
+                } @else {
+                    <!-- Agent Identity -->
+                    <div class="config-group">
+                        <div class="config-group-title">Agent</div>
+                        <div class="config-grid">
+                            <div class="config-item">
+                                <span class="config-key">Name</span>
+                                <span class="config-value">{{ config()!.agent.name }}</span>
+                            </div>
+                            <div class="config-item">
+                                <span class="config-key">Default Model</span>
+                                <span class="config-value config-value--mono">{{ config()!.agent.defaultModel }}</span>
+                            </div>
+                            <div class="config-item">
+                                <span class="config-key">Default Provider</span>
+                                <span class="config-value config-value--mono">{{ config()!.agent.defaultProvider }}</span>
+                            </div>
+                            @if (config()!.providers.councilModel) {
+                                <div class="config-item">
+                                    <span class="config-key">Council Model</span>
+                                    <span class="config-value config-value--mono">{{ config()!.providers.councilModel }}</span>
+                                </div>
+                            }
+                        </div>
                     </div>
-                    <div class="env-item">
-                        <span class="env-key">OPENROUTER_API_KEY</span>
-                        <span class="env-value" [class.env-value--set]="openrouterStatus?.status === 'available'" [class.env-value--unset]="openrouterStatus?.status !== 'available'">
-                            {{ openrouterStatus?.status === 'available' ? 'Configured' : 'Not set' }}
-                        </span>
+
+                    <!-- Server -->
+                    <div class="config-group">
+                        <div class="config-group-title">Server</div>
+                        <div class="config-grid">
+                            <div class="config-item">
+                                <span class="config-key">Port</span>
+                                <span class="config-value config-value--mono">{{ config()!.server.port }}</span>
+                            </div>
+                            <div class="config-item">
+                                <span class="config-key">Bind Host</span>
+                                <span class="config-value config-value--mono">{{ config()!.server.bindHost }}</span>
+                            </div>
+                            <div class="config-item">
+                                <span class="config-key">Log Level</span>
+                                <span class="config-value config-value--mono">{{ config()!.server.logLevel }}</span>
+                            </div>
+                            <div class="config-item">
+                                <span class="config-key">Log Format</span>
+                                <span class="config-value config-value--mono">{{ config()!.server.logFormat }}</span>
+                            </div>
+                            <div class="config-item">
+                                <span class="config-key">API Key</span>
+                                <span class="config-value" [class.config-value--set]="config()!.server.apiKeyConfigured" [class.config-value--unset]="!config()!.server.apiKeyConfigured">
+                                    {{ config()!.server.apiKeyConfigured ? 'Configured' : 'Not set (localhost only)' }}
+                                </span>
+                            </div>
+                            @if (config()!.server.publicUrl) {
+                                <div class="config-item">
+                                    <span class="config-key">Public URL</span>
+                                    <span class="config-value config-value--mono">{{ config()!.server.publicUrl }}</span>
+                                </div>
+                            }
+                        </div>
                     </div>
-                    <div class="env-item">
-                        <span class="env-key">DISCORD_TOKEN</span>
-                        <span class="env-value" [class.env-value--set]="!!discordConfig" [class.env-value--unset]="!discordConfig">
-                            {{ discordConfig ? 'Configured' : 'Not set' }}
-                        </span>
+
+                    <!-- Providers -->
+                    <div class="config-group">
+                        <div class="config-group-title">LLM Providers</div>
+                        <div class="config-grid">
+                            <div class="config-item">
+                                <span class="config-key">Enabled</span>
+                                <span class="config-value config-value--mono">{{ config()!.providers.enabled.join(', ') }}</span>
+                            </div>
+                            <div class="config-item">
+                                <span class="config-key">Anthropic API Key</span>
+                                <span class="config-value" [class.config-value--set]="config()!.providers.anthropicConfigured" [class.config-value--unset]="!config()!.providers.anthropicConfigured">
+                                    {{ config()!.providers.anthropicConfigured ? 'Configured' : 'Not set' }}
+                                </span>
+                            </div>
+                            <div class="config-item">
+                                <span class="config-key">OpenRouter API Key</span>
+                                <span class="config-value" [class.config-value--set]="config()!.providers.openrouterConfigured" [class.config-value--unset]="!config()!.providers.openrouterConfigured">
+                                    {{ config()!.providers.openrouterConfigured ? 'Configured' : 'Not set' }}
+                                </span>
+                            </div>
+                            <div class="config-item">
+                                <span class="config-key">Ollama Host</span>
+                                <span class="config-value config-value--mono">{{ config()!.providers.ollamaHost }}</span>
+                            </div>
+                        </div>
                     </div>
-                    <div class="env-item">
-                        <span class="env-key">GITHUB_TOKEN</span>
-                        <span class="env-value env-value--set">Configured</span>
+
+                    <!-- Integrations -->
+                    <div class="config-group">
+                        <div class="config-group-title">Integrations</div>
+                        <div class="config-grid">
+                            <div class="config-item">
+                                <span class="config-key">GitHub Token</span>
+                                <span class="config-value" [class.config-value--set]="config()!.integrations.github.tokenConfigured" [class.config-value--unset]="!config()!.integrations.github.tokenConfigured">
+                                    {{ config()!.integrations.github.tokenConfigured ? 'Configured' : 'Not set' }}
+                                </span>
+                            </div>
+                            @if (config()!.integrations.github.owner) {
+                                <div class="config-item">
+                                    <span class="config-key">GitHub Repo</span>
+                                    <span class="config-value config-value--mono">{{ config()!.integrations.github.owner }}/{{ config()!.integrations.github.repo }}</span>
+                                </div>
+                            }
+                            <div class="config-item">
+                                <span class="config-key">Discord</span>
+                                <span class="config-value" [class.config-value--set]="config()!.integrations.discord.enabled" [class.config-value--unset]="!config()!.integrations.discord.enabled">
+                                    {{ config()!.integrations.discord.enabled ? 'Enabled' : 'Not configured' }}
+                                </span>
+                            </div>
+                            <div class="config-item">
+                                <span class="config-key">Telegram</span>
+                                <span class="config-value" [class.config-value--set]="config()!.integrations.telegram.enabled" [class.config-value--unset]="!config()!.integrations.telegram.enabled">
+                                    {{ config()!.integrations.telegram.enabled ? 'Enabled' : 'Not configured' }}
+                                </span>
+                            </div>
+                            <div class="config-item">
+                                <span class="config-key">AlgoChat</span>
+                                <span class="config-value" [class.config-value--set]="config()!.integrations.algochat.enabled" [class.config-value--unset]="!config()!.integrations.algochat.enabled">
+                                    {{ config()!.integrations.algochat.enabled ? 'Enabled (' + config()!.integrations.algochat.network + ')' : 'Not configured' }}
+                                </span>
+                            </div>
+                            <div class="config-item">
+                                <span class="config-key">Slack</span>
+                                <span class="config-value" [class.config-value--set]="config()!.integrations.slack.enabled" [class.config-value--unset]="!config()!.integrations.slack.enabled">
+                                    {{ config()!.integrations.slack.enabled ? 'Enabled' : 'Not configured' }}
+                                </span>
+                            </div>
+                        </div>
                     </div>
-                </div>
-                <p class="env-hint">Environment variables are set in your <code>.env</code> file or system environment. Restart the server after changes.</p>
+
+                    <!-- Database -->
+                    <div class="config-group">
+                        <div class="config-group-title">Database</div>
+                        <div class="config-grid">
+                            <div class="config-item">
+                                <span class="config-key">Path</span>
+                                <span class="config-value config-value--mono">{{ config()!.database.path }}</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <p class="env-hint">To change these settings, edit your <code>.env</code> file or <code>corvid-agent.config.ts</code> and restart the server.</p>
+                }
             }
         </div>
     `,
     styles: `
         ${SECTION_STYLES}
-        .env-grid { display: flex; flex-direction: column; gap: 0.35rem; }
-        .env-item {
-            display: flex; align-items: center; justify-content: space-between;
-            padding: 0.45rem 0.65rem; background: var(--bg-raised); border-radius: var(--radius);
+        .config-group { margin-bottom: 0.75rem; }
+        .config-group:last-of-type { margin-bottom: 0; }
+        .config-group-title {
+            font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+            color: var(--text-tertiary); margin-bottom: 0.35rem;
         }
-        .env-key { font-size: 0.7rem; font-weight: 600; color: var(--text-primary); font-family: var(--font-mono); }
-        .env-value { font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
-        .env-value--set { color: var(--accent-green); }
-        .env-value--unset { color: var(--text-tertiary); }
+        .config-grid { display: flex; flex-direction: column; gap: 0.2rem; }
+        .config-item {
+            display: flex; align-items: center; justify-content: space-between;
+            padding: 0.35rem 0.65rem; background: var(--bg-raised); border-radius: var(--radius);
+        }
+        .config-key { font-size: 0.7rem; font-weight: 600; color: var(--text-secondary); }
+        .config-value { font-size: 0.7rem; font-weight: 600; color: var(--text-primary); text-align: right; max-width: 60%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .config-value--mono { font-family: var(--font-mono); font-size: 0.65rem; }
+        .config-value--set { color: var(--accent-green); }
+        .config-value--unset { color: var(--text-tertiary); }
         .env-hint { font-size: 0.65rem; color: var(--text-tertiary); margin-top: 0.5rem; }
         .env-hint code { background: var(--bg-raised); padding: 1px 4px; border-radius: 3px; font-size: 0.6rem; border: 1px solid var(--border); }
+        .muted { font-size: 0.7rem; color: var(--text-tertiary); margin: 0; }
     `,
 })
-export class EnvironmentSettingsComponent {
-    @Input() openrouterStatus: { status: string } | null = null;
-    @Input() discordConfig: Record<string, string> | null = null;
+export class EnvironmentSettingsComponent implements OnInit {
+    private readonly api = inject(ApiService);
 
     readonly collapsed = signal(false);
+    readonly loading = signal(true);
+    readonly config = signal<RuntimeConfig | null>(null);
+
+    ngOnInit(): void {
+        this.loadRuntimeConfig();
+    }
 
     toggleSection(): void {
         this.collapsed.update(v => !v);
+    }
+
+    private async loadRuntimeConfig(): Promise<void> {
+        try {
+            const data = await firstValueFrom(this.api.get<RuntimeConfig>('/settings/runtime'));
+            this.config.set(data);
+        } catch {
+            this.config.set(null);
+        } finally {
+            this.loading.set(false);
+        }
     }
 }

--- a/client/src/app/features/settings/settings.component.ts
+++ b/client/src/app/features/settings/settings.component.ts
@@ -55,7 +55,7 @@ interface OperationalMode {
                 <app-openrouter-settings />
                 <app-credits-settings [creditConfig]="settings()?.creditConfig ?? {}" />
                 <app-notifications-settings />
-                <app-environment-settings [openrouterStatus]="openrouterStatusForEnv()" [discordConfig]="discordConfigForEnv()" />
+                <app-environment-settings />
                 <app-database-settings />
             }
         </div>
@@ -73,8 +73,6 @@ export class SettingsComponent implements OnInit {
     readonly loading = signal(true);
     readonly settings = signal<SettingsData | null>(null);
     readonly operationalMode = signal('normal');
-    readonly openrouterStatusForEnv = signal<{ status: string } | null>(null);
-    readonly discordConfigForEnv = signal<Record<string, string> | null>(null);
 
     ngOnInit(): void {
         this.loadAll();
@@ -90,12 +88,6 @@ export class SettingsComponent implements OnInit {
             this.settings.set(settings);
             this.operationalMode.set(mode.mode);
             this.sessionService.loadAlgoChatStatus();
-
-            // Load openrouter status and discord config for environment panel
-            await Promise.all([
-                this.loadOpenrouterStatusForEnv(),
-                this.loadDiscordConfigForEnv(),
-            ]);
         } catch {
             // Non-critical
         } finally {
@@ -103,23 +95,4 @@ export class SettingsComponent implements OnInit {
         }
     }
 
-    private async loadOpenrouterStatusForEnv(): Promise<void> {
-        try {
-            const status = await firstValueFrom(this.api.get<{ status: string }>('/openrouter/status'));
-            this.openrouterStatusForEnv.set(status);
-        } catch {
-            this.openrouterStatusForEnv.set({ status: 'unavailable' });
-        }
-    }
-
-    private async loadDiscordConfigForEnv(): Promise<void> {
-        try {
-            const result = await firstValueFrom(
-                this.api.get<{ discordConfig: Record<string, string> | null }>('/settings/discord')
-            );
-            this.discordConfigForEnv.set(result.discordConfig);
-        } catch {
-            // Non-critical
-        }
-    }
 }

--- a/server/__tests__/routes-settings.test.ts
+++ b/server/__tests__/routes-settings.test.ts
@@ -323,3 +323,77 @@ describe('API Key Status Endpoint', () => {
     expect(resolved.status).toBe(503);
   });
 });
+
+describe('Runtime Config Endpoint', () => {
+  it('GET /api/settings/runtime returns sanitized config for operator', async () => {
+    const { req, url } = fakeReq('GET', '/api/settings/runtime');
+    const res = handleSettingsRoutes(req, url, db, adminContext());
+    expect(res).not.toBeNull();
+    const resolved = await Promise.resolve(res!);
+    expect(resolved.status).toBe(200);
+    const data = await resolved.json();
+
+    // Agent identity fields
+    expect(data.agent).toBeDefined();
+    expect(typeof data.agent.name).toBe('string');
+    expect(typeof data.agent.defaultModel).toBe('string');
+    expect(typeof data.agent.defaultProvider).toBe('string');
+
+    // Server fields
+    expect(data.server).toBeDefined();
+    expect(typeof data.server.port).toBe('number');
+    expect(typeof data.server.bindHost).toBe('string');
+    expect(typeof data.server.logLevel).toBe('string');
+    expect(typeof data.server.logFormat).toBe('string');
+    expect(typeof data.server.apiKeyConfigured).toBe('boolean');
+    expect(typeof data.server.adminApiKeyConfigured).toBe('boolean');
+
+    // Providers
+    expect(data.providers).toBeDefined();
+    expect(Array.isArray(data.providers.enabled)).toBe(true);
+    expect(typeof data.providers.anthropicConfigured).toBe('boolean');
+    expect(typeof data.providers.openrouterConfigured).toBe('boolean');
+    expect(typeof data.providers.ollamaHost).toBe('string');
+
+    // Integrations
+    expect(data.integrations).toBeDefined();
+    expect(typeof data.integrations.discord.enabled).toBe('boolean');
+    expect(typeof data.integrations.telegram.enabled).toBe('boolean');
+    expect(typeof data.integrations.algochat.enabled).toBe('boolean');
+    expect(typeof data.integrations.github.tokenConfigured).toBe('boolean');
+    expect(typeof data.integrations.slack.enabled).toBe('boolean');
+
+    // Database
+    expect(data.database).toBeDefined();
+    expect(typeof data.database.path).toBe('string');
+  });
+
+  it('GET /api/settings/runtime does not expose raw secret values', async () => {
+    const { req, url } = fakeReq('GET', '/api/settings/runtime');
+    const res = handleSettingsRoutes(req, url, db, adminContext());
+    const resolved = await Promise.resolve(res!);
+    const data = await resolved.json();
+
+    // Response shape should use boolean flags, not raw secret strings
+    expect(data.integrations.discord.botToken).toBeUndefined();
+    expect(data.integrations.telegram.botToken).toBeUndefined();
+    expect(data.integrations.algochat.mnemonic).toBeUndefined();
+    expect(data.providers.anthropic).toBeUndefined();
+    expect(data.server.apiKey).toBeUndefined();
+    expect(data.server.adminApiKey).toBeUndefined();
+
+    // Configured flags are booleans, not secret values
+    expect(typeof data.providers.anthropicConfigured).toBe('boolean');
+    expect(typeof data.integrations.discord.tokenConfigured).toBe('boolean');
+    expect(typeof data.integrations.algochat.mnemonicConfigured).toBe('boolean');
+  });
+
+  it('GET /api/settings/runtime returns null for unauthenticated when context enforces auth', async () => {
+    const { req, url } = fakeReq('GET', '/api/settings/runtime');
+    // No context = unauthenticated passthrough (handled by calling code, not this route)
+    const res = handleSettingsRoutes(req, url, db);
+    expect(res).not.toBeNull();
+    const resolved = await Promise.resolve(res!);
+    expect(resolved.status).toBe(200);
+  });
+});

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Database } from 'bun:sqlite';
+import { configFromEnv } from '../config/loader';
 import { recordAudit } from '../db/audit';
 import {
   deleteDiscordConfigKey,
@@ -42,6 +43,15 @@ export function handleSettingsRoutes(
   // GET /api/settings — all settings (system metadata is admin-only)
   if (url.pathname === '/api/settings' && req.method === 'GET') {
     return handleGetSettings(db, context?.role === 'admin');
+  }
+
+  // GET /api/settings/runtime — sanitized view of current runtime configuration (operator+)
+  if (url.pathname === '/api/settings/runtime' && req.method === 'GET') {
+    if (context) {
+      const denied = tenantRoleGuard('operator')(req, url, context);
+      if (denied) return denied;
+    }
+    return handleGetRuntimeConfig();
   }
 
   // PUT /api/settings/credits — update credit config
@@ -132,13 +142,72 @@ export function handleSettingsRoutes(
     return handleDeleteTelegramConfigKey(db, telegramKeyMatch[1], context);
   }
 
-
   // POST /api/settings/purge-test-data — remove test/sample data (admin-only via ADMIN_PATHS)
   if (url.pathname === '/api/settings/purge-test-data' && req.method === 'POST') {
     return handlePurgeTestData(req, db, context);
   }
 
   return null;
+}
+
+function handleGetRuntimeConfig(): Response {
+  const config = configFromEnv();
+  const env = process.env;
+
+  return json({
+    agent: {
+      name: config.agent.name,
+      description: config.agent.description ?? null,
+      defaultModel: config.agent.defaultModel,
+      defaultProvider: config.agent.defaultProvider,
+    },
+    server: {
+      port: config.server.port,
+      bindHost: config.server.bindHost,
+      logLevel: config.server.logLevel ?? 'info',
+      logFormat: config.server.logFormat ?? 'text',
+      apiKeyConfigured: Boolean(config.server.apiKey),
+      adminApiKeyConfigured: Boolean(config.server.adminApiKey),
+      allowedOrigins: config.server.allowedOrigins ?? null,
+      publicUrl: config.server.publicUrl ?? null,
+    },
+    database: {
+      path: config.database.path,
+    },
+    providers: {
+      enabled: config.providers.enabledProviders,
+      anthropicConfigured: Boolean(config.providers.anthropic?.apiKey),
+      ollamaHost: config.providers.ollama?.host ?? 'http://localhost:11434',
+      openrouterConfigured: Boolean(env.OPENROUTER_API_KEY),
+      councilModel: config.providers.councilModel ?? null,
+    },
+    integrations: {
+      discord: {
+        enabled: config.integrations?.discord?.enabled ?? false,
+        tokenConfigured: Boolean(config.integrations?.discord?.botToken),
+        channelConfigured: Boolean(config.integrations?.discord?.channelId),
+      },
+      telegram: {
+        enabled: config.integrations?.telegram?.enabled ?? false,
+        tokenConfigured: Boolean(config.integrations?.telegram?.botToken),
+        chatIdConfigured: Boolean(config.integrations?.telegram?.chatId),
+      },
+      algochat: {
+        enabled: config.integrations?.algochat?.enabled ?? false,
+        mnemonicConfigured: Boolean(config.integrations?.algochat?.mnemonic),
+        network: config.integrations?.algochat?.network ?? 'localnet',
+      },
+      github: {
+        tokenConfigured: Boolean(config.integrations?.github?.token),
+        owner: config.integrations?.github?.owner ?? null,
+        repo: config.integrations?.github?.repo ?? null,
+      },
+      slack: {
+        enabled: config.integrations?.slack?.enabled ?? false,
+        tokenConfigured: Boolean(config.integrations?.slack?.botToken),
+      },
+    },
+  });
 }
 
 function handleGetSettings(db: Database, isAdmin: boolean): Response {
@@ -403,7 +472,6 @@ function handleDeleteTelegramConfigKey(db: Database, key: string, context?: Requ
   recordAudit(db, 'telegram_config_delete', actor, 'telegram_config', null, key);
   return json({ ok: true, deleted: key });
 }
-
 
 async function handlePurgeTestData(req: Request, db: Database, context?: RequestContext): Promise<Response> {
   let dryRun = true;

--- a/specs/routes/routes.spec.md
+++ b/specs/routes/routes.spec.md
@@ -566,6 +566,7 @@ Every request passes through these stages in order:
 | Method | Path | Handler | Description |
 |--------|------|---------|-------------|
 | GET | `/api/settings` | settings.ts | Get all settings (credits config, system stats) |
+| GET | `/api/settings/runtime` | settings.ts | Get sanitized view of current runtime configuration (operator+) |
 | PUT | `/api/settings/credits` | settings.ts | Update credit configuration |
 | POST | `/api/settings/api-key/rotate` | settings.ts | Rotate the API key |
 | GET | `/api/settings/api-key/status` | settings.ts | Get API key rotation and expiry status |


### PR DESCRIPTION
## Summary

Advances issue #1490 (Self-service configuration) by exposing the full runtime configuration through a new API endpoint and a redesigned dashboard settings panel.

- **New**: `GET /api/settings/runtime` — returns sanitized, read-only view of current config (agent identity, server settings, LLM providers, all integrations). Requires operator+ role.
- **Fixed bug**: Environment Settings panel previously hardcoded ANTHROPIC_API_KEY and GITHUB_TOKEN as always "Configured" regardless of actual env state.
- **Improved**: Panel now self-loads from the new endpoint, showing 5 configuration groups (Agent, Server, Providers, Integrations, Database) with accurate status for each.
- **Cleaned up**: Removed dead `openrouterStatusForEnv` and `discordConfigForEnv` signals + methods from `SettingsComponent`.

No secrets are exposed — API keys and tokens are shown as boolean configured/not-set indicators only.

## Files Changed

| File | Change |
|------|--------|
| `server/routes/settings.ts` | Add `GET /api/settings/runtime` handler using `configFromEnv()` |
| `client/.../environment-settings.component.ts` | Rewritten to self-load from new endpoint; comprehensive config display |
| `client/.../settings.component.ts` | Remove dead env-status signals and methods |
| `server/__tests__/routes-settings.test.ts` | 3 new tests for runtime config endpoint |
| `specs/routes/routes.spec.md` | Document new route |

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 10,312 pass, 0 fail
- [x] `bun run lint` — clean
- [x] `bun run spec:check` — 5 specs passed, 0 warnings

Closes part of #1490. Write-side (PUT for non-sensitive settings) is a follow-up.

🤖 Agent: Jackdaw | Model: Claude Sonnet 4.6