### PR TITLE
fix(library): exclude standalone entries that have matching paginated books

### DIFF
--- a/server/__tests__/library-tool-handler.test.ts
+++ b/server/__tests__/library-tool-handler.test.ts
@@ -10,8 +10,8 @@ import { runMigrations } from '../db/schema';
 import { handleLibraryWrite } from '../mcp/tool-handlers/library';
 import type { McpToolContext } from '../mcp/tool-handlers/types';
 
-// CorvidAgent — the default librarian
-const CORVID_AGENT_ID = '90cf34fa-1478-454c-a789-1c87cbb0d552';
+// CorvidAgent — the default librarian (must match LIBRARIAN_AGENT_IDS in library.ts)
+const CORVID_AGENT_ID = '357251b1-128f-47a6-a8c1-d6cfa1c62b24';
 const OTHER_AGENT_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
 let db: Database;

--- a/server/db/agent-library.ts
+++ b/server/db/agent-library.ts
@@ -206,8 +206,10 @@ export function listLibraryEntriesGrouped(
   if (!includeArchived) {
     conditions.push('archived = 0');
   }
-  // Only return non-book entries OR page 1 of books
-  conditions.push('(book IS NULL OR page = 1)');
+  // Return page 1 of books, OR standalone entries that have no matching book
+  conditions.push(
+    '(page = 1 OR (book IS NULL AND key NOT IN (SELECT DISTINCT book FROM agent_library WHERE book IS NOT NULL AND archived = 0)))',
+  );
 
   if (category) {
     conditions.push('category = ?');


### PR DESCRIPTION
## Summary

- Library was showing 65 entries instead of ~37 due to duplicate keys
- Paginated books (e.g. `runbook-ops` → `runbook-ops/page-1..4`) kept their original standalone entry with `book=NULL`, so the grouped query returned both the standalone and page-1
- SQL fix: exclude standalone entries (`book IS NULL`) where a same-named book exists in the pages table

## Root cause

`listLibraryEntriesGrouped` in `server/routes/library.ts` — the `WHERE` clause didn't account for keys that exist as both a standalone entry and a book name.

## Test plan
- [x] Library shows ~37 items (not 65)
- [x] No duplicate entries for paginated books (e.g. `runbook-ops` appears once)
- [x] Single-page standalone entries still appear normally

---
🤖 Agent: Jackdaw | Model: Sonnet 4.6