### PR TITLE
feat(mcp): integrate cross-channel guard into corvid_send_message handler

### DIFF
--- a/server/mcp/tool-handlers/messaging.ts
+++ b/server/mcp/tool-handlers/messaging.ts
@@ -46,6 +46,10 @@ export async function handleSendMessage(
   }
 
   try {
+    // TODO(#1067): When ctx.sessionSource is 'discord', consider warning or blocking
+    // cross-channel sends. For now, channel affinity is enforced via prompt-level routing
+    // hints in prependRoutingContext() and getResponseRoutingPrompt().
+
     // Resolve to_agent by name (case-insensitive) or ID
     const available = await ctx.agentDirectory.listAvailable();
     const match = available.find(
@@ -107,11 +111,10 @@ export async function handleSendMessage(
     // Record successful send for session rate limiting (#1054)
     ctx.messageRateLimiter?.record(match.agentId);
 
-    let result = `${response}\n\n[thread: ${threadId}]`;
     if (crossChannelCheck.isCrossChannel && crossChannelCheck.advisory) {
-      result += `\n\n${crossChannelCheck.advisory}`;
+      return textResult(`${response}\n\n[thread: ${threadId}]\n\n${crossChannelCheck.advisory}`);
     }
-    return textResult(result);
+    return textResult(`${response}\n\n[thread: ${threadId}]`);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error('MCP send_message failed', { error: message });

--- a/server/mcp/tool-handlers/messaging.ts
+++ b/server/mcp/tool-handlers/messaging.ts
@@ -3,6 +3,7 @@ import { getAgent } from '../../db/agents';
 import { checkCommunicationTier } from '../../lib/communication-tiers';
 import { DedupService } from '../../lib/dedup';
 import { createLogger } from '../../lib/logger';
+import { checkCrossChannelSend } from './cross-channel-guard';
 import type { McpToolContext } from './types';
 import { errorResult, textResult } from './types';
 
@@ -45,10 +46,6 @@ export async function handleSendMessage(
   }
 
   try {
-    // TODO(#1067): When ctx.sessionSource is 'discord', consider warning or blocking
-    // cross-channel sends. For now, channel affinity is enforced via prompt-level routing
-    // hints in prependRoutingContext() and getResponseRoutingPrompt().
-
     // Resolve to_agent by name (case-insensitive) or ID
     const available = await ctx.agentDirectory.listAvailable();
     const match = available.find(
@@ -62,6 +59,11 @@ export async function handleSendMessage(
     if (match.agentId === ctx.agentId) {
       return errorResult('Cannot send a message to yourself.');
     }
+
+    // Cross-channel routing check: detect when an agent in a Discord/Telegram session
+    // calls corvid_send_message. This is advisory-only — we warn the agent but allow
+    // the send to proceed.
+    const crossChannelCheck = checkCrossChannelSend(ctx.sessionSource, ctx.sessionId, ctx.agentId, match.agentId);
 
     // Communication tier enforcement: messages flow downward in the hierarchy.
     // Top → anyone, Mid → mid + bottom, Bottom → bottom only.
@@ -105,7 +107,11 @@ export async function handleSendMessage(
     // Record successful send for session rate limiting (#1054)
     ctx.messageRateLimiter?.record(match.agentId);
 
-    return textResult(`${response}\n\n[thread: ${threadId}]`);
+    let result = `${response}\n\n[thread: ${threadId}]`;
+    if (crossChannelCheck.isCrossChannel && crossChannelCheck.advisory) {
+      result += `\n\n${crossChannelCheck.advisory}`;
+    }
+    return textResult(result);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error('MCP send_message failed', { error: message });


### PR DESCRIPTION
## Summary

This PR integrates the cross-channel guard function into the `corvid_send_message` handler to detect and warn agents about channel affinity constraints.

When an agent session originates from Discord or Telegram and calls `corvid_send_message`, the handler now:
1. Checks for cross-channel routing concerns using `checkCrossChannelSend()`
2. If detected, appends an advisory message to the tool result
3. Allows the send to proceed (advisory-only, non-blocking)

## Changes

- Added import for `checkCrossChannelSend` from cross-channel-guard module
- Integrated the guard check after agent resolution (to use correct target agent ID)
- Appended advisory text to tool result when cross-channel concern detected
- Removed TODO(#1067) comment

## Testing

- Cross-channel-guard unit tests: ✅ 17 pass
- Type checking: ✅ No errors
- Linting: ✅ No issues

## Why

This prevents agents from inadvertently relying on cross-channel message exchange when their final response must flow back through the originating user-facing channel (Discord/Telegram). The guard logs the concern and informs the agent to use `corvid_send_message` only for gathering information, then reply directly in the conversation.

Closes #1067