### PR TITLE
fix(process): persist thread session summary in session-exit-handler

### DIFF
--- a/server/process/session-exit-handler.ts
+++ b/server/process/session-exit-handler.ts
@@ -11,6 +11,7 @@
 import type { Database } from 'bun:sqlite';
 import type { Session } from '../../shared/types';
 import { saveMemory } from '../db/agent-memories';
+import { getThreadIdForSession, updateThreadSessionSummary } from '../db/discord-thread-sessions';
 import { recordObservation } from '../db/observations';
 import { getProject } from '../db/projects';
 import {
@@ -270,6 +271,13 @@ export function persistConversationSummary(db: Database, sessionId: string): voi
 
     const summary = summarizeConversation(conversational.map((m) => ({ role: m.role, content: m.content })));
     updateSessionSummary(db, sessionId, summary);
+
+    // Also persist to the thread session mapping (durable — survives session deletion)
+    const threadId = getThreadIdForSession(db, sessionId);
+    if (threadId) {
+      updateThreadSessionSummary(db, threadId, summary);
+    }
+
     log.debug('Persisted conversation summary to session', { sessionId });
   } catch (err) {
     log.warn('Failed to persist conversation summary', {


### PR DESCRIPTION
## Summary

- `persistConversationSummary` in `session-exit-handler.ts` was missing the `updateThreadSessionSummary` call that exists in `manager.ts`
- Without this, Discord thread context (the durable thread→summary mapping) would not be updated when the extracted handler ran, only the session record itself
- Added `getThreadIdForSession` / `updateThreadSessionSummary` imports and the missing call, bringing the extracted function into parity with the original

## Test plan

- [x] Lint passes (`bun run lint`)
- [x] TypeScript passes (`bun x tsc --noEmit --skipLibCheck`)
- [x] Spec check passes (`bun run spec:check`)
- [x] Start a Discord thread session, let it run, verify thread summary is persisted after exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: Jackdaw | Model: Sonnet 4.6