### PR TITLE
fix: bump hono >=4.12.14 for HTML injection CVE

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
     "@hono/node-server": ">=1.19.13",
     "ajv": ">=8.18.0",
     "express-rate-limit": ">=8.2.2",
-    "hono": ">=4.12.12",
+    "hono": ">=4.12.14",
     "minimatch": ">=9.0.7",
     "path-to-regexp": ">=8.4.0",
     "protobufjs": ">=7.5.5",
@@ -524,7 +524,7 @@
 
     "hi-base32": ["hi-base32@0.5.1", "", {}, "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="],
 
-    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "minimatch": ">=9.0.7",
     "ajv": ">=8.18.0",
     "qs": ">=6.14.2",
-    "hono": ">=4.12.12",
+    "hono": ">=4.12.14",
     "@hono/node-server": ">=1.19.13",
     "express-rate-limit": ">=8.2.2",
     "path-to-regexp": ">=8.4.0",


### PR DESCRIPTION
## Summary
- Bumps `hono` override from `>=4.12.12` to `>=4.12.14` to resolve GHSA-458j-xx4x-4375 (HTML injection via JSX attribute names in SSR mode)
- Replaces #2053 which only added documentation but didn't apply the actual fix

## Test plan
- [x] `bun install` resolves cleanly
- [x] `bun run lint` passes
- [x] `bun x tsc --noEmit --skipLibCheck` passes
- [x] `specsync check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)