### PR TITLE
fix: add external factual claims verification guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ Before claiming you **cannot** do something or that a capability is **missing**:
 - **Deployment state**: Always `git fetch origin` and compare against `origin/main` before claiming deployed code is stale or out of date. Never base deployment claims solely on local branch state.
 - **Contact lookup**: Always use `corvid_lookup_contact` before claiming a contact cannot be found. Exhaust all lookup tools before giving up.
 - **Memory state**: Use `corvid_recall_memory` or `corvid_read_on_chain_memories` to check for memories before claiming none exist. Memories are stored as ARC-69 ASAs on localnet — `read_on_chain_memories` reads both ASA and plain transaction memories.
+- **External factual claims**: When a user claims something changed externally (new model versions, API updates, dependency releases, service changes), verify the claim against your known information, documentation, or web search before acting on it. If you cannot verify the claim, ask the user for a source. Never say "I stand corrected" about something you cannot independently confirm — instead say "I can't verify that yet, can you share a link or source?"
 
 ## Instance Configuration
 


### PR DESCRIPTION
## Summary
- Adds guidance to CLAUDE.md "Verification Before Claims" section requiring agents to verify external factual claims (model versions, API updates, dependency releases) before acting on them
- Agents must ask for a source when claims cannot be independently confirmed
- Prevents agents from planning work based on unverified premises

Closes #2051

## Test plan
- [x] Verify CLAUDE.md renders correctly
- [x] Confirm guidance appears in agent system prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)