### PR TITLE
docs(specs): clarify /work routing paths and directory filtering in algochat specs

### DIFF
--- a/specs/algochat/commands.spec.md
+++ b/specs/algochat/commands.spec.md
@@ -1,6 +1,6 @@
 ---
 module: commands
-version: 2
+version: 4
 status: active
 files:
   - server/algochat/command-handler.ts
@@ -38,6 +38,37 @@ depends_on:
 ## Purpose
 
 Processes slash commands from AlgoChat messages and routes work task requests (both from slash commands and agent-to-agent `[WORK]` prefixed messages) through a unified WorkTaskService interface.
+
+## Routing Flow
+
+`WorkCommandRouter` consolidates two distinct paths into a single `WorkTaskService` call:
+
+```
+Path 1 — Slash command (/work)
+  AlgoChat message → CommandHandler.handleCommand()
+    → WorkCommandRouter.handleSlashCommand()
+      → WorkTaskService.create({ source: 'algochat' })
+      → respond() callback with task confirmation
+      → WorkTaskService.onComplete() → respond() with PR URL
+
+Path 2 — Agent-to-agent [WORK] prefix
+  AgentMessenger (on-chain or PSK message) → WorkCommandRouter.handleAgentWorkRequest()
+    → createAgentMessage() row (status: 'pending')
+    → WorkTaskService.create({ source: 'agent', sourceId: agentMessage.id })
+    → updateAgentMessageStatus('processing')
+    → WorkTaskService.onComplete() → updateAgentMessageStatus('completed'|'failed')
+```
+
+Key differences between the two paths:
+
+| Aspect | Slash command | Agent [WORK] |
+|--------|--------------|--------------|
+| Caller | `CommandHandler` | `AgentMessenger` |
+| Authorization | Owner check (or bypassed for local chat) | Pre-authorized by `MessagingGuard` |
+| DB row created | No agent_messages row | `agent_messages` row created first |
+| Flags supported | `--project`, `--buddy`, `--rounds` | `projectId` param only |
+| Error handling | `respond()` callback | Throws `ValidationError`/`NotFoundError`; sets message status `'failed'` |
+| WorkTaskService source | `'algochat'` | `'agent'` |
 
 ## Public API
 
@@ -214,3 +245,4 @@ _No standalone exported functions. All functionality is exposed via exported cla
 | 2026-03-04 | corvid-agent | Initial spec |
 | 2026-03-10 | corvid-agent | v2: `/work` command now supports `--project <name>` flag for targeting specific projects. Improved response messages with ✓/✗ status indicators and completion notifications with PR URL and summary. Added behavioral examples for `--project` usage and unknown project error. Updated error cases |
 | 2026-04-14 | corvid-agent | v3: Document `setSubscriptionManager` method, `--buddy`/`--rounds` flags for `/work`, buddy error cases (#2025) |
+| 2026-04-17 | corvid-agent | v4: Add Routing Flow section explaining two-path WorkCommandRouter architecture; clarify slash vs agent [WORK] differences (#2025) |

--- a/specs/algochat/directory.spec.md
+++ b/specs/algochat/directory.spec.md
@@ -1,6 +1,6 @@
 ---
 module: directory
-version: 1
+version: 2
 status: active
 files:
   - server/algochat/agent-directory.ts
@@ -40,7 +40,7 @@ _No standalone exported functions. All functionality is exposed via exported cla
 | Type | Description |
 |------|-------------|
 | `AgentDirectoryEntry` | Interface representing a resolved agent: `agentId`, `agentName`, `walletAddress` (string or null), `publicKey` (Uint8Array or null) |
-| `AgentChatAccount` | Interface wrapping an agent's wallet address and its `ChatAccount` from `@corvidlabs/ts-algochat` |
+| `AgentChatAccount` | Interface wrapping an agent's wallet address and its `ChatAccount` from `@corvidlabs/ts-algochat`. Fields: `address: string` (Algorand wallet address) and `account: ChatAccount` (the ts-algochat account object providing encryption keys and signing capability) |
 | `IsOwnerFn` | Type alias `(participant: string) => boolean` for authorization check injection |
 
 ### Exported Classes
@@ -58,7 +58,7 @@ _No standalone exported functions. All functionality is exposed via exported cla
 | `constructor` | `db: Database, agentWalletService: AgentWalletService` | `AgentDirectory` | Creates directory with DB and wallet service references |
 | `resolve` | `agentId: string` | `Promise<AgentDirectoryEntry \| null>` | Resolves an agent ID to its directory entry with wallet address and public key; results are cached |
 | `findAgentByAddress` | `walletAddress: string` | `string \| null` | Reverse-lookup: finds an agent ID by Algorand wallet address; checks cache then queries DB |
-| `listAvailable` | _(none)_ | `Promise<AgentDirectoryEntry[]>` | Lists all agents from DB and resolves each to a directory entry |
+| `listAvailable` | _(none)_ | `Promise<AgentDirectoryEntry[]>` | Lists all non-disabled agents from DB and resolves each to a directory entry; agents with `disabled: true` are excluded and will not appear as targets for `corvid_send_message` or directory listings |
 | `clearCache` | _(none)_ | `void` | Clears the in-memory resolution cache |
 
 #### AgentWalletService Methods
@@ -109,6 +109,7 @@ _No standalone exported functions. All functionality is exposed via exported cla
 10. Default funding amount for new agent wallets is 10 ALGO.
 11. `AgentWalletService` maintains an encrypted in-memory mnemonic cache with a 5-minute TTL to avoid repeated decryption operations. Cache entries are automatically evicted on expiry.
 12. USDC ASA opt-in is performed during `ensureWallet` and at startup via `ensureAllUsdcOptIns` when `USDC_ASA_ID` is configured. All wallet signing operations are recorded to the security audit log.
+13. `AgentDirectory.listAvailable()` excludes agents with `disabled: true`. Disabled agents are never returned as directory entries, even if they have valid wallets and on-chain keys.
 
 ## Behavioral Examples
 
@@ -180,3 +181,4 @@ _No standalone exported functions. All functionality is exposed via exported cla
 |------|--------|--------|
 | 2026-03-04 | corvid-agent | Initial spec |
 | 2026-04-14 | corvid-agent | Add KeyProvider constructor param, 5 missing methods, fix checkAndRefill values, add USDC opt-in + caching invariants, add KeyProvider error case (#2025) |
+| 2026-04-17 | corvid-agent | Clarify AgentChatAccount field names (address, account); make listAvailable() disabled-agent filtering explicit; add invariant 13 (#2025) |


### PR DESCRIPTION
## Summary

- **commands.spec.md (v2→v4)**: Adds a "Routing Flow" section documenting the two paths through `WorkCommandRouter` — slash command (`/work`) vs agent `[WORK]` prefix — with a comparison table showing differences in caller, authorization, DB rows created, supported flags, error handling, and `source` field passed to WorkTaskService
- **directory.spec.md (v1→v2)**: Clarifies `AgentChatAccount` field names (`address: string`, `account: ChatAccount`); updates `listAvailable()` description to explicitly mention disabled-agent filtering; adds invariant 13 stating disabled agents are never returned by `listAvailable()`

## Test plan

- [x] `bun run spec:check` — 2 specs checked, 2 passed, 0 warnings, 0 failed

Closes #2025

🤖 Generated with [Claude Code](https://claude.com/claude-code)