### PR TITLE
fix(ci): re-enable E2E tests in CI pipeline — closes #1988

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,39 +1,33 @@
 name: E2E
 
 on:
-  # Push/PR triggers disabled while E2E tests are paused (conserving CI minutes).
-  # Re-enable push/pull_request triggers when credits are replenished and the
-  # job below is uncommented.  See #1436.
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_call:
   workflow_dispatch:
 
 permissions:
   contents: read
 
-# E2E tests temporarily disabled to conserve CI minutes.
-# Uncomment the job below when GitHub Actions credits are replenished.
 jobs:
-  skip:
-    name: E2E (skipped)
+  e2e:
+    name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
     steps:
-      - run: echo "E2E tests temporarily disabled — see #1436"
-  # e2e:
-  #   name: E2E Tests
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 20
-  #
-  #   steps:
-  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-  #     - uses: ./.github/actions/setup-workspace
-  #
-  #     - name: Build client
-  #       run: bun run build:client
-  #
-  #     - name: Install Playwright
-  #       run: npx playwright install chromium --with-deps
-  #
-  #     - name: Run E2E tests
-  #       run: npx playwright test --config=playwright.config.js
-  #       env:
-  #         CI: true
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Build client
+        run: bun run build:client
+
+      - name: Install Playwright
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: npx playwright test --config=playwright.config.js
+        env:
+          CI: true

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.2",
         "@biomejs/biome": "^2.4.11",
         "@playwright/test": "^1.59.1",
         "@types/bun": "^1.3.12",
@@ -61,6 +62,8 @@
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.112", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-vMFoiDKlOive8p3tphpV1gQaaytOipwGJ+uw9mvvaLQUODSC2+fCdRDAY25i2Tsv+lOtxzXBKctmaDuWqZY7ig=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.88.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.11.2", "", { "dependencies": { "axe-core": "~4.11.3" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
@@ -405,6 +408,8 @@
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "axe-core": ["axe-core@4.11.3", "", {}, "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@corvidlabs/ts-algochat": "^0.4.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
     "@biomejs/biome": "^2.4.11",
     "@playwright/test": "^1.59.1",
     "@types/bun": "^1.3.12",


### PR DESCRIPTION
## Summary

- Re-enables Playwright E2E tests on every push/PR to `main` (was disabled to conserve CI minutes per #1436)
- Removes the placeholder `skip` job and uncomments the real `e2e` job
- Bumps `timeout-minutes` from 20 → 30 to match observed ~17 min local runtime (363 tests, 2 workers)
- Adds missing `@axe-core/playwright` dev dependency used by `e2e/accessibility.spec.ts`

## Verification

Ran the full suite locally before this PR:
```
363 passed (17.4m)
5 skipped
4 did not run
0 failures
```

Exit code 0. `bun run test:e2e` is clean.

## Test plan
- [x] CI runs E2E job on this PR and passes
- [x] Verify the `e2e` job appears (not `skip`) in Actions tab

Closes #1988
Part of #311 (v1.0.0 launch — Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)