### PR TITLE
fix: worktree creation for non-default projects + reduce context loss

### DIFF
--- a/server/__tests__/context-management.test.ts
+++ b/server/__tests__/context-management.test.ts
@@ -304,8 +304,8 @@ describe('summarizeConversation', () => {
       { role: 'assistant', content: 'ok' },
     ];
     const summary = summarizeConversation(messages);
-    expect(summary).toContain('...');
-    expect(summary.length).toBeLessThan(600);
+    // With 500-char slice, a 500-char input fits exactly — no truncation marker
+    expect(summary.length).toBeLessThan(800);
   });
 
   it('includes follow-up messages', () => {
@@ -344,7 +344,7 @@ describe('summarizeConversation', () => {
     ];
     const summary = summarizeConversation(messages);
     expect(summary).toContain('10 total');
-    expect(summary).toContain('and 7 more');
+    expect(summary).toContain('and 4 more');
   });
 });
 

--- a/server/__tests__/direct-process-utils.test.ts
+++ b/server/__tests__/direct-process-utils.test.ts
@@ -543,9 +543,8 @@ describe('summarizeConversation', () => {
       { role: 'assistant', content: 'ok' },
     ];
     const summary = summarizeConversation(messages);
-    expect(summary).toContain('...');
-    // Should not contain the full 500 chars
-    expect(summary.length).toBeLessThan(600);
+    // With 500-char slice, a 500-char input fits exactly — no truncation marker
+    expect(summary.length).toBeLessThan(800);
   });
 
   it('includes follow-up messages', () => {
@@ -575,7 +574,7 @@ describe('summarizeConversation', () => {
     ];
     const summary = summarizeConversation(messages);
     expect(summary).toContain('10 total');
-    expect(summary).toContain('and 7 more');
+    expect(summary).toContain('and 4 more');
   });
 });
 

--- a/server/__tests__/project-dir.test.ts
+++ b/server/__tests__/project-dir.test.ts
@@ -27,8 +27,9 @@ function makeTestProject(overrides: Partial<Project> = {}): Project {
 
 beforeEach(() => {
   mkdirSync(TEST_BASE, { recursive: true });
-  // Create a minimal git repo for testing
+  // Create a minimal git repo for testing (needs .git dir for validation)
   mkdirSync(FAKE_REPO, { recursive: true });
+  mkdirSync(resolve(FAKE_REPO, '.git'), { recursive: true });
 });
 
 afterEach(() => {

--- a/server/algochat/message-router.ts
+++ b/server/algochat/message-router.ts
@@ -790,8 +790,8 @@ export class MessageRouter {
   ): Promise<{ workDir: string; branch: string } | undefined> {
     if (!projectId) return undefined;
     const project = getProject(this.db, projectId);
-    if (!project?.workingDir && !project?.gitUrl) return undefined;
     if (!project) return undefined;
+    if (!project.workingDir && !project.gitUrl) return undefined;
 
     const sessionId = crypto.randomUUID();
     const result = await resolveAndCreateWorktree(project, 'algochat', sessionId);

--- a/server/lib/project-dir.ts
+++ b/server/lib/project-dir.ts
@@ -73,6 +73,27 @@ export async function cleanupEphemeralDir(resolved: ResolvedDir): Promise<void> 
 // ─── Strategy implementations ────────────────────────────────────────────────
 
 function resolvePersistent(project: Project): ResolvedDir {
+  if (!project.workingDir) {
+    return { dir: '', ephemeral: false, error: 'Project has no workingDir configured' };
+  }
+
+  if (!existsSync(project.workingDir)) {
+    return {
+      dir: project.workingDir,
+      ephemeral: false,
+      error: `Project directory does not exist: ${project.workingDir}`,
+    };
+  }
+
+  // Validate it's actually a git repository
+  if (!existsSync(resolve(project.workingDir, '.git'))) {
+    return {
+      dir: project.workingDir,
+      ephemeral: false,
+      error: `Project directory is not a git repository: ${project.workingDir}`,
+    };
+  }
+
   return { dir: project.workingDir, ephemeral: false };
 }
 

--- a/server/process/context-management.ts
+++ b/server/process/context-management.ts
@@ -187,8 +187,8 @@ export function summarizeConversation(
   // Extract key user requests
   const userMessages = messages.filter((m) => m.role === 'user');
   if (userMessages.length > 0) {
-    const firstRequest = userMessages[0].content.slice(0, 300).replace(/\n/g, ' ').trim();
-    points.push(`Original request: ${firstRequest}${userMessages[0].content.length > 300 ? '...' : ''}`);
+    const firstRequest = userMessages[0].content.slice(0, 500).replace(/\n/g, ' ').trim();
+    points.push(`Original request: ${firstRequest}${userMessages[0].content.length > 500 ? '...' : ''}`);
   }
 
   // Extract tool usage summary
@@ -199,23 +199,29 @@ export function summarizeConversation(
 
   // Extract key assistant conclusions (last few assistant messages)
   const assistantMessages = messages.filter((m) => m.role === 'assistant');
-  if (assistantMessages.length > 0) {
-    const last = assistantMessages[assistantMessages.length - 1];
-    const conclusion = last.content.slice(0, 300).replace(/\n/g, ' ').trim();
-    points.push(`Last assistant response: ${conclusion}${last.content.length > 300 ? '...' : ''}`);
+  if (assistantMessages.length > 1) {
+    // Include the last 3 assistant messages for better continuity
+    const recentAssistant = assistantMessages.slice(-3);
+    for (const msg of recentAssistant) {
+      const conclusion = msg.content.slice(0, 400).replace(/\n/g, ' ').trim();
+      points.push(`Last assistant response: ${conclusion}${msg.content.length > 400 ? '...' : ''}`);
+    }
+  } else if (assistantMessages.length === 1) {
+    const conclusion = assistantMessages[0].content.slice(0, 400).replace(/\n/g, ' ').trim();
+    points.push(`Last assistant response: ${conclusion}${assistantMessages[0].content.length > 400 ? '...' : ''}`);
   }
 
-  // Summarize intermediate user follow-ups
+  // Summarize intermediate user follow-ups — keep more context
   if (userMessages.length > 1) {
     const followUps = userMessages.slice(1).map((m) => {
-      const text = m.content.slice(0, 100).replace(/\n/g, ' ').trim();
-      return text + (m.content.length > 100 ? '...' : '');
+      const text = m.content.slice(0, 200).replace(/\n/g, ' ').trim();
+      return text + (m.content.length > 200 ? '...' : '');
     });
-    if (followUps.length <= 5) {
+    if (followUps.length <= 8) {
       points.push(`Follow-up messages: ${followUps.join('; ')}`);
     } else {
       points.push(
-        `Follow-up messages (${followUps.length} total): ${followUps.slice(0, 3).join('; ')}; ... and ${followUps.length - 3} more`,
+        `Follow-up messages (${followUps.length} total): ${followUps.slice(0, 6).join('; ')}; ... and ${followUps.length - 6} more`,
       );
     }
   }

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -53,10 +53,11 @@ const log = createLogger('ProcessManager');
 // through the capped resume path to keep context size manageable.
 //
 // Rationale: Each "turn" (user message + assistant response + tool calls) grows
-// the in-context prompt significantly. Empirically, ~8 turns keeps most sessions
-// well under context-window limits while leaving headroom for tool outputs,
-// system messages, and safety buffers. Revisit if model context windows change.
-const MAX_TURNS_BEFORE_CONTEXT_RESET = 8;
+// the in-context prompt significantly. With modern 200k context windows, 20 turns
+// provides enough continuity for multi-turn Discord conversations while staying
+// well within limits. The progressive compression tiers in context-management.ts
+// handle the cases where individual turns are unusually large.
+const MAX_TURNS_BEFORE_CONTEXT_RESET = 20;
 const DISCORD_RESTRICTED_MESSAGE_PREFIX = 'Discord message:';
 
 // Circuit breaker: if the last N completions in a row were zero-turn,

--- a/server/process/resume-prompt-builder.ts
+++ b/server/process/resume-prompt-builder.ts
@@ -51,7 +51,7 @@ export function buildResumePrompt(
 
   if (messages.length === 0) return newPrompt ?? session.initialPrompt ?? '';
 
-  const recent = messages.slice(-20);
+  const recent = messages.slice(-40);
   const historyLines = recent
     .filter((m) => m.role === 'user' || m.role === 'assistant')
     .map((m) => {


### PR DESCRIPTION
## Summary

Fixes three reported issues:

### 1. `/session` worktree creation fails for non-default projects — closes #2063
- `resolvePersistent()` now validates the directory exists and contains `.git` before returning — gives a clear error instead of a cryptic `fatal: not a git repository`
- Fixed null check ordering in `message-router.ts` `createSessionWorktree()` — was accessing `project.workingDir` before checking `project` exists

### 2. Aggressive context loss in Discord conversations — closes #2064
- **`MAX_TURNS_BEFORE_CONTEXT_RESET`**: 8 → 20 — sessions were being killed and restarted far too aggressively, losing all conversation context
- **Resume message window**: 20 → 40 — more history available when resuming sessions
- **`summarizeConversation()`**: now includes last 3 assistant messages (was 1), expands text slices from 300→500 chars for requests and 300→400 for responses, shows up to 6 follow-ups (was 3) before truncating

### 3. Ollama agents — #2065
Filed as separate issue for investigation. Code review didn't reveal an obvious structural bug — needs runtime diagnosis.

## Test plan
- [x] `bun test server/__tests__/project-dir.test.ts` — 11/11 pass (updated setup to create `.git` dir)
- [x] `bun test server/__tests__/context-management.test.ts` — 56/56 pass (updated thresholds for new summary behavior)
- [x] `bun run lint` — clean
- [x] `bun x tsc --noEmit --skipLibCheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6