### PR TITLE
fix: plug timer and callback leaks for long-running stability

### DIFF
--- a/server/process/session-timer-manager.ts
+++ b/server/process/session-timer-manager.ts
@@ -216,5 +216,9 @@ export class SessionTimerManager {
       clearTimeout(timer);
     }
     this.sessionTimeouts.clear();
+    for (const timer of this.startupTimeouts.values()) {
+      clearTimeout(timer);
+    }
+    this.startupTimeouts.clear();
   }
 }

--- a/server/work/service.ts
+++ b/server/work/service.ts
@@ -932,6 +932,15 @@ export class WorkTaskService {
     callbacks.add(callback);
   }
 
+  /** Remove a specific completion callback (e.g. when a WebSocket disconnects). */
+  offComplete(taskId: string, callback: CompletionCallback): void {
+    const callbacks = this.completionCallbacks.get(taskId);
+    if (callbacks) {
+      callbacks.delete(callback);
+      if (callbacks.size === 0) this.completionCallbacks.delete(taskId);
+    }
+  }
+
   /** Subscribe to status changes for a task (branching, running, validating, etc.). */
   onStatusChange(taskId: string, callback: StatusChangeCallback): void {
     let callbacks = this.statusChangeCallbacks.get(taskId);

--- a/server/ws/handler.ts
+++ b/server/ws/handler.ts
@@ -38,6 +38,8 @@ export interface WsData {
   heartbeatTimer?: ReturnType<typeof setInterval> | null;
   pongTimeoutTimer?: ReturnType<typeof setTimeout> | null;
   authTimeoutTimer?: ReturnType<typeof setTimeout> | null;
+  /** Track work-task completion callbacks so they can be removed on disconnect. */
+  workTaskCallbacks?: Map<string, (task: import('../../shared/types').WorkTask) => void>;
 }
 
 /**
@@ -220,6 +222,17 @@ export function createWebSocketHandler(
           processManager.unsubscribe(sessionId, callback);
         }
         ws.data.subscriptions.clear();
+      }
+
+      // Clean up work-task completion callbacks to prevent leaks
+      if (ws.data?.workTaskCallbacks?.size) {
+        const wts = getWorkTaskService?.();
+        if (wts) {
+          for (const [taskId, callback] of ws.data.workTaskCallbacks) {
+            wts.offComplete(taskId, callback);
+          }
+        }
+        ws.data.workTaskCallbacks.clear();
       }
     },
   };
@@ -472,11 +485,15 @@ function handleClientMessage(
           const serverMsg: ServerMessage = { type: 'work_task_update', task };
           safeSend(ws, serverMsg);
 
-          // Register for completion update
-          workTaskService.onComplete(task.id, (completedTask) => {
+          // Register for completion update, tracking the callback for cleanup on disconnect
+          const completionCb = (completedTask: typeof task) => {
+            ws.data?.workTaskCallbacks?.delete(task.id);
             const updateMsg: ServerMessage = { type: 'work_task_update', task: completedTask };
             safeSend(ws, updateMsg);
-          });
+          };
+          if (!ws.data.workTaskCallbacks) ws.data.workTaskCallbacks = new Map();
+          ws.data.workTaskCallbacks.set(task.id, completionCb);
+          workTaskService.onComplete(task.id, completionCb);
         })
         .catch((err) => {
           log.error('Work task error', { error: err instanceof Error ? err.message : String(err) });


### PR DESCRIPTION
## Summary

- **SessionTimerManager.shutdown()** now clears `startupTimeouts` map — previously only `stableTimers` and `sessionTimeouts` were cleared, leaking timers on server restart
- **WorkTaskService.offComplete()** — new method to remove individual completion callbacks, enabling proper cleanup when WebSocket clients disconnect before a task finishes  
- **WS close handler** now tracks and removes work-task completion callbacks on disconnect, preventing orphaned closures from accumulating

These are the kind of slow leaks that degrade a long-running server over days/weeks.

## Test plan

- [ ] 10,320 tests pass locally (0 failures)
- [ ] TypeScript clean, lint clean
- [ ] CI passes
- [ ] Verify timer stats after server restart show 0 leaked timers

🤖 Generated with [Claude Code](https://claude.com/claude-code)