### PR TITLE
fix: add missing .catch() on voice session creation

### DIFF
--- a/server/discord/voice/voice-session.ts
+++ b/server/discord/voice/voice-session.ts
@@ -170,12 +170,19 @@ export class VoiceSessionRouter {
         // Session is gone — create a new one
         log.info('Voice session expired, creating new one', { guildId });
         this.sessions.delete(guildId);
-        this.ensureSession(guildId).then((newSession) => {
-          if (newSession) {
-            newSession.responding = true;
-            this.processManager.sendMessage(newSession.sessionId, combinedMessage);
-          }
-        });
+        this.ensureSession(guildId)
+          .then((newSession) => {
+            if (newSession) {
+              newSession.responding = true;
+              this.processManager.sendMessage(newSession.sessionId, combinedMessage);
+            }
+          })
+          .catch((err) => {
+            log.error('Failed to create voice session', {
+              guildId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
       }
     }
   }


### PR DESCRIPTION
## Summary

- `ensureSession()` in voice-session.ts was called with `.then()` but no `.catch()`, creating an unhandled promise rejection if session creation failed
- Now properly logs the error with guildId context

Tiny fix but prevents potential server crash under the global `unhandledRejection` handler.

## Test plan

- [x] TypeScript clean
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)