### PR TITLE
fix(ollama): add queue timeout to acquireSlot() — closes #2065

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,39 +1,33 @@
 name: E2E
 
 on:
-  # Push/PR triggers disabled while E2E tests are paused (conserving CI minutes).
-  # Re-enable push/pull_request triggers when credits are replenished and the
-  # job below is uncommented.  See #1436.
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_call:
   workflow_dispatch:
 
 permissions:
   contents: read
 
-# E2E tests temporarily disabled to conserve CI minutes.
-# Uncomment the job below when GitHub Actions credits are replenished.
 jobs:
-  skip:
-    name: E2E (skipped)
+  e2e:
+    name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
     steps:
-      - run: echo "E2E tests temporarily disabled — see #1436"
-  # e2e:
-  #   name: E2E Tests
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 20
-  #
-  #   steps:
-  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-  #     - uses: ./.github/actions/setup-workspace
-  #
-  #     - name: Build client
-  #       run: bun run build:client
-  #
-  #     - name: Install Playwright
-  #       run: npx playwright install chromium --with-deps
-  #
-  #     - name: Run E2E tests
-  #       run: npx playwright test --config=playwright.config.js
-  #       env:
-  #         CI: true
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Build client
+        run: bun run build:client
+
+      - name: Install Playwright
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: npx playwright test --config=playwright.config.js
+        env:
+          CI: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,33 +1,39 @@
 name: E2E
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  # Push/PR triggers disabled while E2E tests are paused (conserving CI minutes).
+  # Re-enable push/pull_request triggers when credits are replenished and the
+  # job below is uncommented.  See #1436.
   workflow_call:
   workflow_dispatch:
 
 permissions:
   contents: read
 
+# E2E tests temporarily disabled to conserve CI minutes.
+# Uncomment the job below when GitHub Actions credits are replenished.
 jobs:
-  e2e:
-    name: E2E Tests
+  skip:
+    name: E2E (skipped)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: ./.github/actions/setup-workspace
-
-      - name: Build client
-        run: bun run build:client
-
-      - name: Install Playwright
-        run: npx playwright install chromium --with-deps
-
-      - name: Run E2E tests
-        run: npx playwright test --config=playwright.config.js
-        env:
-          CI: true
+      - run: echo "E2E tests temporarily disabled — see #1436"
+  # e2e:
+  #   name: E2E Tests
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 20
+  #
+  #   steps:
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+  #     - uses: ./.github/actions/setup-workspace
+  #
+  #     - name: Build client
+  #       run: bun run build:client
+  #
+  #     - name: Install Playwright
+  #       run: npx playwright install chromium --with-deps
+  #
+  #     - name: Run E2E tests
+  #       run: npx playwright test --config=playwright.config.js
+  #       env:
+  #         CI: true

--- a/server/__tests__/providers.test.ts
+++ b/server/__tests__/providers.test.ts
@@ -487,6 +487,35 @@ describe('OllamaProvider', () => {
     provider.releaseSlot('model-a');
   });
 
+  test('acquireSlot returns false when queue timeout fires before slot is available', async () => {
+    // Fill up the single slot
+    await provider.acquireSlot('model-a');
+
+    // Try to acquire with a very short timeout (10ms)
+    const acquirePromise = provider.acquireSlot('model-b', undefined, undefined, 10);
+    const acquired = await acquirePromise;
+    expect(acquired).toBe(false);
+
+    // Original slot holder is unaffected — release it normally
+    provider.releaseSlot('model-a');
+  });
+
+  test('acquireSlot succeeds when slot is released before timeout fires', async () => {
+    // Fill up the single slot
+    await provider.acquireSlot('model-a');
+
+    // Request second slot with a generous timeout
+    const acquirePromise = provider.acquireSlot('model-b', undefined, undefined, 5000);
+
+    // Release first slot — should unblock model-b immediately
+    provider.releaseSlot('model-a');
+    const acquired = await acquirePromise;
+    expect(acquired).toBe(true);
+
+    // Clean up
+    provider.releaseSlot('model-b');
+  });
+
   // ─── deleteModel ──────────────────────────────────────────────────
 
   test('deleteModel returns error when Ollama is down', async () => {

--- a/server/providers/ollama/provider.ts
+++ b/server/providers/ollama/provider.ts
@@ -308,36 +308,71 @@ export class OllamaProvider extends BaseLlmProvider {
    * Acquire an inference slot for the given model. Blocks until enough
    * weight budget is available. Called once before an agent's agentic loop
    * so the model stays loaded (preserves KV cache across turns).
+   *
+   * @param timeoutMs - Max ms to wait in queue before giving up. Defaults to
+   *   OLLAMA_SLOT_WAIT_TIMEOUT_MS env var, or 5 minutes if not set.
+   *   Pass 0 to wait indefinitely (not recommended).
    */
-  async acquireSlot(model: string, signal?: AbortSignal, onStatus?: (msg: string) => void): Promise<boolean> {
+  async acquireSlot(
+    model: string,
+    signal?: AbortSignal,
+    onStatus?: (msg: string) => void,
+    timeoutMs?: number,
+  ): Promise<boolean> {
     const weight = this.getModelWeight(model);
     if (this.activeWeight > 0 && this.activeWeight + weight > this.maxWeight) {
+      const effectiveTimeout =
+        timeoutMs !== undefined
+          ? timeoutMs
+          : parseInt(process.env.OLLAMA_SLOT_WAIT_TIMEOUT_MS ?? String(5 * 60 * 1000), 10);
       const mode = this.gpuDetected === null ? 'detecting' : this.gpuDetected ? 'GPU' : 'CPU';
       onStatus?.(
         `Queued — waiting for model slot (need ${weight}, ${this.activeWeight}/${this.maxWeight} in use, ${mode})`,
       );
-      // Track whether releaseWaiters() granted us the slot before abort fired
+      // Track whether releaseWaiters() granted us the slot before abort/timeout fired
       let granted = false;
+      let timedOut = false;
       await new Promise<void>((resolve) => {
         const waiter = { weight, resolve };
         this.waitQueue.push(waiter);
+
+        // Helper to remove from queue if still waiting
+        const removeFromQueue = (): boolean => {
+          const idx = this.waitQueue.indexOf(waiter);
+          if (idx >= 0) {
+            this.waitQueue.splice(idx, 1);
+            return true; // was still in queue
+          }
+          // releaseWaiters() already popped us and incremented activeWeight
+          granted = true;
+          return false;
+        };
+
         // If caller aborts while queued, remove from wait queue
         signal?.addEventListener(
           'abort',
           () => {
-            const idx = this.waitQueue.indexOf(waiter);
-            if (idx >= 0) {
-              // Still in queue — activeWeight was never incremented
-              this.waitQueue.splice(idx, 1);
-            } else {
-              // releaseWaiters() already popped us and incremented activeWeight
-              granted = true;
-            }
+            removeFromQueue();
             resolve(); // unblock the await
           },
           { once: true },
         );
+
+        // Queue timeout: stop waiting if slot not granted within timeoutMs
+        if (effectiveTimeout > 0) {
+          setTimeout(() => {
+            const stillInQueue = removeFromQueue();
+            if (stillInQueue) {
+              timedOut = true;
+              log.warn(
+                `acquireSlot timed out after ${effectiveTimeout}ms waiting for ${model} (weight=${weight}, active=${this.activeWeight}/${this.maxWeight}, queue=${this.waitQueue.length})`,
+              );
+              resolve();
+            }
+          }, effectiveTimeout);
+        }
       });
+      if (timedOut) return false;
       if (signal?.aborted) {
         if (granted) {
           // Slot was acquired by releaseWaiters before abort — caller owns it

--- a/server/routes/ollama.ts
+++ b/server/routes/ollama.ts
@@ -794,7 +794,8 @@ async function handleClaudeProxyMessages(req: Request): Promise<Response> {
       }
     }
 
-    // Acquire slot
+    // Acquire slot — uses OLLAMA_SLOT_WAIT_TIMEOUT_MS timeout (default 5 min)
+    // to prevent indefinite queue buildup if Ollama stalls or a slot leaks.
     const slotAcquired = await provider.acquireSlot(ollamaModel);
     if (!slotAcquired) {
       return json({ error: 'Model is busy - try again later' }, 503);


### PR DESCRIPTION
## Problem

`acquireSlot()` in `OllamaProvider` had no timeout — if Ollama stalled or a slot leaked (e.g. during an outage with concurrent requests), callers would queue up and wait indefinitely. This caused hanging HTTP requests and a saturated server.

## Fix

- Added `timeoutMs` (4th optional param) to `acquireSlot()`. Defaults to `OLLAMA_SLOT_WAIT_TIMEOUT_MS` env var (5 minutes if not set). Pass `0` to wait indefinitely.
- When the deadline fires while a waiter is still in the queue, it's removed and `false` is returned — the route returns **503** immediately instead of hanging.
- Updated `routes/ollama.ts` comment to document the timeout behavior.

## Tests

Two new unit tests in `server/__tests__/providers.test.ts`:
- `acquireSlot returns false when queue timeout fires before slot is available`
- `acquireSlot succeeds when slot is released before timeout fires`

## Validation

- `bun x tsc --noEmit --skipLibCheck` — clean
- `bun test` — **10,322 pass, 0 fail**
- `bun run spec:check` — 2 specs, 0 warnings, 0 failed

🤖 Agent: Jackdaw | Model: claude-sonnet-4-6