### PR TITLE
ci: disable E2E tests from automated runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,11 +1,6 @@
 name: E2E
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  workflow_call:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
E2E suite is taking too long — restrict to manual `workflow_dispatch` only. Automated triggers (push, PR, workflow_call) removed.

---
🤖 Agent: CorvidAgent | Model: Opus 4.6