### PR TITLE
fix(client): M3 theme polish — cyan palette, compact density

### DIFF
--- a/client/src/app/features/agents/agent-list.component.ts
+++ b/client/src/app/features/agents/agent-list.component.ts
@@ -189,7 +189,7 @@ const INACTIVE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
         .filters { display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap; margin-bottom: 1.25rem; }
         .filters mat-button-toggle-group { text-transform: capitalize; }
         .sort-field { width: 160px; flex-shrink: 0; margin-left: auto; }
-        .sort-field ::ng-deep .mat-mdc-select-value { font-size: 0.75rem; }
+        .sort-field { --mat-select-trigger-text-size: 0.75rem; }
 
         /* Agent Grid — fluid + container-query aware */
         :host { container-type: inline-size; }

--- a/client/src/app/features/agents/agent-list.component.ts
+++ b/client/src/app/features/agents/agent-list.component.ts
@@ -187,7 +187,7 @@ const INACTIVE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
 
         /* Filters */
         .filters { display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap; margin-bottom: 1.25rem; }
-        .filters ::ng-deep .mat-button-toggle-label-content { padding: 0 12px; line-height: 32px; font-size: 0.75rem; text-transform: capitalize; }
+        .filters mat-button-toggle-group { text-transform: capitalize; }
         .sort-field { width: 160px; flex-shrink: 0; margin-left: auto; }
         .sort-field ::ng-deep .mat-mdc-select-value { font-size: 0.75rem; }
 

--- a/client/src/app/features/chat-home/chat-home.component.ts
+++ b/client/src/app/features/chat-home/chat-home.component.ts
@@ -334,15 +334,10 @@ import { MatButtonModule } from '@angular/material/button';
         /* Mat form field for the prompt textarea */
         .chat-home__form-field {
             width: 100%;
-        }
-        .chat-home__form-field .mat-mdc-form-field-flex {
-            background: transparent;
-        }
-        /* Override mat-form-field outline color to match corvid theme */
-        .chat-home__form-field .mdc-notched-outline__leading,
-        .chat-home__form-field .mdc-notched-outline__notch,
-        .chat-home__form-field .mdc-notched-outline__trailing {
-            border-color: transparent !important;
+            --mdc-outlined-text-field-container-color: transparent;
+            --mdc-outlined-text-field-outline-color: transparent;
+            --mdc-outlined-text-field-hover-outline-color: transparent;
+            --mdc-outlined-text-field-focus-outline-color: transparent;
         }
         .chat-home__textarea {
             color: var(--text-primary);
@@ -382,16 +377,11 @@ import { MatButtonModule } from '@angular/material/button';
             min-width: 120px;
             max-width: 180px;
         }
-        .chat-home__picker-field .mdc-notched-outline__leading,
-        .chat-home__picker-field .mdc-notched-outline__notch,
-        .chat-home__picker-field .mdc-notched-outline__trailing {
-            border-color: var(--border) !important;
-        }
-        .chat-home__picker-field .mat-mdc-select-value {
-            color: var(--text-primary);
-        }
-        .chat-home__picker-field label {
-            color: var(--text-tertiary);
+        .chat-home__picker-field {
+            --mdc-outlined-text-field-outline-color: var(--border);
+            --mdc-outlined-text-field-hover-outline-color: var(--border);
+            --mat-select-trigger-text-color: var(--text-primary);
+            --mdc-outlined-text-field-label-text-color: var(--text-tertiary);
         }
 
         /* Send button */

--- a/client/src/app/features/dashboard/dashboard.component.css
+++ b/client/src/app/features/dashboard/dashboard.component.css
@@ -8,8 +8,8 @@
 /* Sandbox banner */
 .sandbox-banner {
     display: flex; align-items: center; gap: .6rem;
-    background: var(--accent-amber-subtle, rgba(245,158,11,.12));
-    border: 1px solid var(--accent-amber, #f59e0b);
+    background: var(--accent-amber-subtle);
+    border: 1px solid var(--accent-amber);
     border-radius: var(--radius); padding: var(--space-2) .9rem;
     margin-bottom: .75rem; font-size: .8rem;
     color: var(--text-primary);
@@ -18,7 +18,7 @@
 .sandbox-banner__text { line-height: 1.4; }
 .sandbox-banner__text code {
     font-family: var(--font-mono, monospace);
-    background: var(--bg-elevated, rgba(255,255,255,.05));
+    background: var(--bg-raised);
     border-radius: var(--radius-sm); padding: 0 4px;
     font-size: .75rem;
 }
@@ -354,7 +354,7 @@
 
 /* System status */
 .section--status {
-    background: var(--bg-raised); border-color: var(--border-bright, #2a2d4a);
+    background: var(--bg-raised); border-color: var(--border-bright);
 }
 .status-list { display: flex; flex-direction: column; gap: .25rem; }
 .status-row { display: flex; justify-content: space-between; align-items: center; padding: .4rem 0; border-bottom: 1px solid var(--border); font-size: .85rem; }
@@ -509,7 +509,7 @@
     background: linear-gradient(180deg, rgba(139,92,246,.03) 0%, var(--bg-surface) 30%);
 }
 .widget[data-widget="system-status"] .section {
-    border-top: 2px solid var(--accent-gold, #f5a623);
+    border-top: 2px solid var(--accent-gold);
     background: linear-gradient(180deg, rgba(245,166,35,.03) 0%, var(--bg-raised) 30%);
 }
 
@@ -531,7 +531,7 @@
 .live-badge {
     display: inline-flex; align-items: center; gap: 4px;
     font-size: .65rem; font-weight: 700; text-transform: uppercase; letter-spacing: .08em;
-    color: var(--accent-green); background: var(--accent-green-dim, rgba(16,185,129,.12));
+    color: var(--accent-green); background: var(--accent-green-dim);
     border: 1px solid var(--accent-green-border); border-radius: 12px;
     padding: 2px 8px; flex-shrink: 0;
 }
@@ -546,7 +546,7 @@
     display: inline-flex; align-items: center; justify-content: center;
     min-width: 20px; height: 20px; padding: 0 6px;
     font-size: .7rem; font-weight: 700;
-    background: var(--accent-green-dim, rgba(16,185,129,.15));
+    background: var(--accent-green-dim);
     border: 1px solid var(--accent-green-border); border-radius: 9px;
     color: var(--accent-green); margin-left: .35rem;
 }
@@ -561,9 +561,9 @@
 .agent-card:hover .agent-card__sparkline { opacity: 0.85; }
 
 /* Sparkline SVG paths */
-.sparkline-area--cyan { fill: var(--accent-cyan-subtle, rgba(6,182,212,.1)); }
-.sparkline-area--amber { fill: var(--accent-amber-subtle, rgba(245,158,11,.1)); }
-.sparkline-area--red { fill: var(--accent-red-subtle, rgba(239,68,68,.1)); }
+.sparkline-area--cyan { fill: var(--accent-cyan-subtle); }
+.sparkline-area--amber { fill: var(--accent-amber-subtle); }
+.sparkline-area--red { fill: var(--accent-red-subtle); }
 .sparkline-area--grey { fill: transparent; }
 
 .sparkline-line--cyan { fill: none; stroke: var(--accent-cyan); stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }

--- a/client/src/app/features/library/library-3d.component.css
+++ b/client/src/app/features/library/library-3d.component.css
@@ -3,7 +3,7 @@
     width: 100%;
     height: clamp(400px, calc(100vh - 160px), 900px);
     min-height: 400px;
-    background: #05050a;
+    background: var(--bg-deep);
     border-radius: var(--radius);
     border: 1px solid var(--border);
     overflow: hidden;
@@ -21,7 +21,7 @@ canvas {
     height: 140px;
     border-radius: var(--radius-md);
     border: 1px solid var(--border-bright);
-    background: rgba(5, 5, 10, 0.85);
+    background: var(--overlay-surface);
     backdrop-filter: blur(4px);
     pointer-events: none;
 }
@@ -39,7 +39,7 @@ canvas {
     align-items: center;
     gap: 6px;
     padding: 3px 10px;
-    background: rgba(5, 5, 10, 0.85);
+    background: var(--overlay-surface);
     border: 1px solid var(--border-bright);
     border-radius: 12px;
     font-size: 0.65rem;
@@ -53,7 +53,7 @@ canvas {
     transition: background 0.15s, border-color 0.15s;
 }
 .lib3d__legend-btn:hover {
-    background: rgba(20, 20, 35, 0.9);
+    background: var(--bg-hover);
     border-color: var(--zone-color);
 }
 .lib3d__legend-dot {
@@ -68,7 +68,7 @@ canvas {
     z-index: 20;
     pointer-events: none;
     padding: 4px 10px;
-    background: rgba(5, 5, 10, 0.9);
+    background: var(--overlay-surface);
     border: 1px solid var(--border-bright);
     border-radius: var(--radius);
     font-size: 0.7rem;
@@ -89,7 +89,7 @@ canvas {
     top: 12px;
     right: 12px;
     padding: 4px 12px;
-    background: rgba(5, 5, 10, 0.85);
+    background: var(--overlay-surface);
     border: 1px solid var(--accent-cyan);
     border-radius: 12px;
     font-size: 0.6rem;

--- a/client/src/app/features/logs/system-logs.component.ts
+++ b/client/src/app/features/logs/system-logs.component.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy, inject, OnInit, OnDestroy, signal }
 import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { ApiService } from '../../core/services/api.service';
@@ -35,22 +36,13 @@ interface CreditTransaction {
 @Component({
     selector: 'app-system-logs',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [RouterLink, RelativeTimePipe, FormsModule, MatButtonModule, MatFormFieldModule, MatInputModule, EmptyStateComponent, SkeletonComponent, PageShellComponent],
+    imports: [RouterLink, RelativeTimePipe, FormsModule, MatButtonModule, MatButtonToggleModule, MatFormFieldModule, MatInputModule, EmptyStateComponent, SkeletonComponent, PageShellComponent],
     template: `
         <app-page-shell title="System Logs" icon="logs">
-            <!-- Tab bar -->
-            <div class="tabs">
-                <button
-                    class="tab-btn"
-                    [class.tab-btn--active]="activeTab() === 'logs'"
-                    (click)="switchTab('logs')"
-                >Event Logs</button>
-                <button
-                    class="tab-btn"
-                    [class.tab-btn--active]="activeTab() === 'credits'"
-                    (click)="switchTab('credits')"
-                >Credit Transactions</button>
-            </div>
+            <mat-button-toggle-group [value]="activeTab()" (change)="switchTab($event.value)" aria-label="Log type">
+                <mat-button-toggle value="logs">Event Logs</mat-button-toggle>
+                <mat-button-toggle value="credits">Credit Transactions</mat-button-toggle>
+            </mat-button-toggle-group>
 
             @if (activeTab() === 'logs') {
                 <!-- Search & Controls -->
@@ -162,27 +154,7 @@ interface CreditTransaction {
         .loading { color: var(--text-secondary); }
         .empty { text-align: center; padding: var(--space-12); color: var(--text-tertiary); }
 
-        /* Tabs */
-        .tabs {
-            display: flex;
-            gap: 0.35rem;
-            margin-bottom: 1rem;
-        }
-        .tab-btn {
-            padding: 0.45rem var(--space-4);
-            min-height: 32px;
-            background: var(--bg-raised);
-            border: 1px solid var(--border);
-            border-radius: var(--radius);
-            color: var(--text-secondary);
-            font-size: 0.75rem;
-            font-family: inherit;
-            font-weight: 600;
-            cursor: pointer;
-            transition: all 0.15s;
-        }
-        .tab-btn:hover { border-color: var(--border-bright); color: var(--text-primary); }
-        .tab-btn--active { border-color: var(--accent-cyan); color: var(--accent-cyan); background: var(--accent-cyan-dim); }
+        mat-button-toggle-group { margin-bottom: 1rem; }
 
         /* Toolbar */
         .log-toolbar {

--- a/client/src/app/features/memory/brain-viewer.component.ts
+++ b/client/src/app/features/memory/brain-viewer.component.ts
@@ -668,8 +668,10 @@ interface ConsolidationResponse {
             flex-shrink: 0;
         }
         .export-panel__chips { display: flex; gap: 0.35rem; flex-wrap: wrap; }
-        .export-category-field { width: 100%; }
-        .export-category-field .mat-mdc-form-field-infix { padding-top: 8px; padding-bottom: 8px; }
+        .export-category-field {
+            width: 100%;
+            --mat-form-field-container-vertical-padding: 8px;
+        }
         .export-panel button[mat-flat-button] { align-self: flex-end; }
 
         /* ─── Sync Banner ────── */

--- a/client/src/app/features/sessions/session-list.component.ts
+++ b/client/src/app/features/sessions/session-list.component.ts
@@ -129,7 +129,6 @@ interface SessionGroup {
 
         .filter-row { display: flex; gap: 0.75rem; margin-bottom: 1rem; align-items: center; flex-wrap: wrap; }
         .filter-row mat-button-toggle-group { font-size: 0.75rem; }
-        .filter-row ::ng-deep .mat-button-toggle-label-content { padding: 0 12px; line-height: 32px; font-size: 0.75rem; }
         .source-field { width: 140px; flex-shrink: 0; }
         .source-field ::ng-deep .mat-mdc-select-value { font-size: 0.75rem; }
 
@@ -176,7 +175,7 @@ interface SessionGroup {
             .filter-row { flex-wrap: nowrap; overflow-x: auto; scrollbar-width: none; -webkit-overflow-scrolling: touch; }
             .filter-row::-webkit-scrollbar { display: none; }
             .filter-row mat-button-toggle-group { flex-shrink: 0; }
-            .filter-row ::ng-deep .mat-button-toggle-label-content { padding: 0 8px; font-size: 0.65rem; }
+            .filter-row mat-button-toggle-group { --mat-button-toggle-label-text-size: 0.65rem; }
             .source-field { width: 120px; }
         }
     `,

--- a/client/src/app/features/sessions/session-list.component.ts
+++ b/client/src/app/features/sessions/session-list.component.ts
@@ -130,7 +130,7 @@ interface SessionGroup {
         .filter-row { display: flex; gap: 0.75rem; margin-bottom: 1rem; align-items: center; flex-wrap: wrap; }
         .filter-row mat-button-toggle-group { font-size: 0.75rem; }
         .source-field { width: 140px; flex-shrink: 0; }
-        .source-field ::ng-deep .mat-mdc-select-value { font-size: 0.75rem; }
+        .source-field { --mat-select-trigger-text-size: 0.75rem; }
 
         .bulk-actions { display: flex; gap: 0.5rem; margin-bottom: 1rem; }
 

--- a/client/src/app/features/settings/credits-settings.component.ts
+++ b/client/src/app/features/settings/credits-settings.component.ts
@@ -55,9 +55,11 @@ import { SECTION_STYLES } from './settings-shared.styles';
         .credit-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 1rem; margin-bottom: 1rem; }
         .credit-field { display: flex; flex-direction: column; gap: 0.3rem; }
         .field { width: 100%; }
-        .field--dirty ::ng-deep .mdc-notched-outline__leading,
-        .field--dirty ::ng-deep .mdc-notched-outline__notch,
-        .field--dirty ::ng-deep .mdc-notched-outline__trailing { border-color: var(--accent-amber) !important; }
+        .field--dirty {
+            --mdc-outlined-text-field-outline-color: var(--accent-amber);
+            --mdc-outlined-text-field-hover-outline-color: var(--accent-amber);
+            --mdc-outlined-text-field-focus-outline-color: var(--accent-amber);
+        }
         .credit-desc { font-size: 0.78rem; color: var(--text-tertiary); margin-top: -0.5rem; }
         .credit-actions { display: flex; gap: 0.5rem; align-items: center; }
         @media (max-width: 600px) { .credit-grid { grid-template-columns: 1fr; } }

--- a/client/src/app/features/work-tasks/work-task-list.component.ts
+++ b/client/src/app/features/work-tasks/work-task-list.component.ts
@@ -257,8 +257,6 @@ import { MatIconModule } from '@angular/material/icon';
         }
         .detail-toggle:hover { border-color: var(--accent-cyan); color: var(--accent-cyan); }
 
-        .tasks__filter-row ::ng-deep .mat-button-toggle-label-content { padding: 0 12px; line-height: 32px; font-size: 0.75rem; }
-
         .tasks__search-row {
             display: flex; gap: 0.5rem; align-items: center; margin-top: 0.5rem;
         }

--- a/client/src/app/features/work-tasks/work-task-list.component.ts
+++ b/client/src/app/features/work-tasks/work-task-list.component.ts
@@ -263,7 +263,7 @@ import { MatIconModule } from '@angular/material/icon';
         .search-field { flex: 1; min-width: 0; }
         .search-field .mat-mdc-form-field-icon-prefix { padding-right: 0.5rem; color: var(--text-tertiary); }
         .agent-filter-field { width: 160px; flex-shrink: 0; }
-        .agent-filter-field ::ng-deep .mat-mdc-select-value { font-size: 0.75rem; }
+        .agent-filter-field { --mat-select-trigger-text-size: 0.75rem; }
 
         .empty {
             text-align: center;

--- a/client/src/app/shared/components/mobile-bottom-nav.component.ts
+++ b/client/src/app/shared/components/mobile-bottom-nav.component.ts
@@ -173,13 +173,11 @@ const NAV_ITEMS: BottomNavItem[] = [
             color: var(--accent-cyan);
         }
 
-        /* Override Material badge positioning */
-        ::ng-deep .bottom-nav__icon-wrapper .mat-badge-content {
-            background: var(--accent-cyan);
-            color: var(--bg-deep);
-            font-size: 0.55rem;
-            font-weight: 700;
-            box-shadow: 0 0 6px var(--accent-cyan-glow);
+        .bottom-nav__icon-wrapper {
+            --mat-badge-background-color: var(--accent-cyan);
+            --mat-badge-text-color: var(--bg-deep);
+            --mat-badge-text-size: 0.55rem;
+            --mat-badge-text-weight: 700;
         }
     `,
 })

--- a/client/src/styles/m3-theme.scss
+++ b/client/src/styles/m3-theme.scss
@@ -135,4 +135,41 @@ $corvid-theme: mat.define-theme((
   // Badge
   --mat-badge-background-color: #00e5ff;
   --mat-badge-text-color: #0c0c14;
+
+  // Toolbar — transparent to let glassmorphism show through
+  --mat-toolbar-container-background-color: transparent;
+  --mat-toolbar-container-text-color: #e8e6f0;
+
+  // Sidenav
+  --mat-sidenav-container-background-color: #0c0c14;
+  --mat-sidenav-content-background-color: #0c0c14;
+  --mat-sidenav-container-text-color: #e8e6f0;
+  --mat-sidenav-container-divider-color: #222438;
+
+  // Ripple — subtle cyan
+  --mat-ripple-color: rgba(0, 229, 255, 0.08);
+
+  // Autocomplete (future-proofing)
+  --mat-autocomplete-background-color: #191b26;
+
+  // Snackbar (future-proofing)
+  --mdc-snackbar-container-color: #191b26;
+  --mdc-snackbar-supporting-text-color: #e8e6f0;
+  --mat-snack-bar-button-color: #00e5ff;
+
+  // Dialog (future-proofing)
+  --mdc-dialog-container-color: #12131c;
+  --mdc-dialog-subhead-color: #e8e6f0;
+  --mdc-dialog-supporting-text-color: #9490ad;
+
+  // Tooltip
+  --mdc-plain-tooltip-container-color: #191b26;
+  --mdc-plain-tooltip-supporting-text-color: #e8e6f0;
+
+  // Progress bar
+  --mdc-linear-progress-active-indicator-color: #00e5ff;
+  --mdc-linear-progress-track-color: rgba(0, 229, 255, 0.1);
+
+  // Progress spinner
+  --mdc-circular-progress-active-indicator-color: #00e5ff;
 }

--- a/client/src/styles/m3-theme.scss
+++ b/client/src/styles/m3-theme.scss
@@ -1,17 +1,15 @@
 // Angular Material M3 — Corvid dark theme
-// Primary: deep purple-black (corvid/crow-inspired)
-// Secondary: amber (warm accent)
+// Primary: cyan (matches --accent-cyan #00e5ff)
+// Tertiary: amber (warm accent)
 
 @use '@angular/material' as mat;
 
-// Include the core styles once (resets, elevation, etc.)
 @include mat.core();
 
-// Define the M3 theme — dark, corvid-inspired
 $corvid-theme: mat.define-theme((
   color: (
     theme-type: dark,
-    primary: mat.$violet-palette,
+    primary: mat.$cyan-palette,
     tertiary: mat.$orange-palette,
   ),
   typography: (
@@ -22,16 +20,67 @@ $corvid-theme: mat.define-theme((
     regular-weight: 400,
   ),
   density: (
-    scale: 0,
+    scale: -2,
   ),
 ));
 
-// Emit theme tokens to :root — components opt-in via their own @include mat.xxx-theme()
 :root {
   @include mat.theme($corvid-theme);
   @include mat.all-component-themes($corvid-theme);
 
-  // Override Material surface/background to match Corvid palette
   --mat-app-background-color: #0c0c14;
   --mat-app-text-color: #e8e6f0;
+
+  // Button toggle — blend with corvid dark surfaces
+  --mat-button-toggle-text-color: #9490ad;
+  --mat-button-toggle-background-color: #12131c;
+  --mat-button-toggle-selected-state-text-color: #00e5ff;
+  --mat-button-toggle-selected-state-background-color: rgba(0, 229, 255, 0.1);
+  --mat-button-toggle-divider-color: #222438;
+  --mat-button-toggle-hover-state-layer-opacity: 0.08;
+  --mat-button-toggle-focus-state-layer-opacity: 0.12;
+  --mat-button-toggle-shape: 6px;
+  --mat-button-toggle-height: 32px;
+  --mat-button-toggle-label-text-size: 0.75rem;
+
+  // Slide toggle — cyan when on
+  --mat-slide-toggle-selected-track-color: #00e5ff;
+  --mat-slide-toggle-selected-handle-color: #0c0c14;
+  --mat-slide-toggle-selected-hover-track-color: #00cce6;
+  --mat-slide-toggle-selected-focus-track-color: #00cce6;
+  --mat-slide-toggle-unselected-track-color: #222438;
+  --mat-slide-toggle-unselected-handle-color: #9490ad;
+
+  // Form fields — dark surfaces with cyan focus
+  --mdc-outlined-text-field-outline-color: #222438;
+  --mdc-outlined-text-field-hover-outline-color: #2e3150;
+  --mdc-outlined-text-field-focus-outline-color: #00e5ff;
+  --mdc-outlined-text-field-label-text-color: #9490ad;
+  --mdc-outlined-text-field-input-text-color: #e8e6f0;
+  --mdc-outlined-text-field-caret-color: #00e5ff;
+  --mat-form-field-container-text-size: 0.85rem;
+
+  // Filled buttons — cyan accent
+  --mdc-filled-button-container-color: rgba(0, 229, 255, 0.12);
+  --mdc-filled-button-label-text-color: #00e5ff;
+
+  // Outlined/stroked buttons
+  --mdc-outlined-button-outline-color: #222438;
+  --mdc-outlined-button-label-text-color: #e8e6f0;
+
+  // FAB
+  --mat-fab-small-foreground-color: #0c0c14;
+  --mat-fab-small-state-layer-color: #00e5ff;
+
+  // Icon buttons
+  --mat-icon-button-state-layer-color: rgba(0, 229, 255, 0.08);
+  --mat-icon-button-icon-color: #9490ad;
+
+  // Select dropdown
+  --mat-select-panel-background-color: #191b26;
+  --mat-select-trigger-text-color: #e8e6f0;
+  --mat-select-enabled-trigger-text-color: #e8e6f0;
+  --mat-option-selected-state-label-text-color: #00e5ff;
+  --mat-option-label-text-color: #e8e6f0;
+  --mat-option-hover-state-layer-color: rgba(0, 229, 255, 0.08);
 }

--- a/client/src/styles/m3-theme.scss
+++ b/client/src/styles/m3-theme.scss
@@ -83,4 +83,56 @@ $corvid-theme: mat.define-theme((
   --mat-option-selected-state-label-text-color: #00e5ff;
   --mat-option-label-text-color: #e8e6f0;
   --mat-option-hover-state-layer-color: rgba(0, 229, 255, 0.08);
+
+  // Tabs — dark surfaces with cyan indicator
+  --mat-tab-header-active-label-text-color: #00e5ff;
+  --mat-tab-header-active-focus-label-text-color: #00e5ff;
+  --mat-tab-header-active-hover-label-text-color: #00e5ff;
+  --mat-tab-header-inactive-label-text-color: #9490ad;
+  --mat-tab-header-inactive-hover-label-text-color: #e8e6f0;
+  --mat-tab-header-active-focus-indicator-color: #00e5ff;
+  --mat-tab-header-active-hover-indicator-color: #00e5ff;
+  --mdc-tab-indicator-active-indicator-color: #00e5ff;
+
+  // Menu — dark panel
+  --mat-menu-container-color: #191b26;
+  --mat-menu-item-label-text-color: #e8e6f0;
+  --mat-menu-item-icon-color: #9490ad;
+  --mat-menu-item-hover-state-layer-color: rgba(0, 229, 255, 0.08);
+  --mat-menu-item-focus-state-layer-color: rgba(0, 229, 255, 0.08);
+  --mat-menu-divider-color: #222438;
+
+  // Card
+  --mdc-elevated-card-container-color: #12131c;
+  --mdc-outlined-card-container-color: #12131c;
+  --mdc-outlined-card-outline-color: #222438;
+
+  // Checkbox — cyan when checked
+  --mdc-checkbox-selected-checkmark-color: #0c0c14;
+  --mdc-checkbox-selected-focus-icon-color: #00e5ff;
+  --mdc-checkbox-selected-hover-icon-color: #00e5ff;
+  --mdc-checkbox-selected-icon-color: #00e5ff;
+  --mdc-checkbox-selected-pressed-icon-color: #00e5ff;
+  --mdc-checkbox-unselected-icon-color: #9490ad;
+  --mdc-checkbox-unselected-hover-icon-color: #e8e6f0;
+
+  // Chips
+  --mat-chip-elevated-container-color: rgba(0, 229, 255, 0.08);
+  --mat-chip-elevated-selected-container-color: rgba(0, 229, 255, 0.15);
+  --mat-chip-label-text-color: #e8e6f0;
+  --mat-chip-selected-label-text-color: #00e5ff;
+  --mat-chip-hover-state-layer-color: rgba(0, 229, 255, 0.08);
+
+  // Divider
+  --mat-divider-color: #222438;
+
+  // List
+  --mat-list-active-indicator-color: rgba(0, 229, 255, 0.1);
+  --mdc-list-list-item-label-text-color: #e8e6f0;
+  --mdc-list-list-item-hover-label-text-color: #e8e6f0;
+  --mdc-list-list-item-hover-state-layer-color: rgba(0, 229, 255, 0.08);
+
+  // Badge
+  --mat-badge-background-color: #00e5ff;
+  --mat-badge-text-color: #0c0c14;
 }


### PR DESCRIPTION
## Summary
- Switch M3 theme from violet to cyan palette to match the app's `--accent-cyan` colors
- Set density to -2 for compact sizing that matches the existing UI
- Add 30+ CSS custom property overrides for button toggles, slide toggles, form fields, selects, FABs, and icon buttons to blend with the dark corvid theme
- Remove broken `::ng-deep .mat-button-toggle-label-content` selectors (3 components)
- Migrate system-logs tab buttons to `mat-button-toggle-group`
- Replace remaining `::ng-deep` overrides with native M3 CSS custom property tokens

## Test plan
- [x] TSC passes
- [x] Build succeeds
- [x] Verify button toggles have cyan selected state
- [x] Verify slide toggles show cyan track when on
- [x] Verify form fields have cyan focus outline
- [x] Verify system-logs tabs work correctly
- [x] Verify compact density looks good on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)