### PR TITLE
feat(client): M3 Phase 2 — complete session-input migration with mat-form-field

### DIFF
--- a/client/src/app/features/sessions/session-input.component.ts
+++ b/client/src/app/features/sessions/session-input.component.ts
@@ -1,32 +1,34 @@
 import { Component, ChangeDetectionStrategy, output, signal, input, ElementRef, viewChild, AfterViewInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { DecimalPipe } from '@angular/common';
+import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
 
 @Component({
     selector: 'app-session-input',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FormsModule, DecimalPipe, MatButtonModule, MatFormFieldModule, MatInputModule],
+    imports: [FormsModule, DecimalPipe, MatInputModule, MatButtonModule, MatFormFieldModule],
     template: `
         <div class="input-bar" [class.input-bar--focused]="focused()">
-            <label for="messageInput" class="sr-only">Send message to session</label>
             <div class="input-bar__wrapper">
-                <textarea
-                    #inputEl
-                    id="messageInput"
-                    class="input-bar__field"
-                    [(ngModel)]="messageText"
-                    [disabled]="disabled()"
-                    [placeholder]="placeholder()"
-                    rows="1"
-                    (keydown.enter)="onEnter($event)"
-                    (input)="autoResize()"
-                    (focus)="focused.set(true)"
-                    (blur)="focused.set(false)"
-                    aria-label="Message input">
-                </textarea>
+                <mat-form-field appearance="outline" class="input-bar__form-field" subscriptSizing="dynamic">
+                    <textarea
+                        matInput
+                        #inputEl
+                        id="messageInput"
+                        [(ngModel)]="messageText"
+                        [disabled]="disabled()"
+                        [placeholder]="placeholder()"
+                        rows="1"
+                        (keydown.enter)="onEnter($event)"
+                        (input)="autoResize()"
+                        (focus)="focused.set(true)"
+                        (blur)="focused.set(false)"
+                        aria-label="Send message to session"
+                        class="input-bar__field">
+                    </textarea>
+                </mat-form-field>
                 <div class="input-bar__hints">
                     @if (messageText().trim().length > 0) {
                         <span class="input-bar__char-count" [class.input-bar__char-count--warn]="messageText().length > 8000">{{ messageText().length | number }}</span>
@@ -35,7 +37,8 @@ import { MatInputModule } from '@angular/material/input';
                     <span class="input-bar__kbd-label">new line</span>
                 </div>
             </div>
-            <button mat-stroked-button
+            <button
+                mat-stroked-button
                 class="input-bar__send"
                 (click)="onSend()"
                 [disabled]="disabled() || messageText().trim().length === 0"
@@ -49,7 +52,6 @@ import { MatInputModule } from '@angular/material/input';
             display: block;
             flex-shrink: 0;
         }
-        .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
         .input-bar {
             display: flex;
             gap: 0.5rem;
@@ -57,6 +59,7 @@ import { MatInputModule } from '@angular/material/input';
             background: var(--bg-surface);
             border-top: 1px solid var(--border);
             transition: border-color 0.2s;
+            align-items: flex-end;
         }
         .input-bar--focused {
             border-top-color: var(--accent-cyan-border);
@@ -67,23 +70,28 @@ import { MatInputModule } from '@angular/material/input';
             flex-direction: column;
             gap: 0.25rem;
         }
-        .input-bar__field {
+        .input-bar__form-field {
             width: 100%;
-            padding: var(--space-2) var(--space-3);
-            background: var(--bg-input);
+        }
+        .input-bar__form-field .mdc-notched-outline__leading,
+        .input-bar__form-field .mdc-notched-outline__notch,
+        .input-bar__form-field .mdc-notched-outline__trailing {
+            border-color: var(--border-bright) !important;
+        }
+        .input-bar__form-field:focus-within .mdc-notched-outline__leading,
+        .input-bar__form-field:focus-within .mdc-notched-outline__notch,
+        .input-bar__form-field:focus-within .mdc-notched-outline__trailing {
+            border-color: var(--accent-cyan) !important;
+        }
+        .input-bar__field {
             color: var(--text-primary);
-            border: 1px solid var(--border-bright);
-            border-radius: var(--radius);
             font-family: inherit;
             font-size: 0.85rem;
             resize: none;
             max-height: 150px;
             overflow-y: auto;
-            transition: height 0.1s ease, border-color 0.15s;
-            box-sizing: border-box;
         }
-        .input-bar__field:focus { outline: none; border-color: var(--accent-cyan); box-shadow: var(--glow-cyan); }
-        .input-bar__field:disabled { opacity: 0.4; }
+        .input-bar__field::placeholder { color: var(--text-tertiary); }
         .input-bar__hints {
             display: flex;
             align-items: center;
@@ -118,23 +126,29 @@ import { MatInputModule } from '@angular/material/input';
             font-size: var(--text-micro);
             color: var(--text-tertiary);
         }
-        .input-bar__send {
+        .input-bar__send.mat-mdc-button-base {
+            color: var(--accent-cyan);
+            border-color: var(--accent-cyan);
+            font-weight: 600;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
             align-self: flex-end;
+            margin-bottom: 1px;
+            flex-shrink: 0;
         }
+        .input-bar__send.mat-mdc-button-base:hover:not(:disabled) {
+            background: var(--accent-cyan-dim);
+            box-shadow: var(--glow-cyan);
+        }
+        .input-bar__send.mat-mdc-button-base:active:not(:disabled) { transform: scale(0.97); }
+        .input-bar__send.mat-mdc-button-base:disabled { opacity: 0.3; }
 
         /* Mobile: tighter input bar */
         @media (max-width: 767px) {
             .input-bar {
                 padding: var(--space-2);
                 gap: 0.375rem;
-            }
-            .input-bar__field {
-                padding: 0.375rem var(--space-2);
-                font-size: 0.8rem;
-            }
-            .input-bar__send {
-                padding: 0.375rem var(--space-3);
-                font-size: 0.7rem;
             }
             .input-bar__hints { display: none; }
         }


### PR DESCRIPTION
Replaces #2097 — applied the session-input migration cleanly on top of current main (which already has the partial migration from #2095).

## Changes
- Wraps textarea in `mat-form-field appearance="outline"` with `subscriptSizing="dynamic"`
- Adds `matInput` directive to textarea
- Removes `.sr-only` label (uses `aria-label` on textarea instead)
- Replaces legacy custom border/focus styles with MDC CSS custom property targeting
- Updates send button styles to use `.mat-mdc-button-base` selector

Closes #2097