### PR TITLE
feat(client): M3 Phase 3 — remove ::ng-deep, migrate checkbox

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -149,12 +149,6 @@ import { KeyboardShortcutsService } from './core/services/keyboard-shortcuts.ser
             }
         }
 
-        /* Hide chat tab bar on mobile — bottom nav handles navigation */
-        @media (max-width: 767px) {
-            :host ::ng-deep app-chat-tab-bar {
-                display: none;
-            }
-        }
     `,
 })
 export class App implements OnInit, OnDestroy {

--- a/client/src/app/features/work-tasks/work-task-detail.component.ts
+++ b/client/src/app/features/work-tasks/work-task-detail.component.ts
@@ -163,16 +163,6 @@ interface DiffFile {
             max-height: 200px; overflow-y: auto;
         }
 
-        /* Syntax highlighting in log content */
-        :host ::ng-deep .log-code-block {
-            display: block; background: var(--bg-surface); border: 1px solid var(--border); border-radius: var(--radius-sm);
-            padding: 0.4rem 0.5rem; margin: 0.25rem 0; font-family: var(--font-mono); font-size: 0.65rem;
-            overflow-x: auto; color: var(--text-primary);
-        }
-        :host ::ng-deep .log-code-inline {
-            background: var(--bg-raised); padding: 1px 4px; border-radius: 3px;
-            font-family: var(--font-mono); font-size: 0.9em; color: var(--accent-magenta);
-        }
 
         /* Diff viewer */
         .diff-summary { margin-bottom: 0.5rem; }

--- a/client/src/app/shared/components/chat-tab-bar.component.ts
+++ b/client/src/app/shared/components/chat-tab-bar.component.ts
@@ -236,6 +236,11 @@ const COLLAPSED_KEY = 'corvid-chat-tabs-collapsed';
             color: var(--accent-cyan);
             border-color: var(--accent-cyan);
         }
+
+        /* Hidden on mobile — bottom nav handles navigation */
+        @media (max-width: 767px) {
+            :host { display: none; }
+        }
     `,
 })
 export class ChatTabBarComponent {

--- a/client/src/app/shared/components/dir-browser.component.ts
+++ b/client/src/app/shared/components/dir-browser.component.ts
@@ -9,11 +9,12 @@ import {
     inject,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 
 @Component({
     selector: 'app-dir-browser',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [MatButtonModule],
+    imports: [MatButtonModule, MatCheckboxModule],
     template: `
         <div class="overlay" (click)="onBackdropClick($event)" (keydown.escape)="onCancel()">
             <div class="browser" role="dialog" aria-label="Browse directories">
@@ -52,10 +53,9 @@ import { MatButtonModule } from '@angular/material/button';
                 }
 
                 <div class="browser__actions">
-                    <label class="browser__toggle">
-                        <input type="checkbox" [checked]="showHidden()" (change)="toggleHidden()" />
+                    <mat-checkbox class="browser__toggle" [checked]="showHidden()" (change)="toggleHidden()">
                         Show hidden
-                    </label>
+                    </mat-checkbox>
                     <div class="browser__buttons">
                         <button mat-flat-button color="primary" (click)="onSelect()">Select</button>
                         <button mat-stroked-button (click)="onCancel()">Cancel</button>
@@ -122,9 +122,7 @@ import { MatButtonModule } from '@angular/material/button';
         }
         .browser__toggle {
             font-size: 0.75rem; color: var(--text-secondary);
-            display: flex; align-items: center; gap: 0.35rem; cursor: pointer;
         }
-        .browser__toggle input { accent-color: var(--accent-cyan); }
         .browser__buttons { display: flex; gap: 0.5rem; }
         .btn {
             padding: 0.4rem var(--space-3); border-radius: var(--radius); font-size: 0.75rem; font-weight: 600;

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1667,3 +1667,17 @@ select:focus {
     .row-lift:hover,
     .node-chip-interactive:hover { transform: none; }
 }
+
+
+/* ── Dynamic HTML content (innerHTML-injected) ─────────────────────────────
+   These classes are injected at runtime and are not processed by Angular view
+   encapsulation, so they must live in the global stylesheet. */
+.log-code-block {
+    display: block; background: var(--bg-surface); border: 1px solid var(--border);
+    border-radius: var(--radius-sm); padding: 0.4rem 0.5rem; margin: 0.25rem 0;
+    font-family: var(--font-mono); font-size: 0.65rem; overflow-x: auto; color: var(--text-primary);
+}
+.log-code-inline {
+    background: var(--bg-raised); padding: 1px 4px; border-radius: 3px;
+    font-family: var(--font-mono); font-size: 0.9em; color: var(--accent-magenta);
+}


### PR DESCRIPTION
## Summary
- **app.ts**: Remove `::ng-deep app-chat-tab-bar` — mobile hide responsibility moved to the component itself
- **chat-tab-bar**: Add `@media (max-width: 767px) { :host { display: none; } }` — proper encapsulation
- **work-task-detail**: Remove `::ng-deep .log-code-block` / `.log-code-inline` — these target `[innerHTML]`-injected content and must be global
- **styles.css**: Add `.log-code-block` and `.log-code-inline` as global rules with comment explaining why
- **dir-browser**: Replace `<input type="checkbox">` with `<mat-checkbox>` + `MatCheckboxModule`

## Test plan
- [ ] Chat tab bar is hidden at ≤767px, visible above
- [ ] Log content in work task detail still shows code highlighting
- [ ] dir-browser "Show hidden" toggle works with Material checkbox
- [ ] No visual regressions in affected components

🤖 Generated with [Claude Code](https://claude.com/claude-code)