### PR TITLE
feat(client): M3 Phase 3 — migrate skill tags and tool names to mat-chip

### DIFF
--- a/client/src/app/features/agents/agent-detail.component.ts
+++ b/client/src/app/features/agents/agent-detail.component.ts
@@ -357,14 +357,14 @@ type Tab = 'overview' | 'sessions' | 'messages' | 'work-tasks' | 'flock' | 'pers
                     @if (agentBundles().length === 0) {
                         <p class="detail__empty">No skill bundles assigned. <a routerLink="/agents/skill-bundles">Manage bundles</a></p>
                     } @else {
-                        <div class="skills-list">
+                        <mat-chip-set aria-label="Assigned skill bundles">
                             @for (ab of agentBundles(); track ab.bundleId) {
-                                <span class="skill-tag">
+                                <mat-chip (removed)="unassignBundle(ab.bundleId)">
                                     {{ getBundleName(ab.bundleId) }}
-                                    <button class="skill-tag__remove" (click)="unassignBundle(ab.bundleId)" title="Remove">&times;</button>
-                                </span>
+                                    <button matChipRemove aria-label="Remove skill bundle">&#x2715;</button>
+                                </mat-chip>
                             }
-                        </div>
+                        </mat-chip-set>
                     }
                 }
             </app-page-shell>
@@ -468,10 +468,6 @@ type Tab = 'overview' | 'sessions' | 'messages' | 'work-tasks' | 'flock' | 'pers
         .persona-info__text { font-size: 0.85rem; color: var(--text-secondary); margin: 0.25rem 0; }
         .skills-assign { display: flex; gap: 0.5rem; align-items: center; margin-bottom: 1rem; }
         .skills-assign__select { flex: 1; }
-        .skills-list { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-        .skill-tag { display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.75rem; padding: 3px 10px; border-radius: var(--radius-sm); background: var(--accent-cyan-dim); color: var(--accent-cyan); border: 1px solid var(--accent-cyan); }
-        .skill-tag__remove { background: none; border: none; color: var(--accent-cyan); cursor: pointer; font-size: 1rem; line-height: 1; padding: 0.2rem 0.3rem; min-width: 24px; min-height: 24px; display: inline-flex; align-items: center; justify-content: center; opacity: 0.6; }
-        .skill-tag__remove:hover { opacity: 1; }
 
         /* Flock Profile */
         .flock-profile { display: flex; flex-direction: column; gap: 1.25rem; }

--- a/client/src/app/features/skill-bundles/skill-bundle-list.component.ts
+++ b/client/src/app/features/skill-bundles/skill-bundle-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, ChangeDetectionStrategy, inject, OnInit, signal, computed } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatChipsModule } from '@angular/material/chips';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { SkillBundleService } from '../../core/services/skill-bundle.service';
@@ -13,7 +14,7 @@ import { PageShellComponent } from '../../shared/components/page-shell.component
 @Component({
     selector: 'app-skill-bundle-list',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FormsModule, MatButtonModule, MatFormFieldModule, MatInputModule, EmptyStateComponent, SkeletonComponent, PageShellComponent],
+    imports: [FormsModule, MatButtonModule, MatChipsModule, MatFormFieldModule, MatInputModule, EmptyStateComponent, SkeletonComponent, PageShellComponent],
     template: `
         <app-page-shell title="Skill Bundles" icon="skills">
             <button actions class="create-btn" (click)="showCreateForm.set(!showCreateForm())">
@@ -136,7 +137,15 @@ import { PageShellComponent } from '../../shared/components/page-shell.component
                                     } @else {
                                         <div class="bundle-card__tools-list">
                                             <strong>Tools:</strong>
-                                            {{ bundle.tools.join(', ') || 'None' }}
+                                            @if (bundle.tools.length === 0) {
+                                                <span class="bundle-card__tools-empty">None</span>
+                                            } @else {
+                                                <mat-chip-set aria-label="Tools in this bundle">
+                                                    @for (tool of bundle.tools; track tool) {
+                                                        <mat-chip>{{ tool }}</mat-chip>
+                                                    }
+                                                </mat-chip-set>
+                                            }
                                         </div>
                                         @if (bundle.promptAdditions) {
                                             <div class="bundle-card__prompt">
@@ -197,7 +206,8 @@ import { PageShellComponent } from '../../shared/components/page-shell.component
         .bundle-card__meta { font-size: 0.75rem; color: var(--text-secondary); }
         .bundle-card__desc { margin: 0.25rem 0 0; font-size: 0.8rem; color: var(--text-secondary); }
         .bundle-card__details { margin-top: 1rem; padding-top: var(--space-4); border-top: 1px solid var(--border); }
-        .bundle-card__tools-list { font-size: 0.85rem; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .bundle-card__tools-list { font-size: 0.85rem; color: var(--text-primary); margin-bottom: 0.5rem; display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+        .bundle-card__tools-empty { color: var(--text-tertiary); }
         .bundle-card__prompt pre { font-size: 0.8rem; color: var(--accent-green); white-space: pre-wrap; margin: 0.25rem 0; }
         @media (max-width: 767px) {
             .form-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary

- **agent-detail**: Replace custom `.skill-tag` spans with `mat-chip-set` / `mat-chip` + `matChipRemove` for the assigned skill bundles list — removable chips with proper M3 semantics
- **skill-bundle-list**: Replace comma-joined tool name text with individual `mat-chip` display chips inside expanded bundle cards
- Remove now-unused custom CSS: `.skill-tag`, `.skill-tag__remove`, `.skills-list`
- Add `MatChipsModule` import to `skill-bundle-list` (already present in `agent-detail`)

Both components use M3 chip patterns: `mat-chip-set` as container, `mat-chip` for each item, `matChipRemove` on the delete button.

Part of #2081 — M3 Phase 3 (Enhanced UX).

## Test plan

- [x] agent-detail Skills tab: assigned bundles render as M3 chips; remove button removes the assignment
- [x] skill-bundle-list: expand a bundle card — tools render as display chips instead of comma-separated text; bundles with no tools show "None"
- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 10334 pass, 14 pre-existing AST failures (unrelated, present on `main`)
- [x] `bun run lint` — clean
- [x] `bun run spec:check` — 1/1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)