### PR TITLE
feat(discord): channel-scoped context retention across sessions

### DIFF
--- a/server/__tests__/graduation-service.test.ts
+++ b/server/__tests__/graduation-service.test.ts
@@ -6,6 +6,7 @@
 import { Database } from 'bun:sqlite';
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { up as upObservations } from '../db/migrations/095_memory_observations';
+import { up as upObservationChannelId } from '../db/migrations/120_observation_channel_id';
 import { boostObservation, getObservation, recordObservation } from '../db/observations';
 import { MemoryGraduationService } from '../memory/graduation-service';
 
@@ -39,6 +40,7 @@ function createTestDb(): Database {
     `);
 
   upObservations(db);
+  upObservationChannelId(db);
   return db;
 }
 

--- a/server/__tests__/observations.test.ts
+++ b/server/__tests__/observations.test.ts
@@ -6,6 +6,7 @@
 import { Database } from 'bun:sqlite';
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { up } from '../db/migrations/095_memory_observations';
+import { up as up120 } from '../db/migrations/120_observation_channel_id';
 import {
   boostObservation,
   countObservations,
@@ -29,6 +30,7 @@ function createTestDb(): Database {
   db.exec(`CREATE TABLE IF NOT EXISTS agents (id TEXT PRIMARY KEY)`);
   db.prepare('INSERT INTO agents (id) VALUES (?)').run(AGENT_ID);
   up(db);
+  up120(db);
   return db;
 }
 

--- a/server/__tests__/session-resume-observations.test.ts
+++ b/server/__tests__/session-resume-observations.test.ts
@@ -16,6 +16,7 @@
 import { Database } from 'bun:sqlite';
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { up as upObservations } from '../db/migrations/095_memory_observations';
+import { up as upObservationChannelId } from '../db/migrations/120_observation_channel_id';
 import {
   boostObservation,
   dismissObservation,
@@ -37,6 +38,7 @@ function createTestDb(): Database {
   db.prepare('INSERT INTO agents (id) VALUES (?)').run(AGENT_ID);
   db.prepare('INSERT INTO sessions (id, agent_id) VALUES (?, ?)').run(SESSION_ID, AGENT_ID);
   upObservations(db);
+  upObservationChannelId(db);
   return db;
 }
 

--- a/server/db/discord-mention-sessions.ts
+++ b/server/db/discord-mention-sessions.ts
@@ -177,6 +177,40 @@ export function updateMentionSessionActivity(db: Database, botMessageId: string)
 }
 
 /**
+ * Get aggregated message history across all recent sessions in a channel.
+ * Returns messages from the most recent sessions (up to maxMessages), ordered chronologically.
+ * Used for channel-scoped context when creating a new session.
+ */
+export function getChannelMessageHistory(
+  db: Database,
+  channelId: string,
+  maxMessages: number = 40,
+  maxAgeHours: number = 24,
+): Array<{ role: string; content: string; sessionId: string; timestamp: string }> {
+  const rows = db
+    .query(
+      `SELECT sm.role, sm.content, sm.session_id, sm.timestamp
+       FROM session_messages sm
+       INNER JOIN discord_mention_sessions dms ON dms.session_id = sm.session_id
+       WHERE dms.channel_id = ?
+         AND dms.created_at > datetime('now', '-' || ? || ' hours')
+         AND sm.role IN ('user', 'assistant')
+       ORDER BY sm.timestamp DESC
+       LIMIT ?`,
+    )
+    .all(channelId, maxAgeHours, maxMessages) as Array<{
+    role: string;
+    content: string;
+    session_id: string;
+    timestamp: string;
+  }>;
+
+  return rows
+    .reverse()
+    .map((r) => ({ role: r.role, content: r.content, sessionId: r.session_id, timestamp: r.timestamp }));
+}
+
+/**
  * Remove mention session entries older than the specified age.
  * @param maxAgeDays Maximum age in days (default: 7)
  */

--- a/server/db/migrations/120_observation_channel_id.ts
+++ b/server/db/migrations/120_observation_channel_id.ts
@@ -1,0 +1,10 @@
+import type { Database } from 'bun:sqlite';
+
+export function up(db: Database): void {
+  db.exec(`ALTER TABLE memory_observations ADD COLUMN channel_id TEXT`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_observations_channel_id ON memory_observations(channel_id) WHERE channel_id IS NOT NULL`);
+}
+
+export function down(db: Database): void {
+  db.exec(`DROP INDEX IF EXISTS idx_observations_channel_id`);
+}

--- a/server/db/observations.ts
+++ b/server/db/observations.ts
@@ -20,6 +20,7 @@ interface ObservationRow {
   graduated_key: string | null;
   created_at: string;
   expires_at: string | null;
+  channel_id: string | null;
 }
 
 function rowToObservation(row: ObservationRow): MemoryObservation {
@@ -37,6 +38,7 @@ function rowToObservation(row: ObservationRow): MemoryObservation {
     graduatedKey: row.graduated_key,
     createdAt: row.created_at,
     expiresAt: row.expires_at,
+    channelId: row.channel_id,
   };
 }
 
@@ -52,6 +54,7 @@ export function recordObservation(
     suggestedKey?: string;
     relevanceScore?: number;
     expiresAt?: string;
+    channelId?: string;
   },
 ): MemoryObservation {
   const id = crypto.randomUUID();
@@ -59,8 +62,8 @@ export function recordObservation(
 
   db.query(
     `INSERT INTO memory_observations
-            (id, agent_id, source, source_id, content, suggested_key, relevance_score, expires_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+            (id, agent_id, source, source_id, content, suggested_key, relevance_score, expires_at, channel_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     id,
     params.agentId,
@@ -70,6 +73,7 @@ export function recordObservation(
     params.suggestedKey ?? null,
     params.relevanceScore ?? 1.0,
     params.expiresAt ?? defaultExpiry,
+    params.channelId ?? null,
   );
 
   const row = db.query('SELECT * FROM memory_observations WHERE id = ?').get(id) as ObservationRow;
@@ -86,7 +90,7 @@ export function getObservation(db: Database, id: string): MemoryObservation | nu
 export function listObservations(
   db: Database,
   agentId: string,
-  opts?: { status?: ObservationStatus; limit?: number; source?: ObservationSource },
+  opts?: { status?: ObservationStatus; limit?: number; source?: ObservationSource; channelId?: string },
 ): MemoryObservation[] {
   const conditions = ['agent_id = ?'];
   const params: (string | number)[] = [agentId];
@@ -98,6 +102,10 @@ export function listObservations(
   if (opts?.source) {
     conditions.push('source = ?');
     params.push(opts.source);
+  }
+  if (opts?.channelId) {
+    conditions.push('channel_id = ?');
+    params.push(opts.channelId);
   }
 
   const limit = opts?.limit ?? 50;

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -69,7 +69,7 @@ type Domain = {
 
 // ── Schema version (bump when adding new migrations) ────────────────
 
-const SCHEMA_VERSION = 119;
+const SCHEMA_VERSION = 120;
 
 // ── Build MIGRATIONS dict ───────────────────────────────────────────
 
@@ -252,6 +252,11 @@ const MIGRATIONS: Record<number, string[]> = {
   119: [
     // Telegram runtime configuration (mirrors discord_config pattern)
     ...telegram.tables,
+  ],
+  120: [
+    // Channel-scoped observations for Discord context retention
+    `ALTER TABLE memory_observations ADD COLUMN channel_id TEXT`,
+    `CREATE INDEX IF NOT EXISTS idx_observations_channel_id ON memory_observations(channel_id) WHERE channel_id IS NOT NULL`,
   ],
 };
 

--- a/server/db/schema/memory.ts
+++ b/server/db/schema/memory.ts
@@ -29,7 +29,8 @@ export const tables: string[] = [
         status            TEXT NOT NULL DEFAULT 'active',
         graduated_key     TEXT DEFAULT NULL,
         created_at        TEXT DEFAULT (datetime('now')),
-        expires_at        TEXT DEFAULT NULL
+        expires_at        TEXT DEFAULT NULL,
+        channel_id        TEXT DEFAULT NULL
     )`,
 ];
 
@@ -43,6 +44,7 @@ export const indexes: string[] = [
   `CREATE INDEX IF NOT EXISTS idx_observations_status ON memory_observations(agent_id, status)`,
   `CREATE INDEX IF NOT EXISTS idx_observations_score ON memory_observations(relevance_score DESC)`,
   `CREATE INDEX IF NOT EXISTS idx_observations_expires ON memory_observations(expires_at) WHERE expires_at IS NOT NULL`,
+  `CREATE INDEX IF NOT EXISTS idx_observations_channel_id ON memory_observations(channel_id) WHERE channel_id IS NOT NULL`,
 ];
 
 export const virtualTables: string[] = [

--- a/server/discord/message-router.ts
+++ b/server/discord/message-router.ts
@@ -12,8 +12,8 @@ import { recordAudit } from '../db/audit';
 import { getChannelProjectId, setChannelProjectId } from '../db/discord-channel-project';
 import { updateDiscordConfig } from '../db/discord-config';
 import {
+  getChannelMessageHistory,
   getLatestMentionSessionByChannel,
-  getLatestSessionIdByChannel,
   getMentionSession,
   saveMentionSession,
   updateMentionSessionActivity,
@@ -443,7 +443,6 @@ export async function handleMessage(ctx: MessageHandlerContext, data: DiscordMes
   if (mode === 'work_intake') {
     await handleWorkIntake(ctx, channelId, data.id, userId, text, data.mentions);
   } else {
-    const previousSessionId = getLatestSessionIdByChannel(ctx.db, channelId) ?? undefined;
     await handleMentionReply(
       ctx,
       channelId,
@@ -454,7 +453,6 @@ export async function handleMessage(ctx: MessageHandlerContext, data: DiscordMes
       data.author.id,
       data.author.username,
       data.attachments,
-      previousSessionId,
     );
   }
 }
@@ -494,7 +492,6 @@ async function handleMentionReply(
   authorId?: string,
   authorUsername?: string,
   attachments?: DiscordAttachment[],
-  previousSessionId?: string,
 ): Promise<void> {
   // Dedup: check if a session already exists for this Discord message ID.
   // The in-memory dedup in handleMessage() covers most cases, but can miss
@@ -582,11 +579,8 @@ async function handleMentionReply(
     await sendDiscordMessage(ctx.delivery, ctx.config.botToken, channelId, `⚠️ ${complexityWarning}`);
   }
 
-  // Build conversation context from previous mention session (if this is a continuation)
-  let previousContext = '';
-  if (previousSessionId) {
-    previousContext = buildMentionSessionContext(ctx.db, previousSessionId);
-  }
+  // Build conversation context from channel history (aggregated across recent sessions)
+  const previousContext = buildChannelContext(ctx.db, channelId);
 
   // Start the process with the text prompt (include attachment URLs so the agent
   // sees image links even though startProcess only accepts strings).
@@ -605,6 +599,7 @@ async function handleMentionReply(
     content: `[discord] ${authorUsername} in #${channelId}: ${cleanText.slice(0, 200)}`,
     suggestedKey: `discord:${session.id}`,
     relevanceScore: 1.5,
+    channelId,
   });
 
   const agentName = agent.name;
@@ -691,7 +686,6 @@ async function handleMentionReplyResume(
       authorId,
       authorUsername,
       attachments,
-      sessionId,
     );
     return;
   }
@@ -737,7 +731,6 @@ async function handleMentionReplyResume(
         authorId,
         authorUsername,
         attachments,
-        sessionId,
       );
       return;
     }
@@ -773,24 +766,22 @@ async function handleMentionReplyResume(
 }
 
 /**
- * Build conversation context from a previous mention session.
- * Used when a mention session ends and a new one is created as a continuation,
- * so the new session has full context of what was discussed.
+ * Build conversation context aggregated across all recent sessions in a channel.
+ * Unlike the old single-session approach, this pulls messages from the last 24 hours
+ * across all sessions tied to this channel, giving seamless continuity.
  */
-function buildMentionSessionContext(db: Database, previousSessionId: string): string {
-  const messages = getSessionMessages(db, previousSessionId);
-  const conversational = messages.filter((m) => m.role === 'user' || m.role === 'assistant').slice(-20);
+function buildChannelContext(db: Database, channelId: string): string {
+  const messages = getChannelMessageHistory(db, channelId, 40, 24);
+  if (messages.length === 0) return '';
 
-  if (conversational.length === 0) return '';
-
-  const historyLines = conversational.map((m) => {
+  const historyLines = messages.map((m) => {
     const role = m.role === 'user' ? 'User' : 'Assistant';
     const text = m.content.length > 2000 ? `${m.content.slice(0, 2000)}...` : m.content;
     return `[${role}]: ${text}`;
   });
   return [
     '<conversation_history>',
-    'The following is the conversation history from this session. Use it for context when responding to the new message.',
+    'The following is the conversation history from this channel. Use it for context when responding to the new message.',
     '',
     ...historyLines,
     '</conversation_history>',

--- a/shared/types/memories.ts
+++ b/shared/types/memories.ts
@@ -50,4 +50,6 @@ export interface MemoryObservation {
   createdAt: string;
   /** Observations expire after this date if not graduated */
   expiresAt: string | null;
+  /** Discord/Telegram channel ID for channel-scoped context */
+  channelId: string | null;
 }


### PR DESCRIPTION
## Summary
- Replace single-session context carry-over with channel-aggregated history — new sessions in a Discord channel now receive the last 40 messages from all recent sessions in that channel (24h window)
- Add `channel_id` column to `memory_observations` (migration 120) so observations can be filtered by channel
- Tag Discord observations with `channelId` at recording time for future channel-scoped filtering

## What changed
- **`getChannelMessageHistory()`** — new DB function that JOINs `session_messages` with `discord_mention_sessions` to pull messages across all sessions for a given channel
- **`buildChannelContext()`** replaces `buildMentionSessionContext()` — uses channel-wide history instead of single-session
- Removed `previousSessionId` parameter from `handleMentionReply()` (no longer needed — context comes from channel, not a specific prior session)
- `listObservations()` now supports optional `channelId` filter

## Test plan
- [x] TypeScript compiles clean (`bun x tsc --noEmit --skipLibCheck`)
- [x] All 61 observation-related tests pass (observations, session-resume-observations, graduation-service, session-memory-autosave)
- [ ] Manual test: @mention agent in Discord channel, let session end, @mention again — new session should have full conversation history from the channel
- [ ] Verify context doesn't leak between different channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)