### PR TITLE
fix: prevent nested conversation_history tags on Discord session resume

### DIFF
--- a/server/__tests__/strip-conversation-history.test.ts
+++ b/server/__tests__/strip-conversation-history.test.ts
@@ -36,6 +36,39 @@ describe('stripConversationHistory', () => {
     const input = '<conversation_history>x</conversation_history>   \n\nfollowing text';
     expect(stripConversationHistory(input)).toBe('following text');
   });
+
+  test('handles nested conversation_history blocks (#2136)', () => {
+    const input = [
+      '<conversation_history>',
+      '[User]: <conversation_history>',
+      'channel context here',
+      '</conversation_history>',
+      'actual user message',
+      '[Assistant]: previous response',
+      '</conversation_history>',
+    ].join('\n');
+    expect(stripConversationHistory(input)).toBe('');
+  });
+
+  test('preserves text after nested blocks (#2136)', () => {
+    const input = [
+      '<conversation_history>',
+      'outer start',
+      '<conversation_history>',
+      'inner content',
+      '</conversation_history>',
+      'outer end',
+      '</conversation_history>',
+      '',
+      'real user message here',
+    ].join('\n');
+    expect(stripConversationHistory(input)).toBe('real user message here');
+  });
+
+  test('strips orphaned closing tags from nesting artifacts', () => {
+    const input = 'some text </conversation_history> more text';
+    expect(stripConversationHistory(input)).toBe('some text more text');
+  });
 });
 
 describe('extractConversationTopics', () => {

--- a/server/db/sessions.ts
+++ b/server/db/sessions.ts
@@ -265,12 +265,11 @@ export function addSessionMessage(
   content: string,
   costUsd: number = 0,
 ): SessionMessage {
-  // Strip any existing conversation_history tags to prevent nesting (#2136)
-  const cleanContent = stripConversationHistory(content);
-
+  // Strip conversation_history tags at storage time to prevent nested tags on resume (#2136)
+  const sanitized = role === 'user' ? stripConversationHistory(content) : content;
   const result = db
     .query(`INSERT INTO session_messages (session_id, role, content, cost_usd) VALUES (?, ?, ?, ?)`)
-    .run(sessionId, role, cleanContent, costUsd);
+    .run(sessionId, role, sanitized, costUsd);
 
   const row = db.query('SELECT * FROM session_messages WHERE id = ?').get(result.lastInsertRowid) as MessageRow;
   return rowToMessage(row);

--- a/server/lib/strip-conversation-history.ts
+++ b/server/lib/strip-conversation-history.ts
@@ -1,6 +1,15 @@
-/** Strip previously injected `<conversation_history>` blocks to prevent recursive nesting (#2122). */
+/** Strip previously injected `<conversation_history>` blocks to prevent recursive nesting (#2122, #2136). */
 export function stripConversationHistory(content: string): string {
-  return content.replace(/<conversation_history>[\s\S]*?<\/conversation_history>\s*/g, '').trim();
+  // Match innermost blocks first (no nested opening tag inside), then loop to collapse nesting.
+  const innermost = /<conversation_history>(?:(?!<conversation_history>)[\s\S])*?<\/conversation_history>\s*/g;
+  let result = content;
+  let prev: string;
+  do {
+    prev = result;
+    result = result.replace(innermost, '');
+  } while (result !== prev);
+  // Strip any orphaned open/close tags left over
+  return result.replace(/<\/?conversation_history>\s*/g, '').trim();
 }
 
 /** Extract main topics from a conversation by looking at user messages. */


### PR DESCRIPTION
## Summary

Fixes #2136 — nested `<conversation_history>` tags caused context loss when Discord sessions resumed.

- **`stripConversationHistory`** now handles nested tags by matching innermost blocks first and looping until stable, plus stripping orphaned open/close tags
- **`addSessionMessage`** strips conversation_history from user messages at storage time (defense in depth — DB never accumulates nested tags)
- Added 3 new test cases for nested tag scenarios

## Test plan
- [x] All 10 strip-conversation-history tests pass (including 3 new nesting tests)
- [x] TypeScript type check passes
- [x] Spec check passes

## Manual verification needed
- @mention agent in Discord, wait for response, reply — verify context is preserved across resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)