### PR TITLE
Fix nested conversation_history tags on Discord resume (#2136)

### DIFF
--- a/server/__tests__/sessions.test.ts
+++ b/server/__tests__/sessions.test.ts
@@ -204,6 +204,34 @@ describe('session messages', () => {
     const session = makeSession();
     expect(getSessionMessages(db, session.id)).toHaveLength(0);
   });
+
+  test('strips conversation_history tags when storing (#2136)', () => {
+    const session = makeSession();
+    const contentWithTags = '<conversation_history>\n[User]: old\n</conversation_history>\nNew question';
+    addSessionMessage(db, session.id, 'user', contentWithTags);
+
+    const msgs = getSessionMessages(db, session.id);
+    expect(msgs[0].content).toBe('New question');
+    expect(msgs[0].content).not.toContain('<conversation_history>');
+  });
+
+  test('strips multiple conversation_history blocks', () => {
+    const session = makeSession();
+    const content = '<conversation_history>a</conversation_history> middle <conversation_history>b</conversation_history> end';
+    addSessionMessage(db, session.id, 'user', content);
+
+    const msgs = getSessionMessages(db, session.id);
+    expect(msgs[0].content).toBe('middle end');
+  });
+
+  test('preserves content without conversation_history tags', () => {
+    const session = makeSession();
+    const content = 'Just a regular message';
+    addSessionMessage(db, session.id, 'user', content);
+
+    const msgs = getSessionMessages(db, session.id);
+    expect(msgs[0].content).toBe('Just a regular message');
+  });
 });
 
 // ── AlgoChat Conversations ──────────────────────────────────────────

--- a/server/db/sessions.ts
+++ b/server/db/sessions.ts
@@ -7,6 +7,7 @@ import type {
   UpdateSessionInput,
 } from '../../shared/types';
 import { createLogger } from '../lib/logger';
+import { stripConversationHistory } from '../lib/strip-conversation-history';
 import { DEFAULT_TENANT_ID } from '../tenant/types';
 import { writeTransaction } from './pool';
 
@@ -264,9 +265,12 @@ export function addSessionMessage(
   content: string,
   costUsd: number = 0,
 ): SessionMessage {
+  // Strip any existing conversation_history tags to prevent nesting (#2136)
+  const cleanContent = stripConversationHistory(content);
+
   const result = db
     .query(`INSERT INTO session_messages (session_id, role, content, cost_usd) VALUES (?, ?, ?, ?)`)
-    .run(sessionId, role, content, costUsd);
+    .run(sessionId, role, cleanContent, costUsd);
 
   const row = db.query('SELECT * FROM session_messages WHERE id = ?').get(result.lastInsertRowid) as MessageRow;
   return rowToMessage(row);


### PR DESCRIPTION
## Summary

Fixes nested `<conversation_history>` tags that cause context loss when Discord sessions resume. The issue occurred when stored messages already containing conversation_history tags were wrapped again by `buildResumePrompt()`.

## Implementation (Defense in Depth)

**Primary fix:** Strip `<conversation_history>` tags when storing messages
- Modified `addSessionMessage()` in `server/db/sessions.ts` to strip tags before inserting into session_messages table
- Prevents any nested tags from ever reaching the resume logic
- Uses existing `stripConversationHistory` utility

**Secondary fix:** Defensive strip in resume path (already implemented)
- `buildResumePrompt()` in `server/process/resume-prompt-builder.ts` already defensively strips tags
- Provides second layer of protection against nested tags

## Test Coverage

Added tests in `server/__tests__/sessions.test.ts`:
- ✓ Strips conversation_history tags when storing (Issue #2136)
- ✓ Strips multiple conversation_history blocks correctly
- ✓ Preserves content without conversation_history tags unchanged

## Verification

- [x] Type check: `bun x tsc --noEmit --skipLibCheck` ✓
- [x] Spec validation: `bun run spec:check` ✓
- [x] Tests: All tests passing ✓

Closes #2136