### PR TITLE
fix: tighten describeCursorToolCall from any to unknown

### DIFF
--- a/server/__tests__/describe-cursor-tool-call.test.ts
+++ b/server/__tests__/describe-cursor-tool-call.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test';
+import { describeCursorToolCall } from '../process/cursor-process';
+
+describe('describeCursorToolCall', () => {
+  test('returns null for null/undefined/non-object input', () => {
+    expect(describeCursorToolCall(null)).toBeNull();
+    expect(describeCursorToolCall(undefined)).toBeNull();
+    expect(describeCursorToolCall('string')).toBeNull();
+    expect(describeCursorToolCall(42)).toBeNull();
+  });
+
+  test('returns null when tool_call is missing or not an object', () => {
+    expect(describeCursorToolCall({})).toBeNull();
+    expect(describeCursorToolCall({ tool_call: null })).toBeNull();
+    expect(describeCursorToolCall({ tool_call: 'not-object' })).toBeNull();
+  });
+
+  test('readToolCall with path extracts basename', () => {
+    const event = { tool_call: { readToolCall: { args: { path: '/foo/bar/package.json' } } } };
+    expect(describeCursorToolCall(event)).toBe('Reading package.json');
+  });
+
+  test('readToolCall without path returns fallback', () => {
+    const event = { tool_call: { readToolCall: { args: {} } } };
+    expect(describeCursorToolCall(event)).toBe('Reading file');
+  });
+
+  test('writeToolCall with path', () => {
+    const event = { tool_call: { writeToolCall: { args: { path: '/src/index.ts' } } } };
+    expect(describeCursorToolCall(event)).toBe('Writing index.ts');
+  });
+
+  test('writeToolCall without path', () => {
+    const event = { tool_call: { writeToolCall: { args: {} } } };
+    expect(describeCursorToolCall(event)).toBe('Writing file');
+  });
+
+  test('editToolCall with path', () => {
+    const event = { tool_call: { editToolCall: { args: { path: '/a/b/utils.ts' } } } };
+    expect(describeCursorToolCall(event)).toBe('Editing utils.ts');
+  });
+
+  test('editToolCall without path', () => {
+    const event = { tool_call: { editToolCall: { args: {} } } };
+    expect(describeCursorToolCall(event)).toBe('Editing file');
+  });
+
+  test('shellToolCall with command', () => {
+    const event = { tool_call: { shellToolCall: { args: { command: 'git status' } } } };
+    expect(describeCursorToolCall(event)).toBe('Running: git status');
+  });
+
+  test('terminalToolCall with command', () => {
+    const event = { tool_call: { terminalToolCall: { args: { command: 'bun test' } } } };
+    expect(describeCursorToolCall(event)).toBe('Running: bun test');
+  });
+
+  test('shellToolCall without command', () => {
+    const event = { tool_call: { shellToolCall: { args: {} } } };
+    expect(describeCursorToolCall(event)).toBe('Running command');
+  });
+
+  test('shellToolCall truncates long commands to 60 chars', () => {
+    const long = 'a'.repeat(100);
+    const event = { tool_call: { shellToolCall: { args: { command: long } } } };
+    expect(describeCursorToolCall(event)).toBe(`Running: ${'a'.repeat(60)}`);
+  });
+
+  test('globToolCall', () => {
+    const event = { tool_call: { globToolCall: { args: {} } } };
+    expect(describeCursorToolCall(event)).toBe('Listing files');
+  });
+
+  test('listFilesToolCall', () => {
+    const event = { tool_call: { listFilesToolCall: { args: {} } } };
+    expect(describeCursorToolCall(event)).toBe('Listing files');
+  });
+
+  test('grepToolCall with pattern', () => {
+    const event = { tool_call: { grepToolCall: { args: { pattern: 'TODO' } } } };
+    expect(describeCursorToolCall(event)).toBe('Searching: TODO');
+  });
+
+  test('searchToolCall with pattern', () => {
+    const event = { tool_call: { searchToolCall: { args: { pattern: 'fixme' } } } };
+    expect(describeCursorToolCall(event)).toBe('Searching: fixme');
+  });
+
+  test('grepToolCall without pattern', () => {
+    const event = { tool_call: { grepToolCall: { args: {} } } };
+    expect(describeCursorToolCall(event)).toBe('Searching files');
+  });
+
+  test('grepToolCall truncates long patterns to 50 chars', () => {
+    const long = 'x'.repeat(80);
+    const event = { tool_call: { grepToolCall: { args: { pattern: long } } } };
+    expect(describeCursorToolCall(event)).toBe(`Searching: ${'x'.repeat(50)}`);
+  });
+
+  test('unknown tool returns "Using <name>"', () => {
+    const event = { tool_call: { customToolCall: { args: {} } } };
+    expect(describeCursorToolCall(event)).toBe('Using custom');
+  });
+
+  test('empty tool_call object returns null', () => {
+    const event = { tool_call: {} };
+    expect(describeCursorToolCall(event)).toBeNull();
+  });
+});

--- a/server/process/cursor-process.ts
+++ b/server/process/cursor-process.ts
@@ -480,35 +480,40 @@ export function buildArgs(project: Project, agent: Agent | null, worktree?: stri
  * Extract a human-readable description from a cursor-agent tool_call event.
  * Returns e.g. "Reading package.json" or "Running: git status"
  */
-export function describeCursorToolCall(event: any): string | null {
-  const tc = event.tool_call;
-  if (!tc || typeof tc !== 'object') return null;
+type CursorToolArgs = { args?: Record<string, string | undefined> };
+type CursorToolCallMap = Record<string, CursorToolArgs | undefined>;
 
-  if (tc.readToolCall) {
-    const path = tc.readToolCall.args?.path;
+export function describeCursorToolCall(event: unknown): string | null {
+  if (!event || typeof event !== 'object') return null;
+  const tc = (event as Record<string, unknown>).tool_call;
+  if (!tc || typeof tc !== 'object') return null;
+  const call = tc as CursorToolCallMap;
+
+  if (call.readToolCall) {
+    const path = call.readToolCall.args?.path;
     return path ? `Reading ${basename(path)}` : 'Reading file';
   }
-  if (tc.writeToolCall) {
-    const path = tc.writeToolCall.args?.path;
+  if (call.writeToolCall) {
+    const path = call.writeToolCall.args?.path;
     return path ? `Writing ${basename(path)}` : 'Writing file';
   }
-  if (tc.editToolCall) {
-    const path = tc.editToolCall.args?.path;
+  if (call.editToolCall) {
+    const path = call.editToolCall.args?.path;
     return path ? `Editing ${basename(path)}` : 'Editing file';
   }
-  if (tc.shellToolCall || tc.terminalToolCall) {
-    const cmd = (tc.shellToolCall ?? tc.terminalToolCall)?.args?.command;
+  if (call.shellToolCall || call.terminalToolCall) {
+    const cmd = (call.shellToolCall ?? call.terminalToolCall)?.args?.command;
     return cmd ? `Running: ${cmd.slice(0, 60)}` : 'Running command';
   }
-  if (tc.globToolCall || tc.listFilesToolCall) {
+  if (call.globToolCall || call.listFilesToolCall) {
     return 'Listing files';
   }
-  if (tc.grepToolCall || tc.searchToolCall) {
-    const pattern = (tc.grepToolCall ?? tc.searchToolCall)?.args?.pattern;
+  if (call.grepToolCall || call.searchToolCall) {
+    const pattern = (call.grepToolCall ?? call.searchToolCall)?.args?.pattern;
     return pattern ? `Searching: ${pattern.slice(0, 50)}` : 'Searching files';
   }
 
-  const toolName = Object.keys(tc)[0]?.replace(/ToolCall$/, '');
+  const toolName = Object.keys(call)[0]?.replace(/ToolCall$/, '');
   return toolName ? `Using ${toolName}` : null;
 }
 


### PR DESCRIPTION
## Summary

- Changes `event: any` to `event: unknown` in `describeCursorToolCall` in `server/process/cursor-process.ts`
- Adds two small local types (`CursorToolArgs`, `CursorToolCallMap`) for structured narrowing inside the function
- Adds a top-level null/object guard that was previously implicit via `any`

The test mock already declared `event: unknown` — this aligns the implementation with what callers actually pass and eliminates the only untyped boundary in this module.

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun run lint` — clean (no Biome violations)
- [x] `bun test server/__tests__/providers-cursor.test.ts` — 42 pass, 0 fail
- [x] Full `bun test` suite — 10444 pass, 0 fail (confirmed on main before branching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)