### PR TITLE
feat: on-chain verification audit guide (#1458)

### DIFF
--- a/client/src/app/core/models/reputation.model.ts
+++ b/client/src/app/core/models/reputation.model.ts
@@ -82,3 +82,26 @@ export interface ReputationHistoryPoint {
     components: ReputationComponents;
     computedAt: string;
 }
+
+export interface ActivitySummary {
+    id: number;
+    period: string;
+    periodStart: string;
+    periodEnd: string;
+    payload: string;
+    hash: string;
+    txid: string | null;
+    publishedAt: string | null;
+    createdAt: string;
+}
+
+export interface MemoryAttestation {
+    id: number;
+    memoryKey: string;
+    agentId: string;
+    hash: string;
+    payload: string;
+    txid: string | null;
+    createdAt: string;
+    publishedAt: string | null;
+}

--- a/client/src/app/core/models/reputation.model.ts
+++ b/client/src/app/core/models/reputation.model.ts
@@ -105,3 +105,30 @@ export interface MemoryAttestation {
     createdAt: string;
     publishedAt: string | null;
 }
+
+export interface AuditGuideNoteFormat {
+    prefix: string;
+    format: string;
+    description: string;
+    fields: { name: string; description: string }[];
+    payloadSchema: string;
+    verifySteps: string[];
+}
+
+export interface AuditGuideIndexerQuery {
+    description: string;
+    method: string;
+    path: string;
+    queryParams: Record<string, string>;
+    note: string;
+}
+
+export interface AuditGuide {
+    version: string;
+    description: string;
+    network: Record<string, { description: string; indexerUrl: string }>;
+    noteFormats: AuditGuideNoteFormat[];
+    indexerQueries: AuditGuideIndexerQuery[];
+    hashVerification: { algorithm: string; encoding: string; example: string };
+    tools: { name: string; url: string; description: string }[];
+}

--- a/client/src/app/core/services/reputation.service.ts
+++ b/client/src/app/core/services/reputation.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { ApiService } from './api.service';
-import type { ReputationScore, ReputationEvent, ScoreExplanation, AgentReputationStats, ReputationHistoryPoint } from '../models/reputation.model';
+import type { ReputationScore, ReputationEvent, ScoreExplanation, AgentReputationStats, ReputationHistoryPoint, ActivitySummary, MemoryAttestation } from '../models/reputation.model';
 import { firstValueFrom } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
@@ -96,6 +96,27 @@ export class ReputationService {
     async getHistory(agentId: string, days = 90): Promise<ReputationHistoryPoint[]> {
         return firstValueFrom(
             this.api.get<ReputationHistoryPoint[]>(`/reputation/history/${agentId}?days=${days}`),
+        );
+    }
+
+    async getActivitySummaries(period?: string, limit = 10): Promise<ActivitySummary[]> {
+        const params = new URLSearchParams();
+        if (period) params.set('period', period);
+        params.set('limit', String(limit));
+        return firstValueFrom(
+            this.api.get<ActivitySummary[]>(`/reputation/summaries?${params}`),
+        );
+    }
+
+    async getMemoryAttestations(agentId: string, limit = 20): Promise<MemoryAttestation[]> {
+        return firstValueFrom(
+            this.api.get<MemoryAttestation[]>(`/memories/attestations?agentId=${agentId}&limit=${limit}`),
+        );
+    }
+
+    async triggerActivitySummary(period: 'daily' | 'weekly'): Promise<{ ok: boolean; hash: string; txid: string | null }> {
+        return firstValueFrom(
+            this.api.post<{ ok: boolean; hash: string; txid: string | null }>('/reputation/summaries', { period }),
         );
     }
 }

--- a/client/src/app/core/services/reputation.service.ts
+++ b/client/src/app/core/services/reputation.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { ApiService } from './api.service';
-import type { ReputationScore, ReputationEvent, ScoreExplanation, AgentReputationStats, ReputationHistoryPoint, ActivitySummary, MemoryAttestation } from '../models/reputation.model';
+import type { ReputationScore, ReputationEvent, ScoreExplanation, AgentReputationStats, ReputationHistoryPoint, ActivitySummary, MemoryAttestation, AuditGuide } from '../models/reputation.model';
 import { firstValueFrom } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
@@ -117,6 +117,12 @@ export class ReputationService {
     async triggerActivitySummary(period: 'daily' | 'weekly'): Promise<{ ok: boolean; hash: string; txid: string | null }> {
         return firstValueFrom(
             this.api.post<{ ok: boolean; hash: string; txid: string | null }>('/reputation/summaries', { period }),
+        );
+    }
+
+    async getAuditGuide(): Promise<AuditGuide> {
+        return firstValueFrom(
+            this.api.get<AuditGuide>('/reputation/audit-guide'),
         );
     }
 }

--- a/client/src/app/features/reputation/reputation.component.ts
+++ b/client/src/app/features/reputation/reputation.component.ts
@@ -10,7 +10,7 @@ import { EmptyStateComponent } from '../../shared/components/empty-state.compone
 import { SkeletonComponent } from '../../shared/components/skeleton.component';
 import { PageShellComponent } from '../../shared/components/page-shell.component';
 import { MetricCardComponent } from '../../shared/components/metric-card.component';
-import type { ReputationScore, ReputationEvent, ScoreExplanation, ComponentExplanation, AgentReputationStats, ReputationHistoryPoint } from '../../core/models/reputation.model';
+import type { ReputationScore, ReputationEvent, ScoreExplanation, ComponentExplanation, AgentReputationStats, ReputationHistoryPoint, ActivitySummary, MemoryAttestation } from '../../core/models/reputation.model';
 
 @Component({
     selector: 'app-reputation',
@@ -23,6 +23,12 @@ import type { ReputationScore, ReputationEvent, ScoreExplanation, ComponentExpla
                 [disabled]="computing()"
                 (click)="onComputeAll()">
                 {{ computing() ? 'Computing...' : 'Compute All' }}
+            </button>
+            <button actions
+                mat-stroked-button
+                [disabled]="triggeringSummary()"
+                (click)="onTriggerSummary('daily')">
+                {{ triggeringSummary() ? 'Publishing…' : 'Publish Daily Summary' }}
             </button>
 
             @if (reputationService.loading()) {
@@ -138,6 +144,27 @@ import type { ReputationScore, ReputationEvent, ScoreExplanation, ComponentExpla
                                 </div>
                             </div>
                         }
+                    </div>
+                }
+
+                @if (activitySummaries().length > 0) {
+                    <div class="summaries-section">
+                        <h4>On-chain Activity Summaries</h4>
+                        <div class="summaries-list">
+                            @for (s of activitySummaries(); track s.id) {
+                                <div class="summary-row">
+                                    <span class="summary-period" [attr.data-period]="s.period">{{ s.period }}</span>
+                                    <span class="summary-dates">{{ formatDate(s.periodStart) }} – {{ formatDate(s.periodEnd) }}</span>
+                                    <span class="summary-hash" title="{{ s.hash }}">{{ s.hash.slice(0, 12) }}…</span>
+                                    @if (s.txid) {
+                                        <span class="summary-txid on-chain" title="{{ s.txid }}">{{ s.txid.slice(0, 8) }}… ✓</span>
+                                    } @else {
+                                        <span class="summary-txid pending">local only</span>
+                                    }
+                                    <span class="summary-time">{{ s.createdAt | relativeTime }}</span>
+                                </div>
+                            }
+                        </div>
                     </div>
                 }
 
@@ -260,6 +287,24 @@ import type { ReputationScore, ReputationEvent, ScoreExplanation, ComponentExpla
                                 <p class="attestation">Attestation: <code>{{ s.attestationHash }}</code></p>
                             } @else {
                                 <button mat-flat-button color="primary" (click)="onCreateAttestation(s.agentId)">Create Attestation</button>
+                            }
+
+                            @if (memoryAttestations().length > 0) {
+                                <h4>On-chain Memory Attestations</h4>
+                                <div class="chain-list">
+                                    @for (att of memoryAttestations(); track att.id) {
+                                        <div class="chain-row">
+                                            <span class="chain-key">{{ att.memoryKey }}</span>
+                                            <span class="chain-hash" title="{{ att.hash }}">{{ att.hash.slice(0, 12) }}…</span>
+                                            @if (att.txid) {
+                                                <span class="chain-txid on-chain" title="{{ att.txid }}">{{ att.txid.slice(0, 8) }}… ✓</span>
+                                            } @else {
+                                                <span class="chain-txid pending">pending</span>
+                                            }
+                                            <span class="chain-time">{{ att.createdAt | relativeTime }}</span>
+                                        </div>
+                                    }
+                                </div>
                             }
                         }
 
@@ -653,11 +698,57 @@ import type { ReputationScore, ReputationEvent, ScoreExplanation, ComponentExpla
         .compare-mini-fill[data-color="orange"] { background: var(--accent-orange); }
         .compare-mini-val { font-size: 0.7rem; color: var(--text-primary); text-align: right; }
 
+        /* Activity summaries */
+        .summaries-section { margin-top: 1.5rem; }
+        .summaries-section h4 { margin: 0 0 0.75rem; color: var(--text-primary); }
+        .summaries-list {
+            background: var(--bg-surface); border: 1px solid var(--border); border-radius: var(--radius);
+            overflow: hidden;
+        }
+        .summary-row {
+            display: grid; grid-template-columns: 60px 1fr 100px 90px 80px;
+            align-items: center; gap: 0.75rem; padding: 0.5rem 0.75rem;
+            font-size: 0.78rem; border-bottom: 1px solid var(--border);
+        }
+        .summary-row:last-child { border-bottom: none; }
+        .summary-period {
+            font-size: 0.65rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
+            padding: 2px 6px; border-radius: 3px; text-align: center;
+            background: var(--bg-raised); color: var(--text-secondary);
+        }
+        .summary-period[data-period="daily"] { color: var(--accent-cyan); border: 1px solid var(--accent-cyan); }
+        .summary-period[data-period="weekly"] { color: var(--accent-purple); border: 1px solid var(--accent-purple); }
+        .summary-dates { color: var(--text-secondary); font-size: 0.72rem; }
+        .summary-hash { font-family: monospace; font-size: 0.72rem; color: var(--text-secondary); }
+        .summary-txid, .chain-txid { font-family: monospace; font-size: 0.72rem; }
+        .summary-txid.on-chain, .chain-txid.on-chain { color: var(--accent-green); }
+        .summary-txid.pending, .chain-txid.pending { color: var(--text-tertiary); font-style: italic; }
+        .summary-time { color: var(--text-tertiary); font-size: 0.7rem; text-align: right; }
+
+        /* Memory attestations */
+        .chain-list {
+            display: flex; flex-direction: column; gap: 0; margin-top: 0.5rem;
+            border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden;
+        }
+        .chain-row {
+            display: grid; grid-template-columns: 1fr 110px 90px 70px;
+            align-items: center; gap: 0.75rem; padding: 0.4rem 0.75rem;
+            font-size: 0.78rem; border-bottom: 1px solid var(--border);
+        }
+        .chain-row:last-child { border-bottom: none; }
+        .chain-key { font-weight: 600; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .chain-hash { font-family: monospace; font-size: 0.72rem; color: var(--text-secondary); }
+        .chain-time { color: var(--text-tertiary); font-size: 0.7rem; text-align: right; }
+
         @media (max-width: 767px) {
             .card-grid { grid-template-columns: 1fr; }
             .agent-card__body { flex-direction: column; align-items: center; }
             .component-bars { width: 100%; }
             .compare-mini-bar { grid-template-columns: 60px 1fr 24px; }
+            .summary-row { grid-template-columns: 55px 1fr 80px; }
+            .summary-hash, .summary-txid { display: none; }
+            .chain-row { grid-template-columns: 1fr 70px; }
+            .chain-hash, .chain-time { display: none; }
         }
     `,
 })
@@ -675,6 +766,9 @@ export class ReputationComponent implements OnInit {
     protected readonly history = signal<ReputationHistoryPoint[]>([]);
     protected readonly showComponents = signal(false);
     protected readonly compareMode = signal(false);
+    protected readonly activitySummaries = signal<ActivitySummary[]>([]);
+    protected readonly memoryAttestations = signal<MemoryAttestation[]>([]);
+    protected readonly triggeringSummary = signal(false);
 
     protected readonly trendWidth = 400;
     protected readonly trendHeight = 80;
@@ -848,6 +942,7 @@ export class ReputationComponent implements OnInit {
         } catch {
             this.loadError.set(true);
         }
+        this.reputationService.getActivitySummaries(undefined, 10).then(s => this.activitySummaries.set(s)).catch(() => {});
     }
 
     protected getAgentName(agentId: string): string {
@@ -906,6 +1001,7 @@ export class ReputationComponent implements OnInit {
         this.explanation.set(null);
         this.stats.set(null);
         this.history.set([]);
+        this.memoryAttestations.set([]);
         try {
             const score = await this.reputationService.getScore(agentId);
             this.selectedScore.set(score);
@@ -914,6 +1010,7 @@ export class ReputationComponent implements OnInit {
                 this.reputationService.getExplanation(agentId).then(ex => this.explanation.set(ex)),
                 this.reputationService.getStats(agentId).then(s => this.stats.set(s)).catch(() => {}),
                 this.reputationService.getHistory(agentId).then(h => this.history.set(h)).catch(() => {}),
+                this.reputationService.getMemoryAttestations(agentId).then(a => this.memoryAttestations.set(a)).catch(() => {}),
             ]);
         } catch {
             this.selectedScore.set(null);
@@ -941,5 +1038,24 @@ export class ReputationComponent implements OnInit {
         } catch {
             this.notify.error('Failed to create attestation');
         }
+    }
+
+    async onTriggerSummary(period: 'daily' | 'weekly'): Promise<void> {
+        this.triggeringSummary.set(true);
+        try {
+            await this.reputationService.triggerActivitySummary(period);
+            const summaries = await this.reputationService.getActivitySummaries(undefined, 10);
+            this.activitySummaries.set(summaries);
+            this.notify.success(`${period === 'daily' ? 'Daily' : 'Weekly'} summary published`);
+        } catch {
+            this.notify.error('Failed to publish summary');
+        } finally {
+            this.triggeringSummary.set(false);
+        }
+    }
+
+    protected formatDate(iso: string): string {
+        const d = new Date(iso);
+        return `${d.getMonth() + 1}/${d.getDate()}`;
     }
 }

--- a/client/src/app/features/reputation/reputation.component.ts
+++ b/client/src/app/features/reputation/reputation.component.ts
@@ -10,7 +10,7 @@ import { EmptyStateComponent } from '../../shared/components/empty-state.compone
 import { SkeletonComponent } from '../../shared/components/skeleton.component';
 import { PageShellComponent } from '../../shared/components/page-shell.component';
 import { MetricCardComponent } from '../../shared/components/metric-card.component';
-import type { ReputationScore, ReputationEvent, ScoreExplanation, ComponentExplanation, AgentReputationStats, ReputationHistoryPoint, ActivitySummary, MemoryAttestation } from '../../core/models/reputation.model';
+import type { ReputationScore, ReputationEvent, ScoreExplanation, ComponentExplanation, AgentReputationStats, ReputationHistoryPoint, ActivitySummary, MemoryAttestation, AuditGuide } from '../../core/models/reputation.model';
 
 @Component({
     selector: 'app-reputation',
@@ -411,6 +411,72 @@ import type { ReputationScore, ReputationEvent, ScoreExplanation, ComponentExpla
                     </div>
                 }
             }
+
+            <div class="audit-guide-section">
+                <div class="audit-guide-toggle" (click)="onToggleAuditGuide()">
+                    <span class="audit-guide-toggle__label">On-Chain Verification Guide</span>
+                    <span class="audit-guide-toggle__chevron">{{ showAuditGuide() ? '▲' : '▼' }}</span>
+                </div>
+                @if (showAuditGuide()) {
+                    @if (auditGuideLoading()) {
+                        <div class="audit-guide-loading">Loading guide…</div>
+                    } @else if (auditGuide(); as guide) {
+                        <div class="audit-guide">
+                            <p class="audit-guide__desc">{{ guide.description }}</p>
+
+                            <h5>Algorand Note Formats</h5>
+                            <div class="audit-formats">
+                                @for (fmt of guide.noteFormats; track fmt.prefix) {
+                                    <div class="audit-format">
+                                        <div class="audit-format__header">
+                                            <code class="audit-format__prefix">{{ fmt.prefix }}</code>
+                                            <span class="audit-format__desc">{{ fmt.description }}</span>
+                                        </div>
+                                        <code class="audit-format__pattern">{{ fmt.format }}</code>
+                                        <div class="audit-format__steps">
+                                            <span class="audit-format__steps-label">Verify:</span>
+                                            <ol>
+                                                @for (step of fmt.verifySteps; track $index) {
+                                                    <li>{{ step }}</li>
+                                                }
+                                            </ol>
+                                        </div>
+                                    </div>
+                                }
+                            </div>
+
+                            <h5>Indexer API Queries</h5>
+                            <div class="audit-queries">
+                                @for (q of guide.indexerQueries; track q.description) {
+                                    <div class="audit-query">
+                                        <span class="audit-query__desc">{{ q.description }}</span>
+                                        <code class="audit-query__path">{{ q.method }} {{ q.path }}</code>
+                                        @if (q.note) {
+                                            <span class="audit-query__note">{{ q.note }}</span>
+                                        }
+                                    </div>
+                                }
+                            </div>
+
+                            <h5>Hash Verification</h5>
+                            <div class="audit-hash">
+                                <p>Algorithm: <strong>{{ guide.hashVerification.algorithm }}</strong> · Encoding: <strong>{{ guide.hashVerification.encoding }}</strong></p>
+                                <pre class="audit-hash__code">{{ guide.hashVerification.example }}</pre>
+                            </div>
+
+                            <h5>Tools</h5>
+                            <div class="audit-tools">
+                                @for (tool of guide.tools; track tool.name) {
+                                    <div class="audit-tool">
+                                        <strong>{{ tool.name }}</strong>
+                                        <span>{{ tool.description }}</span>
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    }
+                }
+            </div>
         </app-page-shell>
     `,
     styles: `
@@ -740,6 +806,81 @@ import type { ReputationScore, ReputationEvent, ScoreExplanation, ComponentExpla
         .chain-hash { font-family: monospace; font-size: 0.72rem; color: var(--text-secondary); }
         .chain-time { color: var(--text-tertiary); font-size: 0.7rem; text-align: right; }
 
+        /* Audit guide */
+        .audit-guide-section {
+            margin-top: 2rem;
+            border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden;
+        }
+        .audit-guide-toggle {
+            display: flex; justify-content: space-between; align-items: center;
+            padding: 0.75rem 1rem; cursor: pointer; background: var(--bg-surface);
+            user-select: none;
+        }
+        .audit-guide-toggle:hover { background: var(--bg-raised); }
+        .audit-guide-toggle__label {
+            font-size: 0.82rem; font-weight: 600; color: var(--text-primary);
+            letter-spacing: 0.02em;
+        }
+        .audit-guide-toggle__chevron { font-size: 0.7rem; color: var(--text-secondary); }
+        .audit-guide-loading { padding: 1rem; color: var(--text-secondary); font-size: 0.82rem; }
+        .audit-guide {
+            padding: 1rem 1.25rem; background: var(--bg-surface);
+            border-top: 1px solid var(--border);
+        }
+        .audit-guide__desc {
+            font-size: 0.82rem; color: var(--text-secondary); margin: 0 0 1rem; line-height: 1.5;
+        }
+        .audit-guide h5 {
+            font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+            color: var(--text-secondary); margin: 1rem 0 0.5rem;
+        }
+        .audit-guide h5:first-of-type { margin-top: 0; }
+        .audit-formats { display: flex; flex-direction: column; gap: 0.75rem; }
+        .audit-format {
+            background: var(--bg-raised); border: 1px solid var(--border); border-radius: var(--radius);
+            padding: 0.75rem 1rem;
+        }
+        .audit-format__header {
+            display: flex; align-items: baseline; gap: 0.75rem; margin-bottom: 0.4rem; flex-wrap: wrap;
+        }
+        .audit-format__prefix {
+            font-size: 0.72rem; background: var(--bg-surface); padding: 1px 6px;
+            border-radius: 3px; color: var(--accent-cyan); border: 1px solid var(--accent-cyan); white-space: nowrap;
+        }
+        .audit-format__desc { font-size: 0.78rem; color: var(--text-secondary); }
+        .audit-format__pattern {
+            display: block; font-size: 0.72rem; color: var(--accent-green);
+            background: var(--bg-surface); padding: 0.3rem 0.5rem; border-radius: 3px;
+            border: 1px solid var(--border); margin-bottom: 0.5rem; word-break: break-all;
+        }
+        .audit-format__steps { font-size: 0.75rem; }
+        .audit-format__steps-label { color: var(--text-secondary); font-weight: 600; display: block; margin-bottom: 0.25rem; }
+        .audit-format__steps ol { margin: 0; padding-left: 1.25rem; }
+        .audit-format__steps li { color: var(--text-secondary); margin-bottom: 0.15rem; line-height: 1.4; }
+        .audit-queries { display: flex; flex-direction: column; gap: 0.5rem; }
+        .audit-query {
+            background: var(--bg-raised); border: 1px solid var(--border); border-radius: var(--radius);
+            padding: 0.5rem 0.75rem;
+        }
+        .audit-query__desc { font-size: 0.78rem; color: var(--text-secondary); display: block; margin-bottom: 0.25rem; }
+        .audit-query__path {
+            font-size: 0.72rem; color: var(--accent-yellow); display: block; word-break: break-all; margin-bottom: 0.2rem;
+        }
+        .audit-query__note { font-size: 0.68rem; color: var(--text-tertiary); font-style: italic; display: block; }
+        .audit-hash { background: var(--bg-raised); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.75rem 1rem; }
+        .audit-hash p { margin: 0 0 0.5rem; font-size: 0.78rem; color: var(--text-secondary); }
+        .audit-hash__code {
+            font-size: 0.72rem; background: var(--bg-surface); padding: 0.5rem; border-radius: 3px;
+            border: 1px solid var(--border); white-space: pre-wrap; word-break: break-all;
+            color: var(--accent-green); margin: 0;
+        }
+        .audit-tools { display: flex; flex-direction: column; gap: 0.35rem; }
+        .audit-tool {
+            display: flex; gap: 0.75rem; font-size: 0.78rem; align-items: baseline;
+        }
+        .audit-tool strong { color: var(--text-primary); white-space: nowrap; }
+        .audit-tool span { color: var(--text-secondary); }
+
         @media (max-width: 767px) {
             .card-grid { grid-template-columns: 1fr; }
             .agent-card__body { flex-direction: column; align-items: center; }
@@ -769,6 +910,9 @@ export class ReputationComponent implements OnInit {
     protected readonly activitySummaries = signal<ActivitySummary[]>([]);
     protected readonly memoryAttestations = signal<MemoryAttestation[]>([]);
     protected readonly triggeringSummary = signal(false);
+    protected readonly auditGuide = signal<AuditGuide | null>(null);
+    protected readonly auditGuideLoading = signal(false);
+    protected readonly showAuditGuide = signal(false);
 
     protected readonly trendWidth = 400;
     protected readonly trendHeight = 80;
@@ -1037,6 +1181,22 @@ export class ReputationComponent implements OnInit {
             this.notify.success('Attestation created');
         } catch {
             this.notify.error('Failed to create attestation');
+        }
+    }
+
+    async onToggleAuditGuide(): Promise<void> {
+        const next = !this.showAuditGuide();
+        this.showAuditGuide.set(next);
+        if (next && !this.auditGuide()) {
+            this.auditGuideLoading.set(true);
+            try {
+                const guide = await this.reputationService.getAuditGuide();
+                this.auditGuide.set(guide);
+            } catch {
+                // guide remains null; panel stays open showing nothing
+            } finally {
+                this.auditGuideLoading.set(false);
+            }
         }
     }
 

--- a/server/__tests__/routes-reputation.test.ts
+++ b/server/__tests__/routes-reputation.test.ts
@@ -421,6 +421,33 @@ describe('Reputation Routes', () => {
     expect(data.feedbackTotal.total).toBe(0);
   });
 
+  // ─── Audit Guide ──────────────────────────────────────────────────────
+
+  it('GET /api/reputation/audit-guide returns structured guide', async () => {
+    const { req, url } = fakeReq('GET', '/api/reputation/audit-guide');
+    const res = await handleReputationRoutes(req, url, db, scorer, attestation)!;
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(200);
+    const data = await res!.json();
+    expect(data.version).toBe('1.0');
+    expect(data.description).toContain('CorvidAgent');
+    expect(data.network).toBeDefined();
+    expect(data.network.localnet).toBeDefined();
+    expect(data.network.mainnet).toBeDefined();
+    expect(Array.isArray(data.noteFormats)).toBe(true);
+    expect(data.noteFormats.length).toBeGreaterThanOrEqual(4);
+    const reputationFormat = data.noteFormats.find((f: { prefix: string }) => f.prefix === 'corvid-reputation');
+    expect(reputationFormat).toBeDefined();
+    expect(reputationFormat.format).toContain('{agentId}');
+    expect(reputationFormat.fields.length).toBeGreaterThanOrEqual(2);
+    expect(reputationFormat.verifySteps.length).toBeGreaterThanOrEqual(3);
+    expect(Array.isArray(data.indexerQueries)).toBe(true);
+    expect(data.indexerQueries.length).toBeGreaterThanOrEqual(3);
+    expect(data.hashVerification.algorithm).toBe('SHA-256');
+    expect(Array.isArray(data.tools)).toBe(true);
+    expect(data.tools.length).toBeGreaterThanOrEqual(1);
+  });
+
   // ─── Unmatched path ──────────────────────────────────────────────────────
 
   it('returns null for unmatched paths', () => {

--- a/server/openapi/routes/reputation.ts
+++ b/server/openapi/routes/reputation.ts
@@ -177,7 +177,13 @@ export const reputationRoutes: RouteEntry[] = [
           version: '1.0',
           description: 'CorvidAgent publishes cryptographic attestations on Algorand...',
           noteFormats: [{ prefix: 'corvid-reputation', format: 'corvid-reputation:{agentId}:{sha256hex}' }],
-          indexerQueries: [{ description: 'Find all reputation attestations', method: 'GET', path: '/v2/accounts/{walletAddress}/transactions' }],
+          indexerQueries: [
+            {
+              description: 'Find all reputation attestations',
+              method: 'GET',
+              path: '/v2/accounts/{walletAddress}/transactions',
+            },
+          ],
           hashVerification: { algorithm: 'SHA-256', encoding: 'hex (64 lowercase characters)' },
           tools: [{ name: 'AlgoNode Indexer', url: 'https://mainnet-idx.algonode.cloud/v2/transactions' }],
         },

--- a/server/openapi/routes/reputation.ts
+++ b/server/openapi/routes/reputation.ts
@@ -164,4 +164,24 @@ export const reputationRoutes: RouteEntry[] = [
       },
     },
   },
+  {
+    method: 'GET',
+    path: '/api/reputation/audit-guide',
+    summary: 'Get on-chain verification guide',
+    tags: ['Reputation'],
+    auth: 'none',
+    responses: {
+      200: {
+        description: 'Structured guide for independently verifying agent actions on Algorand',
+        example: {
+          version: '1.0',
+          description: 'CorvidAgent publishes cryptographic attestations on Algorand...',
+          noteFormats: [{ prefix: 'corvid-reputation', format: 'corvid-reputation:{agentId}:{sha256hex}' }],
+          indexerQueries: [{ description: 'Find all reputation attestations', method: 'GET', path: '/v2/accounts/{walletAddress}/transactions' }],
+          hashVerification: { algorithm: 'SHA-256', encoding: 'hex (64 lowercase characters)' },
+          tools: [{ name: 'AlgoNode Indexer', url: 'https://mainnet-idx.algonode.cloud/v2/transactions' }],
+        },
+      },
+    },
+  },
 ];

--- a/server/routes/reputation.ts
+++ b/server/routes/reputation.ts
@@ -176,7 +176,191 @@ export function handleReputationRoutes(
     }
   }
 
+  // ─── Audit Guide ───────────────────────────────────────────────────────
+
+  if (path === '/api/reputation/audit-guide' && method === 'GET') {
+    return json(buildAuditGuide());
+  }
+
   return null;
+}
+
+function buildAuditGuide(): AuditGuide {
+  return {
+    version: '1.0',
+    description:
+      'CorvidAgent publishes cryptographic attestations on Algorand for every significant agent action. ' +
+      'Any external observer can independently verify what agents have done, when, and with what outcome.',
+    network: {
+      localnet: { description: 'Development — Docker-based local Algorand network', indexerUrl: 'http://localhost:8980' },
+      mainnet: { description: 'Production — Algorand mainnet', indexerUrl: 'https://mainnet-idx.algonode.cloud' },
+    },
+    noteFormats: [
+      {
+        prefix: 'corvid-reputation',
+        format: 'corvid-reputation:{agentId}:{sha256hex}',
+        description: 'Reputation score attestation. Published when an agent reputation score is committed on-chain.',
+        fields: [
+          { name: 'agentId', description: 'Internal agent identifier (UUID or slug)' },
+          { name: 'sha256hex', description: 'Full 64-character SHA-256 hex of the payload JSON' },
+        ],
+        payloadSchema: '{ agentId, overallScore, trustLevel, components: { taskCompletion, peerRating, creditPattern, securityCompliance, activityLevel }, computedAt }',
+        verifySteps: [
+          'Fetch the transaction from the Algorand indexer by txid',
+          'Base64-decode the note field',
+          'The last 64 characters are the SHA-256 hash',
+          'Reconstruct the payload: JSON.stringify({ agentId, overallScore, trustLevel, components, computedAt })',
+          'Compute SHA-256 of the payload and compare with the hash in the note',
+        ],
+      },
+      {
+        prefix: 'corvid-memory',
+        format: 'corvid-memory:{agentId}:{memoryKey}:{hash16}',
+        description: 'Memory promotion attestation. Published when a memory is promoted to long-term on-chain storage.',
+        fields: [
+          { name: 'agentId', description: 'Internal agent identifier' },
+          { name: 'memoryKey', description: 'Key of the promoted memory (e.g. feedback-testing)' },
+          { name: 'hash16', description: 'First 16 characters of the SHA-256 hash of the promotion payload' },
+        ],
+        payloadSchema: '{ memoryKey, agentId, promotedAt }',
+        verifySteps: [
+          'Query indexer for transactions from the agent wallet with note-prefix corvid-memory:',
+          'Decode the note to get the memoryKey and hash16',
+          'Reconstruct payload: JSON.stringify({ memoryKey, agentId, promotedAt })',
+          'Compute SHA-256 and verify the first 16 chars match hash16',
+        ],
+      },
+      {
+        prefix: 'corvid-weekly-summary',
+        format: 'corvid-weekly-summary:{agentId}:{weekLabel}:{sha256hex}',
+        description: 'Weekly outcome analysis attestation. Published each week summarising sessions, PRs, health, and observations.',
+        fields: [
+          { name: 'agentId', description: 'Internal agent identifier' },
+          { name: 'weekLabel', description: 'ISO week string, e.g. 2026-W17' },
+          { name: 'sha256hex', description: 'SHA-256 hash of the weekly summary text' },
+        ],
+        payloadSchema: 'Plain text summary string (hashed as UTF-8)',
+        verifySteps: [
+          'Query indexer with note-prefix corvid-weekly-summary: and the wallet address',
+          'Decode the note and extract weekLabel and hash',
+          'Compute SHA-256 of the summary text and compare',
+        ],
+      },
+      {
+        prefix: 'corvid-daily-review',
+        format: 'corvid-daily-review:{agentId}:{date}:{sha256hex}',
+        description: 'Daily review attestation. Published each day with execution stats, PR counts, health uptime, and observations.',
+        fields: [
+          { name: 'agentId', description: 'Internal agent identifier' },
+          { name: 'date', description: 'Review date in YYYY-MM-DD format' },
+          { name: 'sha256hex', description: 'SHA-256 hash of the daily review summary text' },
+        ],
+        payloadSchema: 'Plain text summary string (hashed as UTF-8)',
+        verifySteps: [
+          'Query indexer with note-prefix corvid-daily-review: and the wallet address',
+          'Decode the note and extract the date and hash',
+          'Compute SHA-256 of the review summary text and compare',
+        ],
+      },
+      {
+        prefix: 'arc69-memory',
+        format: 'ARC-69 ASA (Asset) with description "corvid-agent memory"',
+        description:
+          'Long-term memory stored as an Algorand Standard Asset using the ARC-69 metadata standard. ' +
+          'Each memory key maps to an on-chain ASA whose note field contains the encrypted memory value.',
+        fields: [
+          { name: 'assetName', description: 'Memory key used as the ASA name' },
+          { name: 'description', description: 'Always "corvid-agent memory" for identification' },
+          { name: 'note', description: 'ARC-69 JSON metadata containing the memory value (base64-encoded)' },
+        ],
+        payloadSchema: '{ standard: "arc69", description: "corvid-agent memory", properties: { key, value, updatedAt } }',
+        verifySteps: [
+          'Query indexer for assets created by the agent wallet with unit-name CMEM',
+          'Fetch the latest ARC-69 metadata from the most recent asset configuration transaction',
+          'The note field contains base64-encoded ARC-69 JSON with the memory value',
+        ],
+      },
+    ],
+    indexerQueries: [
+      {
+        description: 'Find all reputation attestations for a wallet address',
+        method: 'GET',
+        path: '/v2/accounts/{walletAddress}/transactions',
+        queryParams: { 'note-prefix': Buffer.from('corvid-reputation:').toString('base64') },
+        note: 'note-prefix must be URL-encoded base64 of "corvid-reputation:"',
+      },
+      {
+        description: 'Find all memory attestations',
+        method: 'GET',
+        path: '/v2/accounts/{walletAddress}/transactions',
+        queryParams: { 'note-prefix': Buffer.from('corvid-memory:').toString('base64') },
+        note: 'note-prefix must be URL-encoded base64 of "corvid-memory:"',
+      },
+      {
+        description: 'Find weekly summary attestations',
+        method: 'GET',
+        path: '/v2/accounts/{walletAddress}/transactions',
+        queryParams: { 'note-prefix': Buffer.from('corvid-weekly-summary:').toString('base64') },
+        note: 'note-prefix must be URL-encoded base64 of "corvid-weekly-summary:"',
+      },
+      {
+        description: 'Fetch a specific transaction by txid',
+        method: 'GET',
+        path: '/v2/transactions/{txid}',
+        queryParams: {},
+        note: 'Returns the full transaction including the base64-encoded note field',
+      },
+      {
+        description: 'Find ARC-69 memory assets owned by a wallet',
+        method: 'GET',
+        path: '/v2/accounts/{walletAddress}/assets',
+        queryParams: {},
+        note: 'Filter by unit-name=CMEM to find corvid-agent memory assets',
+      },
+    ],
+    hashVerification: {
+      algorithm: 'SHA-256',
+      encoding: 'hex (64 lowercase characters)',
+      example:
+        'const payload = JSON.stringify({ agentId, overallScore, trustLevel, components, computedAt });\n' +
+        'const hash = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(payload));\n' +
+        'const hex = Array.from(new Uint8Array(hash)).map(b => b.toString(16).padStart(2, "0")).join("");',
+    },
+    tools: [
+      { name: 'algosdk', url: 'https://developer.algorand.org/docs/sdks/', description: 'Official Algorand SDK for Node.js, Python, Go, Java' },
+      { name: 'algokit', url: 'https://developer.algorand.org/algokit/', description: 'All-in-one Algorand development toolkit' },
+      { name: 'Pera Explorer', url: 'https://explorer.perawallet.app/', description: 'Algorand mainnet block explorer' },
+      { name: 'DappFlow', url: 'https://app.dappflow.org/explorer/home', description: 'Algorand explorer with ARC-69 metadata support' },
+      { name: 'AlgoNode Indexer', url: 'https://mainnet-idx.algonode.cloud/v2/transactions', description: 'Free public Algorand indexer API' },
+    ],
+  };
+}
+
+interface AuditGuideNoteFormat {
+  prefix: string;
+  format: string;
+  description: string;
+  fields: { name: string; description: string }[];
+  payloadSchema: string;
+  verifySteps: string[];
+}
+
+interface AuditGuideIndexerQuery {
+  description: string;
+  method: string;
+  path: string;
+  queryParams: Record<string, string>;
+  note: string;
+}
+
+interface AuditGuide {
+  version: string;
+  description: string;
+  network: Record<string, { description: string; indexerUrl: string }>;
+  noteFormats: AuditGuideNoteFormat[];
+  indexerQueries: AuditGuideIndexerQuery[];
+  hashVerification: { algorithm: string; encoding: string; example: string };
+  tools: { name: string; url: string; description: string }[];
 }
 
 async function handleRecordEvent(req: Request, scorer: ReputationScorer): Promise<Response> {

--- a/server/routes/reputation.ts
+++ b/server/routes/reputation.ts
@@ -192,7 +192,10 @@ function buildAuditGuide(): AuditGuide {
       'CorvidAgent publishes cryptographic attestations on Algorand for every significant agent action. ' +
       'Any external observer can independently verify what agents have done, when, and with what outcome.',
     network: {
-      localnet: { description: 'Development — Docker-based local Algorand network', indexerUrl: 'http://localhost:8980' },
+      localnet: {
+        description: 'Development — Docker-based local Algorand network',
+        indexerUrl: 'http://localhost:8980',
+      },
       mainnet: { description: 'Production — Algorand mainnet', indexerUrl: 'https://mainnet-idx.algonode.cloud' },
     },
     noteFormats: [
@@ -204,7 +207,8 @@ function buildAuditGuide(): AuditGuide {
           { name: 'agentId', description: 'Internal agent identifier (UUID or slug)' },
           { name: 'sha256hex', description: 'Full 64-character SHA-256 hex of the payload JSON' },
         ],
-        payloadSchema: '{ agentId, overallScore, trustLevel, components: { taskCompletion, peerRating, creditPattern, securityCompliance, activityLevel }, computedAt }',
+        payloadSchema:
+          '{ agentId, overallScore, trustLevel, components: { taskCompletion, peerRating, creditPattern, securityCompliance, activityLevel }, computedAt }',
         verifySteps: [
           'Fetch the transaction from the Algorand indexer by txid',
           'Base64-decode the note field',
@@ -233,7 +237,8 @@ function buildAuditGuide(): AuditGuide {
       {
         prefix: 'corvid-weekly-summary',
         format: 'corvid-weekly-summary:{agentId}:{weekLabel}:{sha256hex}',
-        description: 'Weekly outcome analysis attestation. Published each week summarising sessions, PRs, health, and observations.',
+        description:
+          'Weekly outcome analysis attestation. Published each week summarising sessions, PRs, health, and observations.',
         fields: [
           { name: 'agentId', description: 'Internal agent identifier' },
           { name: 'weekLabel', description: 'ISO week string, e.g. 2026-W17' },
@@ -249,7 +254,8 @@ function buildAuditGuide(): AuditGuide {
       {
         prefix: 'corvid-daily-review',
         format: 'corvid-daily-review:{agentId}:{date}:{sha256hex}',
-        description: 'Daily review attestation. Published each day with execution stats, PR counts, health uptime, and observations.',
+        description:
+          'Daily review attestation. Published each day with execution stats, PR counts, health uptime, and observations.',
         fields: [
           { name: 'agentId', description: 'Internal agent identifier' },
           { name: 'date', description: 'Review date in YYYY-MM-DD format' },
@@ -273,7 +279,8 @@ function buildAuditGuide(): AuditGuide {
           { name: 'description', description: 'Always "corvid-agent memory" for identification' },
           { name: 'note', description: 'ARC-69 JSON metadata containing the memory value (base64-encoded)' },
         ],
-        payloadSchema: '{ standard: "arc69", description: "corvid-agent memory", properties: { key, value, updatedAt } }',
+        payloadSchema:
+          '{ standard: "arc69", description: "corvid-agent memory", properties: { key, value, updatedAt } }',
         verifySteps: [
           'Query indexer for assets created by the agent wallet with unit-name CMEM',
           'Fetch the latest ARC-69 metadata from the most recent asset configuration transaction',
@@ -327,11 +334,31 @@ function buildAuditGuide(): AuditGuide {
         'const hex = Array.from(new Uint8Array(hash)).map(b => b.toString(16).padStart(2, "0")).join("");',
     },
     tools: [
-      { name: 'algosdk', url: 'https://developer.algorand.org/docs/sdks/', description: 'Official Algorand SDK for Node.js, Python, Go, Java' },
-      { name: 'algokit', url: 'https://developer.algorand.org/algokit/', description: 'All-in-one Algorand development toolkit' },
-      { name: 'Pera Explorer', url: 'https://explorer.perawallet.app/', description: 'Algorand mainnet block explorer' },
-      { name: 'DappFlow', url: 'https://app.dappflow.org/explorer/home', description: 'Algorand explorer with ARC-69 metadata support' },
-      { name: 'AlgoNode Indexer', url: 'https://mainnet-idx.algonode.cloud/v2/transactions', description: 'Free public Algorand indexer API' },
+      {
+        name: 'algosdk',
+        url: 'https://developer.algorand.org/docs/sdks/',
+        description: 'Official Algorand SDK for Node.js, Python, Go, Java',
+      },
+      {
+        name: 'algokit',
+        url: 'https://developer.algorand.org/algokit/',
+        description: 'All-in-one Algorand development toolkit',
+      },
+      {
+        name: 'Pera Explorer',
+        url: 'https://explorer.perawallet.app/',
+        description: 'Algorand mainnet block explorer',
+      },
+      {
+        name: 'DappFlow',
+        url: 'https://app.dappflow.org/explorer/home',
+        description: 'Algorand explorer with ARC-69 metadata support',
+      },
+      {
+        name: 'AlgoNode Indexer',
+        url: 'https://mainnet-idx.algonode.cloud/v2/transactions',
+        description: 'Free public Algorand indexer API',
+      },
     ],
   };
 }

--- a/specs/routes/routes.spec.md
+++ b/specs/routes/routes.spec.md
@@ -482,6 +482,7 @@ Every request passes through these stages in order:
 | GET | `/api/reputation/identity/:agentId` | reputation.ts | Get identity verification for agent |
 | PUT | `/api/reputation/identity/:agentId` | reputation.ts | Set identity verification tier |
 | POST | `/api/reputation/attestation/:agentId` | reputation.ts | Create reputation attestation |
+| GET | `/api/reputation/audit-guide` | reputation.ts | On-chain verification guide with note formats, indexer queries, and hash verification steps |
 
 ### Billing
 


### PR DESCRIPTION
## Summary

Implements the **'Document the on-chain verification process so anyone can audit'** deliverable from issue #1458 (Full on-chain transparency for all agent actions).

- Adds `GET /api/reputation/audit-guide` — returns a structured JSON guide documenting every Algorand note format used by CorvidAgent, with indexer query examples, SHA-256 hash verification steps, and recommended auditing tools
- Adds `AuditGuide` type to `reputation.model.ts` and `getAuditGuide()` method to `reputation.service.ts`
- Adds collapsible **On-Chain Verification Guide** panel to the reputation dashboard — loads lazily on first expand
- Updates `specs/routes/routes.spec.md` and OpenAPI registry for the new endpoint

### Note formats documented

| Prefix | Purpose |
|--------|---------|
| `corvid-reputation:{agentId}:{sha256hex}` | Reputation score attestation |
| `corvid-memory:{agentId}:{memoryKey}:{hash16}` | Memory promotion attestation |
| `corvid-weekly-summary:{agentId}:{week}:{hash}` | Weekly outcome analysis |
| `corvid-daily-review:{agentId}:{date}:{hash}` | Daily review attestation |
| ARC-69 ASA (corvid-agent memory) | Long-term on-chain memory storage |

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test` — 10452 pass, 0 fail
- [x] `bun run spec:check --force` — 215 passed, 0 warnings, 0 failed
- [x] Navigate to Reputation page → click 'On-Chain Verification Guide' toggle — guide expands with note formats, queries, hash example, tools
- [x] Guide loads lazily (no request on page load, one request on first toggle)
- [x] Collapse and re-expand — shows cached data (no second request)

Partial close of #1458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
