### PR TITLE
fix: type-safe ObservationSource lookup replaces `as any` in manager

### DIFF
--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -1258,7 +1258,7 @@ export class ProcessManager {
       ? listObservations(this.db, session.agentId, {
           status: 'active',
           limit: 10,
-          sourcePreference: (session.source as any) || undefined,
+          sourcePreference: (['discord', 'telegram', 'algochat'] as const).find((s) => s === session.source),
         })
       : [];
     for (const obs of observations) {


### PR DESCRIPTION
## Summary

- `session.source` is typed as `SessionSource` (`'web' | 'algochat' | 'agent' | 'telegram' | 'discord' | 'slack'`)
- `sourcePreference` in `listObservations` expects `ObservationSource`, a different union with only partial overlap
- Previous code used `as any` to bypass the mismatch, silently allowing invalid values (`'web'`, `'agent'`, `'slack'`) to reach the query layer
- Replaced with a typed tuple + `.find()` that returns the correct intersection (`'discord' | 'telegram' | 'algochat'`) or `undefined` — no cast required

**File:** `server/process/manager.ts:1261`

## Test plan

- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun run lint` — clean (Biome, 1109 files)
- [x] `bun test` — 10,486 pass, 0 fail
- [x] `bun run spec:check` — 100% file and LOC coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)