### PR TITLE
fix: type-safe ObservationSource lookup in session observation query

### DIFF
--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -1258,7 +1258,7 @@ export class ProcessManager {
       ? listObservations(this.db, session.agentId, {
           status: 'active',
           limit: 10,
-          sourcePreference: (session.source as any) || undefined,
+          sourcePreference: (['discord', 'telegram', 'algochat'] as const).find((s) => s === session.source),
         })
       : [];
     for (const obs of observations) {


### PR DESCRIPTION
## Summary

- Replaces unsafe \`as any\` cast on \`session.source\` with a typed intersection check against the three valid \`ObservationSource\` values (\`discord\`, \`telegram\`, \`algochat\`)
- The old cast silently permitted the other \`SessionSource\` values (\`web\`, \`agent\`, \`slack\`) to leak into the \`sourcePreference\` field, which only accepts the three channel values
- New expression: \`(['discord', 'telegram', 'algochat'] as const).find((s) => s === session.source)\` — returns the correct value or \`undefined\` with full type safety, no cast required

## Test plan

- [x] \`bun run lint\` — clean (1109 files, no issues)
- [x] \`bun x tsc --noEmit --skipLibCheck\` — clean (0 errors)
- [x] \`bun test\` — 10,500 pass, 0 fail
- [x] \`bun run spec:check\` — 3 specs checked, 3 passed, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)