### PR TITLE
fix: re-inject channel context on mention-reply session resume (#2177)

### DIFF
--- a/server/discord/message-router.ts
+++ b/server/discord/message-router.ts
@@ -728,7 +728,11 @@ async function handleMentionReplyResume(
       typeof contextualContent === 'string'
         ? contextualContent
         : appendAttachmentUrls(withAuthorContext(cleanText, authorId, authorUsername, channelId), attachments);
-    ctx.processManager.resumeProcess(session, resumeText);
+    // Re-inject channel context on resume so the agent sees messages posted by other users
+    // since the last exchange — mirrors the new-session path at buildChannelContext call above.
+    const channelContext = buildChannelContext(ctx.db, channelId);
+    const resumeTextWithContext = channelContext ? `${channelContext}\n\n${resumeText}` : resumeText;
+    ctx.processManager.resumeProcess(session, resumeTextWithContext);
 
     // If resumeProcess failed (e.g. death loop reset, spawn error), fall back to a new session
     if (!ctx.processManager.isRunning(sessionId)) {


### PR DESCRIPTION
## Summary

- Fixes #2177: `handleMentionReplyResume()` now calls `buildChannelContext(ctx.db, channelId)` before `resumeProcess`, mirroring the new-session path in `handleMentionReply()`.
- Without this fix the agent was blind to messages posted by other users in the channel since the last exchange when a session was resumed rather than started fresh.

## Test plan

- [x] TypeScript check: `bun x tsc --noEmit --skipLibCheck` — passes
- [x] Test suite: `bun test` — passes
- [x] Spec check: `bun run spec:check` — passes (8/8 specs, 0 warnings)
- [x] Manual: resume a mention-reply session after another user posts in the same channel — agent should see the intervening messages in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)