### PR TITLE
fix: persist cumulative turn count and add context usage fallback

### DIFF
--- a/server/__tests__/context-compaction.test.ts
+++ b/server/__tests__/context-compaction.test.ts
@@ -15,6 +15,33 @@ describe('turn counter persistence', () => {
     // Look for the pattern after "this.processes.set(session.id, sp)" (in resumeProcess)
     expect(managerSource).toMatch(/this\.processes\.set\(session\.id, sp\);[\s\S]*?turnCount: session\.totalTurns/);
   });
+
+  test('applyCostUpdateIfPresent uses cumulative meta.turnCount, not SDK num_turns', async () => {
+    const managerSource = await Bun.file('server/process/manager.ts').text();
+    // The cost update should use the in-memory cumulative turn count, not the SDK's per-run value
+    expect(managerSource).toContain('meta?.turnCount ?? event.num_turns');
+  });
+
+  test('session_exited event does not include total_cost_usd (avoids zeroing DB)', async () => {
+    const managerSource = await Bun.file('server/process/manager.ts').text();
+    // The exit event should NOT carry total_cost_usd: 0 — that would trigger updateSessionCost(db, id, 0, 0)
+    const exitEventMatch = managerSource.match(/type:\s*['"]session_exited['"][\s\S]*?\}\s*as\s*ClaudeStreamEvent/);
+    expect(exitEventMatch).toBeTruthy();
+    expect(exitEventMatch![0]).not.toContain('total_cost_usd');
+  });
+});
+
+describe('fallback context usage', () => {
+  test('computeFallbackContextUsage method exists on ProcessManager', async () => {
+    const managerSource = await Bun.file('server/process/manager.ts').text();
+    expect(managerSource).toContain('computeFallbackContextUsage');
+  });
+
+  test('fallback is triggered when context_usage has 0 estimated tokens', async () => {
+    const managerSource = await Bun.file('server/process/manager.ts').text();
+    expect(managerSource).toContain('estimatedTokens === 0');
+    expect(managerSource).toContain('computeFallbackContextUsage');
+  });
 });
 
 describe('auto-compact at 90%', () => {

--- a/server/process/event-handler.ts
+++ b/server/process/event-handler.ts
@@ -35,6 +35,7 @@ export interface SessionMetaForEvents {
   lastActivityAt: number;
   lastKnownCostUsd: number;
   source: string;
+  turnCount: number;
 }
 
 /**
@@ -48,9 +49,10 @@ export function applyCostUpdate(
 ): boolean {
   if (event.total_cost_usd === undefined) return true;
 
-  updateSessionCost(deps.db, sessionId, event.total_cost_usd, event.num_turns ?? 0);
-
+  // Use cumulative in-memory turn count — the SDK's num_turns resets each process run
   const meta = deps.getSessionMeta(sessionId);
+  const cumulativeTurns = meta?.turnCount ?? event.num_turns ?? 0;
+  updateSessionCost(deps.db, sessionId, event.total_cost_usd, cumulativeTurns);
   if (meta) {
     const delta = event.total_cost_usd - meta.lastKnownCostUsd;
     if (delta > 0) {

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -32,6 +32,7 @@ import { hasClaudeAccess } from '../providers/router';
 import type { LlmProviderType } from '../providers/types';
 import { ApprovalManager } from './approval-manager';
 import type { ApprovalRequestWire } from './approval-types';
+import { estimateTokens, getContextBudget } from './context-management';
 import { hasCursorAccess as hasCursorCli } from './cursor-process';
 import { startDirectProcess, summarizeConversation } from './direct-process';
 import { SessionEventBus } from './event-bus';
@@ -1527,7 +1528,10 @@ export class ProcessManager {
   ): boolean {
     if (event.total_cost_usd === undefined) return true;
 
-    updateSessionCost(this.db, sessionId, event.total_cost_usd, event.num_turns ?? 0);
+    // Use cumulative in-memory turn count — the SDK's num_turns resets each process run
+    const meta = this.sessionMeta.get(sessionId);
+    const cumulativeTurns = meta?.turnCount ?? event.num_turns ?? 0;
+    updateSessionCost(this.db, sessionId, event.total_cost_usd, cumulativeTurns);
 
     const costMeta = this.sessionMeta.get(sessionId);
     if (costMeta) {
@@ -1614,6 +1618,36 @@ export class ProcessManager {
     }
   }
 
+  private computeFallbackContextUsage(
+    sessionId: string,
+  ): { estimatedTokens: number; contextWindow: number; usagePercent: number; messagesCount: number } | null {
+    try {
+      const session = getSession(this.db, sessionId);
+      if (!session) return null;
+      const agent = session.agentId ? getAgent(this.db, session.agentId) : null;
+      const messages = getSessionMessages(this.db, sessionId);
+      if (messages.length === 0) return null;
+
+      const contextWindow = getContextBudget(agent?.model);
+      const estimatedTokens = messages.reduce((sum, m) => sum + estimateTokens(m.content), 0);
+      const usagePercent = (estimatedTokens / contextWindow) * 100;
+      log.debug('Computed fallback context usage from conversation history', {
+        sessionId: sessionId.slice(0, 8),
+        estimatedTokens,
+        contextWindow,
+        usagePercent: usagePercent.toFixed(1),
+        messagesCount: messages.length,
+      });
+      return { estimatedTokens, contextWindow, usagePercent, messagesCount: messages.length };
+    } catch (err) {
+      log.warn('Failed to compute fallback context usage', {
+        sessionId: sessionId.slice(0, 8),
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
   private handleEvent(sessionId: string, event: ClaudeStreamEvent): void {
     const meta = this.sessionMeta.get(sessionId);
     if (meta) {
@@ -1649,13 +1683,42 @@ export class ProcessManager {
 
     // Track context usage and auto-compact at threshold
     if (event.type === 'context_usage' && meta) {
-      const usage = event as { usagePercent?: number };
-      if (usage.usagePercent != null) {
+      const usage = event as { estimatedTokens?: number; usagePercent?: number };
+      if (usage.usagePercent != null && usage.usagePercent > 0) {
         meta.lastContextUsagePercent = usage.usagePercent;
         if (usage.usagePercent >= AUTO_COMPACT_THRESHOLD) {
           log.info(`Auto-compacting session ${sessionId} at ${usage.usagePercent}% context usage`);
           this.compactSession(sessionId);
         }
+      } else if (usage.estimatedTokens === 0 || usage.usagePercent === 0) {
+        // SDK returned 0 tokens — compute from conversation history as fallback
+        const fallback = this.computeFallbackContextUsage(sessionId);
+        if (fallback) {
+          meta.lastContextUsagePercent = fallback.usagePercent;
+          this.eventBus.emit(sessionId, {
+            type: 'context_usage',
+            session_id: sessionId,
+            ...fallback,
+          } as ClaudeStreamEvent);
+          if (fallback.usagePercent >= AUTO_COMPACT_THRESHOLD) {
+            log.info(`Auto-compacting session ${sessionId} at ${fallback.usagePercent}% context usage (fallback)`);
+            this.compactSession(sessionId);
+          }
+          return;
+        }
+      }
+    }
+
+    // If result arrives and we still have no context usage, emit a fallback
+    if (event.type === 'result' && meta && !meta.lastContextUsagePercent) {
+      const fallback = this.computeFallbackContextUsage(sessionId);
+      if (fallback) {
+        meta.lastContextUsagePercent = fallback.usagePercent;
+        this.eventBus.emit(sessionId, {
+          type: 'context_usage',
+          session_id: sessionId,
+          ...fallback,
+        } as ClaudeStreamEvent);
       }
     }
 
@@ -1798,9 +1861,8 @@ export class ProcessManager {
       type: 'session_exited',
       session_id: sessionId,
       result: 'exited',
-      total_cost_usd: 0,
       duration_ms: 0,
-      num_turns: 0,
+      num_turns: meta?.turnCount ?? 0,
     } as ClaudeStreamEvent);
 
     // Clean up chat worktrees (work task worktrees are cleaned by WorkTaskService)

--- a/server/process/sdk-process.ts
+++ b/server/process/sdk-process.ts
@@ -576,29 +576,31 @@ function extractContextUsageFromResult(
     const primary = modelEntries[0];
     const contextWindow = primary.contextWindow || getContextBudget(model);
     const estimatedTokens = primary.inputTokens;
-    const usagePercent = Math.round((estimatedTokens / contextWindow) * 100);
-    return { estimatedTokens, contextWindow, usagePercent };
-  }
-
-  // Fall back to usage.iterations — last iteration's input_tokens is the current context size
-  const iterations = success.usage?.iterations;
-  if (iterations && iterations.length > 0) {
-    const lastIter = iterations[iterations.length - 1];
-    if ('input_tokens' in lastIter) {
-      const contextWindow = getContextBudget(model);
-      const estimatedTokens = lastIter.input_tokens;
-      const usagePercent = Math.round((estimatedTokens / contextWindow) * 100);
+    if (estimatedTokens > 0) {
+      const usagePercent = (estimatedTokens / contextWindow) * 100;
       return { estimatedTokens, contextWindow, usagePercent };
     }
+    log.debug('modelUsage has 0 inputTokens, falling through', {
+      model,
+      keys: Object.keys(success.modelUsage ?? {}),
+      contextWindow: primary.contextWindow,
+    });
   }
 
-  // Final fallback to cumulative input_tokens
+  // Fall back to cumulative input_tokens from usage
   if (success.usage?.input_tokens) {
     const contextWindow = getContextBudget(model);
     const estimatedTokens = success.usage.input_tokens;
-    const usagePercent = Math.round((estimatedTokens / contextWindow) * 100);
+    const usagePercent = (estimatedTokens / contextWindow) * 100;
     return { estimatedTokens, contextWindow, usagePercent };
   }
+
+  log.debug('No context usage data available from SDK result', {
+    model,
+    hasModelUsage: modelEntries.length > 0,
+    hasUsage: !!success.usage,
+    inputTokens: success.usage?.input_tokens,
+  });
 
   return null;
 }


### PR DESCRIPTION
## Summary

- **Turn counter resetting to 0**: `applyCostUpdateIfPresent` was writing the SDK's per-process-run `num_turns` to the DB. On session exit, a synthetic event with `total_cost_usd: 0, num_turns: 0` zeroed both values. Fixed by using the cumulative in-memory `meta.turnCount` and removing `total_cost_usd` from the exit event.

- **Context usage stuck at 0.0%**: When the SDK's `modelUsage.inputTokens` returns 0, the Discord footer showed ⚪ 0.0%. Added a fallback (`computeFallbackContextUsage`) that estimates context from the stored conversation history via token estimation. Also added debug logging to diagnose when the SDK returns empty data.

- **Dead code cleanup**: Removed the `usage.iterations` fallback path since `BetaUsage` has no `iterations` field (it was always `undefined`).

## Test plan

- [x] All 10,534 tests pass (0 failures)
- [x] TypeScript compiles cleanly (`tsc --noEmit --skipLibCheck`)
- [x] Biome lint passes
- [x] New tests verify turn counter uses `meta.turnCount`, exit event omits `total_cost_usd`, and fallback context usage exists
- [ ] Manual verification: after merge + restart, send multiple messages and confirm turn counter accumulates correctly and context % reflects real usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)