### PR TITLE
fix: round context usage percentage in Discord footer

### DIFF
--- a/server/discord/embeds.ts
+++ b/server/discord/embeds.ts
@@ -185,7 +185,7 @@ export function formatContextUsage(usage: ContextUsage): string {
   const emoji = pct >= 80 ? '🔴' : pct >= 60 ? '🟠' : pct >= 40 ? '🟡' : pct >= 20 ? '🟢' : '⚪';
   const used = formatTokenCount(usage.estimatedTokens);
   const max = formatTokenCount(usage.contextWindow);
-  return `${emoji} ${pct.toFixed(1)}% (${used}/${max})`;
+  return `${emoji} ${Math.round(pct)}% (${used}/${max})`;
 }
 
 function formatTokenCount(tokens: number): string {

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -835,11 +835,13 @@ export class ProcessManager {
     this.startingSession.delete(session.id);
     this.processes.set(session.id, process);
     const now = Date.now();
+    const prevMeta = this.sessionMeta.get(session.id);
     this.sessionMeta.set(session.id, {
       startedAt: now,
       source: (session as { source?: string }).source ?? 'web',
-      restartCount: this.sessionMeta.get(session.id)?.restartCount ?? 0,
-      lastKnownCostUsd: this.sessionMeta.get(session.id)?.lastKnownCostUsd ?? 0,
+      restartCount: prevMeta?.restartCount ?? 0,
+      lastKnownCostUsd: prevMeta?.lastKnownCostUsd ?? 0,
+      lastContextUsagePercent: prevMeta?.lastContextUsagePercent,
       turnCount: 0,
       lastActivityAt: now,
     });
@@ -868,6 +870,33 @@ export class ProcessManager {
       type: 'session_started',
       session_id: session.id,
     } as ClaudeStreamEvent);
+
+    // Emit context usage immediately for resumed sessions so Discord footers
+    // show a real percentage from the start instead of 0%.
+    const meta = this.sessionMeta.get(session.id);
+    if (meta && !meta.lastContextUsagePercent) {
+      const fallback = this.computeFallbackContextUsage(session.id);
+      if (fallback) {
+        meta.lastContextUsagePercent = fallback.usagePercent;
+        this.eventBus.emit(session.id, {
+          type: 'context_usage',
+          session_id: session.id,
+          ...fallback,
+        } as ClaudeStreamEvent);
+      }
+    } else if (meta?.lastContextUsagePercent) {
+      // Carry-over from in-process restart — re-emit so listeners pick it up
+      const agent = session.agentId ? getAgent(this.db, session.agentId) : null;
+      const contextWindow = getContextBudget(agent?.model);
+      const estimatedTokens = Math.round((meta.lastContextUsagePercent / 100) * contextWindow);
+      this.eventBus.emit(session.id, {
+        type: 'context_usage',
+        session_id: session.id,
+        estimatedTokens,
+        contextWindow,
+        usagePercent: meta.lastContextUsagePercent,
+      } as ClaudeStreamEvent);
+    }
   }
 
   private handleApprovalRequest(sessionId: string, request: ApprovalRequestWire): void {
@@ -1630,7 +1659,7 @@ export class ProcessManager {
 
       const contextWindow = getContextBudget(agent?.model);
       const estimatedTokens = messages.reduce((sum, m) => sum + estimateTokens(m.content), 0);
-      const usagePercent = (estimatedTokens / contextWindow) * 100;
+      const usagePercent = Math.round((estimatedTokens / contextWindow) * 100);
       log.debug('Computed fallback context usage from conversation history', {
         sessionId: sessionId.slice(0, 8),
         estimatedTokens,

--- a/server/process/sdk-process.ts
+++ b/server/process/sdk-process.ts
@@ -577,7 +577,7 @@ function extractContextUsageFromResult(
     const contextWindow = primary.contextWindow || getContextBudget(model);
     const estimatedTokens = primary.inputTokens;
     if (estimatedTokens > 0) {
-      const usagePercent = (estimatedTokens / contextWindow) * 100;
+      const usagePercent = Math.round((estimatedTokens / contextWindow) * 100);
       return { estimatedTokens, contextWindow, usagePercent };
     }
     log.debug('modelUsage has 0 inputTokens, falling through', {
@@ -591,7 +591,7 @@ function extractContextUsageFromResult(
   if (success.usage?.input_tokens) {
     const contextWindow = getContextBudget(model);
     const estimatedTokens = success.usage.input_tokens;
-    const usagePercent = (estimatedTokens / contextWindow) * 100;
+    const usagePercent = Math.round((estimatedTokens / contextWindow) * 100);
     return { estimatedTokens, contextWindow, usagePercent };
   }
 


### PR DESCRIPTION
## Summary
- Adds `Math.round()` to all three computation sites for `usagePercent` (`sdk-process.ts` x2, `manager.ts` fallback) so the value is always an integer
- Adds a safety-net `Math.round()` in `formatContextUsage()` display formatter
- Fixes footer showing `0.0139999999999999%` instead of `0%` (or `1%` once it ticks up)

## Test plan
- [x] Existing context-usage and discord-ux-overhaul tests pass (23/23)
- [x] Type check clean
- [ ] Manual: verify footer shows clean integer percentages after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)