### PR TITLE
fix(db): strip conversation_history tags from assistant messages at storage

### DIFF
--- a/server/db/sessions.ts
+++ b/server/db/sessions.ts
@@ -265,8 +265,8 @@ export function addSessionMessage(
   content: string,
   costUsd: number = 0,
 ): SessionMessage {
-  // Strip conversation_history tags at storage time to prevent nested tags on resume (#2136)
-  const sanitized = role === 'user' ? stripConversationHistory(content) : content;
+  // Strip conversation_history tags from all roles at storage time to prevent nested tags on resume (#2136, #2180)
+  const sanitized = stripConversationHistory(content);
   const result = db
     .query(`INSERT INTO session_messages (session_id, role, content, cost_usd) VALUES (?, ?, ?, ?)`)
     .run(sessionId, role, sanitized, costUsd);


### PR DESCRIPTION
## Summary

- Extends the `#2136` fix to cover **assistant** messages in addition to user messages.
- `addSessionMessage` in `server/db/sessions.ts` previously only called `stripConversationHistory` for `role === 'user'`. If an assistant message echoed back context tags, they would persist in the DB and re-nest on session resume.
- Now `stripConversationHistory` is applied unconditionally for all roles.

One-line change in `server/db/sessions.ts:269`.

## Test plan

- [x] Start a session, confirm assistant messages with context tags are stored cleanly in the DB
- [x] Resume a session and verify no nested `<conversation_history>` tags appear
- [x] `bun run lint` passes
- [x] `bun x tsc --noEmit --skipLibCheck` passes (no new errors vs main — 3581 pre-existing errors identical on both branches)

Closes #2180

🤖 Generated with [Claude Code](https://claude.com/claude-code)