### PR TITLE
fix(test): update context usage test expectations to match rounded format

### DIFF
--- a/server/__tests__/discord-ux-overhaul.test.ts
+++ b/server/__tests__/discord-ux-overhaul.test.ts
@@ -944,7 +944,7 @@ describe('progress-response real-time context usage', () => {
 
       // Should have edited the progress embed with usage in the footer
       const editWithUsage = calls.find(
-        (c: any) => c.method === 'edit' && c.data?.embeds?.[0]?.footer?.text?.includes('25.0%'),
+        (c: any) => c.method === 'edit' && c.data?.embeds?.[0]?.footer?.text?.includes('25%'),
       );
       expect(editWithUsage).toBeDefined();
     } finally {
@@ -995,7 +995,7 @@ describe('progress-response real-time context usage', () => {
       const edits = calls.filter((c: any) => c.method === 'edit');
       const lastEdit = edits[edits.length - 1] as any;
       expect(lastEdit.data.embeds[0].description).toContain('Reading file...');
-      expect(lastEdit.data.embeds[0].footer.text).toContain('45.0%');
+      expect(lastEdit.data.embeds[0].footer.text).toContain('45%');
     } finally {
       const cb = pendingSubscribers.find((s) => s.sessionId === 'session-ctx-2')?.callback;
       if (cb) cb('session-ctx-2', { type: 'result', result: '' });
@@ -1167,7 +1167,7 @@ describe('progress-response real-time context usage', () => {
         (c: any) =>
           c.method === 'edit' &&
           c.data?.embeds?.[0]?.description === '✅ Done' &&
-          c.data?.embeds?.[0]?.footer?.text?.includes('75.0%'),
+          c.data?.embeds?.[0]?.footer?.text?.includes('75%'),
       );
       expect(doneEdit).toBeDefined();
     } finally {


### PR DESCRIPTION
## Summary
- Updates 3 test expectations in `discord-ux-overhaul.test.ts` that expected decimal percentages (e.g. `25.0%`) but `formatContextUsage` now uses `Math.round()` producing integer percentages (e.g. `25%`)
- This was broken by #2193 which rounded the percentage but didn't update the corresponding test assertions

## Test plan
- [x] All 3 previously-failing tests now pass locally
- [x] Full test suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)