### PR TITLE
fix(discord): persist turn count immediately on user message

### DIFF
--- a/server/db/sessions.ts
+++ b/server/db/sessions.ts
@@ -208,6 +208,10 @@ export function updateSessionCost(db: Database, id: string, costUsd: number, tur
   );
 }
 
+export function updateSessionTurns(db: Database, id: string, turns: number): void {
+  db.query("UPDATE sessions SET total_turns = ?, updated_at = datetime('now') WHERE id = ?").run(turns, id);
+}
+
 export function updateSessionAlgoSpent(db: Database, id: string, microAlgos: number): void {
   db.query(
     "UPDATE sessions SET total_algo_spent = total_algo_spent + ?, updated_at = datetime('now') WHERE id = ?",

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -18,6 +18,7 @@ import {
   updateSessionPid,
   updateSessionStatus,
   updateSessionSummary,
+  updateSessionTurns,
 } from '../db/sessions';
 import { recordApiCost } from '../db/spending';
 import { createLogger } from '../lib/logger';
@@ -1467,7 +1468,10 @@ export class ProcessManager {
     addSessionMessage(this.db, sessionId, 'user', textContent || '[image attachment(s)]');
 
     const meta = this.sessionMeta.get(sessionId);
-    if (meta) meta.turnCount++;
+    if (meta) {
+      meta.turnCount++;
+      updateSessionTurns(this.db, sessionId, meta.turnCount);
+    }
 
     return true;
   }

--- a/specs/db/sessions/sessions.spec.md
+++ b/specs/db/sessions/sessions.spec.md
@@ -35,6 +35,7 @@ No business logic lives here -- just SQL queries with row-to-domain mapping.
 | `updateSessionPid` | `(db: Database, id: string, pid: number \| null)` | `void` | Update the OS process ID (null when process exits) |
 | `updateSessionStatus` | `(db: Database, id: string, status: string)` | `void` | Set session status (idle, running, stopped, error, paused) |
 | `updateSessionCost` | `(db: Database, id: string, costUsd: number, turns: number)` | `void` | Update cumulative cost and turn count |
+| `updateSessionTurns` | `(db: Database, id: string, turns: number)` | `void` | Update turn count independently of cost (for immediate persistence on user message) |
 | `updateSessionAlgoSpent` | `(db: Database, id: string, microAlgos: number)` | `void` | Increment total ALGO spent (additive, not replacement) |
 | `updateSessionSummary` | `(db: Database, id: string, summary: string)` | `void` | Update the conversation summary for cross-session context carry-over |
 | `getPreviousThreadSessionSummary` | `(db: Database, threadId: string)` | `string \| null` | Get conversation summary from the most recent Discord thread session |
@@ -120,7 +121,7 @@ No business logic lives here -- just SQL queries with row-to-domain mapping.
 
 | Module | What is used |
 |--------|-------------|
-| `server/process/manager.ts` | `getSession`, `getSessionMessages`, `updateSessionPid`, `updateSessionStatus`, `updateSessionCost`, `updateSessionAgent`, `addSessionMessage`, `createSession`, `getParticipantForSession` |
+| `server/process/manager.ts` | `getSession`, `getSessionMessages`, `updateSessionPid`, `updateSessionStatus`, `updateSessionCost`, `updateSessionTurns`, `updateSessionAgent`, `addSessionMessage`, `createSession`, `getParticipantForSession` |
 | `server/work/service.ts` | `createSession` |
 | `server/scheduler/service.ts` | `createSession` |
 | `server/routes/sessions.ts` | All session CRUD functions |


### PR DESCRIPTION
## Summary

- Turn count (`total_turns`) was only written to DB inside `updateSessionCost()`, which fires when the agent finishes responding — not when the user sends a message
- Discord progress embeds read `total_turns` from DB on every refresh, so the turn number appeared stuck during long agent turns
- Added `updateSessionTurns()` to persist the count immediately when `sendMessage()` increments it

## Changes

- `server/db/sessions.ts` — new `updateSessionTurns()` function
- `server/process/manager.ts` — call it right after incrementing `meta.turnCount`
- `specs/db/sessions/sessions.spec.md` — document the new export

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit --skipLibCheck`)
- [x] All 10,540 tests pass (`bun test`)
- [x] Specsync passes with zero warnings (`specsync check --force`)
- [ ] Verify in Discord that turn count updates immediately when sending a message during a long agent response

🤖 Generated with [Claude Code](https://claude.com/claude-code)