### PR TITLE
fix(discord): persist turn count across server restarts

### DIFF
--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -837,17 +837,20 @@ export class ProcessManager {
     this.processes.set(session.id, process);
     const now = Date.now();
     const prevMeta = this.sessionMeta.get(session.id);
+    const dbTurns = session.totalTurns ?? 0;
+    const resumedTurnCount = Math.max(prevMeta?.turnCount ?? 0, dbTurns, 1);
     this.sessionMeta.set(session.id, {
       startedAt: now,
       source: (session as { source?: string }).source ?? 'web',
       restartCount: prevMeta?.restartCount ?? 0,
       lastKnownCostUsd: prevMeta?.lastKnownCostUsd ?? 0,
       lastContextUsagePercent: prevMeta?.lastContextUsagePercent,
-      turnCount: 0,
+      turnCount: resumedTurnCount,
       lastActivityAt: now,
     });
     updateSessionPid(this.db, session.id, process.pid);
     updateSessionStatus(this.db, session.id, 'running');
+    updateSessionTurns(this.db, session.id, resumedTurnCount);
 
     const verify = this.db.query('SELECT status, pid FROM sessions WHERE id = ?').get(session.id) as {
       status: string;


### PR DESCRIPTION
## Summary
- `registerProcess` was resetting `turnCount` to 0 (then 1) on every server restart, ignoring the `total_turns` already in the database
- After multiple restarts during a session, the completion embed showed a count far below the actual number of user messages (e.g., 8 instead of 39)
- Now loads `session.totalTurns` from the DB and takes `Math.max(inMemory, dbTurns, 1)` so the count survives restarts

## Test plan
- [x] TypeScript type check passes
- [x] All tests pass
- [x] All 216 specs pass
- [ ] Restart server and verify completion embed shows correct cumulative turn count

🤖 Generated with [Claude Code](https://claude.com/claude-code)