### PR TITLE
fix(discord): increment turn count on process resume

### DIFF
--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -799,9 +799,14 @@ export class ProcessManager {
 
     const effectiveProject = { ...project, workingDir: resolved.dir };
 
-    // Save the user message and build resume prompt
+    // Save the user message and increment turn count
     if (prompt) {
       addSessionMessage(this.db, session.id, 'user', prompt);
+      const newTurns = (session.totalTurns ?? 0) + 1;
+      updateSessionTurns(this.db, session.id, newTurns);
+      session.totalTurns = newTurns;
+      const existingMeta = this.sessionMeta.get(session.id);
+      if (existingMeta) existingMeta.turnCount = newTurns;
     }
     const resumePrompt = this.buildResumePrompt(session, prompt);
 


### PR DESCRIPTION
## Summary
- When a session's process exits and a new message triggers `resumeProcess`, the turn count was not being incremented — only `sendMessage` did it
- This caused turns to silently go uncounted after process restarts, which Kyn caught in Discord
- Now `resumeProcess` increments the turn count and updates both the DB and in-memory meta, matching `sendMessage` behavior

## Test plan
- [x] All 26 tests pass
- [x] Context compaction tests pass
- [ ] Verify in Discord: send messages across a process restart and confirm turn count increments

🤖 Generated with [Claude Code](https://claude.com/claude-code)