### PR TITLE
fix(auto-update): log git fetch failures instead of silently returning

### DIFF
--- a/server/polling/auto-update.ts
+++ b/server/polling/auto-update.ts
@@ -53,7 +53,13 @@ export class AutoUpdateService {
         stdout: 'pipe',
         stderr: 'pipe',
       });
-      if (fetchResult.exitCode !== 0) return;
+      if (fetchResult.exitCode !== 0) {
+        log.warn('git fetch failed — skipping auto-update check', {
+          exitCode: fetchResult.exitCode,
+          stderr: fetchResult.stderr.toString().trim(),
+        });
+        return;
+      }
 
       // Only auto-update if we're on the main branch
       const currentBranch = Bun.spawnSync(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], {


### PR DESCRIPTION
## Summary

- `AutoUpdateService.check()` silently returned when `git fetch origin main` failed (non-zero exit code)
- This made network outages, auth failures, and misconfigured remotes completely invisible in production logs
- Now emits a `warn` log with exit code and stderr so operators can diagnose why auto-update checks are being skipped

## Test plan

- [ ] Existing mention-polling tests pass (64 tests, 0 failures confirmed)
- [ ] TypeScript type check passes (`bunx tsc --noEmit --skipLibCheck`)
- [ ] Full test suite passes (10,540 tests, 0 failures on main)

## Quality audit context

This was identified during a routine quality scan. Other findings for future consideration:
- `discord/message-router.ts` lines 186/197: best-effort catch blocks with no logging
- `routes/block-explorer.ts` lines 292/362: query builder typed as `any` (likely intentional due to SDK builder chains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)