### PR TITLE
feat(discord): show turn count in embed footers

### DIFF
--- a/server/db/sessions.ts
+++ b/server/db/sessions.ts
@@ -212,6 +212,11 @@ export function updateSessionCost(db: Database, id: string, costUsd: number, tur
   );
 }
 
+export function getSessionTurns(db: Database, id: string): number {
+  const row = db.query('SELECT total_turns FROM sessions WHERE id = ?').get(id) as { total_turns: number } | null;
+  return row?.total_turns ?? 0;
+}
+
 export function updateSessionTurns(db: Database, id: string, turns: number): void {
   db.query("UPDATE sessions SET total_turns = ?, updated_at = datetime('now') WHERE id = ?").run(turns, id);
 }

--- a/server/discord/embeds.ts
+++ b/server/discord/embeds.ts
@@ -196,10 +196,10 @@ function formatTokenCount(tokens: number): string {
 
 /**
  * Build a detailed footer string with full session context.
- * Format: `AgentName · model · project · sid:XXXXXX · status | 🟢 32% (64k/200k)`
+ * Format: `AgentName · model · project · sid:XXXXXX · status | T:5 | 🟢 32% (64k/200k)`
  * Segments are omitted when their value is not provided.
  */
-export function buildFooterText(ctx: FooterContext, contextUsage?: ContextUsage): string {
+export function buildFooterText(ctx: FooterContext, contextUsage?: ContextUsage, turns?: number): string {
   const parts: string[] = [ctx.agentName];
   if (ctx.agentModel) {
     parts.push(ctx.agentModel);
@@ -214,10 +214,14 @@ export function buildFooterText(ctx: FooterContext, contextUsage?: ContextUsage)
     parts.push(ctx.status);
   }
   const base = parts.join(' · ');
-  if (contextUsage) {
-    return `${base} | ${formatContextUsage(contextUsage)}`;
+  const segments: string[] = [base];
+  if (turns && turns > 0) {
+    segments.push(`T:${turns}`);
   }
-  return base;
+  if (contextUsage) {
+    segments.push(formatContextUsage(contextUsage));
+  }
+  return segments.join(' | ');
 }
 
 /**

--- a/server/discord/thread-response/embed-response.ts
+++ b/server/discord/thread-response/embed-response.ts
@@ -1,4 +1,5 @@
 import type { Database } from 'bun:sqlite';
+import { getSessionTurns } from '../../db/sessions';
 import type { DeliveryTracker } from '../../lib/delivery-tracker';
 import { createLogger } from '../../lib/logger';
 import type { EventCallback } from '../../process/interfaces';
@@ -76,11 +77,14 @@ export function subscribeForResponseWithEmbed(
 
   /** Post or upgrade the progress message. First call sends it, subsequent calls edit it. */
   const updateProgressMessage = async (description: string, status: string, embedColor?: number) => {
+    const turns = getSessionTurns(db, sessionId);
     const embed = {
       description,
       color: embedColor ?? 0x95a5a6,
       author,
-      footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName, status }, latestContextUsage) },
+      footer: {
+        text: buildFooterText({ agentName, agentModel, sessionId, projectName, status }, latestContextUsage, turns),
+      },
     };
     if (progressMessageId) {
       await editEmbed(delivery, botToken, threadId, progressMessageId, embed);
@@ -122,6 +126,7 @@ export function subscribeForResponseWithEmbed(
         // If we have an existing progress message, update it to show the crash.
         // Otherwise send a new embed.
         if (progressMessageId) {
+          const crashTurns = getSessionTurns(db, sessionId);
           editEmbed(delivery, botToken, threadId, progressMessageId, {
             description: 'The agent session ended unexpectedly. Send a message to resume.',
             color: 0xff3355,
@@ -130,6 +135,7 @@ export function subscribeForResponseWithEmbed(
               text: buildFooterText(
                 { agentName, agentModel, sessionId, projectName, status: 'crashed' },
                 latestContextUsage,
+                crashTurns,
               ),
             },
           }).catch((err) => {
@@ -139,6 +145,7 @@ export function subscribeForResponseWithEmbed(
             });
           });
         } else {
+          const crashTurns = getSessionTurns(db, sessionId);
           sendEmbedWithButtons(
             delivery,
             botToken,
@@ -151,6 +158,7 @@ export function subscribeForResponseWithEmbed(
                 text: buildFooterText(
                   { agentName, agentModel, sessionId, projectName, status: 'crashed' },
                   latestContextUsage,
+                  crashTurns,
                 ),
               },
             },
@@ -197,13 +205,14 @@ export function subscribeForResponseWithEmbed(
     const text = buffer;
     buffer = '';
 
+    const turns = getSessionTurns(db, sessionId);
     const parts = visibleEmbedParts(text);
     for (const part of parts) {
       await sendEmbed(delivery, botToken, threadId, {
         description: part,
         color,
         author,
-        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }, latestContextUsage) },
+        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }, latestContextUsage, turns) },
       });
     }
   };
@@ -228,6 +237,7 @@ export function subscribeForResponseWithEmbed(
               : 'png';
       const filename = `image.${ext}`;
       const attachment: DiscordFileAttachment = { name: filename, data, contentType: ct };
+      const imgTurns = getSessionTurns(db, sessionId);
       await sendEmbedWithFiles(
         delivery,
         botToken,
@@ -236,7 +246,9 @@ export function subscribeForResponseWithEmbed(
           image: { url: `attachment://${filename}` },
           color,
           author,
-          footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }, latestContextUsage) },
+          footer: {
+            text: buildFooterText({ agentName, agentModel, sessionId, projectName }, latestContextUsage, imgTurns),
+          },
         },
         [attachment],
       );
@@ -322,6 +334,7 @@ export function subscribeForResponseWithEmbed(
     if (event.type === 'context_warning') {
       const warning = event as { level?: string; message?: string; usagePercent?: number };
       if (warning.level === 'critical') {
+        const warnTurns = getSessionTurns(db, sessionId);
         sendEmbed(delivery, botToken, threadId, {
           description: `⚠️ ${warning.message || `Context usage at ${warning.usagePercent}%`}`,
           color: 0xf0b232, // yellow/warning
@@ -330,6 +343,7 @@ export function subscribeForResponseWithEmbed(
             text: buildFooterText(
               { agentName, agentModel, sessionId, projectName, status: 'context warning' },
               latestContextUsage,
+              warnTurns,
             ),
           },
         }).catch((err) => {
@@ -350,6 +364,7 @@ export function subscribeForResponseWithEmbed(
 
       // Mark the progress message as done (if it exists) before sending the completion embed
       if (progressMessageId) {
+        const doneTurns = getSessionTurns(db, sessionId);
         editEmbed(delivery, botToken, threadId, progressMessageId, {
           description: '✅ Done',
           color: 0x57f287,
@@ -358,6 +373,7 @@ export function subscribeForResponseWithEmbed(
             text: buildFooterText(
               { agentName, agentModel, sessionId, projectName, status: 'done' },
               latestContextUsage,
+              doneTurns,
             ),
           },
         }).catch((err) => {
@@ -518,6 +534,7 @@ export function subscribeForResponseWithEmbed(
       const { title, description, color: errColor } = sessionErrorEmbed(errorType, errEvent.error?.message);
 
       // If we have a progress message, update it to show the error; otherwise send new
+      const errTurns = getSessionTurns(db, sessionId);
       if (progressMessageId) {
         editEmbed(delivery, botToken, threadId, progressMessageId, {
           title,
@@ -528,6 +545,7 @@ export function subscribeForResponseWithEmbed(
             text: buildFooterText(
               { agentName, agentModel, sessionId, projectName, status: errorType },
               latestContextUsage,
+              errTurns,
             ),
           },
         }).catch((err) => {
@@ -550,6 +568,7 @@ export function subscribeForResponseWithEmbed(
               text: buildFooterText(
                 { agentName, agentModel, sessionId, projectName, status: errorType },
                 latestContextUsage,
+                errTurns,
               ),
             },
           },

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -1080,6 +1080,9 @@ export class ProcessManager {
 
     if (prompt) {
       addSessionMessage(this.db, session.id, 'user', prompt);
+      const newTurns = (session.totalTurns ?? 0) + 1;
+      updateSessionTurns(this.db, session.id, newTurns);
+      session.totalTurns = newTurns;
     }
 
     const providerType = effectiveAgent?.provider as LlmProviderType | undefined;

--- a/specs/db/sessions/sessions.spec.md
+++ b/specs/db/sessions/sessions.spec.md
@@ -35,6 +35,7 @@ No business logic lives here -- just SQL queries with row-to-domain mapping.
 | `updateSessionPid` | `(db: Database, id: string, pid: number \| null)` | `void` | Update the OS process ID (null when process exits) |
 | `updateSessionStatus` | `(db: Database, id: string, status: string)` | `void` | Set session status (idle, running, stopped, error, paused) |
 | `updateSessionCost` | `(db: Database, id: string, costUsd: number, turns: number)` | `void` | Update cumulative cost and turn count |
+| `getSessionTurns` | `(db: Database, id: string)` | `number` | Lightweight read of `total_turns` for a session (returns 0 if not found) |
 | `updateSessionTurns` | `(db: Database, id: string, turns: number)` | `void` | Update turn count independently of cost (for immediate persistence on user message) |
 | `updateSessionAlgoSpent` | `(db: Database, id: string, microAlgos: number)` | `void` | Increment total ALGO spent (additive, not replacement) |
 | `updateSessionContextTokens` | `(db: Database, id: string, tokens: number, contextWindow: number)` | `void` | Persist real context token count and window size from API |
@@ -127,6 +128,7 @@ No business logic lives here -- just SQL queries with row-to-domain mapping.
 | `server/scheduler/service.ts` | `createSession` |
 | `server/routes/sessions.ts` | All session CRUD functions |
 | `server/algochat/bridge.ts` | Conversation CRUD functions |
+| `server/discord/thread-response/embed-response.ts` | `getSessionTurns` |
 
 ## Database Tables
 


### PR DESCRIPTION
## Summary
- Add `T:X` turn counter to all thread-based Discord embed footers (response, progress, thinking, crash, error, context warning, done, and image embeds)
- Fix turn count not incrementing on session resume for persistent/worktree projects (`manager.ts`)
- Add lightweight `getSessionTurns()` DB getter and update sessions spec

## Test plan
- [ ] Start a Discord thread session and verify `T:1` appears in the first response footer
- [ ] Send multiple messages and confirm turn count increments in each embed
- [ ] Resume a session and verify turns continue incrementing (not resetting)
- [ ] Verify progress/thinking embeds also show the turn counter
- [ ] Verify crash/error embeds show the correct turn count

🤖 Generated with [Claude Code](https://claude.com/claude-code)