### PR TITLE
fix(discord): emit context_usage on resume so footer shows fresh tokens

### DIFF
--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -1304,8 +1304,20 @@ export class ProcessManager {
     updateSessionTurns(this.db, session.id, totalTurns);
     const existingMeta = this.sessionMeta.get(session.id);
     if (existingMeta) existingMeta.turnCount = totalTurns;
-    session.lastContextTokens = estimateTokens(resumePrompt);
-    session.lastContextWindow = getContextBudget(agentModel);
+    const tokens = estimateTokens(resumePrompt);
+    const contextWindow = getContextBudget(agentModel);
+    session.lastContextTokens = tokens;
+    session.lastContextWindow = contextWindow;
+    updateSessionContextTokens(this.db, session.id, tokens, contextWindow);
+    const usagePercent = contextWindow > 0 ? Math.round((tokens / contextWindow) * 100) : 0;
+    if (existingMeta) existingMeta.lastContextUsagePercent = usagePercent;
+    this.eventBus.emit(session.id, {
+      type: 'context_usage',
+      session_id: session.id,
+      estimatedTokens: tokens,
+      contextWindow,
+      usagePercent,
+    } as ClaudeStreamEvent);
   }
 
   private buildResumePrompt(session: Session, newPrompt?: string): { prompt: string; activeTurns: number } {


### PR DESCRIPTION
## Summary
- After session resume, `applyResumeMetrics` computed the token estimate but never emitted it as a `context_usage` event or persisted it to DB
- The Discord embed footer kept displaying stale pre-resume token values (e.g. 55k) while turn count correctly reset
- Now persists tokens via `updateSessionContextTokens`, updates `lastContextUsagePercent` in session meta, and emits a `context_usage` event so the Discord footer immediately reflects the real post-resume context size

Reported by Kyn in Discord.

## Test plan
- [x] All 34 resume context tests pass
- [x] Type check clean
- [x] Verify Discord footer updates correctly after session resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)