### PR TITLE
spec(process): session keep-alive follow-up specs — sdk-process, process-spawner, session-lifecycle

### DIFF
--- a/server/process/process-spawner.ts
+++ b/server/process/process-spawner.ts
@@ -419,3 +419,49 @@ export function releaseEphemeralDir(deps: Pick<ProcessSpawnerDeps, 'ephemeralDir
     });
   });
 }
+
+/**
+ * Warm-start: feed a new message into an existing waiting process via sendMessage().
+ *
+ * Returns true if the message was delivered. Returns false if the process is dead
+ * or done — the caller must fall back to coldStartProcess().
+ *
+ * This is a stub for the session keep-alive implementation (#2224).
+ */
+export async function warmStartProcess(
+  deps: ProcessSpawnerDeps,
+  session: Session,
+  message: string,
+): Promise<boolean> {
+  const proc = deps.processes.get(session.id);
+  if (!proc) return false;
+  if (!proc.isAlive()) return false;
+
+  try {
+    return proc.sendMessage(message);
+  } catch (err) {
+    log.warn('warmStartProcess: sendMessage threw, falling back to cold start', {
+      sessionId: session.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}
+
+/**
+ * Cold-start: full spawn with directory resolution and context reconstruction.
+ *
+ * Equivalent to startWithResolvedDir — this named export makes the warm/cold
+ * distinction explicit for callers implementing the keep-alive pattern (#2224).
+ */
+export async function coldStartProcess(
+  deps: ProcessSpawnerDeps,
+  session: Session,
+  project: Project,
+  agent: Agent,
+  prompt: string,
+  provider?: LlmProvider,
+  options?: SpawnOptions,
+): Promise<void> {
+  return startWithResolvedDir(deps, session, project, agent, prompt, provider, options);
+}

--- a/specs/process/process-spawner.spec.md
+++ b/specs/process/process-spawner.spec.md
@@ -39,6 +39,92 @@ Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested a
 | `startWithResolvedDir` | `(deps, session, project, agent, prompt, provider?, options?)` | `Promise<void>` | Resolve project directory for non-persistent strategies, then dispatch to SDK or direct spawn |
 | `resumeWithResolvedDir` | `(deps, session, project, agent, resumePrompt, provider?, userPrompt?)` | `Promise<void>` | Resume a session with directory resolution, save user prompt, delegate to `startWithResolvedDir` |
 | `releaseEphemeralDir` | `(deps, sessionId)` | `void` | Cleanup helper: remove and destroy ephemeral dirs on session exit (idempotent) |
+| `warmStartProcess` | `(deps, session, message)` | `Promise<boolean>` | Feed a new message into an existing waiting process via `sendMessage()`. Returns `true` on success, `false` if process dead or done — caller should fall back to cold start |
+| `coldStartProcess` | `(deps, session, project, agent, prompt, provider?, options?)` | `Promise<void>` | Full cold-start spawn: directory resolution, context reconstruction, process creation. Equivalent to `startWithResolvedDir` |
+
+## Warm-start vs Cold-start Spawn Paths
+
+### Path Selection
+
+ProcessManager chooses the spawn path based on current session state:
+
+| Condition | Path |
+|-----------|------|
+| Session in `idle` state (no process) | Cold-start |
+| Process crashed (`isAlive() === false`) | Cold-start |
+| Idle timeout exceeded | Cold-start |
+| Explicit reset requested | Cold-start |
+| Session in `waiting` state, process alive | Warm-start |
+| Session in `responding` state (queue slot available) | Warm-start (queued) |
+
+### Warm-start Spawn Path
+
+`warmStartProcess(deps, session, message)` handles turns 2+ without process restart:
+
+1. **Verify process alive**: Call `isAlive()` on stored process handle
+   - If `false` → return `false` (caller falls back to cold-start)
+
+2. **Send via `sendMessage()`**
+   - Call `process.sendMessage(message.content)`
+   - Returns `false` if process is done/aborted — caller falls back to cold-start
+   - Returns `true` on success; process resumes from waiting state
+
+3. **Update session metadata**
+   - Reset activity timestamp (`lastActivityAt = now`)
+   - Increment turn counter
+   - No PID update (same process)
+
+4. **No directory resolution needed**: Process retains its working directory from cold start
+
+**What is NOT done on warm-start:**
+- No `spawnSdkProcess()` / `spawnDirectProcess()` call
+- No MCP context rebuild
+- No system prompt re-injection
+- No `registerSpawnedProcess()` (process already registered)
+
+### Cold-start Spawn Path
+
+`coldStartProcess(deps, session, project, agent, prompt, provider?, options?)` is the full path:
+
+1. **Resolve project directory** (via `startWithResolvedDir`)
+   - Persistent strategy: reuse existing dir
+   - Ephemeral strategy: create fresh dir (tracked in `ephemeralDirs` map)
+
+2. **Build context**
+   - Resolve session config (persona/skill prompts, tool permissions)
+   - Build MCP context (unless `conversationOnly`)
+
+3. **Spawn process** (SDK or direct based on `provider`)
+   - Calls `spawnSdkProcess` or `spawnDirectProcess`
+
+4. **Register process** (via `registerSpawnedProcess`)
+   - Clears starting guard
+   - Writes PID/status to DB
+   - Starts timers (stable, timeout)
+   - Emits `session_started`
+
+### Spawn Error Handling
+
+**Warm-start failure → automatic cold-start fallback:**
+
+```
+warmStartProcess() fails (returns false or throws)
+  → log: "warm start failed, falling back to cold start"
+  → call coldStartProcess() with same session and message
+  → if cold start also fails → emit session_error, set status = error
+```
+
+**Failure modes and responses:**
+
+| Failure | Warm-start Response | Cold-start Response |
+|---------|--------------------|--------------------|
+| Process not alive | Return `false` → caller cold-starts | Spawn error → emit session_error |
+| `sendMessage` returns false | Return `false` → caller cold-starts | N/A |
+| `sendMessage` throws | Catch, return `false` → caller cold-starts | N/A |
+| Directory resolution fails | N/A (no dir needed) | Starting guard cleared, error emitted |
+| Spawn throws | N/A | Status = error, session_error emitted |
+
+**No retry on warm-start**: If `warmStartProcess` returns `false`, the caller immediately tries cold-start. No backoff between warm and cold — the fallback is instantaneous.
 
 ## Invariants
 
@@ -48,6 +134,8 @@ Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested a
 4. **Spawn errors emit both `error` and `session_error`**: Failed spawns emit a generic `error` event and a structured `session_error` event with `severity: fatal, recoverable: false`
 5. **Ephemeral dir tracked per session**: Ephemeral directories are stored in the `ephemeralDirs` map keyed by session ID and cleaned up via `releaseEphemeralDir`
 6. **Provider routing**: Direct-mode providers use `spawnDirectProcess`; SDK-mode (or Ollama with proxy enabled) uses `spawnSdkProcess`
+7. **Warm-start never calls `registerSpawnedProcess`**: Warm starts reuse the already-registered process. Calling register again would corrupt PID/timer state
+8. **Cold-start fallback is unconditional**: Any `warmStartProcess` failure (return `false` or throw) triggers an immediate cold-start attempt. The caller must not silently drop the message
 
 ## Behavioral Examples
 
@@ -69,6 +157,23 @@ Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested a
 - **When** `spawnSdkProcess` is called
 - **Then** no MCP servers are created and `conversationOnly` is passed through to `startSdkProcess`
 
+### Scenario: Warm start succeeds (turn 2+)
+
+- **Given** a session in `waiting` state with a live process
+- **When** `warmStartProcess(deps, session, message)` is called
+- **Then** `isAlive()` returns `true`
+- **And** `sendMessage(message.content)` is called and returns `true`
+- **And** the function returns `true`
+- **And** no `registerSpawnedProcess()` or `spawnSdkProcess()` is called
+
+### Scenario: Warm start falls back to cold start on dead process
+
+- **Given** a session whose process crashed silently (orphan)
+- **When** `warmStartProcess(deps, session, message)` is called
+- **Then** `isAlive()` returns `false`, function returns `false`
+- **And** the caller invokes `coldStartProcess()` with the same message
+- **And** session is cold-started with full context reconstruction
+
 ## Error Cases
 
 | Condition | Behavior |
@@ -76,6 +181,9 @@ Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested a
 | SDK process spawn throws | Session status set to `error`, `error` + `session_error` events emitted, function returns without registering |
 | Direct process spawn throws | Same as SDK spawn failure |
 | Directory resolution fails | Starting guard cleared, `error` event emitted with `dir_resolution_error` type |
+| `warmStartProcess`: process not alive | Returns `false`; caller falls back to cold-start |
+| `warmStartProcess`: `sendMessage` returns `false` | Returns `false`; caller falls back to cold-start |
+| `warmStartProcess`: `sendMessage` throws | Caught internally, returns `false`; caller falls back to cold-start |
 
 ## Dependencies
 
@@ -105,3 +213,4 @@ Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested a
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-04-16 | Jackdaw | Initial extraction from manager.ts |
+| 2026-05-02 | Jackdaw | Session keep-alive: add warmStartProcess/coldStartProcess stubs, warm vs cold path sections, fallback invariants (#2232) |

--- a/specs/process/sdk-process.spec.md
+++ b/specs/process/sdk-process.spec.md
@@ -46,6 +46,69 @@ This is the execution boundary between the corvid-agent system and the Claude Ag
 | `isApiError` | `(error: string)` | `boolean` | Check if an error string matches known API error patterns |
 | `mapSdkMessageToEvent` | `(message: SDKMessage, sessionId: string)` | `ClaudeStreamEvent \| null` | Convert an SDK message to a stream event for the event bus |
 
+### SdkProcess Handle Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pid` | `number` | Monotonically increasing pseudo-PID (starts at 900,000) |
+| `sendMessage` | `(content: string \| ContentBlockParam[]) => boolean` | Feed a message to the process — works for both cold-start initial prompt and warm-start subsequent turns. Returns `false` if the process is done or aborted |
+| `kill` | `() => void` | Abort the running query via AbortController |
+| `isAlive` | `() => boolean` | Returns `true` if the query generator has not completed or errored |
+
+## Process Lifecycle (Keep-Alive)
+
+### Current Model: Process-Per-Session
+
+With the session keep-alive architecture, SDK processes outlive a single turn. After the `query()` generator completes a response, the process remains alive in the `waiting` state — ready to accept the next input via `streamInput()`.
+
+```
+[Cold Start]                    [Warm Start (2nd+ turn)]
+     ↓                                   ↓
+startSdkProcess()              streamInput(nextMessage)
+     ↓                                   ↓
+query() generator starts        query() generator resumes
+     ↓                                   ↓
+model responds (tokens stream)  model responds (tokens stream)
+     ↓                                   ↓
+generator calls streamInput()   generator calls streamInput()
+     ↓                                   ↓
+process enters waiting state    process enters waiting state
+```
+
+**Key shift from turn-per-process:** Generator completion does NOT kill the process. `startSdkProcess()` is only called once per session (cold start). `streamInput()` handles all subsequent turns.
+
+### Input Streaming
+
+`sendMessage(content)` is the unified API for feeding new messages into a process — used for both the initial cold-start prompt and all subsequent warm-start turns. Internally it calls the SDK's `q.streamInput()` to deliver the message to the generator.
+
+- **Non-blocking**: returns after enqueueing; the process handles it asynchronously
+- **Returns `false`** when the process is done or aborted (inputDone flag is set internally)
+- **One message at a time**: calling `sendMessage()` while model is already generating queues the message (handled by ProcessManager's input queue — sdk-process itself does not queue)
+- **No system prompt re-injection**: the process retains its full in-memory context from previous turns
+
+### Waiting State Handling
+
+When the `query()` generator yields (model finishes a response), the SDK awaits the next `streamInput()` call before resuming. During this window:
+
+- Process is alive (`isAlive() === true`)
+- `inputDone` is `false`
+- No cleanup occurs (no GC, no context reset)
+- Prompt cache remains hot in model's in-memory state
+- Activity timeout is ticking (2h default)
+
+The process remains in-memory with its full conversation context intact. The ProcessManager tracks this as `waiting` state. When the timeout fires, ProcessManager kills the process and transitions the session to `idle`.
+
+### State Transitions (SDK Layer)
+
+| From | To | Trigger |
+|------|----|---------|
+| — | responding | `startSdkProcess()` called (cold start) |
+| responding | waiting | `query()` generator awaits `streamInput()` |
+| waiting | responding | `streamInput(content)` called |
+| any | done | `kill()` called or unrecoverable error |
+
+These map to process-manager states: `running/responding` → `responding`, waiting = `waiting`, done = `idle/error`.
+
 ## Invariants
 
 1. **Protected file enforcement**: `canUseTool` blocks `Write`, `Edit`, `MultiEdit` on protected paths and `Bash` commands with write operators targeting protected paths. This runs BEFORE bypass mode checks — even `full-auto` agents cannot modify protected files
@@ -60,6 +123,10 @@ This is the execution boundary between the corvid-agent system and the Claude Ag
 9. **MCP stream timeout**: `CLAUDE_CODE_STREAM_CLOSE_TIMEOUT` is hardcoded to 7,200,000ms (2 hours) to prevent tools from dying during long autonomous sessions
 10. **Tool permissions vs allowed tools**: `sdkOptions.tools` defines which tools are available. `allowedTools` (auto-approve) is NOT set — all tools go through `canUseTool` for approval
 11. **Symlink resolution for protected paths**: `isProtectedPath()` resolves symlinks via `realpathSync()` before matching, preventing bypass via symlink creation targeting protected files
+12. **Process lifetime equals session lifetime**: The SDK process is not killed when the `query()` generator yields between turns. It remains alive until timeout, explicit `kill()`, or unrecoverable error. Generator completion ≠ process death
+13. **`sendMessage` is the unified input API**: Both cold-start initial prompts and warm-start subsequent turns use `sendMessage()`. The same method feeds the SDK's internal input channel regardless of turn number. Returns `false` when the process is done (inputDone flag is set)
+14. **`sendMessage` is safe to call after exit**: When `inputDone=true` or the AbortController is aborted, `sendMessage()` returns `false` without throwing, allowing the caller to handle gracefully
+15. **Context persists across warm turns**: No system prompt re-injection occurs on warm starts. The process's in-memory conversation state accumulates naturally across turns, keeping prompt cache hot
 
 ## Behavioral Examples
 
@@ -88,6 +155,20 @@ This is the execution boundary between the corvid-agent system and the Claude Ag
 - **When** the agent uses any tool
 - **Then** `canUseTool` creates an `ApprovalRequest`, sends it via `onApprovalRequest`, and waits for user resolution
 
+### Scenario: Warm start — process survives between turns
+
+- **Given** a process that has just completed its first response (generator yielded)
+- **When** the ProcessManager calls `isAlive()`
+- **Then** returns `true` (process is in waiting state)
+- **And** calling `sendMessage(nextMessage)` delivers the next turn and returns `true`
+
+### Scenario: `sendMessage` rejected after process exits
+
+- **Given** a process where `kill()` was called
+- **When** `sendMessage(content)` is called
+- **Then** returns `false` (inputDone is set)
+- **And** no error is thrown
+
 ## Error Cases
 
 | Condition | Behavior |
@@ -97,6 +178,8 @@ This is the execution boundary between the corvid-agent system and the Claude Ag
 | API outage (3+ consecutive API errors) | `onApiOutage()` called, no `onExit` |
 | `sendMessage` after process done | Returns `false` |
 | `sendMessage` after abort | Returns `false` |
+| `sendMessage` when process is done/aborted | Returns `false` immediately, no throw |
+| `sendMessage` during active response | Message is accepted and queued by the SDK's internal queue; ProcessManager should prefer its own input queue to avoid races |
 
 ## Dependencies
 
@@ -140,3 +223,4 @@ Internal constants (not env-configurable):
 | 2026-03-06 | corvid-agent | Added realpathSync() symlink resolution to prevent protected-path bypass attacks. |
 | 2026-03-14 | corvid-agent | Added channel affinity routing: prependRoutingContext + getResponseRoutingPrompt for Claude/SDK path |
 | 2026-03-28 | corvid-agent | Added getProjectContextPrompt to system prompt append — pins active project to survive context compression (#1628) |
+| 2026-05-02 | Jackdaw | Session keep-alive: document process-per-session model, streamInput mechanics, waiting state handling, new invariants 12-15, updated SdkProcess handle fields (#2231) |

--- a/specs/process/session-lifecycle.spec.md
+++ b/specs/process/session-lifecycle.spec.md
@@ -62,8 +62,8 @@ Manages automated session cleanup, TTL-based expiration, per-project session lim
 
 ## Invariants
 
-1. Sessions in `'running'` status are never cleaned up by automated expiration or limit enforcement. Sessions in `'paused'` status are protected from TTL expiration but are subject to per-project limit enforcement if older than 24 hours.
-2. Session TTL expiration only applies to sessions in terminal states (`'idle'`, `'completed'`, `'error'`, `'stopped'`).
+1. Sessions in `'running'` or `'waiting'` status are never cleaned up by automated expiration or limit enforcement. Both states represent live processes that must not be killed by the lifecycle manager — only the ProcessManager's inactivity timeout (2h) may terminate a `waiting` session. Sessions in `'paused'` status are protected from TTL expiration but are subject to per-project limit enforcement if older than 24 hours.
+2. Session TTL expiration only applies to sessions in terminal states (`'idle'`, `'completed'`, `'error'`, `'stopped'`). The `waiting` state is non-terminal — the process is alive and may resume at any moment — so it is excluded from TTL expiration.
 3. Per-project session limit enforcement deletes the oldest non-`'running'` sessions first (including `'paused'`), but only those older than 24 hours. Sessions younger than 24 hours are protected from limit-based cleanup to prevent a burst of new sessions from evicting recently-created sessions that users still expect to be resumable.
 4. All session deletions cascade within a transaction: `algochat_conversations` FK nullified, `session_messages` deleted, `escalation_queue` entries deleted, then the session row itself.
 5. The cleanup timer is idempotent: calling `start()` when already running logs a warning and does not create a duplicate timer.
@@ -86,6 +86,20 @@ Manages automated session cleanup, TTL-based expiration, per-project session lim
 - **Given** `maxSessionsPerProject` is 100 and project `"proj-1"` has 110 non-running sessions, but 15 of the oldest are younger than 24 hours
 - **When** `runCleanup` executes
 - **Then** only sessions older than 24 hours are deleted; younger sessions are preserved even though the project remains over the limit
+
+### Scenario: Waiting session protected from TTL expiration
+
+- **Given** the SessionLifecycleManager is started with a 7-day TTL
+- **When** the periodic cleanup runs and finds a session in `'waiting'` status last updated 10 days ago
+- **Then** that session is NOT expired — it has a live process and is protected by invariant #1
+- **And** only the ProcessManager's 2-hour inactivity timeout (not the lifecycle TTL) can terminate it
+
+### Scenario: Waiting session excluded from per-project limit enforcement
+
+- **Given** `maxSessionsPerProject` is 100 and project `"proj-1"` has 105 sessions: 100 idle + 5 waiting
+- **When** `runCleanup` executes
+- **Then** the 5 `waiting` sessions are excluded from limit enforcement
+- **And** only idle sessions older than 24 hours are candidates for deletion
 
 ### Scenario: Session creation gating
 - **Given** project `"proj-1"` has 100 sessions
@@ -129,3 +143,4 @@ Manages automated session cleanup, TTL-based expiration, per-project session lim
 |------|--------|--------|
 | 2026-03-04 | corvid-agent | Initial spec |
 | 2026-03-18 | corvid-agent | v3: Removed protected-paths exports (now in dedicated `protected-paths.spec.md`). Added 24-hour minimum age guard to `enforceSessionLimits`. Fixes #1221 |
+| 2026-05-02 | Jackdaw | Session keep-alive: `waiting` status protected from TTL expiration and limit enforcement (same as `running`). Invariants 1-2 updated, behavioral examples added (#2233) |


### PR DESCRIPTION
## Summary

Follow-up spec updates for the session keep-alive epic (#2222), building on the process-manager.spec.md architecture defined in PR #2230.

Closes #2231, #2232, #2233

### sdk-process.spec.md (#2231)
- Documents the **process-per-session model**: generator yield ≠ process death — process stays alive in `waiting` state between turns
- `sendMessage()` described as unified API for both cold-start initial prompts and warm-start subsequent turns
- New **Process Lifecycle**, **Input Streaming**, and **Waiting State Handling** sections
- New invariants 12–15: process lifetime = session lifetime, sendMessage safety, context persistence
- New behavioral examples for warm start and sendMessage-after-exit

### process-spawner.spec.md (#2232)
- Adds `warmStartProcess` and `coldStartProcess` exported stubs (also added to source in `process-spawner.ts`)
- New **Warm-start vs Cold-start Spawn Paths** section with path selection table
- Step-by-step procedures for each path; fallback strategy: warm failure → immediate cold
- New invariants 7–8 for warm-start correctness

### session-lifecycle.spec.md (#2233)
- Invariants 1–2: `waiting` state explicitly protected from TTL expiration and limit enforcement (same as `running`)
- New behavioral examples showing waiting sessions survive the 7-day TTL cleanup

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun run spec:check` — 216 passed, 0 failed
- [x] `warmStartProcess` and `coldStartProcess` stubs compile without errors
- [x] Implementation of #2224 (persistent process) should reference these specs

🤖 Agent: Jackdaw | Model: claude-sonnet-4-6