### PR TITLE
feat(process): session keep-alive with input queue

### DIFF
--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -63,6 +63,10 @@ const DISCORD_RESTRICTED_MESSAGE_PREFIX = 'Discord message:';
 // refuse to resume — the session is in a death loop.
 const ZERO_TURN_CIRCUIT_BREAKER_THRESHOLD = 3;
 
+// Maximum number of messages to queue while model is responding.
+// When full, sendMessage() returns false (backpressure signal).
+const PROCESS_INPUT_QUEUE_MAX_DEPTH = parseInt(process.env.PROCESS_INPUT_QUEUE_MAX_DEPTH ?? '10', 10);
+
 /** Auto-compact the session when context usage reaches this percentage. */
 const AUTO_COMPACT_THRESHOLD = 90;
 
@@ -176,6 +180,16 @@ export class ProcessManager {
   private ephemeralDirs: Map<string, ResolvedDir> = new Map();
   /** Guard against concurrent resume/start for the same session. */
   private startingSession: Set<string> = new Set();
+  /** Sessions where the model is currently generating a response. */
+  private respondingSessions: Set<string> = new Set();
+  /** Input queue for messages arriving while model is responding. */
+  private inputQueues: Map<
+    string,
+    Array<{
+      content: string | import('@anthropic-ai/sdk/resources/messages/messages').ContentBlockParam[];
+      timestamp: number;
+    }>
+  > = new Map();
   private db: Database;
   readonly approvalManager: ApprovalManager;
   readonly ownerQuestionManager: OwnerQuestionManager;
@@ -303,7 +317,7 @@ export class ProcessManager {
   private cleanupStaleSessions(): void {
     const result = this.db
       .query(
-        `UPDATE sessions SET status = 'idle', pid = NULL, restart_pending = 1 WHERE status IN ('running', 'loading')`,
+        `UPDATE sessions SET status = 'idle', pid = NULL, restart_pending = 1 WHERE status IN ('running', 'loading', 'waiting')`,
       )
       .run();
     if (result.changes > 0) {
@@ -857,6 +871,8 @@ export class ProcessManager {
     updateSessionPid(this.db, session.id, process.pid);
     updateSessionStatus(this.db, session.id, 'running');
     updateSessionTurns(this.db, session.id, resumedTurnCount);
+    // Mark as responding immediately — process is handling the initial prompt
+    this.respondingSessions.add(session.id);
 
     const verify = this.db.query('SELECT status, pid FROM sessions WHERE id = ?').get(session.id) as {
       status: string;
@@ -1296,6 +1312,8 @@ export class ProcessManager {
     this.finalizeTokenTracking(sessionId);
     cp.kill();
     this.processes.delete(sessionId);
+    this.respondingSessions.delete(sessionId);
+    this.inputQueues.delete(sessionId);
     updateSessionPid(this.db, sessionId, null);
 
     return true;
@@ -1427,7 +1445,9 @@ export class ProcessManager {
     const logLevel = (process.env.LOG_LEVEL ?? 'info').toLowerCase();
     if (process.env.LOG_TOKEN_BREAKDOWN === 'true' || logLevel === 'debug') {
       const summaryTokens = meta?.contextSummary ? estimateTokens(meta.contextSummary) : 0;
-      const obsText = observations.map((o) => `- [${o.source}] (score: ${o.relevanceScore.toFixed(1)}) ${o.content}`).join('\n');
+      const obsText = observations
+        .map((o) => `- [${o.source}] (score: ${o.relevanceScore.toFixed(1)}) ${o.content}`)
+        .join('\n');
       const obsTokens = estimateTokens(obsText);
       const historyText = historyLines.join('\n');
       const historyTokens = estimateTokens(historyText);
@@ -1515,6 +1535,8 @@ export class ProcessManager {
   cleanupSessionState(sessionId: string): void {
     this.startingSession.delete(sessionId);
     this.processes.delete(sessionId);
+    this.respondingSessions.delete(sessionId);
+    this.inputQueues.delete(sessionId);
     this.eventBus.removeSessionSubscribers(sessionId);
     this.finalizeTokenTracking(sessionId);
     this.resilienceManager.deletePausedSession(sessionId);
@@ -1559,12 +1581,12 @@ export class ProcessManager {
     const cp = this.processes.get(sessionId);
     if (!cp) return false;
 
-    const sent = cp.sendMessage(content);
-    if (!sent) {
-      log.warn(`Failed to write to stdin for session ${sessionId}`);
-      // The process can no longer accept input — remove from Map so that
-      // the caller's subsequent resumeProcess() detects the stale state and restarts.
+    // Evict zombie processes immediately
+    if (!cp.isAlive()) {
+      log.warn(`Evicting dead process for session ${sessionId}`);
       this.processes.delete(sessionId);
+      this.respondingSessions.delete(sessionId);
+      this.inputQueues.delete(sessionId);
       return false;
     }
 
@@ -1576,6 +1598,41 @@ export class ProcessManager {
             .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
             .map((b) => b.text)
             .join('\n');
+
+    // If model is currently responding, queue the message for the next turn
+    if (this.respondingSessions.has(sessionId)) {
+      const queue = this.inputQueues.get(sessionId) ?? [];
+      if (queue.length >= PROCESS_INPUT_QUEUE_MAX_DEPTH) {
+        log.warn(`Input queue full for session ${sessionId} (depth=${queue.length}), rejecting message`);
+        return false;
+      }
+      queue.push({ content, timestamp: Date.now() });
+      this.inputQueues.set(sessionId, queue);
+      addSessionMessage(this.db, sessionId, 'user', textContent || '[image attachment(s)]');
+      if (textContent) this.recordMessageObservation(sessionId, 'user', textContent);
+      const meta = this.sessionMeta.get(sessionId);
+      if (meta) {
+        meta.turnCount++;
+        updateSessionTurns(this.db, sessionId, meta.turnCount);
+      }
+      incrementSessionCumulativeTurns(this.db, sessionId);
+      log.debug(`Queued message for session ${sessionId} (queue depth: ${queue.length})`);
+      return true;
+    }
+
+    // Process is waiting — send directly (warm turn)
+    const sent = cp.sendMessage(content);
+    if (!sent) {
+      log.warn(`Failed to write to stdin for session ${sessionId}`);
+      // The process can no longer accept input — remove from Map so that
+      // the caller's subsequent resumeProcess() detects the stale state and restarts.
+      this.processes.delete(sessionId);
+      return false;
+    }
+
+    // Mark as responding so concurrent messages get queued
+    this.respondingSessions.add(sessionId);
+
     addSessionMessage(this.db, sessionId, 'user', textContent || '[image attachment(s)]');
     if (textContent) this.recordMessageObservation(sessionId, 'user', textContent);
 
@@ -1587,6 +1644,37 @@ export class ProcessManager {
     incrementSessionCumulativeTurns(this.db, sessionId);
 
     return true;
+  }
+
+  /** Flush the input queue for a session after the model finishes a turn. */
+  private flushInputQueue(sessionId: string): void {
+    const queue = this.inputQueues.get(sessionId);
+    if (!queue || queue.length === 0) {
+      this.inputQueues.delete(sessionId);
+      return;
+    }
+
+    const cp = this.processes.get(sessionId);
+    if (!cp?.isAlive()) {
+      this.inputQueues.delete(sessionId);
+      return;
+    }
+
+    const item = queue.shift();
+    if (!item) return;
+    if (queue.length === 0) this.inputQueues.delete(sessionId);
+
+    const sent = cp.sendMessage(item.content);
+    if (!sent) {
+      log.warn(`Failed to send queued message to session ${sessionId} — evicting process`);
+      this.processes.delete(sessionId);
+      this.inputQueues.delete(sessionId);
+      return;
+    }
+
+    // Mark as responding again for the next turn
+    this.respondingSessions.add(sessionId);
+    log.debug(`Flushed queued message for session ${sessionId} (${queue.length} remaining)`);
   }
 
   isRunning(sessionId: string): boolean {
@@ -1872,6 +1960,16 @@ export class ProcessManager {
       }
     }
 
+    // Model completed a turn: clear responding state, transition to 'waiting' if alive
+    if (event.type === 'result') {
+      this.respondingSessions.delete(sessionId);
+      if (this.processes.has(sessionId)) {
+        updateSessionStatus(this.db, sessionId, 'waiting');
+        // Drain input queue — send next queued message if any
+        this.flushInputQueue(sessionId);
+      }
+    }
+
     this.eventBus.emit(sessionId, event);
   }
 
@@ -1898,6 +1996,8 @@ export class ProcessManager {
       }
       case 'assistant':
       case 'message_start':
+        // Track that the model is actively generating a response
+        this.respondingSessions.add(sessionId);
         status = 'running';
         break;
       case 'result':
@@ -2327,10 +2427,10 @@ export class ProcessManager {
       }
     }
 
-    // Fix DB-level stuck sessions: marked "running" but no live process.
+    // Fix DB-level stuck sessions: marked "running" or "waiting" but no live process.
     // This catches cases where handleExit was never called (crash, OOM, signal).
     const stuckSessions = this.db
-      .query(`SELECT id, pid FROM sessions WHERE status IN ('running', 'loading')`)
+      .query(`SELECT id, pid FROM sessions WHERE status IN ('running', 'loading', 'waiting')`)
       .all() as { id: string; pid: number | null }[];
 
     for (const row of stuckSessions) {
@@ -2345,12 +2445,14 @@ export class ProcessManager {
           cp.kill(); // Ensure the process is fully stopped
           this.processes.delete(row.id);
         }
+        this.respondingSessions.delete(row.id);
+        this.inputQueues.delete(row.id);
         updateSessionStatus(this.db, row.id, 'idle');
         updateSessionPid(this.db, row.id, null);
         this.timerManager.cleanupSession(row.id);
         this.approvalManager.cancelSession(row.id);
         log.warn(
-          `Pruned stuck session ${row.id} (pid=${row.pid}) — ${deadInMap ? 'process dead but still in Map' : 'DB said running but no process exists'}`,
+          `Pruned stuck session ${row.id} (pid=${row.pid}) — ${deadInMap ? 'process dead but still in Map' : 'DB said running/waiting but no process exists'}`,
         );
         pruned++;
       }

--- a/server/process/process-spawner.ts
+++ b/server/process/process-spawner.ts
@@ -428,11 +428,7 @@ export function releaseEphemeralDir(deps: Pick<ProcessSpawnerDeps, 'ephemeralDir
  *
  * This is a stub for the session keep-alive implementation (#2224).
  */
-export async function warmStartProcess(
-  deps: ProcessSpawnerDeps,
-  session: Session,
-  message: string,
-): Promise<boolean> {
+export async function warmStartProcess(deps: ProcessSpawnerDeps, session: Session, message: string): Promise<boolean> {
   const proc = deps.processes.get(session.id);
   if (!proc) return false;
   if (!proc.isAlive()) return false;

--- a/server/process/process-spawner.ts
+++ b/server/process/process-spawner.ts
@@ -419,3 +419,49 @@ export function releaseEphemeralDir(deps: Pick<ProcessSpawnerDeps, 'ephemeralDir
     });
   });
 }
+
+/**
+ * Warm-start: feed a new message into an existing waiting process via sendMessage().
+ *
+ * Returns true if the message was delivered. Returns false if the process is dead
+ * or done — the caller must fall back to coldStartProcess().
+ *
+ * This is a stub for the session keep-alive implementation (#2224).
+ */
+export async function warmStartProcess(
+  deps: ProcessSpawnerDeps,
+  session: Session,
+  message: string,
+): Promise<boolean> {
+  const proc = deps.processes.get(session.id);
+  if (!proc) return false;
+  if (!proc.isAlive()) return false;
+
+  try {
+    return proc.sendMessage(message);
+  } catch (err) {
+    log.warn('warmStartProcess: sendMessage threw, falling back to cold start', {
+      sessionId: session.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}
+
+/**
+ * Cold-start: full spawn with directory resolution and context reconstruction.
+ *
+ * Equivalent to startWithResolvedDir — this named export makes the warm/cold
+ * distinction explicit for callers implementing the keep-alive pattern (#2224).
+ */
+export async function coldStartProcess(
+  deps: ProcessSpawnerDeps,
+  session: Session,
+  project: Project,
+  agent: Agent,
+  prompt: string,
+  provider?: LlmProvider,
+  options?: SpawnOptions,
+): Promise<void> {
+  return startWithResolvedDir(deps, session, project, agent, prompt, provider, options);
+}

--- a/server/process/session-lifecycle.ts
+++ b/server/process/session-lifecycle.ts
@@ -100,7 +100,7 @@ export class SessionLifecycleManager {
       .query(`
             SELECT id, pid, name, agent_id, source
             FROM sessions
-            WHERE status = 'running'
+            WHERE status IN ('running', 'waiting')
         `)
       .all() as Array<{ id: string; pid: number | null; name: string; agent_id: string; source: string }>;
 
@@ -321,7 +321,7 @@ export class SessionLifecycleManager {
       .query(`
             SELECT project_id, COUNT(*) as session_count
             FROM sessions
-            WHERE status != 'running'
+            WHERE status NOT IN ('running', 'waiting')
             GROUP BY project_id
             HAVING session_count > ?
         `)
@@ -339,7 +339,7 @@ export class SessionLifecycleManager {
       const oldestSessions = this.db
         .query(`
                 SELECT id FROM sessions
-                WHERE project_id = ? AND status != 'running'
+                WHERE project_id = ? AND status NOT IN ('running', 'waiting')
                 AND updated_at < datetime('now', '-' || ? || ' seconds')
                 ORDER BY updated_at ASC
                 LIMIT ?
@@ -401,7 +401,7 @@ export class SessionLifecycleManager {
   private updateActiveSessionCount(): void {
     this.activeSessionCount = queryCount(
       this.db,
-      "SELECT COUNT(*) as cnt FROM sessions WHERE status IN ('running', 'paused')",
+      "SELECT COUNT(*) as cnt FROM sessions WHERE status IN ('running', 'waiting', 'paused')",
     );
   }
 

--- a/shared/types/sessions.ts
+++ b/shared/types/sessions.ts
@@ -1,4 +1,13 @@
-export type SessionStatus = 'idle' | 'loading' | 'running' | 'thinking' | 'tool_use' | 'paused' | 'stopped' | 'error';
+export type SessionStatus =
+  | 'idle'
+  | 'loading'
+  | 'running'
+  | 'thinking'
+  | 'tool_use'
+  | 'waiting'
+  | 'paused'
+  | 'stopped'
+  | 'error';
 export type SessionSource = 'web' | 'algochat' | 'agent' | 'telegram' | 'discord' | 'slack';
 
 export interface Session {

--- a/specs/process/process-spawner.spec.md
+++ b/specs/process/process-spawner.spec.md
@@ -39,6 +39,92 @@ Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested a
 | `startWithResolvedDir` | `(deps, session, project, agent, prompt, provider?, options?)` | `Promise<void>` | Resolve project directory for non-persistent strategies, then dispatch to SDK or direct spawn |
 | `resumeWithResolvedDir` | `(deps, session, project, agent, resumePrompt, provider?, userPrompt?)` | `Promise<void>` | Resume a session with directory resolution, save user prompt, delegate to `startWithResolvedDir` |
 | `releaseEphemeralDir` | `(deps, sessionId)` | `void` | Cleanup helper: remove and destroy ephemeral dirs on session exit (idempotent) |
+| `warmStartProcess` | `(deps, session, message)` | `Promise<boolean>` | Feed a new message into an existing waiting process via `sendMessage()`. Returns `true` on success, `false` if process dead or done — caller should fall back to cold start |
+| `coldStartProcess` | `(deps, session, project, agent, prompt, provider?, options?)` | `Promise<void>` | Full cold-start spawn: directory resolution, context reconstruction, process creation. Equivalent to `startWithResolvedDir` |
+
+## Warm-start vs Cold-start Spawn Paths
+
+### Path Selection
+
+ProcessManager chooses the spawn path based on current session state:
+
+| Condition | Path |
+|-----------|------|
+| Session in `idle` state (no process) | Cold-start |
+| Process crashed (`isAlive() === false`) | Cold-start |
+| Idle timeout exceeded | Cold-start |
+| Explicit reset requested | Cold-start |
+| Session in `waiting` state, process alive | Warm-start |
+| Session in `responding` state (queue slot available) | Warm-start (queued) |
+
+### Warm-start Spawn Path
+
+`warmStartProcess(deps, session, message)` handles turns 2+ without process restart:
+
+1. **Verify process alive**: Call `isAlive()` on stored process handle
+   - If `false` → return `false` (caller falls back to cold-start)
+
+2. **Send via `sendMessage()`**
+   - Call `process.sendMessage(message.content)`
+   - Returns `false` if process is done/aborted — caller falls back to cold-start
+   - Returns `true` on success; process resumes from waiting state
+
+3. **Update session metadata**
+   - Reset activity timestamp (`lastActivityAt = now`)
+   - Increment turn counter
+   - No PID update (same process)
+
+4. **No directory resolution needed**: Process retains its working directory from cold start
+
+**What is NOT done on warm-start:**
+- No `spawnSdkProcess()` / `spawnDirectProcess()` call
+- No MCP context rebuild
+- No system prompt re-injection
+- No `registerSpawnedProcess()` (process already registered)
+
+### Cold-start Spawn Path
+
+`coldStartProcess(deps, session, project, agent, prompt, provider?, options?)` is the full path:
+
+1. **Resolve project directory** (via `startWithResolvedDir`)
+   - Persistent strategy: reuse existing dir
+   - Ephemeral strategy: create fresh dir (tracked in `ephemeralDirs` map)
+
+2. **Build context**
+   - Resolve session config (persona/skill prompts, tool permissions)
+   - Build MCP context (unless `conversationOnly`)
+
+3. **Spawn process** (SDK or direct based on `provider`)
+   - Calls `spawnSdkProcess` or `spawnDirectProcess`
+
+4. **Register process** (via `registerSpawnedProcess`)
+   - Clears starting guard
+   - Writes PID/status to DB
+   - Starts timers (stable, timeout)
+   - Emits `session_started`
+
+### Spawn Error Handling
+
+**Warm-start failure → automatic cold-start fallback:**
+
+```
+warmStartProcess() fails (returns false or throws)
+  → log: "warm start failed, falling back to cold start"
+  → call coldStartProcess() with same session and message
+  → if cold start also fails → emit session_error, set status = error
+```
+
+**Failure modes and responses:**
+
+| Failure | Warm-start Response | Cold-start Response |
+|---------|--------------------|--------------------|
+| Process not alive | Return `false` → caller cold-starts | Spawn error → emit session_error |
+| `sendMessage` returns false | Return `false` → caller cold-starts | N/A |
+| `sendMessage` throws | Catch, return `false` → caller cold-starts | N/A |
+| Directory resolution fails | N/A (no dir needed) | Starting guard cleared, error emitted |
+| Spawn throws | N/A | Status = error, session_error emitted |
+
+**No retry on warm-start**: If `warmStartProcess` returns `false`, the caller immediately tries cold-start. No backoff between warm and cold — the fallback is instantaneous.
 
 ## Invariants
 
@@ -48,6 +134,8 @@ Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested a
 4. **Spawn errors emit both `error` and `session_error`**: Failed spawns emit a generic `error` event and a structured `session_error` event with `severity: fatal, recoverable: false`
 5. **Ephemeral dir tracked per session**: Ephemeral directories are stored in the `ephemeralDirs` map keyed by session ID and cleaned up via `releaseEphemeralDir`
 6. **Provider routing**: Direct-mode providers use `spawnDirectProcess`; SDK-mode (or Ollama with proxy enabled) uses `spawnSdkProcess`
+7. **Warm-start never calls `registerSpawnedProcess`**: Warm starts reuse the already-registered process. Calling register again would corrupt PID/timer state
+8. **Cold-start fallback is unconditional**: Any `warmStartProcess` failure (return `false` or throw) triggers an immediate cold-start attempt. The caller must not silently drop the message
 
 ## Behavioral Examples
 
@@ -69,6 +157,23 @@ Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested a
 - **When** `spawnSdkProcess` is called
 - **Then** no MCP servers are created and `conversationOnly` is passed through to `startSdkProcess`
 
+### Scenario: Warm start succeeds (turn 2+)
+
+- **Given** a session in `waiting` state with a live process
+- **When** `warmStartProcess(deps, session, message)` is called
+- **Then** `isAlive()` returns `true`
+- **And** `sendMessage(message.content)` is called and returns `true`
+- **And** the function returns `true`
+- **And** no `registerSpawnedProcess()` or `spawnSdkProcess()` is called
+
+### Scenario: Warm start falls back to cold start on dead process
+
+- **Given** a session whose process crashed silently (orphan)
+- **When** `warmStartProcess(deps, session, message)` is called
+- **Then** `isAlive()` returns `false`, function returns `false`
+- **And** the caller invokes `coldStartProcess()` with the same message
+- **And** session is cold-started with full context reconstruction
+
 ## Error Cases
 
 | Condition | Behavior |
@@ -76,6 +181,9 @@ Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested a
 | SDK process spawn throws | Session status set to `error`, `error` + `session_error` events emitted, function returns without registering |
 | Direct process spawn throws | Same as SDK spawn failure |
 | Directory resolution fails | Starting guard cleared, `error` event emitted with `dir_resolution_error` type |
+| `warmStartProcess`: process not alive | Returns `false`; caller falls back to cold-start |
+| `warmStartProcess`: `sendMessage` returns `false` | Returns `false`; caller falls back to cold-start |
+| `warmStartProcess`: `sendMessage` throws | Caught internally, returns `false`; caller falls back to cold-start |
 
 ## Dependencies
 
@@ -105,3 +213,4 @@ Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested a
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-04-16 | Jackdaw | Initial extraction from manager.ts |
+| 2026-05-02 | Jackdaw | Session keep-alive: add warmStartProcess/coldStartProcess stubs, warm vs cold path sections, fallback invariants (#2232) |

--- a/specs/process/sdk-process.spec.md
+++ b/specs/process/sdk-process.spec.md
@@ -46,6 +46,69 @@ This is the execution boundary between the corvid-agent system and the Claude Ag
 | `isApiError` | `(error: string)` | `boolean` | Check if an error string matches known API error patterns |
 | `mapSdkMessageToEvent` | `(message: SDKMessage, sessionId: string)` | `ClaudeStreamEvent \| null` | Convert an SDK message to a stream event for the event bus |
 
+### SdkProcess Handle Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pid` | `number` | Monotonically increasing pseudo-PID (starts at 900,000) |
+| `sendMessage` | `(content: string \| ContentBlockParam[]) => boolean` | Feed a message to the process — works for both cold-start initial prompt and warm-start subsequent turns. Returns `false` if the process is done or aborted |
+| `kill` | `() => void` | Abort the running query via AbortController |
+| `isAlive` | `() => boolean` | Returns `true` if the query generator has not completed or errored |
+
+## Process Lifecycle (Keep-Alive)
+
+### Current Model: Process-Per-Session
+
+With the session keep-alive architecture, SDK processes outlive a single turn. After the `query()` generator completes a response, the process remains alive in the `waiting` state — ready to accept the next input via `streamInput()`.
+
+```
+[Cold Start]                    [Warm Start (2nd+ turn)]
+     ↓                                   ↓
+startSdkProcess()              streamInput(nextMessage)
+     ↓                                   ↓
+query() generator starts        query() generator resumes
+     ↓                                   ↓
+model responds (tokens stream)  model responds (tokens stream)
+     ↓                                   ↓
+generator calls streamInput()   generator calls streamInput()
+     ↓                                   ↓
+process enters waiting state    process enters waiting state
+```
+
+**Key shift from turn-per-process:** Generator completion does NOT kill the process. `startSdkProcess()` is only called once per session (cold start). `streamInput()` handles all subsequent turns.
+
+### Input Streaming
+
+`sendMessage(content)` is the unified API for feeding new messages into a process — used for both the initial cold-start prompt and all subsequent warm-start turns. Internally it calls the SDK's `q.streamInput()` to deliver the message to the generator.
+
+- **Non-blocking**: returns after enqueueing; the process handles it asynchronously
+- **Returns `false`** when the process is done or aborted (inputDone flag is set internally)
+- **One message at a time**: calling `sendMessage()` while model is already generating queues the message (handled by ProcessManager's input queue — sdk-process itself does not queue)
+- **No system prompt re-injection**: the process retains its full in-memory context from previous turns
+
+### Waiting State Handling
+
+When the `query()` generator yields (model finishes a response), the SDK awaits the next `streamInput()` call before resuming. During this window:
+
+- Process is alive (`isAlive() === true`)
+- `inputDone` is `false`
+- No cleanup occurs (no GC, no context reset)
+- Prompt cache remains hot in model's in-memory state
+- Activity timeout is ticking (2h default)
+
+The process remains in-memory with its full conversation context intact. The ProcessManager tracks this as `waiting` state. When the timeout fires, ProcessManager kills the process and transitions the session to `idle`.
+
+### State Transitions (SDK Layer)
+
+| From | To | Trigger |
+|------|----|---------|
+| — | responding | `startSdkProcess()` called (cold start) |
+| responding | waiting | `query()` generator awaits `streamInput()` |
+| waiting | responding | `streamInput(content)` called |
+| any | done | `kill()` called or unrecoverable error |
+
+These map to process-manager states: `running/responding` → `responding`, waiting = `waiting`, done = `idle/error`.
+
 ## Invariants
 
 1. **Protected file enforcement**: `canUseTool` blocks `Write`, `Edit`, `MultiEdit` on protected paths and `Bash` commands with write operators targeting protected paths. This runs BEFORE bypass mode checks — even `full-auto` agents cannot modify protected files
@@ -60,6 +123,10 @@ This is the execution boundary between the corvid-agent system and the Claude Ag
 9. **MCP stream timeout**: `CLAUDE_CODE_STREAM_CLOSE_TIMEOUT` is hardcoded to 7,200,000ms (2 hours) to prevent tools from dying during long autonomous sessions
 10. **Tool permissions vs allowed tools**: `sdkOptions.tools` defines which tools are available. `allowedTools` (auto-approve) is NOT set — all tools go through `canUseTool` for approval
 11. **Symlink resolution for protected paths**: `isProtectedPath()` resolves symlinks via `realpathSync()` before matching, preventing bypass via symlink creation targeting protected files
+12. **Process lifetime equals session lifetime**: The SDK process is not killed when the `query()` generator yields between turns. It remains alive until timeout, explicit `kill()`, or unrecoverable error. Generator completion ≠ process death
+13. **`sendMessage` is the unified input API**: Both cold-start initial prompts and warm-start subsequent turns use `sendMessage()`. The same method feeds the SDK's internal input channel regardless of turn number. Returns `false` when the process is done (inputDone flag is set)
+14. **`sendMessage` is safe to call after exit**: When `inputDone=true` or the AbortController is aborted, `sendMessage()` returns `false` without throwing, allowing the caller to handle gracefully
+15. **Context persists across warm turns**: No system prompt re-injection occurs on warm starts. The process's in-memory conversation state accumulates naturally across turns, keeping prompt cache hot
 
 ## Behavioral Examples
 
@@ -88,6 +155,20 @@ This is the execution boundary between the corvid-agent system and the Claude Ag
 - **When** the agent uses any tool
 - **Then** `canUseTool` creates an `ApprovalRequest`, sends it via `onApprovalRequest`, and waits for user resolution
 
+### Scenario: Warm start — process survives between turns
+
+- **Given** a process that has just completed its first response (generator yielded)
+- **When** the ProcessManager calls `isAlive()`
+- **Then** returns `true` (process is in waiting state)
+- **And** calling `sendMessage(nextMessage)` delivers the next turn and returns `true`
+
+### Scenario: `sendMessage` rejected after process exits
+
+- **Given** a process where `kill()` was called
+- **When** `sendMessage(content)` is called
+- **Then** returns `false` (inputDone is set)
+- **And** no error is thrown
+
 ## Error Cases
 
 | Condition | Behavior |
@@ -97,6 +178,8 @@ This is the execution boundary between the corvid-agent system and the Claude Ag
 | API outage (3+ consecutive API errors) | `onApiOutage()` called, no `onExit` |
 | `sendMessage` after process done | Returns `false` |
 | `sendMessage` after abort | Returns `false` |
+| `sendMessage` when process is done/aborted | Returns `false` immediately, no throw |
+| `sendMessage` during active response | Message is accepted and queued by the SDK's internal queue; ProcessManager should prefer its own input queue to avoid races |
 
 ## Dependencies
 
@@ -140,3 +223,4 @@ Internal constants (not env-configurable):
 | 2026-03-06 | corvid-agent | Added realpathSync() symlink resolution to prevent protected-path bypass attacks. |
 | 2026-03-14 | corvid-agent | Added channel affinity routing: prependRoutingContext + getResponseRoutingPrompt for Claude/SDK path |
 | 2026-03-28 | corvid-agent | Added getProjectContextPrompt to system prompt append — pins active project to survive context compression (#1628) |
+| 2026-05-02 | Jackdaw | Session keep-alive: document process-per-session model, streamInput mechanics, waiting state handling, new invariants 12-15, updated SdkProcess handle fields (#2231) |

--- a/specs/process/session-lifecycle.spec.md
+++ b/specs/process/session-lifecycle.spec.md
@@ -62,8 +62,8 @@ Manages automated session cleanup, TTL-based expiration, per-project session lim
 
 ## Invariants
 
-1. Sessions in `'running'` status are never cleaned up by automated expiration or limit enforcement. Sessions in `'paused'` status are protected from TTL expiration but are subject to per-project limit enforcement if older than 24 hours.
-2. Session TTL expiration only applies to sessions in terminal states (`'idle'`, `'completed'`, `'error'`, `'stopped'`).
+1. Sessions in `'running'` or `'waiting'` status are never cleaned up by automated expiration or limit enforcement. Both states represent live processes that must not be killed by the lifecycle manager — only the ProcessManager's inactivity timeout (2h) may terminate a `waiting` session. Sessions in `'paused'` status are protected from TTL expiration but are subject to per-project limit enforcement if older than 24 hours.
+2. Session TTL expiration only applies to sessions in terminal states (`'idle'`, `'completed'`, `'error'`, `'stopped'`). The `waiting` state is non-terminal — the process is alive and may resume at any moment — so it is excluded from TTL expiration.
 3. Per-project session limit enforcement deletes the oldest non-`'running'` sessions first (including `'paused'`), but only those older than 24 hours. Sessions younger than 24 hours are protected from limit-based cleanup to prevent a burst of new sessions from evicting recently-created sessions that users still expect to be resumable.
 4. All session deletions cascade within a transaction: `algochat_conversations` FK nullified, `session_messages` deleted, `escalation_queue` entries deleted, then the session row itself.
 5. The cleanup timer is idempotent: calling `start()` when already running logs a warning and does not create a duplicate timer.
@@ -86,6 +86,20 @@ Manages automated session cleanup, TTL-based expiration, per-project session lim
 - **Given** `maxSessionsPerProject` is 100 and project `"proj-1"` has 110 non-running sessions, but 15 of the oldest are younger than 24 hours
 - **When** `runCleanup` executes
 - **Then** only sessions older than 24 hours are deleted; younger sessions are preserved even though the project remains over the limit
+
+### Scenario: Waiting session protected from TTL expiration
+
+- **Given** the SessionLifecycleManager is started with a 7-day TTL
+- **When** the periodic cleanup runs and finds a session in `'waiting'` status last updated 10 days ago
+- **Then** that session is NOT expired — it has a live process and is protected by invariant #1
+- **And** only the ProcessManager's 2-hour inactivity timeout (not the lifecycle TTL) can terminate it
+
+### Scenario: Waiting session excluded from per-project limit enforcement
+
+- **Given** `maxSessionsPerProject` is 100 and project `"proj-1"` has 105 sessions: 100 idle + 5 waiting
+- **When** `runCleanup` executes
+- **Then** the 5 `waiting` sessions are excluded from limit enforcement
+- **And** only idle sessions older than 24 hours are candidates for deletion
 
 ### Scenario: Session creation gating
 - **Given** project `"proj-1"` has 100 sessions
@@ -129,3 +143,4 @@ Manages automated session cleanup, TTL-based expiration, per-project session lim
 |------|--------|--------|
 | 2026-03-04 | corvid-agent | Initial spec |
 | 2026-03-18 | corvid-agent | v3: Removed protected-paths exports (now in dedicated `protected-paths.spec.md`). Added 24-hour minimum age guard to `enforceSessionLimits`. Fixes #1221 |
+| 2026-05-02 | Jackdaw | Session keep-alive: `waiting` status protected from TTL expiration and limit enforcement (same as `running`). Invariants 1-2 updated, behavioral examples added (#2233) |


### PR DESCRIPTION
## Summary

Implements the core session keep-alive architecture from issue #2224.

- **SDK processes persist between turns** — after the model completes a response (`result` event), the process enters `waiting` state instead of exiting. The next message is delivered via `streamInput()` with ~5-10ms latency instead of spawning a fresh process (~500-1000ms + 8k context tokens).
- **Input queue** — messages arriving while the model is mid-response are queued (max depth 10, configurable via `PROCESS_INPUT_QUEUE_MAX_DEPTH`). Queue drains automatically after each turn. Full queue returns `false` (backpressure signal to caller).
- **`waiting` session status** — new status added to `SessionStatus` type. Protected from TTL expiration and per-project limit enforcement in `SessionLifecycleManager`.
- **Correct stale-session handling** — `waiting` sessions are reset to `idle` on startup (their processes died with the server), and the orphan pruner detects/cleans them.

### Architecture (implements spec from PRs #2230 and #2234)

```
Cold start (first turn):          Warm start (2nd+ turn):
  startProcess()                    sendMessage() → streamInput()
       ↓                                   ↓
  registerProcess()              model responds (no spawn overhead)
  respondingSessions.add()               ↓
       ↓                           result event fires
  model responds                  respondingSessions.clear()
       ↓                           DB status → 'waiting'
  result event fires               flushInputQueue() if queued msgs
  respondingSessions.clear()
  DB status → 'waiting'
  process stays in map
```

## Files changed

| File | Change |
|------|--------|
| `shared/types/sessions.ts` | Add `'waiting'` to `SessionStatus` |
| `server/process/manager.ts` | Input queue, responding tracking, keep-alive transitions |
| `server/process/session-lifecycle.ts` | Protect `waiting` sessions from TTL/limit cleanup |
| `server/process/process-spawner.ts` | Biome format fix on `warmStartProcess` stub |

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test` — 10627 pass, 0 fail
- [x] `bun run spec:check` — 3 specs checked, 100% coverage

Closes #2224

🤖 Agent: Jackdaw | Model: Sonnet 4.6