### PR TITLE
spec(process): add keep-alive lifecycle to process specs

### DIFF
--- a/specs/process/process-manager.spec.md
+++ b/specs/process/process-manager.spec.md
@@ -1,6 +1,6 @@
 ---
 module: process-manager
-version: 1
+version: 2
 status: active
 files:
   - server/process/manager.ts
@@ -31,6 +31,45 @@ depends_on:
 Central orchestration hub for agent session lifecycles. Manages starting, stopping, resuming, and monitoring Claude agent processes. Integrates every subsystem: persona/skill prompt injection, MCP tool resolution, credit deduction, provider routing (SDK vs direct, Claude vs Ollama), approval workflows, timeout management, auto-restart for AlgoChat sessions, and API outage recovery.
 
 This is the most complex module in the system (~1135 lines after decomposition). It is the single point through which all agent sessions are created and managed. MCP service management and session config resolution have been extracted into dedicated modules.
+
+## Keep-Alive Architecture
+
+The ProcessManager implements a warm-path / cold-path routing strategy for session continuity:
+
+### Warm Path (Keep-Alive)
+
+When a session's SDK process is still alive after its last model turn (`isAlive() === true`), follow-up messages are delivered via `sendMessage()` → `streamInput()`. This bypasses context reconstruction entirely — the model already has the full conversation in its context window.
+
+**Warm path flow:**
+1. `resumeProcess(session, prompt)` called
+2. Check `processes.has(sessionId)` and `process.isAlive()`
+3. Process is alive → call `sendMessage(sessionId, prompt)`
+4. `sendMessage` feeds via `streamInput()`, model processes immediately
+5. If `sendMessage` returns `false` (streamInput failed) → fall through to cold path
+
+### Cold Path (Fallback)
+
+When no live process exists (process died, TTL expired, first message, server restart), the full context reconstruction flow runs. This is the current behavior and remains the default for all non-keep-alive sessions.
+
+**Cold path flow:**
+1. `resumeProcess(session, prompt)` called
+2. No live process (or warm sendMessage failed)
+3. `buildResumePrompt()` constructs context from DB (conversation history, observations, summaries)
+4. `startWithResolvedDir()` spawns a new SDK process with the resume prompt
+5. New process starts fresh with reconstructed context
+
+### When Keep-Alive is Enabled
+
+Keep-alive is enabled per-session via `SpawnOptions.keepAlive`. When enabled:
+- `startProcess()` passes `keepAlive: true` to `startSdkProcess()`
+- The SDK process enters warm state after each model turn instead of exiting
+- `SessionTimerManager` starts a keep-alive TTL timer (distinct from the inactivity timeout)
+- On TTL expiry, the warm process is killed (transitions to cold path for next message)
+- The keep-alive TTL resets on each successful `sendMessage()`
+
+### Token Savings
+
+The warm path avoids re-sending: system prompt (~2-4K tokens), conversation history (variable, often 10-50K tokens), observations (~1-2K tokens), and persona/skill prompts (~1-2K tokens). For a typical 20-message conversation, this saves ~80-90% of input tokens per turn.
 
 ## Public API
 
@@ -240,11 +279,11 @@ Side effects on construction:
 | `setOwnerCheck` | `(fn: (address) => boolean)` | `void` | Inject owner check for credit exemption |
 | `setMcpServices` | `(services: McpServices)` | `void` | Register all MCP-related services for corvid_* tools (delegates to McpServiceContainer) |
 | `startProcess` | `(session: Session, prompt?: string, options?: { depth?, schedulerMode? })` | `void` | Start a new agent process. Routes to SDK or direct based on provider |
-| `resumeProcess` | `(session: Session, prompt?: string)` | `void` | Resume an existing session. Builds history-aware prompt, handles context reset |
+| `resumeProcess` | `(session: Session, prompt?: string)` | `void` | Resume an existing session. Checks for warm process first (warm path) — if alive, delivers via `sendMessage`. Falls back to cold path (build resume prompt, spawn new process) when no live process exists or warm delivery fails |
 | `stopProcess` | `(sessionId: string, reason?: string)` | `void` | Kill process, set status to stopped, emit session_stopped, clean up state |
 | `cleanupSessionState` | `(sessionId: string)` | `void` | Remove all in-memory state for a session (idempotent) |
 | `getMemoryStats` | `()` | `{ processes, subscribers, sessionMeta, pausedSessions, sessionTimeouts, stableTimers, startupTimeouts, globalSubscribers }` | Snapshot of in-memory map sizes |
-| `sendMessage` | `(sessionId: string, content: string \| ContentBlockParam[])` | `boolean` | Send a message to a running process. Persists to DB, tracks turns |
+| `sendMessage` | `(sessionId: string, content: string \| ContentBlockParam[])` | `boolean` | Send a message to a running process via `streamInput()`. Persists to DB, tracks turns, resets keep-alive TTL on success. Returns `false` if process is dead or streamInput fails |
 | `isRunning` | `(sessionId: string)` | `boolean` | Check if a process is active |
 | `subscribe` | `(sessionId: string, callback: EventCallback)` | `void` | Subscribe to session events (replays thinking state for late subscribers) |
 | `unsubscribe` | `(sessionId: string, callback: EventCallback)` | `void` | Unsubscribe from session events |
@@ -283,6 +322,10 @@ Side effects on construction:
 13. **Orphan pruning**: Every 5 minutes, removes subscriber/meta entries for sessions with no active process and not paused
 14. **Memory cleanup single source**: `cleanupSessionState` is the single entry point for all cleanup (process, meta, subscribers, paused state, timers, approval/question managers)
 15. **Cursor per-turn metrics**: When the Cursor CLI completes a model turn it emits `result` events that must not be broadcast (Discord and other listeners treat `result` as session end). The manager accepts synthetic `session_turn_metrics` events from `cursor-process` to persist cost and `session_metrics` rows without broadcasting `result`
+16. **Warm path priority**: `resumeProcess` always checks for a live warm process before falling back to a cold start. The warm path is attempted first; only on failure (process dead, `sendMessage` returns `false`) does cold-path context reconstruction run. This ensures we never needlessly discard a live process's context
+17. **Keep-alive TTL management**: Warm processes have a configurable inactivity TTL (`KEEP_ALIVE_TTL_MS`, default 15 minutes) managed by `SessionTimerManager`. The TTL resets on each successful `sendMessage()`. On expiry, the process is killed via `kill()` and removed from the `processes` map. The next message triggers a cold start
+18. **Warm-to-cold fallback transparency**: When the warm path fails (streamInput error), `resumeProcess` falls through to the cold path silently — the caller and the end user see no difference. A `warm_path_failed` event is emitted for observability but does not surface to the user
+19. **Keep-alive and context reset coexistence**: The existing context reset (after `MAX_TURNS_BEFORE_CONTEXT_RESET` turns) still applies to keep-alive sessions. When triggered, the warm process is killed, a conversation summary is saved, and the next message starts a cold path with compressed context
 
 ## Behavioral Examples
 
@@ -322,6 +365,30 @@ Side effects on construction:
 - **When** 5 minutes pass and API health check succeeds
 - **Then** the session is automatically resumed
 
+### Scenario: Warm path resume — process still alive
+
+- **Given** a session with `keepAlive = true` whose SDK process completed its last turn 5 minutes ago and is in warm state (`isAlive() = true`)
+- **When** `resumeProcess(session, "follow-up question")` is called
+- **Then** the warm process is detected, `sendMessage(sessionId, "follow-up question")` delivers via `streamInput()`, the model processes immediately without context reconstruction, and the keep-alive TTL resets
+
+### Scenario: Warm path failure falls through to cold path
+
+- **Given** a session with `keepAlive = true` whose SDK process is in warm state, but the underlying query has silently closed
+- **When** `resumeProcess(session, "follow-up question")` is called
+- **Then** `sendMessage()` attempts `streamInput()` which fails, returns `false`, a `warm_path_failed` event is emitted, the dead process is evicted from the map, and cold-path context reconstruction runs to spawn a fresh process
+
+### Scenario: Keep-alive TTL expires
+
+- **Given** a warm SDK process that last received a message 15 minutes ago (default TTL)
+- **When** the keep-alive TTL timer fires
+- **Then** the process is killed, removed from the `processes` map, and DB status updated to `idle`. The next message triggers a cold start via `resumeProcess`
+
+### Scenario: Context reset on a keep-alive session
+
+- **Given** a keep-alive session that has processed 40 user messages via the warm path
+- **When** the 41st message arrives and `MAX_TURNS_BEFORE_CONTEXT_RESET` is exceeded
+- **Then** the warm process is killed, a conversation summary is saved as a memory observation, and the message is processed via a cold start with the compressed context
+
 ### Scenario: Credit exhaustion mid-session
 
 - **Given** an AlgoChat session from a non-owner wallet with 1 credit remaining
@@ -340,6 +407,9 @@ Side effects on construction:
 | `resumeSession` for non-paused session | Returns `false` |
 | Max restarts exceeded (3) | Session left in error state, no more retries |
 | Auto-resume max attempts exceeded (10) | Session set to `error`, `auto_resume_exhausted` event emitted |
+| Warm path `sendMessage` fails | `warm_path_failed` event emitted, falls through to cold path transparently |
+| Keep-alive TTL expires | Process killed, status set to `idle`, next message triggers cold start |
+| Warm process receives context overflow signal | Process killed, summary saved, cold start with compressed context |
 
 ## Dependencies
 
@@ -410,6 +480,7 @@ Internal constants (not env-configurable):
 | `MAX_TURNS_BEFORE_CONTEXT_RESET` | `40` | Turns before killing for context reset |
 | `ZERO_TURN_CIRCUIT_BREAKER_THRESHOLD` | `3` | Consecutive zero-turn completions before refusing to resume |
 | `DISCORD_RESTRICTED_MESSAGE_PREFIX` | `'Discord message:'` | Session name prefix for restricted Discord `/message` sessions |
+| `KEEP_ALIVE_TTL_MS` | `900000` | 15 min idle TTL for warm processes before automatic kill |
 
 ## Change Log
 
@@ -425,3 +496,4 @@ Internal constants (not env-configurable):
 | 2026-04-16 | corvid-agent | Document McpServiceContainer methods/isAvailable, full McpServices/BuildContextOptions fields, startStartupTimeout/clearStartupTimeout, fix applyCostUpdate return type (boolean), fix sendMessage signature (ContentBlockParam[]), add flushActiveSessionSummaries, fix getStats to include startupTimeouts, inline EventHandlerDeps/ExitHandlerDeps fields, remove RoutingDecision duplicate, collapse exported-types table with Source column (#2022) |
 | 2026-04-20 | corvid-agent | Add approval-flow.ts (approval request/response bridge) and persona-injector.ts (persona+skill injection facade); add session-lifecycle.ts to files list; document new exported functions |
 | 2026-04-22 | corvid-agent | Add `isAlive()` to `SdkProcess` interface; sendMessage evicts zombie processes from Map; orphan pruner detects dead-in-Map processes via `isAlive()` (#2127) |
+| 2026-05-04 | corvid-agent | v2: Keep-alive architecture — warm path vs cold path routing in resumeProcess, KEEP_ALIVE_TTL_MS, warm_path_failed event, context reset coexistence (#2222, #2223) |

--- a/specs/process/process-spawner.spec.md
+++ b/specs/process/process-spawner.spec.md
@@ -1,6 +1,6 @@
 ---
 module: process-spawner
-version: 1
+version: 2
 status: active
 files:
   - server/process/process-spawner.ts
@@ -19,6 +19,23 @@ Low-level process spawning extracted from `manager.ts`. Handles the mechanics of
 
 Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested and wired without circular imports back to the ProcessManager class.
 
+## Keep-Alive Integration
+
+The process spawner is the **cold path only**. It is never called when the warm path succeeds — warm path delivery happens entirely within `ProcessManager.resumeProcess()` via `sendMessage()`.
+
+### Warm Path Guard
+
+Before calling any spawner function, the `ProcessManager` checks whether a live warm process already exists for the session. The spawner functions are only reached when:
+1. No process exists in the `processes` map
+2. The process exists but `isAlive()` returns `false`
+3. Warm path `sendMessage()` was attempted but returned `false`
+
+This means `spawnSdkProcess`, `spawnDirectProcess`, `startWithResolvedDir`, and `resumeWithResolvedDir` are all cold-path-only and will never race with a warm process.
+
+### keepAlive Pass-Through
+
+`SpawnOptions` includes a new `keepAlive?: boolean` field. When set, it is passed through to `startSdkProcess()` so the SDK process enters warm state after each model turn. The spawner itself does not manage the keep-alive lifecycle — that responsibility belongs to `ProcessManager` and `SessionTimerManager`.
+
 ## Public API
 
 ### Exported Types
@@ -27,7 +44,7 @@ Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested a
 |------|-------------|
 | `SessionMetaForSpawn` | Mutable session metadata tracked in-memory: startedAt, source, restartCount, lastKnownCostUsd, turnCount, lastActivityAt, contextSummary |
 | `ProcessSpawnerDeps` | Dependency bag for all spawner functions: db, approvalManager, timerManager, process/meta/ephemeral maps, event callbacks, MCP context builder |
-| `SpawnOptions` | Common options for start/resume calls: depth, schedulerMode, schedulerActionType, conversationOnly, toolAllowList, mcpToolAllowList |
+| `SpawnOptions` | Common options for start/resume calls: depth, schedulerMode, schedulerActionType, conversationOnly, toolAllowList, mcpToolAllowList, keepAlive |
 
 ### Exported Functions
 
@@ -48,6 +65,8 @@ Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested a
 4. **Spawn errors emit both `error` and `session_error`**: Failed spawns emit a generic `error` event and a structured `session_error` event with `severity: fatal, recoverable: false`
 5. **Ephemeral dir tracked per session**: Ephemeral directories are stored in the `ephemeralDirs` map keyed by session ID and cleaned up via `releaseEphemeralDir`
 6. **Provider routing**: Direct-mode providers use `spawnDirectProcess`; SDK-mode (or Ollama with proxy enabled) uses `spawnSdkProcess`
+7. **Cold-path-only execution**: All spawner functions assume no warm process exists for the target session. The warm path guard in `ProcessManager.resumeProcess()` ensures spawner functions are only called when the warm path is unavailable or has failed
+8. **keepAlive pass-through**: When `SpawnOptions.keepAlive` is `true`, it is forwarded to `startSdkProcess()` via `SdkProcessOptions.keepAlive`. The spawner does not interpret or manage this flag — it merely passes it through
 
 ## Behavioral Examples
 
@@ -68,6 +87,18 @@ Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested a
 - **Given** `conversationOnly: true` in spawn options
 - **When** `spawnSdkProcess` is called
 - **Then** no MCP servers are created and `conversationOnly` is passed through to `startSdkProcess`
+
+### Scenario: Cold start with keepAlive enabled
+
+- **Given** a session with no live process and `keepAlive = true` in spawn options
+- **When** `spawnSdkProcess` is called (after warm path guard confirmed no warm process)
+- **Then** `startSdkProcess` is called with `keepAlive: true` in its options, and the resulting process will enter warm state after its first model turn instead of exiting
+
+### Scenario: Spawner not called when warm process exists
+
+- **Given** a session with a live warm SDK process (`isAlive() = true`)
+- **When** `resumeProcess` is called on the `ProcessManager`
+- **Then** the warm path delivers via `sendMessage()` and no spawner function is invoked
 
 ## Error Cases
 
@@ -105,3 +136,4 @@ Uses a dependency-injection pattern (`ProcessSpawnerDeps`) so it can be tested a
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-04-16 | Jackdaw | Initial extraction from manager.ts |
+| 2026-05-04 | corvid-agent | v2: Keep-alive integration — warm path guard, keepAlive pass-through in SpawnOptions, cold-path-only invariant (#2222, #2232) |

--- a/specs/process/sdk-process.spec.md
+++ b/specs/process/sdk-process.spec.md
@@ -1,6 +1,6 @@
 ---
 module: sdk-process
-version: 1
+version: 2
 status: active
 files:
   - server/process/sdk-process.ts
@@ -20,14 +20,51 @@ Wraps the `@anthropic-ai/claude-agent-sdk` `query()` function into a controllabl
 
 This is the execution boundary between the corvid-agent system and the Claude Agent SDK.
 
+## Keep-Alive Lifecycle
+
+In keep-alive mode, the SDK process survives between model turns. Instead of exiting after one model turn and requiring a cold restart with full context reconstruction, the process enters a **warm** state — alive, idle, and ready to accept the next message via `streamInput()`.
+
+### Process States
+
+| State | `isAlive()` | `isWarm()` | Description |
+|-------|-------------|------------|-------------|
+| **processing** | `true` | `false` | Model is actively generating a response |
+| **warm** | `true` | `true` | Turn complete, process idle, waiting for next `streamInput()` call |
+| **dead** | `false` | `false` | Process exited (explicit kill, TTL expiry, error, or abort) |
+
+### Warm Path vs Cold Path
+
+- **Warm path**: Process is alive (`isAlive() === true`). New user messages are fed via `sendMessage()` → `streamInput()`. No context reconstruction needed — the model already has full conversation history in its context window. This is ~10x cheaper in tokens than a cold start.
+- **Cold path (fallback)**: Process is dead. A new `query()` call is made with a resume prompt containing reconstructed context (conversation history, observations, summaries). This is the current behavior and remains the fallback for all cases where the warm path is unavailable.
+
+### State Transitions
+
+```
+start() ──→ [processing] ──→ model turn complete ──→ [warm]
+                                                        │
+                                                        ├──→ streamInput() ──→ [processing]
+                                                        ├──→ TTL expires ──→ [dead]
+                                                        └──→ kill() ──→ [dead]
+
+[processing] ──→ error/abort ──→ [dead]
+[dead] ──→ (requires new startSdkProcess call = cold start)
+```
+
+### Key Constraints
+
+1. A warm process holds its full context window in memory (model-side). This is the source of token savings but also means each warm process consumes model context capacity.
+2. Warm processes must be killed after a configurable inactivity TTL (`KEEP_ALIVE_TTL_MS`) to avoid unbounded resource consumption. The TTL resets on each successful `sendMessage()`.
+3. If `streamInput()` fails on a warm process (e.g., the query silently closed), the process transitions to dead and the caller must fall back to a cold start.
+4. The `onTurnComplete` callback (new) fires when the model finishes a turn but the process stays alive, distinct from `onExit` which fires when the process truly dies.
+
 ## Public API
 
 ### Exported Types
 
 | Type | Description |
 |------|-------------|
-| `SdkProcessOptions` | Full configuration for starting an SDK process: session, project, agent, prompt, callbacks, MCP servers, persona/skill prompts |
-| `SdkProcess` | Running process handle: `{ pid, sendMessage, kill, isAlive }` |
+| `SdkProcessOptions` | Full configuration for starting an SDK process: session, project, agent, prompt, callbacks, MCP servers, persona/skill prompts. Includes `keepAlive?: boolean` to enable warm process mode |
+| `SdkProcess` | Running process handle: `{ pid, sendMessage, kill, isAlive, isWarm }` |
 
 ### Exported Constants
 
@@ -41,7 +78,7 @@ This is the execution boundary between the corvid-agent system and the Claude Ag
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
-| `startSdkProcess` | `(options: SdkProcessOptions)` | `SdkProcess` | Start a Claude Agent SDK query with full configuration, returns process handle |
+| `startSdkProcess` | `(options: SdkProcessOptions)` | `SdkProcess` | Start a Claude Agent SDK query with full configuration, returns process handle. When `options.keepAlive` is true, the process enters warm state after each model turn instead of exiting |
 | `buildSafeEnv` | `(projectEnvVars?: Record<string, string>)` | `Record<string, string>` | Build sandboxed environment from allowlist + project env vars |
 | `isApiError` | `(error: string)` | `boolean` | Check if an error string matches known API error patterns |
 | `mapSdkMessageToEvent` | `(message: SDKMessage, sessionId: string)` | `ClaudeStreamEvent \| null` | Convert an SDK message to a stream event for the event bus |
@@ -60,6 +97,9 @@ This is the execution boundary between the corvid-agent system and the Claude Ag
 9. **MCP stream timeout**: `CLAUDE_CODE_STREAM_CLOSE_TIMEOUT` is hardcoded to 7,200,000ms (2 hours) to prevent tools from dying during long autonomous sessions
 10. **Tool permissions vs allowed tools**: `sdkOptions.tools` defines which tools are available. `allowedTools` (auto-approve) is NOT set — all tools go through `canUseTool` for approval
 11. **Symlink resolution for protected paths**: `isProtectedPath()` resolves symlinks via `realpathSync()` before matching, preventing bypass via symlink creation targeting protected files
+12. **Keep-alive turn boundary**: When `keepAlive` is enabled, the async output consumer detects model turn completion (via SDK `result` message type) and transitions to warm state instead of calling `onExit`. The `onTurnComplete` callback fires with turn metrics (cost, tokens, duration). The process remains alive for subsequent `streamInput()` calls
+13. **Warm process input guard**: `sendMessage()` on a warm process resets the keep-alive TTL timer (managed externally by `SessionTimerManager`). If `streamInput()` throws or the query has silently closed, `sendMessage()` returns `false`, sets `inputDone = true`, and the caller must initiate a cold start
+14. **Keep-alive opt-in**: `keepAlive` defaults to `false` for backward compatibility. Only sessions explicitly started with `keepAlive: true` enter the warm state. All existing behavior (single-turn, exit on completion) is preserved when `keepAlive` is `false`
 
 ## Behavioral Examples
 
@@ -88,6 +128,24 @@ This is the execution boundary between the corvid-agent system and the Claude Ag
 - **When** the agent uses any tool
 - **Then** `canUseTool` creates an `ApprovalRequest`, sends it via `onApprovalRequest`, and waits for user resolution
 
+### Scenario: Keep-alive process stays warm after model turn
+
+- **Given** a running SDK process with `keepAlive = true`
+- **When** the model finishes generating its response (SDK yields `result` message)
+- **Then** `onTurnComplete` fires with turn metrics, the process enters warm state (`isWarm() = true`, `isAlive() = true`), and the async consumer continues waiting for more SDK messages
+
+### Scenario: Warm process receives follow-up message
+
+- **Given** a warm SDK process (`isWarm() = true`)
+- **When** `sendMessage("follow-up question")` is called
+- **Then** `streamInput()` feeds the message, the process transitions from warm to processing (`isWarm() = false`), and the model begins generating a new response
+
+### Scenario: Warm process streamInput failure triggers cold-start fallback
+
+- **Given** a warm SDK process
+- **When** `sendMessage()` is called but `streamInput()` throws (query silently closed)
+- **Then** `sendMessage()` returns `false`, `inputDone` is set to `true`, `isAlive()` returns `false`, and the caller must initiate a cold start
+
 ## Error Cases
 
 | Condition | Behavior |
@@ -97,6 +155,8 @@ This is the execution boundary between the corvid-agent system and the Claude Ag
 | API outage (3+ consecutive API errors) | `onApiOutage()` called, no `onExit` |
 | `sendMessage` after process done | Returns `false` |
 | `sendMessage` after abort | Returns `false` |
+| `streamInput` throws on warm process | `inputDone = true`, returns `false`, caller falls back to cold start |
+| Keep-alive process receives context overflow | `onTurnComplete` fires with overflow flag, process killed, next message triggers cold start with compressed context |
 
 ## Dependencies
 
@@ -140,3 +200,4 @@ Internal constants (not env-configurable):
 | 2026-03-06 | corvid-agent | Added realpathSync() symlink resolution to prevent protected-path bypass attacks. |
 | 2026-03-14 | corvid-agent | Added channel affinity routing: prependRoutingContext + getResponseRoutingPrompt for Claude/SDK path |
 | 2026-03-28 | corvid-agent | Added getProjectContextPrompt to system prompt append — pins active project to survive context compression (#1628) |
+| 2026-05-04 | corvid-agent | v2: Keep-alive lifecycle — warm process state, `isWarm()` method, `onTurnComplete` callback, `keepAlive` option, streamInput failure fallback (#2222, #2223) |

--- a/specs/process/session-lifecycle.spec.md
+++ b/specs/process/session-lifecycle.spec.md
@@ -1,6 +1,6 @@
 ---
 module: session-lifecycle
-version: 1
+version: 2
 status: active
 files:
   - server/process/session-lifecycle.ts
@@ -20,7 +20,27 @@ depends_on:
 
 ## Purpose
 
-Manages automated session cleanup, TTL-based expiration, per-project session limits, and orphaned resource reclamation.
+Manages automated session cleanup, TTL-based expiration, per-project session limits, and orphaned resource reclamation. Also defines the keep-alive process TTL — a short-lived timer that governs how long warm SDK processes remain alive between model turns.
+
+## TTL Hierarchy
+
+The session lifecycle manages two distinct TTL concepts:
+
+| TTL Type | Default | Scope | What it governs |
+|----------|---------|-------|-----------------|
+| **Session TTL** | 7 days | DB session record | When idle/completed/error sessions are deleted from the database |
+| **Keep-Alive TTL** | 15 minutes | Live SDK process | How long a warm process stays alive between model turns before being killed |
+
+These are independent timers with different purposes:
+- **Session TTL** is about database hygiene — cleaning up old session records that are no longer useful
+- **Keep-Alive TTL** is about resource management — preventing warm processes from holding model context indefinitely
+
+### Keep-Alive TTL Lifecycle
+
+The keep-alive TTL is managed by `SessionTimerManager` (not `SessionLifecycleManager`) because it operates on live processes, not DB records. However, `SessionLifecycleManager` is responsible for:
+1. Including warm process state in `getStats()` reporting
+2. Treating sessions with warm processes as "active" — protecting them from cleanup just like running sessions
+3. Coordinating with `ProcessManager.cleanupSessionState()` when a session with a warm process is force-cleaned
 
 ## Public API
 
@@ -34,7 +54,7 @@ Manages automated session cleanup, TTL-based expiration, per-project session lim
 
 | Type | Description |
 |------|-------------|
-| `SessionLifecycleConfig` | Configuration interface: `sessionTtlMs` (default 7 days), `cleanupIntervalMs` (default 1 hour), `maxSessionsPerProject` (default 100). |
+| `SessionLifecycleConfig` | Configuration interface: `sessionTtlMs` (default 7 days), `cleanupIntervalMs` (default 1 hour), `maxSessionsPerProject` (default 100), `keepAliveTtlMs` (default 15 minutes — passed to `SessionTimerManager` for warm process timeout). |
 | `SessionCleanupStats` | Cleanup result stats: `expiredSessions`, `orphanedProcesses`, `staleSubscriptions`, `memoryFreedMB`. |
 
 ### Exported Constants
@@ -55,20 +75,22 @@ Manages automated session cleanup, TTL-based expiration, per-project session lim
 | `start` | — | `void` | Starts the automatic cleanup process. Runs an initial cleanup immediately, then schedules periodic cleanup at `cleanupIntervalMs`. |
 | `stop` | — | `void` | Stops the automatic cleanup timer. |
 | `runCleanup` | — | `Promise<SessionCleanupStats>` | Runs a full cleanup cycle: expires old sessions, removes orphaned messages, enforces project session limits, and reports memory delta. |
-| `getStats` | — | `{ activeSessions, totalSessions, sessionsByStatus, oldestSessionAge }` | Returns current session statistics from the database. |
+| `getStats` | — | `{ activeSessions, totalSessions, sessionsByStatus, oldestSessionAge, warmProcessCount? }` | Returns current session statistics from the database. `warmProcessCount` is optionally provided when a process map reference is available, indicating how many sessions have live warm processes. |
 | `canCreateSession` | `projectId: string` | `boolean` | Returns whether a new session can be created for the given project (under the max limit). |
 | `cleanupSession` | `sessionId: string` | `Promise<boolean>` | Force-deletes a specific session and all related data (messages, escalations, algochat conversation references) in a transaction. |
 | `getAndClearRestartPendingSessions` | — | `string[]` | Returns session IDs marked `restart_pending = 1` (interrupted by server restart) and clears the flag. Called on startup to resume orphaned sessions. |
 
 ## Invariants
 
-1. Sessions in `'running'` status are never cleaned up by automated expiration or limit enforcement. Sessions in `'paused'` status are protected from TTL expiration but are subject to per-project limit enforcement if older than 24 hours.
+1. Sessions in `'running'` status are never cleaned up by automated expiration or limit enforcement. Sessions in `'paused'` status are protected from TTL expiration but are subject to per-project limit enforcement if older than 24 hours. Sessions with warm processes (status may be `'idle'` in DB but with a live process in memory) are treated as effectively running and protected from all automated cleanup.
 2. Session TTL expiration only applies to sessions in terminal states (`'idle'`, `'completed'`, `'error'`, `'stopped'`).
 3. Per-project session limit enforcement deletes the oldest non-`'running'` sessions first (including `'paused'`), but only those older than 24 hours. Sessions younger than 24 hours are protected from limit-based cleanup to prevent a burst of new sessions from evicting recently-created sessions that users still expect to be resumable.
 4. All session deletions cascade within a transaction: `algochat_conversations` FK nullified, `session_messages` deleted, `escalation_queue` entries deleted, then the session row itself.
 5. The cleanup timer is idempotent: calling `start()` when already running logs a warning and does not create a duplicate timer.
 6. Expired session cleanup is batched (up to 100 per cycle) to avoid blocking the event loop.
 7. `cleanupSession` is transactional: either all related data is deleted or none is.
+8. **Warm process protection**: Automated cleanup (TTL expiration + per-project limits) must check whether a session has a live warm process before deleting. A session with a warm process is never eligible for automated cleanup regardless of its DB status or age.
+9. **Keep-alive TTL delegation**: The keep-alive TTL timer is owned by `SessionTimerManager`, not `SessionLifecycleManager`. The lifecycle manager only needs to be aware of warm processes for protection during cleanup — it does not start, reset, or clear keep-alive timers.
 
 ## Behavioral Examples
 
@@ -91,6 +113,18 @@ Manages automated session cleanup, TTL-based expiration, per-project session lim
 - **Given** project `"proj-1"` has 100 sessions
 - **When** `canCreateSession("proj-1")` is called
 - **Then** returns `false`
+
+### Scenario: Warm process protects session from TTL expiration
+
+- **Given** a session in `'idle'` status (DB) that was last updated 8 days ago (past the 7-day TTL), but has a live warm SDK process in memory
+- **When** `runCleanup` executes and checks for expired sessions
+- **Then** the session is skipped because it has a warm process, even though its DB status and age would normally qualify it for expiration
+
+### Scenario: Force cleanup kills warm process
+
+- **Given** a session with a live warm process
+- **When** `cleanupSession(sessionId)` is called explicitly
+- **Then** `ProcessManager.cleanupSessionState()` is called first to kill the warm process and release resources, then the session and its related data are deleted in a transaction
 
 ### Scenario: Force cleanup of a specific session
 - **Given** session `"sess-123"` exists with messages and escalation entries
@@ -129,3 +163,4 @@ Manages automated session cleanup, TTL-based expiration, per-project session lim
 |------|--------|--------|
 | 2026-03-04 | corvid-agent | Initial spec |
 | 2026-03-18 | corvid-agent | v3: Removed protected-paths exports (now in dedicated `protected-paths.spec.md`). Added 24-hour minimum age guard to `enforceSessionLimits`. Fixes #1221 |
+| 2026-05-04 | corvid-agent | v2: Keep-alive TTL — TTL hierarchy (session vs process), warm process protection from cleanup, keepAliveTtlMs in config, warmProcessCount in stats (#2222, #2233) |


### PR DESCRIPTION
## Summary

Phase 1 of #2222 (Session Keep-Alive Architecture). Updates all four process module specs to define the warm path vs cold path architecture:

- **sdk-process.spec.md** — Process state machine (`processing` → `warm` → `dead`), `isWarm()`, `onTurnComplete`, `streamInput()`, 3 new invariants
- **process-manager.spec.md** — Warm path priority routing, TTL management (`KEEP_ALIVE_TTL_MS`), token savings analysis (80-90% reduction), 4 new invariants
- **process-spawner.spec.md** — Cold-path-only documentation, `keepAlive` pass-through in `SpawnOptions`, 2 new invariants
- **session-lifecycle.spec.md** — TTL hierarchy table, warm process protection from automated cleanup, `warmProcessCount` in stats, 2 new invariants

Closes #2223, #2232, #2233

## Test plan

- [x] `bun run spec:check --force` — all 216 specs pass
- [x] `bun x tsc --noEmit --skipLibCheck` — typecheck passes
- [x] Spec coverage: 581/581 files (100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)