### PR TITLE
feat(process): implement keep-alive state machine and warm path (Phase 2)

### DIFF
--- a/server/__tests__/agent-messenger.test.ts
+++ b/server/__tests__/agent-messenger.test.ts
@@ -35,11 +35,13 @@ function createMockProcessManager() {
     setOwnerCheck: mock(() => {}),
     getMemoryStats: mock(() => ({
       processes: 0,
+      warmProcesses: 0,
       subscribers: 0,
       sessionMeta: 0,
       pausedSessions: 0,
       sessionTimeouts: 0,
       stableTimers: 0,
+      keepAliveTimers: 0,
       globalSubscribers: 0,
     })),
     cleanupSessionState: mock(() => {}),

--- a/server/__tests__/chain-continuation-integration.test.ts
+++ b/server/__tests__/chain-continuation-integration.test.ts
@@ -72,11 +72,13 @@ function createMockProcessManager(db: Database) {
     unsubscribeAll: mock(() => {}),
     getMemoryStats: mock(() => ({
       processes: 0,
+      warmProcesses: 0,
       subscribers: 0,
       sessionMeta: 0,
       pausedSessions: 0,
       sessionTimeouts: 0,
       stableTimers: 0,
+      keepAliveTimers: 0,
       globalSubscribers: 0,
     })),
     cleanupSessionState: mock(() => {}),

--- a/server/__tests__/process-manager-cleanup.test.ts
+++ b/server/__tests__/process-manager-cleanup.test.ts
@@ -92,11 +92,13 @@ describe('getMemoryStats', () => {
   test('returns zero counts on fresh instance', () => {
     const stats = pm.getMemoryStats();
     expect(stats.processes).toBe(0);
+    expect(stats.warmProcesses).toBe(0);
     expect(stats.subscribers).toBe(0);
     expect(stats.sessionMeta).toBe(0);
     expect(stats.pausedSessions).toBe(0);
     expect(stats.sessionTimeouts).toBe(0);
     expect(stats.stableTimers).toBe(0);
+    expect(stats.keepAliveTimers).toBe(0);
     expect(stats.globalSubscribers).toBe(0);
   });
 
@@ -244,6 +246,7 @@ function makeMockProcess(alive: boolean = true): SdkProcess {
       killed = true;
     },
     isAlive: () => alive && !killed,
+    isWarm: () => false,
   };
 }
 

--- a/server/__tests__/process-manager-compact.test.ts
+++ b/server/__tests__/process-manager-compact.test.ts
@@ -18,6 +18,7 @@ function makeMockProcess(sendResult: boolean = true): SdkProcess {
     sendMessage: () => sendResult,
     kill: () => {},
     isAlive: () => true,
+    isWarm: () => false,
   };
 }
 

--- a/server/__tests__/process-manager-sendmessage.test.ts
+++ b/server/__tests__/process-manager-sendmessage.test.ts
@@ -26,6 +26,7 @@ function makeMockProcess(sendResult: boolean = true, alive: boolean = true): Sdk
     sendMessage: () => sendResult,
     kill: () => {},
     isAlive: () => alive,
+    isWarm: () => false,
   };
 }
 

--- a/server/__tests__/session-timer-manager.test.ts
+++ b/server/__tests__/session-timer-manager.test.ts
@@ -35,6 +35,7 @@ describe('SessionTimerManager', () => {
       expect(stats.sessionTimeouts).toBe(0);
       expect(stats.stableTimers).toBe(0);
       expect(stats.startupTimeouts).toBe(0);
+      expect(stats.keepAliveTimers).toBe(0);
     });
 
     it('accepts custom config', () => {
@@ -272,14 +273,17 @@ describe('SessionTimerManager', () => {
       manager.startStableTimer('s1');
       manager.startSessionTimeout('s1');
       manager.startStartupTimeout('s1');
+      manager.startKeepAliveTtl('s1');
       expect(manager.getStats().stableTimers).toBe(1);
       expect(manager.getStats().sessionTimeouts).toBe(1);
       expect(manager.getStats().startupTimeouts).toBe(1);
+      expect(manager.getStats().keepAliveTimers).toBe(1);
 
       manager.cleanupSession('s1');
       expect(manager.getStats().stableTimers).toBe(0);
       expect(manager.getStats().sessionTimeouts).toBe(0);
       expect(manager.getStats().startupTimeouts).toBe(0);
+      expect(manager.getStats().keepAliveTimers).toBe(0);
     });
   });
 

--- a/server/__tests__/work-task-dedup.test.ts
+++ b/server/__tests__/work-task-dedup.test.ts
@@ -56,11 +56,13 @@ function createMockProcessManager(): ProcessManager {
     unsubscribeAll: mock(() => {}),
     getMemoryStats: mock(() => ({
       processes: 0,
+      warmProcesses: 0,
       subscribers: 0,
       sessionMeta: 0,
       pausedSessions: 0,
       sessionTimeouts: 0,
       stableTimers: 0,
+      keepAliveTimers: 0,
       globalSubscribers: 0,
     })),
     cleanupSessionState: mock(() => {}),

--- a/server/__tests__/work-task-drain.test.ts
+++ b/server/__tests__/work-task-drain.test.ts
@@ -51,11 +51,13 @@ function createMockProcessManager(): ProcessManager {
     unsubscribeAll: mock(() => {}),
     getMemoryStats: mock(() => ({
       processes: 0,
+      warmProcesses: 0,
       subscribers: 0,
       sessionMeta: 0,
       pausedSessions: 0,
       sessionTimeouts: 0,
       stableTimers: 0,
+      keepAliveTimers: 0,
       globalSubscribers: 0,
     })),
     cleanupSessionState: mock(() => {}),

--- a/server/__tests__/work-task-test-helpers.ts
+++ b/server/__tests__/work-task-test-helpers.ts
@@ -182,11 +182,13 @@ export function createMockProcessManager(
     unsubscribeAll: mock(() => {}),
     getMemoryStats: mock(() => ({
       processes: 0,
+      warmProcesses: 0,
       subscribers: 0,
       sessionMeta: 0,
       pausedSessions: 0,
       sessionTimeouts: 0,
       stableTimers: 0,
+      keepAliveTimers: 0,
       globalSubscribers: 0,
     })),
     cleanupSessionState: mock(() => {}),

--- a/server/process/cursor-process.ts
+++ b/server/process/cursor-process.ts
@@ -430,7 +430,11 @@ export function spawnCursorProcess(options: CursorProcessOptions): SdkProcess {
     return !killed;
   }
 
-  return { pid, sendMessage, kill, isAlive };
+  function isWarm(): boolean {
+    return false; // Cursor processes do not support keep-alive
+  }
+
+  return { pid, sendMessage, kill, isAlive, isWarm };
 }
 
 export function buildArgs(project: Project, agent: Agent | null, worktree?: string, worktreeBase?: string): string[] {

--- a/server/process/direct-process.ts
+++ b/server/process/direct-process.ts
@@ -1164,7 +1164,11 @@ export function startDirectProcess(options: DirectProcessOptions): SdkProcess {
     return !aborted;
   }
 
-  return { pid: pseudoPid, sendMessage, kill, isAlive };
+  function isWarm(): boolean {
+    return false; // Direct processes do not support keep-alive
+  }
+
+  return { pid: pseudoPid, sendMessage, kill, isAlive, isWarm };
 }
 
 // ── Nudge system ──────────────────────────────────────────────────────────

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -42,7 +42,7 @@ import { startDirectProcess, summarizeConversation } from './direct-process';
 import { SessionEventBus } from './event-bus';
 import { McpServiceContainer, type McpServices } from './mcp-service-container';
 import { OwnerQuestionManager } from './owner-question-manager';
-import { type SdkProcess, startSdkProcess } from './sdk-process';
+import { type SdkProcess, type TurnCompleteMetrics, startSdkProcess } from './sdk-process';
 import { resolveSessionConfig } from './session-config-resolver';
 import { MAX_RESTARTS, SessionResilienceManager } from './session-resilience-manager';
 import { SessionTimerManager } from './session-timer-manager';
@@ -65,6 +65,12 @@ const ZERO_TURN_CIRCUIT_BREAKER_THRESHOLD = 3;
 
 /** Auto-compact the session when context usage reaches this percentage. */
 const AUTO_COMPACT_THRESHOLD = 90;
+
+/** Keep-alive TTL default in ms. Configurable via KEEP_ALIVE_TTL_MS env var. */
+const KEEP_ALIVE_TTL_MS = parseInt(process.env.KEEP_ALIVE_TTL_MS ?? String(15 * 60 * 1000), 10);
+
+/** Whether keep-alive is globally enabled. Opt-in via KEEP_ALIVE_ENABLED env var. */
+const KEEP_ALIVE_ENABLED = process.env.KEEP_ALIVE_ENABLED === 'true';
 
 /** Result of a provider routing decision — exported for testing. */
 export interface RoutingDecision {
@@ -227,6 +233,10 @@ export class ProcessManager {
           'Session timed out waiting for the model to respond. The model endpoint may be down or overloaded. Try again or use a different agent.',
         );
         this.stopProcess(sessionId, 'startup_timeout');
+      },
+      onKeepAliveExpiry: (sessionId) => {
+        log.info(`Keep-alive TTL expired for session ${sessionId} — killing warm process`);
+        this.stopProcess(sessionId, 'keep_alive_ttl_expired');
       },
       isRunning: (sessionId) => this.processes.has(sessionId),
       getLastActivityAt: (sessionId) => this.sessionMeta.get(sessionId)?.lastActivityAt,
@@ -962,10 +972,35 @@ export class ProcessManager {
     }
 
     if (this.processes.has(session.id)) {
-      if (prompt) {
-        this.sendMessage(session.id, prompt);
+      const proc = this.processes.get(session.id)!;
+      if (proc.isAlive()) {
+        if (prompt) {
+          const sent = this.sendMessage(session.id, prompt);
+          if (sent) {
+            // Warm path succeeded — reset keep-alive TTL
+            if (proc.isWarm()) {
+              this.timerManager.clearKeepAliveTtl(session.id);
+            }
+            return;
+          }
+          // Warm path sendMessage failed — fall through to cold-start
+          log.warn(`Warm path sendMessage failed for session ${session.id} — falling through to cold start`);
+          this.eventBus.emit(session.id, {
+            type: 'system',
+            subtype: 'warm_path_failed',
+            message: { content: 'Warm path failed, falling back to cold start' },
+          } as ClaudeStreamEvent);
+          this.processes.delete(session.id);
+          this.timerManager.clearKeepAliveTtl(session.id);
+          // Fall through to cold-start below
+        } else {
+          return; // No prompt, process is alive — nothing to do
+        }
+      } else {
+        // Process is in the map but dead — clean up and fall through to cold-start
+        this.processes.delete(session.id);
+        this.timerManager.clearKeepAliveTtl(session.id);
       }
-      return;
     }
 
     // Circuit breaker: detect zero-turn death loops.
@@ -1215,6 +1250,8 @@ export class ProcessManager {
           externalMcpConfigs: resumeExternalMcpConfigs,
           conversationOnly: isConversationOnly,
           toolAllowList: resumeToolAllowList,
+          keepAlive: KEEP_ALIVE_ENABLED,
+          onTurnComplete: KEEP_ALIVE_ENABLED ? (metrics) => this.handleTurnComplete(session.id, metrics) : undefined,
         });
       }
     } catch (err) {
@@ -1427,7 +1464,9 @@ export class ProcessManager {
     const logLevel = (process.env.LOG_LEVEL ?? 'info').toLowerCase();
     if (process.env.LOG_TOKEN_BREAKDOWN === 'true' || logLevel === 'debug') {
       const summaryTokens = meta?.contextSummary ? estimateTokens(meta.contextSummary) : 0;
-      const obsText = observations.map((o) => `- [${o.source}] (score: ${o.relevanceScore.toFixed(1)}) ${o.content}`).join('\n');
+      const obsText = observations
+        .map((o) => `- [${o.source}] (score: ${o.relevanceScore.toFixed(1)}) ${o.content}`)
+        .join('\n');
       const obsTokens = estimateTokens(obsText);
       const historyText = historyLines.join('\n');
       const historyTokens = estimateTokens(historyText);
@@ -1529,21 +1568,29 @@ export class ProcessManager {
    */
   getMemoryStats(): {
     processes: number;
+    warmProcesses: number;
     subscribers: number;
     sessionMeta: number;
     pausedSessions: number;
     sessionTimeouts: number;
     stableTimers: number;
+    keepAliveTimers: number;
     globalSubscribers: number;
   } {
     const timerStats = this.timerManager.getStats();
+    let warmCount = 0;
+    for (const proc of this.processes.values()) {
+      if (proc.isWarm()) warmCount++;
+    }
     return {
       processes: this.processes.size,
+      warmProcesses: warmCount,
       subscribers: this.eventBus.getSubscriberCount(),
       sessionMeta: this.sessionMeta.size,
       pausedSessions: this.resilienceManager.pausedSessionCount,
       sessionTimeouts: timerStats.sessionTimeouts,
       stableTimers: timerStats.stableTimers,
+      keepAliveTimers: timerStats.keepAliveTimers,
       globalSubscribers: this.eventBus.getGlobalSubscriberCount(),
     };
   }
@@ -1559,13 +1606,22 @@ export class ProcessManager {
     const cp = this.processes.get(sessionId);
     if (!cp) return false;
 
+    const wasWarm = cp.isWarm();
     const sent = cp.sendMessage(content);
     if (!sent) {
-      log.warn(`Failed to write to stdin for session ${sessionId}`);
+      log.warn(`Failed to write to stdin for session ${sessionId}`, { wasWarm });
       // The process can no longer accept input — remove from Map so that
       // the caller's subsequent resumeProcess() detects the stale state and restarts.
       this.processes.delete(sessionId);
+      this.timerManager.clearKeepAliveTtl(sessionId);
       return false;
+    }
+
+    // Reset keep-alive TTL on successful message delivery to warm process
+    if (wasWarm) {
+      this.timerManager.clearKeepAliveTtl(sessionId);
+      // Restart normal session inactivity timeout since process is now active
+      this.timerManager.startSessionTimeout(sessionId);
     }
 
     // Persist as text for session history (extract text from multimodal content)
@@ -1582,6 +1638,7 @@ export class ProcessManager {
     const meta = this.sessionMeta.get(sessionId);
     if (meta) {
       meta.turnCount++;
+      meta.lastActivityAt = Date.now();
       updateSessionTurns(this.db, sessionId, meta.turnCount);
     }
     incrementSessionCumulativeTurns(this.db, sessionId);
@@ -2035,6 +2092,30 @@ export class ProcessManager {
     } else {
       this.cleanupSessionState(sessionId);
     }
+  }
+
+  /**
+   * Handle keep-alive turn completion. Process enters warm state — start TTL
+   * timer and clear the normal session inactivity timeout.
+   */
+  private handleTurnComplete(sessionId: string, metrics: TurnCompleteMetrics): void {
+    log.info(`Session ${sessionId} turn complete — process entering warm state`, {
+      costUsd: metrics.totalCostUsd,
+      durationMs: metrics.durationMs,
+      numTurns: metrics.numTurns,
+    });
+
+    // Start keep-alive TTL — process will be killed if no new message arrives
+    this.timerManager.startKeepAliveTtl(sessionId, KEEP_ALIVE_TTL_MS);
+
+    // Clear the normal inactivity timeout — warm processes use keep-alive TTL instead
+    this.timerManager.clearSessionTimeout(sessionId);
+
+    this.eventBus.emit(sessionId, {
+      type: 'system',
+      subtype: 'turn_complete',
+      message: { content: JSON.stringify({ warm: true, ...metrics }) },
+    } as ClaudeStreamEvent);
   }
 
   /**

--- a/server/process/process-spawner.ts
+++ b/server/process/process-spawner.ts
@@ -24,7 +24,7 @@ import type { ApprovalManager } from './approval-manager';
 import type { ApprovalRequestWire } from './approval-types';
 import { startDirectProcess } from './direct-process';
 import { resolveDirectToolAllowList } from './provider-routing';
-import type { SdkProcess } from './sdk-process';
+import type { SdkProcess, TurnCompleteMetrics } from './sdk-process';
 import { startSdkProcess } from './sdk-process';
 import { resolveSessionConfig } from './session-config-resolver';
 import type { SessionTimerManager } from './session-timer-manager';
@@ -59,6 +59,7 @@ export interface ProcessSpawnerDeps {
   onExit: (sessionId: string, code: number | null, errorMessage?: string) => void;
   onApprovalRequest: (sessionId: string, request: ApprovalRequestWire) => void;
   onApiOutage: (sessionId: string) => void;
+  onTurnComplete: (sessionId: string, metrics: TurnCompleteMetrics) => void;
   emitToSession: (sessionId: string, event: ClaudeStreamEvent) => void;
   extendTimeout: (sessionId: string, additionalMs: number) => boolean;
   buildMcpContext: (
@@ -80,6 +81,8 @@ export interface SpawnOptions {
   conversationOnly?: boolean;
   toolAllowList?: string[];
   mcpToolAllowList?: string[];
+  /** When true, SDK process enters warm state after each model turn instead of exiting. */
+  keepAlive?: boolean;
 }
 
 /**
@@ -150,7 +153,8 @@ export function spawnSdkProcess(
   prompt: string,
   options: SpawnOptions = {},
 ): void {
-  const { depth, schedulerMode, schedulerActionType, conversationOnly, toolAllowList, mcpToolAllowList } = options;
+  const { depth, schedulerMode, schedulerActionType, conversationOnly, toolAllowList, mcpToolAllowList, keepAlive } =
+    options;
   const effectiveProject = session.workDir ? { ...project, workingDir: session.workDir } : project;
   const config = resolveSessionConfig(deps.db, agent, session.agentId, session.projectId);
 
@@ -198,6 +202,8 @@ export function spawnSdkProcess(
       skillPrompt: config.skillPrompt,
       conversationOnly: isNoTools || conversationOnly,
       toolAllowList: isRestrictedTools ? toolAllowList : undefined,
+      keepAlive,
+      onTurnComplete: keepAlive ? (metrics) => deps.onTurnComplete(session.id, metrics) : undefined,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/server/process/sdk-process.ts
+++ b/server/process/sdk-process.ts
@@ -98,6 +98,12 @@ export function isApiError(error: string): boolean {
   return false;
 }
 
+export interface TurnCompleteMetrics {
+  totalCostUsd: number;
+  durationMs: number;
+  numTurns: number;
+}
+
 export interface SdkProcessOptions {
   session: Session;
   project: Project;
@@ -119,6 +125,10 @@ export interface SdkProcessOptions {
   conversationOnly?: boolean;
   /** When provided, only these built-in tools are allowed — all others are disallowed. */
   toolAllowList?: string[];
+  /** When true, process enters warm state after each model turn instead of exiting. */
+  keepAlive?: boolean;
+  /** Fires when model finishes a turn but process stays alive (keepAlive mode only). */
+  onTurnComplete?: (metrics: TurnCompleteMetrics) => void;
 }
 
 /** All built-in Claude Code tools that must be blocked in conversation-only mode. */
@@ -155,6 +165,8 @@ export interface SdkProcess {
   kill: () => void;
   /** Returns true if the process can still accept and process messages. */
   isAlive: () => boolean;
+  /** Returns true if the process completed a turn and is idle waiting for streamInput(). */
+  isWarm: () => boolean;
 }
 
 let nextPseudoPid = 900_000;
@@ -176,11 +188,14 @@ export function startSdkProcess(options: SdkProcessOptions): SdkProcess {
     skillPrompt,
     conversationOnly,
     toolAllowList,
+    keepAlive,
+    onTurnComplete,
   } = options;
 
   const abortController = new AbortController();
   const pseudoPid = nextPseudoPid++;
   let inputDone = false;
+  let warm = false;
 
   const canUseTool: CanUseTool = async (toolName, input, _opts) => {
     // Protected path check — runs BEFORE bypass modes so even full-auto agents are blocked
@@ -470,12 +485,30 @@ export function startSdkProcess(options: SdkProcessOptions): SdkProcess {
         if (event) {
           onEvent(event);
         }
+
+        // Keep-alive turn boundary: when keepAlive is enabled and model finishes a turn,
+        // transition to warm state instead of exiting. The async iterator stays open
+        // waiting for streamInput() to feed a new user message.
+        if (message.type === 'result' && keepAlive) {
+          warm = true;
+          log.info(`SDK process entering warm state for session ${session.id}`, { pid: pseudoPid });
+          if (onTurnComplete) {
+            const result = message as import('@anthropic-ai/claude-agent-sdk').SDKResultMessage;
+            onTurnComplete({
+              totalCostUsd: result.total_cost_usd ?? 0,
+              durationMs: result.duration_ms ?? 0,
+              numTurns: result.num_turns ?? 0,
+            });
+          }
+        }
       }
       if (messageCount === 0) {
         log.warn(`SDK query completed with 0 messages for session ${session.id}`, { prompt: prompt.slice(0, 100) });
       }
+      warm = false;
       onExit(0);
     } catch (err) {
+      warm = false;
       if (err instanceof Error && err.name === 'AbortError') {
         onExit(0);
         return;
@@ -504,6 +537,7 @@ export function startSdkProcess(options: SdkProcessOptions): SdkProcess {
       onExit(1, errorMsg);
     } finally {
       inputDone = true;
+      warm = false;
     }
   })();
 
@@ -515,6 +549,12 @@ export function startSdkProcess(options: SdkProcessOptions): SdkProcess {
         `sendMessage rejected for session ${session.id}: inputDone=${inputDone}, aborted=${abortController.signal.aborted}`,
       );
       return false;
+    }
+
+    const wasWarm = warm;
+    if (warm) {
+      warm = false; // Transition from warm → processing
+      log.info(`SDK process transitioning warm → processing for session ${session.id}`, { pid: pseudoPid });
     }
 
     const isMultimodal = Array.isArray(content);
@@ -539,7 +579,12 @@ export function startSdkProcess(options: SdkProcessOptions): SdkProcess {
       log.warn(`streamInput failed for session ${session.id}`, {
         error: err instanceof Error ? err.message : String(err),
         stack: err instanceof Error ? err.stack : undefined,
+        wasWarm,
       });
+      // If streamInput fails on a warm process, mark as done so caller falls back to cold start
+      if (wasWarm) {
+        inputDone = true;
+      }
     });
 
     return true;
@@ -555,7 +600,11 @@ export function startSdkProcess(options: SdkProcessOptions): SdkProcess {
     return !inputDone && !abortController.signal.aborted;
   }
 
-  return { pid: pseudoPid, sendMessage, kill, isAlive };
+  function isWarm(): boolean {
+    return warm && !inputDone && !abortController.signal.aborted;
+  }
+
+  return { pid: pseudoPid, sendMessage, kill, isAlive, isWarm };
 }
 
 /**

--- a/server/process/session-timer-manager.ts
+++ b/server/process/session-timer-manager.ts
@@ -19,6 +19,8 @@ export interface SessionTimerCallbacks {
   onStablePeriod: (sessionId: string) => void;
   /** Called when a session produces no events within the startup window. */
   onStartupTimeout: (sessionId: string) => void;
+  /** Called when a warm process's keep-alive TTL expires. */
+  onKeepAliveExpiry?: (sessionId: string) => void;
   /** Check whether a session has an active process. */
   isRunning: (sessionId: string) => boolean;
   /** Get the last activity timestamp for a session (epoch ms), or undefined if not tracked. */
@@ -34,6 +36,8 @@ export interface SessionTimerConfig {
   timeoutCheckIntervalMs: number;
   /** Max time (ms) to wait for the first event after process registration. Default: 90s. */
   startupTimeoutMs: number;
+  /** Keep-alive TTL for warm processes in ms. Default: 15 minutes. */
+  keepAliveTtlMs: number;
 }
 
 const DEFAULT_CONFIG: SessionTimerConfig = {
@@ -41,6 +45,7 @@ const DEFAULT_CONFIG: SessionTimerConfig = {
   stablePeriodMs: 10 * 60 * 1000,
   timeoutCheckIntervalMs: 60_000,
   startupTimeoutMs: parseInt(process.env.STARTUP_TIMEOUT_MS ?? '90000', 10),
+  keepAliveTtlMs: parseInt(process.env.KEEP_ALIVE_TTL_MS ?? String(15 * 60 * 1000), 10),
 };
 
 export class SessionTimerManager {
@@ -50,6 +55,7 @@ export class SessionTimerManager {
   private stableTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
   private sessionTimeouts: Map<string, ReturnType<typeof setTimeout>> = new Map();
   private startupTimeouts: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  private keepAliveTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
   private timeoutTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(callbacks: SessionTimerCallbacks, config: Partial<SessionTimerConfig> = {}) {
@@ -180,6 +186,30 @@ export class SessionTimerManager {
   }
 
   /**
+   * Start (or reset) the keep-alive TTL for a warm process.
+   * On expiry, fires onKeepAliveExpiry — the process should be killed.
+   */
+  startKeepAliveTtl(sessionId: string, ttlMs?: number): void {
+    this.clearKeepAliveTtl(sessionId);
+    const effectiveTtl = ttlMs ?? this.config.keepAliveTtlMs;
+    const timer = setTimeout(() => {
+      this.keepAliveTimers.delete(sessionId);
+      if (!this.callbacks.isRunning(sessionId)) return;
+      log.info(`Keep-alive TTL expired for session ${sessionId}`, { ttlMs: effectiveTtl });
+      this.callbacks.onKeepAliveExpiry?.(sessionId);
+    }, effectiveTtl);
+    this.keepAliveTimers.set(sessionId, timer);
+  }
+
+  clearKeepAliveTtl(sessionId: string): void {
+    const timer = this.keepAliveTimers.get(sessionId);
+    if (timer) {
+      clearTimeout(timer);
+      this.keepAliveTimers.delete(sessionId);
+    }
+  }
+
+  /**
    * Clean up all timers for a specific session.
    * Called during session cleanup to prevent timer leaks.
    */
@@ -187,16 +217,18 @@ export class SessionTimerManager {
     this.clearStableTimer(sessionId);
     this.clearSessionTimeout(sessionId);
     this.clearStartupTimeout(sessionId);
+    this.clearKeepAliveTtl(sessionId);
   }
 
   /**
    * Get the count of active timers for monitoring.
    */
-  getStats(): { sessionTimeouts: number; stableTimers: number; startupTimeouts: number } {
+  getStats(): { sessionTimeouts: number; stableTimers: number; startupTimeouts: number; keepAliveTimers: number } {
     return {
       sessionTimeouts: this.sessionTimeouts.size,
       startupTimeouts: this.startupTimeouts.size,
       stableTimers: this.stableTimers.size,
+      keepAliveTimers: this.keepAliveTimers.size,
     };
   }
 
@@ -220,5 +252,9 @@ export class SessionTimerManager {
       clearTimeout(timer);
     }
     this.startupTimeouts.clear();
+    for (const timer of this.keepAliveTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.keepAliveTimers.clear();
   }
 }

--- a/specs/process/sdk-process.spec.md
+++ b/specs/process/sdk-process.spec.md
@@ -65,6 +65,7 @@ start() ──→ [processing] ──→ model turn complete ──→ [warm]
 |------|-------------|
 | `SdkProcessOptions` | Full configuration for starting an SDK process: session, project, agent, prompt, callbacks, MCP servers, persona/skill prompts. Includes `keepAlive?: boolean` to enable warm process mode |
 | `SdkProcess` | Running process handle: `{ pid, sendMessage, kill, isAlive, isWarm }` |
+| `TurnCompleteMetrics` | Metrics passed to `onTurnComplete` callback: `{ totalCostUsd, durationMs, numTurns }` |
 
 ### Exported Constants
 


### PR DESCRIPTION
## Summary

Core implementation of session keep-alive (#2222, Phase 2). SDK processes can now survive between model turns in a **warm** state, avoiding full context reconstruction on follow-up messages (~80-90% input token savings).

### Changes

- **SdkProcess** (`sdk-process.ts`): `isWarm()` method, `keepAlive`/`onTurnComplete` options, warm state tracking with `processing → warm → dead` transitions, `streamInput` failure handling on warm processes
- **SessionTimerManager** (`session-timer-manager.ts`): Keep-alive TTL timers (default 15min via `KEEP_ALIVE_TTL_MS`), `startKeepAliveTtl`/`clearKeepAliveTtl` methods, separate from session inactivity timeouts
- **ProcessManager** (`manager.ts`): Warm path routing in `resumeProcess` (check warm process first, fall through to cold-start on failure), `handleTurnComplete` for TTL management, TTL reset on `sendMessage`, `warmProcesses`/`keepAliveTimers` in stats
- **ProcessSpawner** (`process-spawner.ts`): `keepAlive` in `SpawnOptions`, `onTurnComplete` in `ProcessSpawnerDeps`
- **DirectProcess/CursorProcess**: `isWarm: () => false` (keep-alive is SDK-only)
- **Spec**: Documented `TurnCompleteMetrics` export

### Activation

Opt-in via `KEEP_ALIVE_ENABLED=true` env var (defaults to off for backward compatibility). Per-session control planned for Phase 3.

### Verification

- TypeScript: ✅ clean
- Lint: ✅ clean (1 pre-existing import organization info)
- Tests: ✅ 10,627 pass, 0 fail
- Specs: ✅ 216 pass, 0 fail

## Test plan

- [x] Set `KEEP_ALIVE_ENABLED=true` and verify warm path activates after model turn
- [x] Verify cold-start fallback when `streamInput()` fails on warm process
- [x] Verify keep-alive TTL expiry kills warm process after 15min idle
- [x] Verify `KEEP_ALIVE_ENABLED=false` (default) preserves existing single-turn behavior
- [x] Confirm `getMemoryStats()` reports `warmProcesses` and `keepAliveTimers` correctly

Tracking: #2240 (Phase 2 checkbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)