### PR TITLE
feat(keep-alive): Phase 3 — per-session flag, coexistence, dashboard warm badges

### DIFF
--- a/client/src/app/core/models/session.model.ts
+++ b/client/src/app/core/models/session.model.ts
@@ -17,6 +17,7 @@ export interface Session {
     totalTurns: number;
     councilLaunchId: string | null;
     councilRole: 'member' | 'reviewer' | 'chairman' | 'discusser' | null;
+    keepAlive: boolean;
     createdAt: string;
     updatedAt: string;
 }

--- a/client/src/app/features/sessions/session-list.component.ts
+++ b/client/src/app/features/sessions/session-list.component.ts
@@ -104,7 +104,12 @@ interface SessionGroup {
                                    [class.session-table__row--running]="session.status === 'running' || session.status === 'loading'">
                                     <span class="session-table__name" [title]="sessionDisplayName(session)">{{ sessionDisplayName(session) }}</span>
                                     <span class="session-table__agent" [title]="getAgentName(session.agentId)">{{ getAgentName(session.agentId) }}</span>
-                                    <span><app-status-badge [status]="session.status" /></span>
+                                    <span>
+                                        <app-status-badge [status]="session.status" />
+                                        @if (session.keepAlive && session.status === 'idle') {
+                                            <span class="warm-badge" title="Process warm — instant resume">warm</span>
+                                        }
+                                    </span>
                                     <span class="session-table__cost">\${{ session.totalCostUsd | number:'1.2-4' }}</span>
                                     <span class="session-table__source">{{ session.source }}</span>
                                     <span class="session-table__time" [title]="session.updatedAt | absoluteTime">{{ session.updatedAt | relativeTime }}</span>
@@ -167,6 +172,13 @@ interface SessionGroup {
             display: block; width: 100%; margin-top: 0.5rem;
             color: var(--accent-cyan); font-size: 0.75rem; font-weight: 600;
             text-transform: uppercase; letter-spacing: 0.05em;
+        }
+
+        .warm-badge {
+            display: inline-block; margin-left: 4px; padding: 1px 5px;
+            border-radius: var(--radius-sm); font-size: 0.6rem; font-weight: 600;
+            text-transform: uppercase; letter-spacing: 0.06em;
+            background: var(--accent-amber-dim); color: var(--accent-amber); border: 1px solid var(--accent-amber-border);
         }
 
         @media (max-width: 767px) {

--- a/client/src/app/features/sessions/session-view.component.ts
+++ b/client/src/app/features/sessions/session-view.component.ts
@@ -40,6 +40,9 @@ type SessionTab = 'conversation' | 'memory' | 'info';
                         @if (s.status === 'running' || s.status === 'thinking' || s.status === 'tool_use') {
                             <span class="session-view__live-dot" title="Session is active"></span>
                         }
+                        @if (s.keepAlive && s.status === 'idle') {
+                            <span class="session-view__warm-badge" title="Process warm — instant resume">warm</span>
+                        }
                     </div>
                     <div class="session-view__meta">
                         <span class="meta-item"><span class="meta-label">Agent</span> {{ agentName() }}</span>
@@ -252,6 +255,12 @@ type SessionTab = 'conversation' | 'memory' | 'info';
         @keyframes livePulse {
             0%, 100% { opacity: 1; box-shadow: 0 0 6px var(--accent-green-glow); }
             50% { opacity: 0.5; box-shadow: 0 0 12px var(--accent-green-glow); }
+        }
+        .session-view__warm-badge {
+            display: inline-block; padding: 1px 6px;
+            border-radius: var(--radius-sm); font-size: 0.6rem; font-weight: 600;
+            text-transform: uppercase; letter-spacing: 0.06em;
+            background: var(--accent-amber-dim); color: var(--accent-amber); border: 1px solid var(--accent-amber-border);
         }
         .session-view__meta { display: flex; gap: 0.75rem; font-size: 0.7rem; color: var(--text-secondary); margin-left: auto; flex-wrap: wrap; align-items: center; }
         .meta-item { white-space: nowrap; }

--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -38,7 +38,7 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Server modules | 47 |
 | API routes | 55 modules (~236 endpoints) |
 | Database tables | 114 |
-| Database migrations | 49 (squashed baseline) |
+| Database migrations | 50 (squashed baseline) |
 | MCP tools | 62 corvid_* handlers |
 | Unit tests | 4,242 test files |
 | E2E tests | 360 across 33 Playwright specs |

--- a/server/__tests__/a2a-invocation-guard.test.ts
+++ b/server/__tests__/a2a-invocation-guard.test.ts
@@ -64,6 +64,7 @@ const MOCK_SESSION = {
   councilRole: null,
   workDir: null,
   creditsConsumed: 0,
+  keepAlive: false,
   lastContextTokens: null,
   lastContextWindow: null,
   createdAt: '2026-01-01T00:00:00.000Z',

--- a/server/__tests__/a2a-tasks.test.ts
+++ b/server/__tests__/a2a-tasks.test.ts
@@ -51,6 +51,7 @@ const MOCK_SESSION = {
   councilRole: null,
   workDir: null,
   creditsConsumed: 0,
+  keepAlive: false,
   lastContextTokens: null,
   lastContextWindow: null,
   createdAt: '2026-01-01T00:00:00.000Z',

--- a/server/__tests__/ollama-stall-escalator.test.ts
+++ b/server/__tests__/ollama-stall-escalator.test.ts
@@ -40,6 +40,7 @@ const mockGetSession = mock((_db: unknown, _id: string) => ({
   councilRole: null,
   workDir: null,
   creditsConsumed: 0,
+  keepAlive: false,
   lastContextTokens: null,
   lastContextWindow: null,
   createdAt: new Date().toISOString(),

--- a/server/db/migrations/127_session_keep_alive.ts
+++ b/server/db/migrations/127_session_keep_alive.ts
@@ -1,0 +1,12 @@
+import type { Database } from 'bun:sqlite';
+
+export function up(db: Database): void {
+  const columns = db.query('PRAGMA table_info(sessions)').all() as { name: string }[];
+  if (!columns.find((c) => c.name === 'keep_alive')) {
+    db.exec(`ALTER TABLE sessions ADD COLUMN keep_alive INTEGER NOT NULL DEFAULT 0`);
+  }
+}
+
+export function down(_db: Database): void {
+  // SQLite does not support DROP COLUMN in older versions; no-op rollback
+}

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -308,6 +308,7 @@ const MIGRATIONS: Record<number, string[]> = {
   ],
   125: [`ALTER TABLE sessions ADD COLUMN cumulative_turns INTEGER DEFAULT 0`],
   126: [`ALTER TABLE councils ADD COLUMN min_trust_level TEXT`],
+  127: [`ALTER TABLE sessions ADD COLUMN keep_alive INTEGER NOT NULL DEFAULT 0`],
 };
 
 // ── Schema version ──────────────────────────────────────────────────

--- a/server/db/sessions.ts
+++ b/server/db/sessions.ts
@@ -31,6 +31,7 @@ interface SessionRow {
   council_role: string | null;
   work_dir: string | null;
   credits_consumed: number;
+  keep_alive: number;
   last_context_tokens: number | null;
   last_context_window: number | null;
   created_at: string;
@@ -72,6 +73,7 @@ function rowToSession(row: SessionRow): Session {
     councilRole: (row.council_role as Session['councilRole']) ?? null,
     workDir: row.work_dir ?? null,
     creditsConsumed: row.credits_consumed ?? 0,
+    keepAlive: row.keep_alive === 1,
     lastContextTokens: row.last_context_tokens ?? null,
     lastContextWindow: row.last_context_window ?? null,
     createdAt: row.created_at,
@@ -129,8 +131,8 @@ export function createSession(db: Database, input: CreateSessionInput, tenantId:
   const initialStatus = source === 'agent' ? 'loading' : 'idle';
 
   db.query(
-    `INSERT INTO sessions (id, project_id, agent_id, name, source, initial_prompt, status, council_launch_id, council_role, work_dir, tenant_id)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO sessions (id, project_id, agent_id, name, source, initial_prompt, status, council_launch_id, council_role, work_dir, keep_alive, tenant_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     id,
     input.projectId ?? null,
@@ -142,6 +144,7 @@ export function createSession(db: Database, input: CreateSessionInput, tenantId:
     input.councilLaunchId ?? null,
     input.councilRole ?? null,
     input.workDir ?? null,
+    input.keepAlive ? 1 : 0,
     tenantId,
   );
 
@@ -175,6 +178,10 @@ export function updateSession(
   if (input.status !== undefined) {
     fields.push('status = ?');
     values.push(input.status);
+  }
+  if (input.keepAlive !== undefined) {
+    fields.push('keep_alive = ?');
+    values.push(input.keepAlive ? 1 : 0);
   }
 
   if (fields.length === 0) return existing;

--- a/server/lib/validation.ts
+++ b/server/lib/validation.ts
@@ -266,11 +266,13 @@ export const CreateSessionSchema = z.object({
   initialPrompt: z.string().optional(),
   councilLaunchId: z.string().optional(),
   councilRole: z.enum(['member', 'reviewer', 'chairman', 'discusser']).optional(),
+  keepAlive: z.boolean().optional(),
 });
 
 export const UpdateSessionSchema = z.object({
   name: z.string().optional(),
   status: z.enum(['idle', 'loading', 'running', 'paused', 'stopped', 'error']).optional(),
+  keepAlive: z.boolean().optional(),
 });
 
 export const ResumeSessionSchema = z

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -1331,6 +1331,7 @@ export class ProcessManager {
     } as ClaudeStreamEvent);
 
     this.finalizeTokenTracking(sessionId);
+    this.timerManager.clearKeepAliveTtl(sessionId);
     cp.kill();
     this.processes.delete(sessionId);
     updateSessionPid(this.db, sessionId, null);
@@ -1622,6 +1623,7 @@ export class ProcessManager {
       this.timerManager.clearKeepAliveTtl(sessionId);
       // Restart normal session inactivity timeout since process is now active
       this.timerManager.startSessionTimeout(sessionId);
+      updateSessionStatus(this.db, sessionId, 'running');
     }
 
     // Persist as text for session history (extract text from multimodal content)
@@ -2104,6 +2106,9 @@ export class ProcessManager {
       durationMs: metrics.durationMs,
       numTurns: metrics.numTurns,
     });
+
+    // Mark session idle in DB — the process is warm but waiting for input
+    updateSessionStatus(this.db, sessionId, 'idle');
 
     // Start keep-alive TTL — process will be killed if no new message arrives
     this.timerManager.startKeepAliveTtl(sessionId, KEEP_ALIVE_TTL_MS);

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -1250,8 +1250,8 @@ export class ProcessManager {
           externalMcpConfigs: resumeExternalMcpConfigs,
           conversationOnly: isConversationOnly,
           toolAllowList: resumeToolAllowList,
-          keepAlive: KEEP_ALIVE_ENABLED,
-          onTurnComplete: KEEP_ALIVE_ENABLED ? (metrics) => this.handleTurnComplete(session.id, metrics) : undefined,
+          keepAlive: session.keepAlive || KEEP_ALIVE_ENABLED,
+          onTurnComplete: (session.keepAlive || KEEP_ALIVE_ENABLED) ? (metrics) => this.handleTurnComplete(session.id, metrics) : undefined,
         });
       }
     } catch (err) {

--- a/shared/types/sessions.ts
+++ b/shared/types/sessions.ts
@@ -17,6 +17,7 @@ export interface Session {
   councilRole: 'member' | 'reviewer' | 'chairman' | 'discusser' | null;
   workDir: string | null;
   creditsConsumed: number;
+  keepAlive: boolean;
   lastContextTokens: number | null;
   lastContextWindow: number | null;
   createdAt: string;
@@ -50,9 +51,12 @@ export interface CreateSessionInput {
   toolAccessPolicy?: ToolAccessPolicy;
   /** Specific expensive tools to enable even under standard/restricted policy. */
   allowedExpensiveTools?: string[];
+  /** Enable keep-alive for this session (process stays warm between turns). */
+  keepAlive?: boolean;
 }
 
 export interface UpdateSessionInput {
   name?: string;
   status?: SessionStatus;
+  keepAlive?: boolean;
 }

--- a/specs/db/sessions/sessions.spec.md
+++ b/specs/db/sessions/sessions.spec.md
@@ -6,6 +6,7 @@ files:
   - server/db/sessions.ts
   - server/db/migrations/115_algochat_unique_participant.ts
   - server/db/migrations/125_cumulative_turns.ts
+  - server/db/migrations/127_session_keep_alive.ts
 db_tables:
   - sessions
   - session_messages
@@ -71,6 +72,13 @@ No business logic lives here -- just SQL queries with row-to-domain mapping.
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
 | `up` | `(db: Database)` | `void` | Adds `cumulative_turns` column to sessions table (guarded by PRAGMA table_info), backfills from `total_turns` |
+| `down` | `(_db: Database)` | `void` | No-op (column addition is not reversed) |
+
+### Exported Migration Functions — `server/db/migrations/127_session_keep_alive.ts`
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `up` | `(db: Database)` | `void` | Adds `keep_alive` column to sessions table (guarded by PRAGMA table_info) |
 | `down` | `(_db: Database)` | `void` | No-op (column addition is not reversed) |
 
 ## Invariants
@@ -158,6 +166,7 @@ No business logic lives here -- just SQL queries with row-to-domain mapping.
 | total_algo_spent | REAL | DEFAULT 0 | Cumulative microALGOs spent |
 | total_turns | INTEGER | DEFAULT 0 | Number of conversation turns (resets on context compaction) |
 | cumulative_turns | INTEGER | DEFAULT 0 | Total turns across all context windows (never resets) |
+| keep_alive | INTEGER | NOT NULL, DEFAULT 0 | Per-session keep-alive flag (boolean: 0=off, 1=on) |
 | council_launch_id | TEXT | nullable | Links to council_launches if part of a council |
 | council_role | TEXT | nullable | chairman/member/synthesizer |
 | work_dir | TEXT | nullable | Override working directory (e.g. git worktree) |
@@ -201,3 +210,4 @@ No environment variables. This module is a pure data layer.
 |------|--------|--------|
 | 2026-02-19 | corvid-agent | Initial spec |
 | 2026-05-01 | corvid-agent | Add cumulative_turns column, getSessionCumulativeTurns, incrementSessionCumulativeTurns (#2216) |
+| 2026-05-04 | corvid-agent | Add keep_alive column for per-session keep-alive flag (Phase 3) |


### PR DESCRIPTION
## Summary

Phase 3 of the keep-alive epic (#2222, tracked in #2240):

- **Phase 3.1** — Per-session `keep_alive` DB column (migration 127). Sessions can now opt into keep-alive individually via API, OR'd with the global `KEEP_ALIVE_ENABLED` env var. Added to `CreateSessionInput`, `UpdateSessionInput`, validation schemas, and DB layer.
- **Phase 3.2** — Context reset coexistence. `compactSession` now clears the keep-alive TTL timer, preventing dangling timers when a warm process gets compacted.
- **Phase 3.3** — Session status tracking for warm processes. Sets session status to `idle` when process enters warm state (waiting for input), back to `running` when warm path delivers a new message.
- **Phase 3.4** — Dashboard warm badges. Amber "warm" badge appears in both session list and session detail view when `keepAlive=true` and status is `idle` — indicates process is warm and will resume instantly.

## Files changed

- `server/db/migrations/127_session_keep_alive.ts` — new migration
- `server/db/schema/index.ts` — migration 127 entry
- `server/db/sessions.ts` — `SessionRow`, `rowToSession`, `createSession`, `updateSession` updated
- `server/lib/validation.ts` — `CreateSessionSchema`, `UpdateSessionSchema` updated
- `server/process/manager.ts` — per-session flag, compaction TTL cleanup, status transitions
- `shared/types/sessions.ts` — `Session`, `CreateSessionInput`, `UpdateSessionInput` updated
- `client/src/app/core/models/session.model.ts` — `keepAlive` field added
- `client/src/app/features/sessions/session-list.component.ts` — warm badge
- `client/src/app/features/sessions/session-view.component.ts` — warm badge
- `specs/db/sessions/sessions.spec.md` — spec updated with new column and migration
- Test mocks updated (3 files)

## Test plan

- [x] TypeScript typecheck passes
- [x] 10,627 tests pass, 0 failures
- [x] 216 specs pass, 0 failures
- [x] Angular client builds successfully
- [x] Enable `KEEP_ALIVE_ENABLED=true`, send two messages to same session within 15min, verify warm badge appears in dashboard
- [x] Toggle `keepAlive` via API on a session, verify per-session override works
- [x] Verify compaction of a warm session clears the TTL timer cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)