### PR TITLE
fix(keep-alive): wire keepAlive params into initial start path

### DIFF
--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -661,6 +661,8 @@ export class ProcessManager {
         skillPrompt: config.skillPrompt,
         conversationOnly: isNoTools || conversationOnly,
         toolAllowList: isRestrictedTools ? toolAllowList : undefined,
+        keepAlive: session.keepAlive || KEEP_ALIVE_ENABLED,
+        onTurnComplete: (session.keepAlive || KEEP_ALIVE_ENABLED) ? (metrics) => this.handleTurnComplete(session.id, metrics) : undefined,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- **Bug**: `keepAlive` and `onTurnComplete` params were only passed in the resume path (line 1253) but missing from the initial `startSdkProcessWrapped()` call (line 648)
- **Effect**: Keep-alive never activated on first session start — the process always exited to idle instead of entering warm state
- **Fix**: Added the same two params to the initial start path, matching the resume path

Closes part of #2240 (Phase 4 testing revealed this)

## Test plan
- [x] Restart server with fix
- [x] Enable keep-alive on a session
- [x] Send first message → verify process enters warm state (logs show "entering warm state")
- [x] Send second message → verify warm path is used (logs show warm path, not cold start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)