### PR TITLE
fix(keep-alive): persistent message queue prevents stdin close

### DIFF
--- a/server/__tests__/sdk-process.test.ts
+++ b/server/__tests__/sdk-process.test.ts
@@ -20,6 +20,7 @@ import {
   buildSafeEnv,
   ENV_ALLOWLIST,
   isApiError,
+  MessageQueue,
   mapSdkMessageToEvent,
 } from '../process/sdk-process';
 import type { ClaudeStreamEvent } from '../process/types';
@@ -616,5 +617,145 @@ describe('messaging safety prompt for sdk-process', () => {
     expect(combined).toContain(agentSystemPrompt);
     expect(combined).toContain(agentAppendPrompt);
     expect(combined).toContain('## Messaging Safety');
+  });
+});
+
+// ── MessageQueue (keep-alive persistent input queue) ────────────────────────
+
+function makeUserMsg(content: string): import('@anthropic-ai/claude-agent-sdk').SDKUserMessage {
+  return {
+    type: 'user',
+    message: { role: 'user', content },
+    parent_tool_use_id: null,
+    session_id: 'test-session',
+  } as import('@anthropic-ai/claude-agent-sdk').SDKUserMessage;
+}
+
+describe('MessageQueue', () => {
+  test('implements AsyncIterable protocol', () => {
+    const q = new MessageQueue();
+    expect(q[Symbol.asyncIterator]()).toBe(q);
+  });
+
+  test('enqueue then next returns the message', async () => {
+    const q = new MessageQueue();
+    const msg = makeUserMsg('hello');
+    q.enqueue(msg);
+
+    const result = await q.next();
+    expect(result.done).toBe(false);
+    expect(result.value).toBe(msg);
+  });
+
+  test('delivers messages in FIFO order', async () => {
+    const q = new MessageQueue();
+    const m1 = makeUserMsg('first');
+    const m2 = makeUserMsg('second');
+    const m3 = makeUserMsg('third');
+    q.enqueue(m1);
+    q.enqueue(m2);
+    q.enqueue(m3);
+
+    expect((await q.next()).value).toBe(m1);
+    expect((await q.next()).value).toBe(m2);
+    expect((await q.next()).value).toBe(m3);
+  });
+
+  test('next() blocks until a message is enqueued', async () => {
+    const q = new MessageQueue();
+    const msg = makeUserMsg('delayed');
+
+    const promise = q.next();
+
+    // Enqueue after a microtask to prove next() was waiting
+    queueMicrotask(() => q.enqueue(msg));
+
+    const result = await promise;
+    expect(result.done).toBe(false);
+    expect(result.value).toBe(msg);
+  });
+
+  test('close() resolves a pending next() with done: true', async () => {
+    const q = new MessageQueue();
+
+    const promise = q.next();
+    q.close();
+
+    const result = await promise;
+    expect(result.done).toBe(true);
+  });
+
+  test('next() returns done immediately after close with empty queue', async () => {
+    const q = new MessageQueue();
+    q.close();
+
+    const result = await q.next();
+    expect(result.done).toBe(true);
+  });
+
+  test('drains buffered messages before signalling done after close', async () => {
+    const q = new MessageQueue();
+    const m1 = makeUserMsg('buffered-1');
+    const m2 = makeUserMsg('buffered-2');
+    q.enqueue(m1);
+    q.enqueue(m2);
+    q.close();
+
+    const r1 = await q.next();
+    expect(r1.done).toBe(false);
+    expect(r1.value).toBe(m1);
+
+    const r2 = await q.next();
+    expect(r2.done).toBe(false);
+    expect(r2.value).toBe(m2);
+
+    const r3 = await q.next();
+    expect(r3.done).toBe(true);
+  });
+
+  test('enqueue after close is silently ignored', async () => {
+    const q = new MessageQueue();
+    q.close();
+    q.enqueue(makeUserMsg('ignored'));
+
+    const result = await q.next();
+    expect(result.done).toBe(true);
+  });
+
+  test('works as async iterable with for-await', async () => {
+    const q = new MessageQueue();
+    const messages = [makeUserMsg('a'), makeUserMsg('b'), makeUserMsg('c')];
+    for (const m of messages) q.enqueue(m);
+    q.close();
+
+    const collected: string[] = [];
+    for await (const msg of q) {
+      const content = (msg as { message: { content: string } }).message.content;
+      collected.push(content);
+    }
+
+    expect(collected).toEqual(['a', 'b', 'c']);
+  });
+
+  test('interleaved enqueue and next', async () => {
+    const q = new MessageQueue();
+
+    q.enqueue(makeUserMsg('1'));
+    expect((await q.next()).value.message.content).toBe('1');
+
+    q.enqueue(makeUserMsg('2'));
+    q.enqueue(makeUserMsg('3'));
+    expect((await q.next()).value.message.content).toBe('2');
+    expect((await q.next()).value.message.content).toBe('3');
+
+    const pending = q.next();
+    q.enqueue(makeUserMsg('4'));
+    expect((await pending).value.message.content).toBe('4');
+  });
+
+  test('multiple close calls do not throw', () => {
+    const q = new MessageQueue();
+    q.close();
+    expect(() => q.close()).not.toThrow();
   });
 });

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -661,6 +661,8 @@ export class ProcessManager {
         skillPrompt: config.skillPrompt,
         conversationOnly: isNoTools || conversationOnly,
         toolAllowList: isRestrictedTools ? toolAllowList : undefined,
+        keepAlive: session.keepAlive || KEEP_ALIVE_ENABLED,
+        onTurnComplete: (session.keepAlive || KEEP_ALIVE_ENABLED) ? (metrics) => this.handleTurnComplete(session.id, metrics) : undefined,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/server/process/sdk-process.ts
+++ b/server/process/sdk-process.ts
@@ -31,7 +31,7 @@ const log = createLogger('SdkProcess');
  * Stays open until explicitly closed, preventing the SDK from calling
  * endInput() on the CLI process stdin.
  */
-class MessageQueue implements AsyncIterable<SDKUserMessage>, AsyncIterator<SDKUserMessage> {
+export class MessageQueue implements AsyncIterable<SDKUserMessage>, AsyncIterator<SDKUserMessage> {
   private queue: SDKUserMessage[] = [];
   private waiting: ((result: IteratorResult<SDKUserMessage>) => void) | null = null;
   private closed = false;

--- a/server/process/sdk-process.ts
+++ b/server/process/sdk-process.ts
@@ -6,6 +6,7 @@ import {
   type Query,
   query,
   type SDKMessage,
+  type SDKUserMessage,
 } from '@anthropic-ai/claude-agent-sdk';
 import type { Agent, McpServerConfig as DbMcpServerConfig, Project, Session } from '../../shared/types';
 import { createLogger } from '../lib/logger';
@@ -24,6 +25,53 @@ import { BASH_WRITE_OPERATORS, extractFilePathsFromInput, isProtectedPath } from
 import type { ClaudeStreamEvent } from './types';
 
 const log = createLogger('SdkProcess');
+
+/**
+ * Persistent async iterable message queue for keep-alive sessions.
+ * Stays open until explicitly closed, preventing the SDK from calling
+ * endInput() on the CLI process stdin.
+ */
+class MessageQueue implements AsyncIterable<SDKUserMessage>, AsyncIterator<SDKUserMessage> {
+  private queue: SDKUserMessage[] = [];
+  private waiting: ((result: IteratorResult<SDKUserMessage>) => void) | null = null;
+  private closed = false;
+
+  enqueue(msg: SDKUserMessage): void {
+    if (this.closed) return;
+    if (this.waiting) {
+      const resolve = this.waiting;
+      this.waiting = null;
+      resolve({ done: false, value: msg });
+    } else {
+      this.queue.push(msg);
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.waiting) {
+      const resolve = this.waiting;
+      this.waiting = null;
+      resolve({ done: true, value: undefined as unknown as SDKUserMessage });
+    }
+  }
+
+  next(): Promise<IteratorResult<SDKUserMessage>> {
+    if (this.queue.length > 0) {
+      return Promise.resolve({ done: false, value: this.queue.shift()! });
+    }
+    if (this.closed) {
+      return Promise.resolve({ done: true, value: undefined as unknown as SDKUserMessage });
+    }
+    return new Promise((resolve) => {
+      this.waiting = resolve;
+    });
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<SDKUserMessage> {
+    return this;
+  }
+}
 
 // Environment variables safe to pass to agent subprocesses.
 // Everything else (ALGOCHAT_MNEMONIC, WALLET_ENCRYPTION_KEY, API_KEY, etc.) is excluded.
@@ -448,9 +496,21 @@ export function startSdkProcess(options: SdkProcessOptions): SdkProcess {
     cwd: sdkOptions.cwd,
   });
 
-  // Start the SDK query
+  // Start the SDK query.
+  // For keep-alive sessions, pass an AsyncIterable instead of a string prompt.
+  // This prevents the SDK from setting isSingleUserTurn=true, which would close
+  // stdin after the first result and kill the process.
+  const inputQueue = keepAlive ? new MessageQueue() : null;
+  if (inputQueue) {
+    inputQueue.enqueue({
+      type: 'user',
+      message: { role: 'user', content: effectivePrompt },
+      parent_tool_use_id: null,
+      session_id: session.id,
+    });
+  }
   const q: Query = query({
-    prompt: effectivePrompt,
+    prompt: inputQueue ?? effectivePrompt,
     options: sdkOptions,
   });
 
@@ -565,33 +625,45 @@ export function startSdkProcess(options: SdkProcessOptions): SdkProcess {
       contentPreview: isMultimodal ? JSON.stringify(content).slice(0, 300) : (content as string).slice(0, 200),
     });
 
-    // Stream input to the running query
-    q.streamInput(
-      (async function* () {
-        yield {
-          type: 'user' as const,
-          message: { role: 'user' as const, content },
-          parent_tool_use_id: null,
-          session_id: session.id,
-        } as import('@anthropic-ai/claude-agent-sdk').SDKUserMessage;
-      })(),
-    ).catch((err) => {
-      log.warn(`streamInput failed for session ${session.id}`, {
-        error: err instanceof Error ? err.message : String(err),
-        stack: err instanceof Error ? err.stack : undefined,
-        wasWarm,
+    // Stream input to the running query.
+    // For keep-alive sessions, enqueue to the persistent input queue (stdin stays open).
+    // For non-keep-alive, use streamInput which closes stdin after the message.
+    if (inputQueue) {
+      inputQueue.enqueue({
+        type: 'user',
+        message: { role: 'user', content },
+        parent_tool_use_id: null,
+        session_id: session.id,
       });
-      // If streamInput fails on a warm process, mark as done so caller falls back to cold start
-      if (wasWarm) {
-        inputDone = true;
-      }
-    });
+    } else {
+      q.streamInput(
+        (async function* () {
+          yield {
+            type: 'user' as const,
+            message: { role: 'user' as const, content },
+            parent_tool_use_id: null,
+            session_id: session.id,
+          } as SDKUserMessage;
+        })(),
+      ).catch((err) => {
+        log.warn(`streamInput failed for session ${session.id}`, {
+          error: err instanceof Error ? err.message : String(err),
+          stack: err instanceof Error ? err.stack : undefined,
+          wasWarm,
+        });
+        // If streamInput fails on a warm process, mark as done so caller falls back to cold start
+        if (wasWarm) {
+          inputDone = true;
+        }
+      });
+    }
 
     return true;
   }
 
   function kill(): void {
     inputDone = true;
+    inputQueue?.close();
     abortController.abort();
     q.close();
   }

--- a/specs/process/sdk-process.spec.md
+++ b/specs/process/sdk-process.spec.md
@@ -84,6 +84,12 @@ start() ──→ [processing] ──→ model turn complete ──→ [warm]
 | `isApiError` | `(error: string)` | `boolean` | Check if an error string matches known API error patterns |
 | `mapSdkMessageToEvent` | `(message: SDKMessage, sessionId: string)` | `ClaudeStreamEvent \| null` | Convert an SDK message to a stream event for the event bus |
 
+### Exported Classes
+
+| Class | Implements | Description |
+|-------|-----------|-------------|
+| `MessageQueue` | `AsyncIterable<SDKUserMessage>`, `AsyncIterator<SDKUserMessage>` | Persistent async message queue for keep-alive sessions. Keeps stdin open so the SDK does not call `endInput()` after the first turn. Messages are enqueued via `enqueue()` and consumed by the SDK's `streamInput()`. Call `close()` on session teardown |
+
 ## Invariants
 
 1. **Protected file enforcement**: `canUseTool` blocks `Write`, `Edit`, `MultiEdit` on protected paths and `Bash` commands with write operators targeting protected paths. This runs BEFORE bypass mode checks — even `full-auto` agents cannot modify protected files


### PR DESCRIPTION
## Summary

- **Root cause**: `query()` with a string prompt sets `isSingleUserTurn=true` in the SDK. After the first `result` message, the SDK calls `endInput()` which closes stdin — killing the warm process immediately after entering warm state.
- **Fix**: For keep-alive sessions, pass an `AsyncIterable<SDKUserMessage>` (persistent `MessageQueue`) instead of a string prompt. This keeps `isSingleUserTurn=false`, stdin stays open, and the CLI process stays alive for true multi-turn warm-path operation.
- Subsequent messages enqueue to the `MessageQueue` instead of using `streamInput()`, keeping the single async iterator running.

Closes the "warm state lasts milliseconds" bug from the keep-alive feature (#2240).

## Test plan

- [x] Enable keep-alive on a session, send a message, verify warm state persists after turn completes
- [x] Send a follow-up message on the warm session, verify it uses the warm path (no cold start)
- [x] Verify non-keep-alive sessions still work normally with the original string prompt path
- [x] Verify `kill()` properly closes the queue and terminates the process

🤖 Generated with [Claude Code](https://claude.com/claude-code)