### PR TITLE
feat(telegram): keep-alive warm-turn support for Telegram bridge

### DIFF
--- a/server/__tests__/telegram-bridge.test.ts
+++ b/server/__tests__/telegram-bridge.test.ts
@@ -20,6 +20,7 @@ interface TelegramBridgeInternals {
   consecutiveErrors: number;
   dedup: DedupService;
   userSessions: Map<number, string>;
+  sessionCallbacks: Map<string, EventCallback>;
   userMessageTimestamps: Map<number, number[]>;
   poll: () => Promise<void>;
   handleUpdate: (update: { update_id: number; message?: TelegramMessage }) => Promise<void>;
@@ -802,6 +803,138 @@ describe('subscribeForResponse', () => {
     await new Promise((r) => setTimeout(r, 100));
     expect(pm.unsubscribe).toHaveBeenCalledWith(session.id, expect.any(Function));
     expect(sentTexts).toHaveLength(0);
+  });
+});
+
+describe('keep-alive warm turns', () => {
+  test('stays subscribed after result when keep_alive=1', async () => {
+    const pm = createMockProcessManager();
+    const bridge = new TelegramBridge(db, pm, defaultConfig);
+    mockApiCapture(bridge);
+    const agent = createAgent(db, { name: 'Test Agent', model: 'sonnet', voiceEnabled: false });
+    const project = createProject(db, { name: 'Test Project', workingDir: '/tmp/test' });
+    const session = createSession(db, {
+      projectId: project.id,
+      agentId: agent.id,
+      name: 'Test',
+      source: 'telegram',
+      keepAlive: true,
+    });
+    const holder = captureSubscribe(pm);
+    internals(bridge).subscribeForResponse(session.id, 12345);
+
+    // First warm turn completes
+    holder.cb!(session.id, makeAssistantEvent('Turn 1 response'));
+    holder.cb!(session.id, makeResultEvent());
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Callback should still be registered (not unsubscribed)
+    expect(pm.unsubscribe).not.toHaveBeenCalled();
+    expect(internals(bridge).sessionCallbacks.has(session.id)).toBe(true);
+  });
+
+  test('sends response for each warm turn', async () => {
+    const pm = createMockProcessManager();
+    const bridge = new TelegramBridge(db, pm, defaultConfig);
+    const sentTexts = mockApiCapture(bridge);
+    const agent = createAgent(db, { name: 'Test Agent', model: 'sonnet', voiceEnabled: false });
+    const project = createProject(db, { name: 'Test Project', workingDir: '/tmp/test' });
+    const session = createSession(db, {
+      projectId: project.id,
+      agentId: agent.id,
+      name: 'Test',
+      source: 'telegram',
+      keepAlive: true,
+    });
+    const holder = captureSubscribe(pm);
+    internals(bridge).subscribeForResponse(session.id, 12345);
+
+    // First turn
+    holder.cb!(session.id, makeAssistantEvent('First answer'));
+    holder.cb!(session.id, makeResultEvent());
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Second turn (same callback, warm path)
+    holder.cb!(session.id, makeAssistantEvent('Second answer'));
+    holder.cb!(session.id, makeResultEvent());
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(sentTexts.some((m) => m === 'First answer')).toBe(true);
+    expect(sentTexts.some((m) => m === 'Second answer')).toBe(true);
+    expect(pm.unsubscribe).not.toHaveBeenCalled();
+  });
+
+  test('unsubscribes on session_exited even with keep_alive=1', async () => {
+    const pm = createMockProcessManager();
+    const bridge = new TelegramBridge(db, pm, defaultConfig);
+    mockApiCapture(bridge);
+    const agent = createAgent(db, { name: 'Test Agent', model: 'sonnet', voiceEnabled: false });
+    const project = createProject(db, { name: 'Test Project', workingDir: '/tmp/test' });
+    const session = createSession(db, {
+      projectId: project.id,
+      agentId: agent.id,
+      name: 'Test',
+      source: 'telegram',
+      keepAlive: true,
+    });
+    const holder = captureSubscribe(pm);
+    internals(bridge).subscribeForResponse(session.id, 12345);
+
+    // Warm turn then session exits (TTL expired or explicit stop)
+    holder.cb!(session.id, makeAssistantEvent('Last response'));
+    holder.cb!(session.id, makeResultEvent());
+    await new Promise((r) => setTimeout(r, 100));
+    holder.cb!(session.id, makeSessionExitedEvent());
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(pm.unsubscribe).toHaveBeenCalledWith(session.id, expect.any(Function));
+    expect(internals(bridge).sessionCallbacks.has(session.id)).toBe(false);
+  });
+
+  test('deduplicates: second subscribeForResponse replaces first callback', () => {
+    const pm = createMockProcessManager();
+    const bridge = new TelegramBridge(db, pm, defaultConfig);
+    const agent = createAgent(db, { name: 'Test Agent', model: 'sonnet', voiceEnabled: false });
+    const project = createProject(db, { name: 'Test Project', workingDir: '/tmp/test' });
+    const session = createSession(db, {
+      projectId: project.id,
+      agentId: agent.id,
+      name: 'Test',
+      source: 'telegram',
+      keepAlive: true,
+    });
+    internals(bridge).subscribeForResponse(session.id, 12345, 1);
+    const firstCallback = internals(bridge).sessionCallbacks.get(session.id);
+
+    internals(bridge).subscribeForResponse(session.id, 12345, 2);
+    const secondCallback = internals(bridge).sessionCallbacks.get(session.id);
+
+    // Old callback was unsubscribed, new one is in place
+    expect(pm.unsubscribe).toHaveBeenCalledWith(session.id, firstCallback);
+    expect(secondCallback).not.toBe(firstCallback);
+    expect(pm.subscribe).toHaveBeenCalledTimes(2);
+  });
+
+  test('non-keep-alive session still unsubscribes on result', async () => {
+    const pm = createMockProcessManager();
+    const bridge = new TelegramBridge(db, pm, defaultConfig);
+    mockApiCapture(bridge);
+    const agent = createAgent(db, { name: 'Test Agent', model: 'sonnet', voiceEnabled: false });
+    const project = createProject(db, { name: 'Test Project', workingDir: '/tmp/test' });
+    const session = createSession(db, {
+      projectId: project.id,
+      agentId: agent.id,
+      name: 'Test',
+      source: 'telegram',
+    });
+    const holder = captureSubscribe(pm);
+    internals(bridge).subscribeForResponse(session.id, 12345);
+    holder.cb!(session.id, makeAssistantEvent('Normal response'));
+    holder.cb!(session.id, makeResultEvent());
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(pm.unsubscribe).toHaveBeenCalledWith(session.id, expect.any(Function));
+    expect(internals(bridge).sessionCallbacks.has(session.id)).toBe(false);
   });
 });
 

--- a/server/telegram/bridge.ts
+++ b/server/telegram/bridge.ts
@@ -44,6 +44,10 @@ export class TelegramBridge {
   // Map Telegram userId → active sessionId
   private userSessions: Map<number, string> = new Map();
 
+  // Track active response subscriptions: sessionId → EventCallback
+  // Used to dedup subscriptions on keep-alive re-messages and clean up on session exit.
+  private sessionCallbacks: Map<string, EventCallback> = new Map();
+
   // Per-user rate limiting: userId → timestamps of recent messages
   private userMessageTimestamps: Map<number, number[]> = new Map();
   private readonly RATE_LIMIT_WINDOW_MS = 60_000;
@@ -409,6 +413,13 @@ export class TelegramBridge {
   }
 
   private subscribeForResponse(sessionId: string, chatId: number, replyTo?: number): void {
+    // Dedup: replace existing subscription to prevent duplicate responses on keep-alive re-messages.
+    const existing = this.sessionCallbacks.get(sessionId);
+    if (existing) {
+      this.processManager.unsubscribe(sessionId, existing);
+      this.sessionCallbacks.delete(sessionId);
+    }
+
     let buffer = '';
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -436,6 +447,7 @@ export class TelegramBridge {
     const cleanup = () => {
       if (debounceTimer) clearTimeout(debounceTimer);
       this.processManager.unsubscribe(sessionId, callback);
+      this.sessionCallbacks.delete(sessionId);
     };
 
     const callback: EventCallback = (_sid, event) => {
@@ -452,8 +464,18 @@ export class TelegramBridge {
       }
 
       if (event.type === 'result') {
-        cleanup();
-        flush();
+        // Check if keep-alive is enabled — warm turn complete, stay subscribed for the next turn
+        const kaRow = this.db
+          .query<{ keep_alive: number }, [string]>('SELECT keep_alive FROM sessions WHERE id = ?')
+          .get(sessionId);
+        if (kaRow?.keep_alive === 1) {
+          if (debounceTimer) clearTimeout(debounceTimer);
+          debounceTimer = null;
+          void flush();
+        } else {
+          cleanup();
+          flush();
+        }
       }
 
       if (event.type === 'session_error') {
@@ -471,6 +493,7 @@ export class TelegramBridge {
       }
     };
 
+    this.sessionCallbacks.set(sessionId, callback);
     this.processManager.subscribe(sessionId, callback);
   }
 


### PR DESCRIPTION
## Summary

Phase 3 of the Session Keep-Alive epic (#2222): adds warm-turn support to the Telegram bridge so sessions with `keep_alive=1` stay subscribed between turns instead of dropping the subscription after the first response.

### The Problem

Before this PR, `subscribeForResponse` always called `cleanup()` on `result`, which unsubscribed the event callback. With keep-alive enabled, the callback was gone after turn 1, causing subsequent warm turns to have no listener to deliver responses.

There was also no protection against duplicate callbacks when keep-alive caused multiple `subscribeForResponse` calls for the same active session.

### Changes

**`server/telegram/bridge.ts`**
- Add `sessionCallbacks: Map<string, EventCallback>` to track the active subscription per session
- `subscribeForResponse` now unsubscribes any existing callback before registering a new one (dedup)
- On `result`: check `keep_alive` flag in DB; if enabled, flush the buffer and reset for the next turn but **stay subscribed**; non-keep-alive sessions unsubscribe as before
- `cleanup()` now also removes the session from `sessionCallbacks`
- `session_exited` always unsubscribes and cleans up (keep-alive TTL expired or explicit stop)

**`server/__tests__/telegram-bridge.test.ts`**
- Add `sessionCallbacks` to the internals interface
- 5 new tests: stay-subscribed after warm turn, multi-turn delivery, exited cleanup, dedup on re-subscribe, non-keep-alive backward compat

### Verification

- TypeScript: ✅ clean
- Lint: ✅ clean (1 pre-existing schema info)
- Tests: ✅ 10,655 pass, 0 fail (75 Telegram-specific)
- Specs: ✅ 13/13 pass, 100% file + LOC coverage

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test server/__tests__/telegram-bridge.test.ts` — 75/75 pass
- [x] `bun test` — 10,655 pass, 0 fail
- [x] `bun run spec:check` — 13/13 pass

Tracking: #2240 (Phase 3 — Telegram bridge integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)