### PR TITLE
refactor(discord): unified CorvidEmbed builder + TTL fix

### DIFF
--- a/server/__tests__/embed-builder.test.ts
+++ b/server/__tests__/embed-builder.test.ts
@@ -1,0 +1,734 @@
+/**
+ * Tests for the unified CorvidEmbed builder.
+ *
+ * Covers: color palette, button registry, chainable builder, footer
+ * construction, context usage, turns, stats, buttons, overrides, author
+ * blocks, all preset factory methods, and edge cases.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  CorvidEmbed,
+  EMBED_BUTTONS,
+  EMBED_COLORS,
+  type EmbedAgentIdentity,
+} from '../discord/embed-builder';
+import { ButtonStyle } from '../discord/types';
+import type { FooterContext } from '../discord/embeds';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const CTX: FooterContext = {
+  agentName: 'Rook',
+  agentModel: 'claude-sonnet-4-6',
+  sessionId: 'abcdef1234567890',
+  projectName: 'corvid-agent',
+};
+
+const AUTHOR: EmbedAgentIdentity = {
+  agentName: 'Rook',
+  displayIcon: '🐦',
+  avatarUrl: 'https://example.com/rook.png',
+};
+
+// ── EMBED_COLORS ─────────────────────────────────────────────────────────────
+
+describe('EMBED_COLORS', () => {
+  test('has all expected keys', () => {
+    expect(EMBED_COLORS).toHaveProperty('neutral');
+    expect(EMBED_COLORS).toHaveProperty('working');
+    expect(EMBED_COLORS).toHaveProperty('success');
+    expect(EMBED_COLORS).toHaveProperty('warning');
+    expect(EMBED_COLORS).toHaveProperty('error');
+    expect(EMBED_COLORS).toHaveProperty('errorAlt');
+  });
+
+  test('neutral is gray (0x95a5a6)', () => {
+    expect(EMBED_COLORS.neutral).toBe(0x95a5a6);
+  });
+
+  test('working is blurple (0x5865f2)', () => {
+    expect(EMBED_COLORS.working).toBe(0x5865f2);
+  });
+
+  test('success is green (0x57f287)', () => {
+    expect(EMBED_COLORS.success).toBe(0x57f287);
+  });
+
+  test('warning is yellow (0xf0b232)', () => {
+    expect(EMBED_COLORS.warning).toBe(0xf0b232);
+  });
+
+  test('error is red (0xff3355)', () => {
+    expect(EMBED_COLORS.error).toBe(0xff3355);
+  });
+
+  test('errorAlt is Discord red (0xed4245)', () => {
+    expect(EMBED_COLORS.errorAlt).toBe(0xed4245);
+  });
+});
+
+// ── EMBED_BUTTONS ─────────────────────────────────────────────────────────────
+
+describe('EMBED_BUTTONS', () => {
+  test('has all expected keys', () => {
+    expect(EMBED_BUTTONS).toHaveProperty('new_session');
+    expect(EMBED_BUTTONS).toHaveProperty('archive');
+    expect(EMBED_BUTTONS).toHaveProperty('create_issue');
+    expect(EMBED_BUTTONS).toHaveProperty('resume');
+    expect(EMBED_BUTTONS).toHaveProperty('continue_thread');
+  });
+
+  test('new_session has correct shape', () => {
+    expect(EMBED_BUTTONS.new_session.label).toBe('New Session');
+    expect(EMBED_BUTTONS.new_session.emoji).toBe('🔄');
+    expect(EMBED_BUTTONS.new_session.customId).toBe('new_session');
+    expect(EMBED_BUTTONS.new_session.style).toBe(ButtonStyle.SUCCESS);
+  });
+
+  test('archive has correct shape', () => {
+    expect(EMBED_BUTTONS.archive.label).toBe('Archive');
+    expect(EMBED_BUTTONS.archive.emoji).toBe('📦');
+    expect(EMBED_BUTTONS.archive.customId).toBe('archive_thread');
+    expect(EMBED_BUTTONS.archive.style).toBe(ButtonStyle.SECONDARY);
+  });
+
+  test('create_issue has correct shape', () => {
+    expect(EMBED_BUTTONS.create_issue.label).toBe('Create Issue');
+    expect(EMBED_BUTTONS.create_issue.emoji).toBe('📋');
+    expect(EMBED_BUTTONS.create_issue.customId).toBe('create_issue');
+    expect(EMBED_BUTTONS.create_issue.style).toBe(ButtonStyle.PRIMARY);
+  });
+
+  test('resume has correct shape', () => {
+    expect(EMBED_BUTTONS.resume.label).toBe('Resume');
+    expect(EMBED_BUTTONS.resume.emoji).toBe('🔄');
+    expect(EMBED_BUTTONS.resume.customId).toBe('resume_thread');
+    expect(EMBED_BUTTONS.resume.style).toBe(ButtonStyle.SUCCESS);
+  });
+
+  test('continue_thread has correct shape', () => {
+    expect(EMBED_BUTTONS.continue_thread.label).toBe('Continue in Thread');
+    expect(EMBED_BUTTONS.continue_thread.emoji).toBe('🧵');
+    expect(EMBED_BUTTONS.continue_thread.customId).toBe('continue_thread');
+    expect(EMBED_BUTTONS.continue_thread.style).toBe(ButtonStyle.PRIMARY);
+  });
+});
+
+// ── Builder — basic fields ────────────────────────────────────────────────────
+
+describe('CorvidEmbed builder — basic fields', () => {
+  test('setTitle sets title on embed', () => {
+    const { embed } = new CorvidEmbed().setTitle('My Title').build();
+    expect(embed.title).toBe('My Title');
+  });
+
+  test('setDescription sets description on embed', () => {
+    const { embed } = new CorvidEmbed().setDescription('My description').build();
+    expect(embed.description).toBe('My description');
+  });
+
+  test('setColor sets color on embed', () => {
+    const { embed } = new CorvidEmbed().setColor(EMBED_COLORS.success).build();
+    expect(embed.color).toBe(EMBED_COLORS.success);
+  });
+
+  test('addField appends a field', () => {
+    const { embed } = new CorvidEmbed().addField('Name', 'Value', true).build();
+    expect(embed.fields).toHaveLength(1);
+    expect(embed.fields![0]).toEqual({ name: 'Name', value: 'Value', inline: true });
+  });
+
+  test('addField without inline does not include inline property', () => {
+    const { embed } = new CorvidEmbed().addField('Name', 'Value').build();
+    expect(embed.fields![0]).not.toHaveProperty('inline');
+  });
+
+  test('setFields replaces all fields', () => {
+    const fields = [
+      { name: 'A', value: '1' },
+      { name: 'B', value: '2', inline: true },
+    ];
+    const { embed } = new CorvidEmbed()
+      .addField('Old', 'field')
+      .setFields(fields)
+      .build();
+    expect(embed.fields).toHaveLength(2);
+    expect(embed.fields![0].name).toBe('A');
+  });
+
+  test('setImage sets image url', () => {
+    const { embed } = new CorvidEmbed().setImage('https://example.com/img.png').build();
+    expect(embed.image).toEqual({ url: 'https://example.com/img.png' });
+  });
+
+  test('setThumbnail sets thumbnail url', () => {
+    const { embed } = new CorvidEmbed().setThumbnail('https://example.com/thumb.png').build();
+    expect(embed.thumbnail).toEqual({ url: 'https://example.com/thumb.png' });
+  });
+
+  test('build returns no components when no buttons set', () => {
+    const result = new CorvidEmbed().setTitle('Test').build();
+    expect(result.components).toBeUndefined();
+  });
+
+  test('empty builder produces empty embed object', () => {
+    const { embed } = new CorvidEmbed().build();
+    expect(embed.title).toBeUndefined();
+    expect(embed.description).toBeUndefined();
+    expect(embed.footer).toBeUndefined();
+    expect(embed.author).toBeUndefined();
+  });
+});
+
+// ── Builder — footer ──────────────────────────────────────────────────────────
+
+describe('CorvidEmbed builder — footer', () => {
+  test('no footer produced when no agent is set', () => {
+    const { embed } = new CorvidEmbed().setDescription('Hello').build();
+    expect(embed.footer).toBeUndefined();
+  });
+
+  test('footer includes agent name when setAgent is called', () => {
+    const { embed } = new CorvidEmbed()
+      .setAgent({ agentName: 'Rook' })
+      .build();
+    expect(embed.footer?.text).toContain('Rook');
+  });
+
+  test('footer includes model when agentModel is on identity (via setProject/setSession)', () => {
+    // model comes from FooterContext — need to check that setAgent + context flows through
+    const { embed } = new CorvidEmbed()
+      .setAgent(AUTHOR)
+      .setSession('abcdef1234567890')
+      .setProject('corvid-agent')
+      .setStatus('thinking')
+      .build();
+    const footer = embed.footer!.text;
+    expect(footer).toContain('Rook');
+    expect(footer).toContain('sid:abcdef12');
+    expect(footer).toContain('corvid-agent');
+    expect(footer).toContain('thinking');
+  });
+
+  test('withContextUsage adds usage to footer', () => {
+    const { embed } = new CorvidEmbed()
+      .setAgent({ agentName: 'Rook' })
+      .withContextUsage({ usagePercent: 32, estimatedTokens: 64000, contextWindow: 200000 })
+      .build();
+    const footer = embed.footer!.text;
+    expect(footer).toContain('32%');
+    expect(footer).toContain('64k');
+    expect(footer).toContain('200k');
+  });
+
+  test('withTurns adds turn counter to footer', () => {
+    const { embed } = new CorvidEmbed()
+      .setAgent({ agentName: 'Rook' })
+      .withTurns(5)
+      .build();
+    expect(embed.footer!.text).toContain('T:5');
+  });
+
+  test('withTurns with cumulativeTurns shows T:x(n) format', () => {
+    const { embed } = new CorvidEmbed()
+      .setAgent({ agentName: 'Rook' })
+      .withTurns(5, 23)
+      .build();
+    expect(embed.footer!.text).toContain('T:5(23)');
+  });
+
+  test('withStats uses buildFooterWithStats', () => {
+    const { embed } = new CorvidEmbed()
+      .setAgent({ agentName: 'Rook' })
+      .setStatus('done')
+      .withStats({ filesChanged: 3, turns: 7, tools: 15 })
+      .build();
+    const footer = embed.footer!.text;
+    expect(footer).toContain('3 files');
+    expect(footer).toContain('7 turns');
+    expect(footer).toContain('15 tools');
+  });
+
+  test('withStats with cumulativeTurns shows cumulative in footer', () => {
+    const { embed } = new CorvidEmbed()
+      .setAgent({ agentName: 'Rook' })
+      .withStats({ turns: 5, tools: 10 }, 23)
+      .build();
+    const footer = embed.footer!.text;
+    expect(footer).toContain('5 turns (23 total)');
+  });
+
+  test('withStats with contextUsage includes both stats and usage', () => {
+    const { embed } = new CorvidEmbed()
+      .setAgent({ agentName: 'Rook' })
+      .withStats({ turns: 3 })
+      .withContextUsage({ usagePercent: 50, estimatedTokens: 100000, contextWindow: 200000 })
+      .build();
+    const footer = embed.footer!.text;
+    expect(footer).toContain('3 turns');
+    expect(footer).toContain('50%');
+  });
+});
+
+// ── Builder — author ──────────────────────────────────────────────────────────
+
+describe('CorvidEmbed builder — author', () => {
+  test('setAgent builds author from identity', () => {
+    const { embed } = new CorvidEmbed()
+      .setAgent({ agentName: 'Rook', displayIcon: '🐦', avatarUrl: 'https://example.com/rook.png' })
+      .build();
+    expect(embed.author?.name).toBe('🐦 Rook');
+    expect(embed.author?.icon_url).toBe('https://example.com/rook.png');
+  });
+
+  test('agent without displayIcon does not prepend emoji to name', () => {
+    const { embed } = new CorvidEmbed()
+      .setAgent({ agentName: 'Rook' })
+      .build();
+    expect(embed.author?.name).toBe('Rook');
+  });
+
+  test('setAuthor overrides agent-derived author', () => {
+    const { embed } = new CorvidEmbed()
+      .setAgent({ agentName: 'Rook' })
+      .setAuthor({ name: 'Custom Author', icon_url: 'https://example.com/icon.png' })
+      .build();
+    expect(embed.author?.name).toBe('Custom Author');
+    expect(embed.author?.icon_url).toBe('https://example.com/icon.png');
+  });
+
+  test('no author when neither setAgent nor setAuthor is called', () => {
+    const { embed } = new CorvidEmbed().setTitle('Test').build();
+    expect(embed.author).toBeUndefined();
+  });
+});
+
+// ── Builder — buttons ─────────────────────────────────────────────────────────
+
+describe('CorvidEmbed builder — buttons', () => {
+  test('withButtons produces action row components', () => {
+    const { components } = new CorvidEmbed()
+      .withButtons(['new_session', 'archive'])
+      .build();
+    expect(components).toHaveLength(1);
+    expect(components![0].components).toHaveLength(2);
+  });
+
+  test('button labels match EMBED_BUTTONS definitions', () => {
+    const { components } = new CorvidEmbed()
+      .withButtons(['new_session', 'create_issue', 'archive'])
+      .build();
+    const labels = components![0].components.map((b) => b.label);
+    expect(labels).toContain('New Session');
+    expect(labels).toContain('Create Issue');
+    expect(labels).toContain('Archive');
+  });
+
+  test('button customIds match EMBED_BUTTONS definitions', () => {
+    const { components } = new CorvidEmbed()
+      .withButtons(['resume'])
+      .build();
+    expect(components![0].components[0].custom_id).toBe('resume_thread');
+  });
+
+  test('withButtonOverride changes customId for specified key', () => {
+    const { components } = new CorvidEmbed()
+      .withButtons(['continue_thread'])
+      .withButtonOverride('continue_thread', 'continue_thread:session-xyz')
+      .build();
+    expect(components![0].components[0].custom_id).toBe('continue_thread:session-xyz');
+  });
+
+  test('withButtonOverride does not affect other buttons', () => {
+    const { components } = new CorvidEmbed()
+      .withButtons(['new_session', 'continue_thread'])
+      .withButtonOverride('continue_thread', 'continue_thread:sess')
+      .build();
+    expect(components![0].components[0].custom_id).toBe('new_session');
+    expect(components![0].components[1].custom_id).toBe('continue_thread:sess');
+  });
+
+  test('no components when withButtons is not called', () => {
+    const result = new CorvidEmbed().setDescription('Hello').build();
+    expect(result.components).toBeUndefined();
+  });
+
+  test('button emoji is set on action row component', () => {
+    const { components } = new CorvidEmbed()
+      .withButtons(['archive'])
+      .build();
+    expect(components![0].components[0].emoji?.name).toBe('📦');
+  });
+});
+
+// ── Preset: progress ──────────────────────────────────────────────────────────
+
+describe('CorvidEmbed.progress()', () => {
+  test('has correct color', () => {
+    const { embed } = CorvidEmbed.progress(CTX, AUTHOR).build();
+    expect(embed.color).toBe(EMBED_COLORS.neutral);
+  });
+
+  test('description contains working phrase', () => {
+    const { embed } = CorvidEmbed.progress(CTX, AUTHOR).build();
+    expect(embed.description).toContain('working on it');
+  });
+
+  test('footer contains agent name', () => {
+    const { embed } = CorvidEmbed.progress(CTX, AUTHOR).build();
+    expect(embed.footer?.text).toContain('Rook');
+  });
+
+  test('footer status is thinking', () => {
+    const { embed } = CorvidEmbed.progress(CTX, AUTHOR).build();
+    expect(embed.footer?.text).toContain('thinking');
+  });
+
+  test('author block is built from identity', () => {
+    const { embed } = CorvidEmbed.progress(CTX, AUTHOR).build();
+    expect(embed.author?.name).toContain('Rook');
+  });
+
+  test('no buttons', () => {
+    const { components } = CorvidEmbed.progress(CTX, AUTHOR).build();
+    expect(components).toBeUndefined();
+  });
+});
+
+// ── Preset: toolStatus ────────────────────────────────────────────────────────
+
+describe('CorvidEmbed.toolStatus()', () => {
+  test('description has hourglass prefix and message', () => {
+    const { embed } = CorvidEmbed.toolStatus('Running tests...', CTX, AUTHOR).build();
+    expect(embed.description).toBe('⏳ Running tests...');
+  });
+
+  test('color is neutral gray', () => {
+    const { embed } = CorvidEmbed.toolStatus('Checking files', CTX, AUTHOR).build();
+    expect(embed.color).toBe(EMBED_COLORS.neutral);
+  });
+
+  test('footer status is working...', () => {
+    const { embed } = CorvidEmbed.toolStatus('Doing stuff', CTX, AUTHOR).build();
+    expect(embed.footer?.text).toContain('working...');
+  });
+});
+
+// ── Preset: warm ──────────────────────────────────────────────────────────────
+
+describe('CorvidEmbed.warm()', () => {
+  test('description contains Discord timestamp', () => {
+    const unix = 1800000000;
+    const { embed } = CorvidEmbed.warm(CTX, AUTHOR, unix).build();
+    expect(embed.description).toContain(`<t:${unix}:R>`);
+  });
+
+  test('description starts with ✅ Done', () => {
+    const { embed } = CorvidEmbed.warm(CTX, AUTHOR, 9999999).build();
+    expect(embed.description).toMatch(/^✅ Done/);
+  });
+
+  test('color is success green', () => {
+    const { embed } = CorvidEmbed.warm(CTX, AUTHOR, 9999999).build();
+    expect(embed.color).toBe(EMBED_COLORS.success);
+  });
+
+  test('footer status is warm', () => {
+    const { embed } = CorvidEmbed.warm(CTX, AUTHOR, 9999999).build();
+    expect(embed.footer?.text).toContain('warm');
+  });
+});
+
+// ── Preset: done ─────────────────────────────────────────────────────────────
+
+describe('CorvidEmbed.done()', () => {
+  test('description is ✅ Done', () => {
+    const { embed } = CorvidEmbed.done(CTX, AUTHOR).build();
+    expect(embed.description).toBe('✅ Done');
+  });
+
+  test('color is success green', () => {
+    const { embed } = CorvidEmbed.done(CTX, AUTHOR).build();
+    expect(embed.color).toBe(EMBED_COLORS.success);
+  });
+
+  test('footer status is done', () => {
+    const { embed } = CorvidEmbed.done(CTX, AUTHOR).build();
+    expect(embed.footer?.text).toContain('done');
+  });
+});
+
+// ── Preset: completion ────────────────────────────────────────────────────────
+
+describe('CorvidEmbed.completion()', () => {
+  test('color is success green', () => {
+    const { embed } = CorvidEmbed.completion(CTX, AUTHOR).build();
+    expect(embed.color).toBe(EMBED_COLORS.success);
+  });
+
+  test('has New Session, Create Issue, and Archive buttons', () => {
+    const { components } = CorvidEmbed.completion(CTX, AUTHOR).build();
+    const labels = components![0].components.map((b) => b.label);
+    expect(labels).toContain('New Session');
+    expect(labels).toContain('Create Issue');
+    expect(labels).toContain('Archive');
+  });
+
+  test('description mentions session complete', () => {
+    const { embed } = CorvidEmbed.completion(CTX, AUTHOR).build();
+    expect(embed.description?.toLowerCase()).toContain('session complete');
+  });
+});
+
+// ── Preset: crash ─────────────────────────────────────────────────────────────
+
+describe('CorvidEmbed.crash()', () => {
+  test('color is error red', () => {
+    const { embed } = CorvidEmbed.crash(CTX, AUTHOR).build();
+    expect(embed.color).toBe(EMBED_COLORS.error);
+  });
+
+  test('description mentions ended unexpectedly', () => {
+    const { embed } = CorvidEmbed.crash(CTX, AUTHOR).build();
+    expect(embed.description?.toLowerCase()).toContain('ended unexpectedly');
+  });
+
+  test('has Resume button', () => {
+    const { components } = CorvidEmbed.crash(CTX, AUTHOR).build();
+    const labels = components![0].components.map((b) => b.label);
+    expect(labels).toContain('Resume');
+  });
+});
+
+// ── Preset: error ─────────────────────────────────────────────────────────────
+
+describe('CorvidEmbed.error()', () => {
+  test('context_exhausted maps to correct title and yellow color', () => {
+    const { embed } = CorvidEmbed.error('context_exhausted', CTX, AUTHOR).build();
+    expect(embed.title).toBe('Context Limit Reached');
+    expect(embed.color).toBe(0xf0b232);
+  });
+
+  test('credits_exhausted maps to correct title', () => {
+    const { embed } = CorvidEmbed.error('credits_exhausted', CTX, AUTHOR).build();
+    expect(embed.title).toBe('Credits Exhausted');
+  });
+
+  test('crash type maps to red color', () => {
+    const { embed } = CorvidEmbed.error('crash', CTX, AUTHOR).build();
+    expect(embed.color).toBe(0xff3355);
+  });
+
+  test('unknown error type uses fallback message', () => {
+    const { embed } = CorvidEmbed.error('unknown_error', CTX, AUTHOR, 'Custom fallback message').build();
+    expect(embed.title).toBe('Session Error');
+    expect(embed.description).toBe('Custom fallback message');
+  });
+
+  test('footer contains agent name', () => {
+    const { embed } = CorvidEmbed.error('timeout', CTX, AUTHOR).build();
+    expect(embed.footer?.text).toContain('Rook');
+  });
+});
+
+// ── Preset: timeout ───────────────────────────────────────────────────────────
+
+describe('CorvidEmbed.timeout()', () => {
+  test('color is warning yellow', () => {
+    const { embed } = CorvidEmbed.timeout(CTX, AUTHOR).build();
+    expect(embed.color).toBe(EMBED_COLORS.warning);
+  });
+
+  test('title is Taking Too Long', () => {
+    const { embed } = CorvidEmbed.timeout(CTX, AUTHOR).build();
+    expect(embed.title).toBe('Taking Too Long');
+  });
+
+  test('description mentions background', () => {
+    const { embed } = CorvidEmbed.timeout(CTX, AUTHOR).build();
+    expect(embed.description?.toLowerCase()).toContain('background');
+  });
+});
+
+// ── Preset: workTaskQueued ────────────────────────────────────────────────────
+
+describe('CorvidEmbed.workTaskQueued()', () => {
+  test('title is Task Queued', () => {
+    const { embed } = CorvidEmbed.workTaskQueued('task-123', 'Write tests').build();
+    expect(embed.title).toBe('Task Queued');
+  });
+
+  test('color is blurple working', () => {
+    const { embed } = CorvidEmbed.workTaskQueued('task-123', 'Write tests').build();
+    expect(embed.color).toBe(EMBED_COLORS.working);
+  });
+
+  test('description contains task id', () => {
+    const { embed } = CorvidEmbed.workTaskQueued('task-abc', 'Do something').build();
+    expect(embed.description).toContain('task-abc');
+  });
+
+  test('long descriptions are truncated at 200 chars with ellipsis', () => {
+    const longDesc = 'x'.repeat(250);
+    const { embed } = CorvidEmbed.workTaskQueued('task-1', longDesc).build();
+    expect(embed.description).toContain('...');
+    // 200 chars of x + "..." = 203 chars, plus "**task-1**\n\n" prefix
+    const parts = embed.description!.split('\n\n');
+    expect(parts[1].length).toBeLessThanOrEqual(203);
+  });
+
+  test('short descriptions are not truncated', () => {
+    const { embed } = CorvidEmbed.workTaskQueued('task-1', 'Short').build();
+    expect(embed.description).not.toContain('...');
+  });
+});
+
+// ── Preset: workTaskStatus ────────────────────────────────────────────────────
+
+describe('CorvidEmbed.workTaskStatus()', () => {
+  test('branching status produces workspace message', () => {
+    const { embed } = CorvidEmbed.workTaskStatus('task-1', 'branching').build();
+    expect(embed.description).toContain('workspace');
+    expect(embed.color).toBe(EMBED_COLORS.working);
+  });
+
+  test('running status mentions agent working', () => {
+    const { embed } = CorvidEmbed.workTaskStatus('task-1', 'running').build();
+    expect(embed.description).toContain('Agent working');
+    expect(embed.color).toBe(EMBED_COLORS.working);
+  });
+
+  test('running with iteration > 1 shows iteration count', () => {
+    const { embed } = CorvidEmbed.workTaskStatus('task-1', 'running', 3).build();
+    expect(embed.description).toContain('iteration 3');
+  });
+
+  test('validating status uses yellow color', () => {
+    const { embed } = CorvidEmbed.workTaskStatus('task-1', 'validating').build();
+    expect(embed.color).toBe(EMBED_COLORS.warning);
+    expect(embed.description).toContain('Validating');
+  });
+
+  test('unknown status falls back to working color', () => {
+    const { embed } = CorvidEmbed.workTaskStatus('task-1', 'queued').build();
+    expect(embed.color).toBe(EMBED_COLORS.working);
+  });
+
+  test('title is Task Update', () => {
+    const { embed } = CorvidEmbed.workTaskStatus('task-1', 'running').build();
+    expect(embed.title).toBe('Task Update');
+  });
+
+  test('description contains task id', () => {
+    const { embed } = CorvidEmbed.workTaskStatus('task-xyz', 'branching').build();
+    expect(embed.description).toContain('task-xyz');
+  });
+});
+
+// ── Preset: workTaskCompleted ─────────────────────────────────────────────────
+
+describe('CorvidEmbed.workTaskCompleted()', () => {
+  test('title is Task Completed', () => {
+    const { embed } = CorvidEmbed.workTaskCompleted('task-1', 'Did the thing').build();
+    expect(embed.title).toBe('Task Completed');
+  });
+
+  test('color is success green', () => {
+    const { embed } = CorvidEmbed.workTaskCompleted('task-1', 'Did the thing').build();
+    expect(embed.color).toBe(EMBED_COLORS.success);
+  });
+
+  test('description contains task description', () => {
+    const { embed } = CorvidEmbed.workTaskCompleted('task-1', 'Did the thing').build();
+    expect(embed.description).toBe('Did the thing');
+  });
+
+  test('long descriptions are truncated at 300 chars', () => {
+    const { embed } = CorvidEmbed.workTaskCompleted('task-1', 'x'.repeat(400)).build();
+    expect(embed.description?.length).toBeLessThanOrEqual(300);
+  });
+
+  test('has task id in fields', () => {
+    const { embed } = CorvidEmbed.workTaskCompleted('task-abc', 'Done').build();
+    const taskField = embed.fields?.find((f) => f.value === 'task-abc');
+    expect(taskField).toBeDefined();
+  });
+});
+
+// ── Preset: workTaskFailed ────────────────────────────────────────────────────
+
+describe('CorvidEmbed.workTaskFailed()', () => {
+  test('title is Task Failed', () => {
+    const { embed } = CorvidEmbed.workTaskFailed('task-1', 'Something broke').build();
+    expect(embed.title).toBe('Task Failed');
+  });
+
+  test('color is errorAlt (Discord red)', () => {
+    const { embed } = CorvidEmbed.workTaskFailed('task-1', 'Something broke').build();
+    expect(embed.color).toBe(EMBED_COLORS.errorAlt);
+  });
+
+  test('description contains failure description', () => {
+    const { embed } = CorvidEmbed.workTaskFailed('task-1', 'Something broke').build();
+    expect(embed.description).toBe('Something broke');
+  });
+
+  test('long descriptions are truncated at 300 chars', () => {
+    const { embed } = CorvidEmbed.workTaskFailed('task-1', 'x'.repeat(400)).build();
+    expect(embed.description?.length).toBeLessThanOrEqual(300);
+  });
+
+  test('has task id in fields', () => {
+    const { embed } = CorvidEmbed.workTaskFailed('task-xyz', 'Failed').build();
+    const taskField = embed.fields?.find((f) => f.value === 'task-xyz');
+    expect(taskField).toBeDefined();
+  });
+});
+
+// ── Chaining ──────────────────────────────────────────────────────────────────
+
+describe('CorvidEmbed chaining', () => {
+  test('all setters return the same builder instance', () => {
+    const builder = new CorvidEmbed();
+    expect(builder.setTitle('T')).toBe(builder);
+    expect(builder.setDescription('D')).toBe(builder);
+    expect(builder.setColor(0)).toBe(builder);
+    expect(builder.setAgent({ agentName: 'X' })).toBe(builder);
+    expect(builder.setSession('s')).toBe(builder);
+    expect(builder.setProject('p')).toBe(builder);
+    expect(builder.setStatus('st')).toBe(builder);
+    expect(builder.setAuthor({ name: 'A' })).toBe(builder);
+    expect(builder.withContextUsage({ usagePercent: 1, estimatedTokens: 1, contextWindow: 1 })).toBe(builder);
+    expect(builder.withTurns(1)).toBe(builder);
+    expect(builder.withStats({})).toBe(builder);
+    expect(builder.addField('n', 'v')).toBe(builder);
+    expect(builder.setFields([])).toBe(builder);
+    expect(builder.setImage('u')).toBe(builder);
+    expect(builder.setThumbnail('u')).toBe(builder);
+    expect(builder.withButtons(['archive'])).toBe(builder);
+    expect(builder.withButtonOverride('archive', 'x')).toBe(builder);
+  });
+
+  test('full chained build produces expected embed', () => {
+    const { embed, components } = new CorvidEmbed()
+      .setTitle('Session Done')
+      .setDescription('✅ Done')
+      .setColor(EMBED_COLORS.success)
+      .setAgent({ agentName: 'Rook', displayIcon: '🐦' })
+      .setSession('sess-001')
+      .setProject('my-project')
+      .setStatus('done')
+      .withTurns(10)
+      .withButtons(['new_session', 'archive'])
+      .build();
+
+    expect(embed.title).toBe('Session Done');
+    expect(embed.description).toBe('✅ Done');
+    expect(embed.color).toBe(EMBED_COLORS.success);
+    expect(embed.author?.name).toBe('🐦 Rook');
+    expect(embed.footer?.text).toContain('Rook');
+    expect(embed.footer?.text).toContain('T:10');
+    expect(components).toHaveLength(1);
+    expect(components![0].components).toHaveLength(2);
+  });
+});

--- a/server/__tests__/embed-builder.test.ts
+++ b/server/__tests__/embed-builder.test.ts
@@ -195,19 +195,25 @@ describe('CorvidEmbed builder — footer', () => {
     expect(embed.footer?.text).toContain('Rook');
   });
 
-  test('footer includes model when agentModel is on identity (via setProject/setSession)', () => {
-    // model comes from FooterContext — need to check that setAgent + context flows through
+  test('footer includes model when set via setModel', () => {
     const { embed } = new CorvidEmbed()
       .setAgent(AUTHOR)
+      .setModel('claude-sonnet-4-6')
       .setSession('abcdef1234567890')
       .setProject('corvid-agent')
       .setStatus('thinking')
       .build();
     const footer = embed.footer!.text;
     expect(footer).toContain('Rook');
+    expect(footer).toContain('claude-sonnet-4-6');
     expect(footer).toContain('sid:abcdef12');
     expect(footer).toContain('corvid-agent');
     expect(footer).toContain('thinking');
+  });
+
+  test('presets pass agentModel from FooterContext to footer', () => {
+    const { embed } = CorvidEmbed.progress(CTX, AUTHOR).build();
+    expect(embed.footer!.text).toContain('claude-sonnet-4-6');
   });
 
   test('withContextUsage adds usage to footer', () => {
@@ -539,14 +545,9 @@ describe('CorvidEmbed.timeout()', () => {
     expect(embed.color).toBe(EMBED_COLORS.warning);
   });
 
-  test('title is Taking Too Long', () => {
+  test('description mentions taking too long', () => {
     const { embed } = CorvidEmbed.timeout(CTX, AUTHOR).build();
-    expect(embed.title).toBe('Taking Too Long');
-  });
-
-  test('description mentions background', () => {
-    const { embed } = CorvidEmbed.timeout(CTX, AUTHOR).build();
-    expect(embed.description?.toLowerCase()).toContain('background');
+    expect(embed.description?.toLowerCase()).toContain('taking too long');
   });
 });
 

--- a/server/__tests__/embed-builder.test.ts
+++ b/server/__tests__/embed-builder.test.ts
@@ -649,10 +649,9 @@ describe('CorvidEmbed.workTaskCompleted()', () => {
     expect(embed.description?.length).toBeLessThanOrEqual(300);
   });
 
-  test('has task id in fields', () => {
+  test('has task id in footer', () => {
     const { embed } = CorvidEmbed.workTaskCompleted('task-abc', 'Done').build();
-    const taskField = embed.fields?.find((f) => f.value === 'task-abc');
-    expect(taskField).toBeDefined();
+    expect(embed.footer?.text).toBe('Task: task-abc');
   });
 });
 
@@ -679,10 +678,9 @@ describe('CorvidEmbed.workTaskFailed()', () => {
     expect(embed.description?.length).toBeLessThanOrEqual(300);
   });
 
-  test('has task id in fields', () => {
+  test('has task id in footer', () => {
     const { embed } = CorvidEmbed.workTaskFailed('task-xyz', 'Failed').build();
-    const taskField = embed.fields?.find((f) => f.value === 'task-xyz');
-    expect(taskField).toBeDefined();
+    expect(embed.footer?.text).toBe('Task: task-xyz');
   });
 });
 

--- a/server/discord/embed-builder.ts
+++ b/server/discord/embed-builder.ts
@@ -1,0 +1,477 @@
+/**
+ * Unified Discord embed builder for the corvid-agent platform.
+ *
+ * Provides a canonical color palette, button registry, and a chainable
+ * CorvidEmbed builder class that all embed construction sites should use.
+ * Integrates with existing footer, author, and action-row helpers from
+ * embeds.ts so all formatting stays consistent.
+ */
+
+import {
+  buildActionRow,
+  buildAgentAuthor,
+  buildFooterText,
+  buildFooterWithStats,
+  type ContextUsage,
+  type DiscordEmbed,
+  type DiscordEmbedAuthor,
+  type FooterContext,
+  type FooterStats,
+} from './embeds';
+import { sessionErrorEmbed } from './thread-response/utils';
+import type { DiscordActionRow } from './types';
+import { ButtonStyle } from './types';
+
+// ── Color palette ────────────────────────────────────────────────────────────
+
+/** Canonical color values for all Discord embeds in the corvid-agent platform. */
+export const EMBED_COLORS = {
+  /** Gray — neutral / progress / acknowledged */
+  neutral: 0x95a5a6,
+  /** Blurple — active work / queue */
+  working: 0x5865f2,
+  /** Green — success / done / warm */
+  success: 0x57f287,
+  /** Yellow — warning / timeout / validating */
+  warning: 0xf0b232,
+  /** Red — crash / fatal error */
+  error: 0xff3355,
+  /** Discord red — task failed */
+  errorAlt: 0xed4245,
+} as const;
+
+// ── Button registry ──────────────────────────────────────────────────────────
+
+/** Definition of a single button for use with buildActionRow. */
+export interface ButtonDef {
+  label: string;
+  emoji: string;
+  customId: string;
+  style: number;
+}
+
+/** Canonical button definitions for embed action rows. */
+export const EMBED_BUTTONS = {
+  new_session: {
+    label: 'New Session',
+    emoji: '🔄',
+    customId: 'new_session',
+    style: ButtonStyle.SUCCESS,
+  },
+  archive: {
+    label: 'Archive',
+    emoji: '📦',
+    customId: 'archive_thread',
+    style: ButtonStyle.SECONDARY,
+  },
+  create_issue: {
+    label: 'Create Issue',
+    emoji: '📋',
+    customId: 'create_issue',
+    style: ButtonStyle.PRIMARY,
+  },
+  resume: {
+    label: 'Resume',
+    emoji: '🔄',
+    customId: 'resume_thread',
+    style: ButtonStyle.SUCCESS,
+  },
+  continue_thread: {
+    label: 'Continue in Thread',
+    emoji: '🧵',
+    customId: 'continue_thread',
+    style: ButtonStyle.PRIMARY,
+  },
+} as const satisfies Record<string, ButtonDef>;
+
+export type EmbedButtonKey = keyof typeof EMBED_BUTTONS;
+
+// ── Builder ──────────────────────────────────────────────────────────────────
+
+/** Return type of CorvidEmbed.build(). */
+export interface BuiltEmbed {
+  embed: DiscordEmbed;
+  components?: DiscordActionRow[];
+}
+
+/** Agent identity for building embed author blocks. */
+export interface EmbedAgentIdentity {
+  agentName: string;
+  displayIcon?: string | null;
+  avatarUrl?: string | null;
+}
+
+/**
+ * Chainable builder for Discord embeds with auto-constructed footers,
+ * author blocks, and button rows.
+ *
+ * Usage:
+ * ```ts
+ * const { embed, components } = new CorvidEmbed()
+ *   .setTitle('Session complete')
+ *   .setDescription('✅ Done')
+ *   .setColor(EMBED_COLORS.success)
+ *   .setAgent({ agentName: 'Rook', displayIcon: '🐦' })
+ *   .withButtons(['new_session', 'archive'])
+ *   .build();
+ * ```
+ */
+export class CorvidEmbed {
+  private _title?: string;
+  private _description?: string;
+  private _color?: number;
+  private _authorOverride?: DiscordEmbedAuthor;
+  private _agentIdentity?: EmbedAgentIdentity;
+  private _fields: Array<{ name: string; value: string; inline?: boolean }> = [];
+  private _image?: string;
+  private _thumbnail?: string;
+  private _timestamp?: string;
+
+  // Footer context
+  private _agentName?: string;
+  private _agentModel?: string;
+  private _sessionId?: string;
+  private _projectName?: string;
+  private _status?: string;
+
+  // Footer stats
+  private _contextUsage?: ContextUsage;
+  private _turns?: number;
+  private _cumulativeTurns?: number;
+  private _stats?: FooterStats;
+
+  // Buttons
+  private _buttonKeys: EmbedButtonKey[] = [];
+  private _buttonOverrides: Partial<Record<EmbedButtonKey, string>> = {};
+
+  // ── Chainable setters ──────────────────────────────────────────────
+
+  setTitle(title: string): this {
+    this._title = title;
+    return this;
+  }
+
+  setDescription(description: string): this {
+    this._description = description;
+    return this;
+  }
+
+  setColor(color: number): this {
+    this._color = color;
+    return this;
+  }
+
+  /** Set the agent identity for both author block and footer context. */
+  setAgent(identity: EmbedAgentIdentity): this {
+    this._agentIdentity = identity;
+    this._agentName = identity.agentName;
+    return this;
+  }
+
+  setSession(sessionId: string): this {
+    this._sessionId = sessionId;
+    return this;
+  }
+
+  setProject(projectName: string): this {
+    this._projectName = projectName;
+    return this;
+  }
+
+  setStatus(status: string): this {
+    this._status = status;
+    return this;
+  }
+
+  /** Override the author block directly (bypasses setAgent). */
+  setAuthor(author: DiscordEmbedAuthor): this {
+    this._authorOverride = author;
+    return this;
+  }
+
+  withContextUsage(usage: ContextUsage): this {
+    this._contextUsage = usage;
+    return this;
+  }
+
+  withTurns(turns: number, cumulativeTurns?: number): this {
+    this._turns = turns;
+    this._cumulativeTurns = cumulativeTurns;
+    return this;
+  }
+
+  withStats(stats: FooterStats, cumulativeTurns?: number): this {
+    this._stats = stats;
+    this._cumulativeTurns = cumulativeTurns;
+    return this;
+  }
+
+  addField(name: string, value: string, inline?: boolean): this {
+    this._fields.push({ name, value, ...(inline !== undefined ? { inline } : {}) });
+    return this;
+  }
+
+  setFields(fields: Array<{ name: string; value: string; inline?: boolean }>): this {
+    this._fields = [...fields];
+    return this;
+  }
+
+  setImage(url: string): this {
+    this._image = url;
+    return this;
+  }
+
+  setThumbnail(url: string): this {
+    this._thumbnail = url;
+    return this;
+  }
+
+  /**
+   * Add buttons to the embed's action row.
+   * Keys must be from EMBED_BUTTONS.
+   */
+  withButtons(keys: EmbedButtonKey[]): this {
+    this._buttonKeys = keys;
+    return this;
+  }
+
+  /**
+   * Override the customId for a specific button key at build time.
+   * Useful for per-session dynamic button IDs (e.g. `continue_thread:session-id`).
+   */
+  withButtonOverride(key: EmbedButtonKey, customId: string): this {
+    this._buttonOverrides = { ...this._buttonOverrides, [key]: customId };
+    return this;
+  }
+
+  // ── Build ──────────────────────────────────────────────────────────
+
+  build(): BuiltEmbed {
+    const embed: DiscordEmbed = {};
+
+    if (this._title) embed.title = this._title;
+    if (this._description) embed.description = this._description;
+    if (this._color !== undefined) embed.color = this._color;
+    if (this._timestamp) embed.timestamp = this._timestamp;
+
+    if (this._fields.length > 0) {
+      embed.fields = this._fields;
+    }
+
+    if (this._image) embed.image = { url: this._image };
+    if (this._thumbnail) embed.thumbnail = { url: this._thumbnail };
+
+    // Author block — explicit override takes precedence over identity
+    if (this._authorOverride) {
+      embed.author = this._authorOverride;
+    } else if (this._agentIdentity) {
+      embed.author = buildAgentAuthor(this._agentIdentity);
+    }
+
+    // Footer — only built when an agent name is present
+    if (this._agentName) {
+      const ctx: FooterContext = {
+        agentName: this._agentName,
+        ...(this._agentModel ? { agentModel: this._agentModel } : {}),
+        ...(this._sessionId ? { sessionId: this._sessionId } : {}),
+        ...(this._projectName ? { projectName: this._projectName } : {}),
+        ...(this._status ? { status: this._status } : {}),
+      };
+
+      const footerText = this._stats
+        ? buildFooterWithStats(ctx, this._stats, this._contextUsage, this._cumulativeTurns)
+        : buildFooterText(ctx, this._contextUsage, this._turns, this._cumulativeTurns);
+
+      embed.footer = { text: footerText };
+    }
+
+    // Buttons — only built when keys are set
+    let components: DiscordActionRow[] | undefined;
+    if (this._buttonKeys.length > 0) {
+      const buttonDefs = this._buttonKeys.map((key) => {
+        const base = EMBED_BUTTONS[key];
+        const customId = this._buttonOverrides[key] ?? base.customId;
+        return { label: base.label, emoji: base.emoji, customId, style: base.style };
+      });
+      components = [buildActionRow(...buttonDefs)];
+    }
+
+    return { embed, ...(components ? { components } : {}) };
+  }
+
+  // ── Static preset factories ────────────────────────────────────────
+
+  /**
+   * Gray "Received — working on it..." progress embed.
+   * Sent immediately when a Discord message is received.
+   */
+  static progress(ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
+    return new CorvidEmbed()
+      .setDescription('Received — working on it...')
+      .setColor(EMBED_COLORS.neutral)
+      .setAgent(author)
+      .setSession(ctx.sessionId ?? '')
+      .setProject(ctx.projectName ?? '')
+      .setStatus('thinking');
+  }
+
+  /**
+   * Gray tool-status embed with a custom message.
+   * Used for live tool execution status updates.
+   */
+  static toolStatus(message: string, ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
+    return new CorvidEmbed()
+      .setDescription(`⏳ ${message}`)
+      .setColor(EMBED_COLORS.neutral)
+      .setAgent(author)
+      .setSession(ctx.sessionId ?? '')
+      .setProject(ctx.projectName ?? '')
+      .setStatus('working...');
+  }
+
+  /**
+   * Green "✅ Done · Expires <t:X:R>" embed for warm (keep-alive) sessions.
+   */
+  static warm(ctx: FooterContext, author: EmbedAgentIdentity, expiresAtUnix: number): CorvidEmbed {
+    return new CorvidEmbed()
+      .setDescription(`✅ Done · Expires <t:${expiresAtUnix}:R>`)
+      .setColor(EMBED_COLORS.success)
+      .setAgent(author)
+      .setSession(ctx.sessionId ?? '')
+      .setProject(ctx.projectName ?? '')
+      .setStatus('warm');
+  }
+
+  /**
+   * Green "✅ Done" embed for completed sessions.
+   * Used when editing the progress embed after a result arrives.
+   */
+  static done(ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
+    return new CorvidEmbed()
+      .setDescription('✅ Done')
+      .setColor(EMBED_COLORS.success)
+      .setAgent(author)
+      .setSession(ctx.sessionId ?? '')
+      .setProject(ctx.projectName ?? '')
+      .setStatus('done');
+  }
+
+  /**
+   * Green "Session complete" embed with New Session, Create Issue, and Archive buttons.
+   * Sent at the end of a session as the final summary embed.
+   */
+  static completion(ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
+    return new CorvidEmbed()
+      .setDescription('Session complete. Start a new session or archive this thread.')
+      .setColor(EMBED_COLORS.success)
+      .setAgent(author)
+      .setSession(ctx.sessionId ?? '')
+      .setProject(ctx.projectName ?? '')
+      .setStatus('done')
+      .withButtons(['new_session', 'create_issue', 'archive']);
+  }
+
+  /**
+   * Red "ended unexpectedly" embed with a Resume button.
+   * Sent when an agent process crashes.
+   */
+  static crash(ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
+    return new CorvidEmbed()
+      .setDescription('The agent ended unexpectedly. Press Resume to restart.')
+      .setColor(EMBED_COLORS.error)
+      .setAgent(author)
+      .setSession(ctx.sessionId ?? '')
+      .setProject(ctx.projectName ?? '')
+      .setStatus('crashed')
+      .withButtons(['resume']);
+  }
+
+  /**
+   * Error embed derived from sessionErrorEmbed.
+   * Maps known error types (context_exhausted, credits_exhausted, timeout, crash,
+   * spawn_error) to user-facing titles, descriptions, and colors.
+   */
+  static error(errorType: string, ctx: FooterContext, author: EmbedAgentIdentity, fallbackMessage?: string): CorvidEmbed {
+    const { title, description, color } = sessionErrorEmbed(errorType, fallbackMessage);
+    return new CorvidEmbed()
+      .setTitle(title)
+      .setDescription(description)
+      .setColor(color)
+      .setAgent(author)
+      .setSession(ctx.sessionId ?? '')
+      .setProject(ctx.projectName ?? '')
+      .setStatus('error');
+  }
+
+  /**
+   * Yellow "taking too long" timeout warning embed.
+   */
+  static timeout(ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
+    return new CorvidEmbed()
+      .setTitle('Taking Too Long')
+      .setDescription('The session is taking longer than expected. It will continue in the background.')
+      .setColor(EMBED_COLORS.warning)
+      .setAgent(author)
+      .setSession(ctx.sessionId ?? '')
+      .setProject(ctx.projectName ?? '')
+      .setStatus('timeout');
+  }
+
+  /**
+   * Blurple "Task Queued" embed for work task intake.
+   */
+  static workTaskQueued(taskId: string, description: string): CorvidEmbed {
+    const truncated = description.slice(0, 200) + (description.length > 200 ? '...' : '');
+    return new CorvidEmbed()
+      .setTitle('Task Queued')
+      .setDescription(`**${taskId}**\n\n${truncated}`)
+      .setColor(EMBED_COLORS.working);
+  }
+
+  /**
+   * Blurple/yellow status update embed for running work tasks.
+   * Maps branching, running, and validating to appropriate descriptions.
+   */
+  static workTaskStatus(taskId: string, status: string, iterationCount?: number): CorvidEmbed {
+    const statusMap: Record<string, { desc: string; color: number }> = {
+      branching: { desc: '⚙️ Setting up workspace and creating branch...', color: EMBED_COLORS.working },
+      running: {
+        desc: `🤖 Agent working${(iterationCount ?? 1) > 1 ? ` (iteration ${iterationCount})` : ''}...`,
+        color: EMBED_COLORS.working,
+      },
+      validating: { desc: '🔍 Validating changes...', color: EMBED_COLORS.warning },
+    };
+
+    const { desc, color } = statusMap[status] ?? {
+      desc: `Status: ${status}`,
+      color: EMBED_COLORS.working,
+    };
+
+    return new CorvidEmbed()
+      .setTitle('Task Update')
+      .setDescription(`**${taskId}**\n\n${desc}`)
+      .setColor(color);
+  }
+
+  /**
+   * Green "Task Completed" embed for successfully completed work tasks.
+   */
+  static workTaskCompleted(taskId: string, description: string): CorvidEmbed {
+    return new CorvidEmbed()
+      .setTitle('Task Completed')
+      .setDescription(description.slice(0, 300))
+      .setColor(EMBED_COLORS.success)
+      .addField('Task', taskId, true);
+  }
+
+  /**
+   * Red alt "Task Failed" embed for failed work tasks.
+   */
+  static workTaskFailed(taskId: string, description: string): CorvidEmbed {
+    return new CorvidEmbed()
+      .setTitle('Task Failed')
+      .setDescription(description.slice(0, 300))
+      .setColor(EMBED_COLORS.errorAlt)
+      .addField('Task', taskId, true);
+  }
+}

--- a/server/discord/embed-builder.ts
+++ b/server/discord/embed-builder.ts
@@ -134,7 +134,8 @@ export class CorvidEmbed {
   private _projectName?: string;
   private _status?: string;
 
-  // Footer stats
+  // Footer
+  private _footerOverride?: string;
   private _contextUsage?: ContextUsage;
   private _turns?: number;
   private _cumulativeTurns?: number;
@@ -231,6 +232,11 @@ export class CorvidEmbed {
     return this;
   }
 
+  setFooter(text: string): this {
+    this._footerOverride = text;
+    return this;
+  }
+
   /**
    * Add buttons to the embed's action row.
    * Keys must be from EMBED_BUTTONS.
@@ -273,8 +279,10 @@ export class CorvidEmbed {
       embed.author = buildAgentAuthor(this._agentIdentity);
     }
 
-    // Footer — only built when an agent name is present
-    if (this._agentName) {
+    // Footer — explicit override takes precedence, then auto-build from agent context
+    if (this._footerOverride) {
+      embed.footer = { text: this._footerOverride };
+    } else if (this._agentName) {
       const ctx: FooterContext = {
         agentName: this._agentName,
         ...(this._agentModel ? { agentModel: this._agentModel } : {}),
@@ -415,12 +423,13 @@ export class CorvidEmbed {
   /**
    * Blurple "Task Queued" embed for work task intake.
    */
-  static workTaskQueued(taskId: string, description: string): CorvidEmbed {
+  static workTaskQueued(taskId: string, description: string, status?: string): CorvidEmbed {
     const truncated = description.slice(0, 200) + (description.length > 200 ? '...' : '');
     return new CorvidEmbed()
       .setTitle('Task Queued')
       .setDescription(`**${taskId}**\n\n${truncated}`)
-      .setColor(EMBED_COLORS.working);
+      .setColor(EMBED_COLORS.working)
+      .setFooter(`Status: ${status ?? 'queued'}`);
   }
 
   /**
@@ -445,7 +454,8 @@ export class CorvidEmbed {
     return new CorvidEmbed()
       .setTitle('Task Update')
       .setDescription(`**${taskId}**\n\n${desc}`)
-      .setColor(color);
+      .setColor(color)
+      .setFooter(`Status: ${status}`);
   }
 
   /**
@@ -456,7 +466,7 @@ export class CorvidEmbed {
       .setTitle('Task Completed')
       .setDescription(description.slice(0, 300))
       .setColor(EMBED_COLORS.success)
-      .addField('Task', taskId, true);
+      .setFooter(`Task: ${taskId}`);
   }
 
   /**
@@ -467,6 +477,6 @@ export class CorvidEmbed {
       .setTitle('Task Failed')
       .setDescription(description.slice(0, 300))
       .setColor(EMBED_COLORS.errorAlt)
-      .addField('Task', taskId, true);
+      .setFooter(`Task: ${taskId}`);
   }
 }

--- a/server/discord/embed-builder.ts
+++ b/server/discord/embed-builder.ts
@@ -168,6 +168,11 @@ export class CorvidEmbed {
     return this;
   }
 
+  setModel(model: string): this {
+    this._agentModel = model;
+    return this;
+  }
+
   setSession(sessionId: string): this {
     this._sessionId = sessionId;
     return this;
@@ -305,14 +310,20 @@ export class CorvidEmbed {
    * Gray "Received — working on it..." progress embed.
    * Sent immediately when a Discord message is received.
    */
+  private static applyContext(builder: CorvidEmbed, ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
+    builder.setAgent(author);
+    if (ctx.agentModel) builder.setModel(ctx.agentModel);
+    if (ctx.sessionId) builder.setSession(ctx.sessionId);
+    if (ctx.projectName) builder.setProject(ctx.projectName);
+    return builder;
+  }
+
   static progress(ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
-    return new CorvidEmbed()
+    const b = new CorvidEmbed()
       .setDescription('Received — working on it...')
       .setColor(EMBED_COLORS.neutral)
-      .setAgent(author)
-      .setSession(ctx.sessionId ?? '')
-      .setProject(ctx.projectName ?? '')
       .setStatus('thinking');
+    return CorvidEmbed.applyContext(b, ctx, author);
   }
 
   /**
@@ -320,26 +331,22 @@ export class CorvidEmbed {
    * Used for live tool execution status updates.
    */
   static toolStatus(message: string, ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
-    return new CorvidEmbed()
+    const b = new CorvidEmbed()
       .setDescription(`⏳ ${message}`)
       .setColor(EMBED_COLORS.neutral)
-      .setAgent(author)
-      .setSession(ctx.sessionId ?? '')
-      .setProject(ctx.projectName ?? '')
       .setStatus('working...');
+    return CorvidEmbed.applyContext(b, ctx, author);
   }
 
   /**
    * Green "✅ Done · Expires <t:X:R>" embed for warm (keep-alive) sessions.
    */
   static warm(ctx: FooterContext, author: EmbedAgentIdentity, expiresAtUnix: number): CorvidEmbed {
-    return new CorvidEmbed()
+    const b = new CorvidEmbed()
       .setDescription(`✅ Done · Expires <t:${expiresAtUnix}:R>`)
       .setColor(EMBED_COLORS.success)
-      .setAgent(author)
-      .setSession(ctx.sessionId ?? '')
-      .setProject(ctx.projectName ?? '')
       .setStatus('warm');
+    return CorvidEmbed.applyContext(b, ctx, author);
   }
 
   /**
@@ -347,13 +354,11 @@ export class CorvidEmbed {
    * Used when editing the progress embed after a result arrives.
    */
   static done(ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
-    return new CorvidEmbed()
+    const b = new CorvidEmbed()
       .setDescription('✅ Done')
       .setColor(EMBED_COLORS.success)
-      .setAgent(author)
-      .setSession(ctx.sessionId ?? '')
-      .setProject(ctx.projectName ?? '')
       .setStatus('done');
+    return CorvidEmbed.applyContext(b, ctx, author);
   }
 
   /**
@@ -361,14 +366,12 @@ export class CorvidEmbed {
    * Sent at the end of a session as the final summary embed.
    */
   static completion(ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
-    return new CorvidEmbed()
-      .setDescription('Session complete. Start a new session or archive this thread.')
+    const b = new CorvidEmbed()
+      .setDescription('Session complete. Send a message to continue the conversation.')
       .setColor(EMBED_COLORS.success)
-      .setAgent(author)
-      .setSession(ctx.sessionId ?? '')
-      .setProject(ctx.projectName ?? '')
       .setStatus('done')
       .withButtons(['new_session', 'create_issue', 'archive']);
+    return CorvidEmbed.applyContext(b, ctx, author);
   }
 
   /**
@@ -376,14 +379,12 @@ export class CorvidEmbed {
    * Sent when an agent process crashes.
    */
   static crash(ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
-    return new CorvidEmbed()
-      .setDescription('The agent ended unexpectedly. Press Resume to restart.')
+    const b = new CorvidEmbed()
+      .setDescription('The agent session ended unexpectedly. Send a message to resume.')
       .setColor(EMBED_COLORS.error)
-      .setAgent(author)
-      .setSession(ctx.sessionId ?? '')
-      .setProject(ctx.projectName ?? '')
       .setStatus('crashed')
       .withButtons(['resume']);
+    return CorvidEmbed.applyContext(b, ctx, author);
   }
 
   /**
@@ -393,28 +394,22 @@ export class CorvidEmbed {
    */
   static error(errorType: string, ctx: FooterContext, author: EmbedAgentIdentity, fallbackMessage?: string): CorvidEmbed {
     const { title, description, color } = sessionErrorEmbed(errorType, fallbackMessage);
-    return new CorvidEmbed()
+    const b = new CorvidEmbed()
       .setTitle(title)
       .setDescription(description)
       .setColor(color)
-      .setAgent(author)
-      .setSession(ctx.sessionId ?? '')
-      .setProject(ctx.projectName ?? '')
-      .setStatus('error');
+      .setStatus(errorType);
+    return CorvidEmbed.applyContext(b, ctx, author);
   }
 
   /**
    * Yellow "taking too long" timeout warning embed.
    */
   static timeout(ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
-    return new CorvidEmbed()
-      .setTitle('Taking Too Long')
-      .setDescription('The session is taking longer than expected. It will continue in the background.')
-      .setColor(EMBED_COLORS.warning)
-      .setAgent(author)
-      .setSession(ctx.sessionId ?? '')
-      .setProject(ctx.projectName ?? '')
-      .setStatus('timeout');
+    const b = new CorvidEmbed()
+      .setDescription('The agent appears to be taking too long. It may still be working — send a message to check.')
+      .setColor(EMBED_COLORS.warning);
+    return CorvidEmbed.applyContext(b, ctx, author);
   }
 
   /**

--- a/server/discord/embeds.ts
+++ b/server/discord/embeds.ts
@@ -740,3 +740,5 @@ export async function sendMessageWithFiles(
 
 /** Re-export splitEmbedDescription and collapseCodeBlocks for use by other modules. */
 export { collapseCodeBlocks, splitEmbedDescription } from './message-formatter';
+
+export { CorvidEmbed, EMBED_BUTTONS, EMBED_COLORS, type EmbedAgentIdentity, type EmbedButtonKey } from './embed-builder';

--- a/server/discord/thread-response/adaptive-response.ts
+++ b/server/discord/thread-response/adaptive-response.ts
@@ -5,13 +5,13 @@ import type { ProcessManager } from '../../process/manager';
 import { extractContentImageUrls, extractContentText } from '../../process/types';
 import {
   agentColor,
-  buildActionRow,
-  buildAgentAuthor,
-  buildFooterText,
+  CorvidEmbed,
   type ContextUsage,
   collapseCodeBlocks,
   type DiscordFileAttachment,
+  type EmbedAgentIdentity,
   editEmbed,
+  type FooterContext,
   hexColorToInt,
   sendEmbed,
   sendEmbedWithButtons,
@@ -19,7 +19,6 @@ import {
   sendReplyEmbed,
   sendTypingIndicator,
 } from '../embeds';
-import { ButtonStyle } from '../types';
 import { visibleEmbedParts } from './utils';
 
 const log = createLogger('DiscordThreadManager');
@@ -55,7 +54,8 @@ export function subscribeForAdaptiveInlineResponse(
   const TYPING_TIMEOUT_MS = 4 * 60 * 1000;
   let receivedAnyActivity = false;
   const color = hexColorToInt(displayColor) ?? agentColor(agentName);
-  const author = buildAgentAuthor({ agentName, displayIcon, avatarUrl });
+  const footerCtx: FooterContext = { agentName, agentModel, sessionId, projectName };
+  const authorIdentity: EmbedAgentIdentity = { agentName, displayIcon, avatarUrl };
 
   // Progress embed state — only created when tool use is detected
   let progressMessageId: string | null = null;
@@ -68,10 +68,11 @@ export function subscribeForAdaptiveInlineResponse(
       clearTyping();
       log.warn('Process died while typing indicator active (adaptive)', { sessionId, channelId });
       if (!receivedAnyContent) {
-        sendEmbed(delivery, botToken, channelId, {
-          description: 'The agent session ended unexpectedly. Send a message to start a new session.',
-          color: 0xff3355,
-        }).catch((err) => {
+        const { embed: crashEmbed } = new CorvidEmbed()
+          .setDescription('The agent session ended unexpectedly. Send a message to start a new session.')
+          .setColor(0xff3355)
+          .build();
+        sendEmbed(delivery, botToken, channelId, crashEmbed).catch((err) => {
           log.warn('Failed to send crash embed', {
             channelId,
             error: err instanceof Error ? err.message : String(err),
@@ -92,10 +93,13 @@ export function subscribeForAdaptiveInlineResponse(
     clearInterval(typingInterval);
     log.warn('Typing indicator safety timeout reached (adaptive)', { sessionId, channelId });
     if (!receivedAnyActivity) {
-      sendEmbed(delivery, botToken, channelId, {
-        description: 'The agent appears to be taking too long. It may still be working \u2014 send a message to check.',
-        color: 0xf0b232,
-      }).catch((err) => {
+      const { embed: timeoutEmbed } = new CorvidEmbed()
+        .setDescription(
+          'The agent appears to be taking too long. It may still be working — send a message to check.',
+        )
+        .setColor(0xf0b232)
+        .build();
+      sendEmbed(delivery, botToken, channelId, timeoutEmbed).catch((err) => {
         log.warn('Failed to send timeout embed', {
           channelId,
           error: err instanceof Error ? err.message : String(err),
@@ -117,12 +121,15 @@ export function subscribeForAdaptiveInlineResponse(
     const parts = visibleEmbedParts(text);
     for (let i = 0; i < parts.length; i++) {
       let sentId: string | null = null;
-      const embedPayload = {
-        description: parts[i],
-        color,
-        author,
-        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }, latestContextUsage) },
-      };
+      const contentBuilder = new CorvidEmbed()
+        .setDescription(parts[i])
+        .setColor(color)
+        .setAgent(authorIdentity)
+        .setModel(agentModel)
+        .setSession(sessionId);
+      if (projectName) contentBuilder.setProject(projectName);
+      if (latestContextUsage) contentBuilder.withContextUsage(latestContextUsage);
+      const { embed: embedPayload } = contentBuilder.build();
       if (i === 0) {
         sentId = await sendReplyEmbed(delivery, botToken, channelId, replyToMessageId, embedPayload);
         // Fall back to non-reply if the referenced message no longer exists
@@ -143,17 +150,10 @@ export function subscribeForAdaptiveInlineResponse(
   const upgradeToProgressMode = () => {
     if (progressMode) return;
     progressMode = true;
-    sendEmbed(delivery, botToken, channelId, {
-      description: 'Working on your request...',
-      color: 0x5865f2,
-      author,
-      footer: {
-        text: buildFooterText(
-          { agentName, agentModel, sessionId, projectName, status: 'starting...' },
-          latestContextUsage,
-        ),
-      },
-    })
+    const progressBuilder = CorvidEmbed.progress(footerCtx, authorIdentity);
+    if (latestContextUsage) progressBuilder.withContextUsage(latestContextUsage);
+    const { embed: progressEmbed } = progressBuilder.build();
+    sendEmbed(delivery, botToken, channelId, progressEmbed)
       .then((msgId) => {
         progressMessageId = msgId;
       })
@@ -185,18 +185,16 @@ export function subscribeForAdaptiveInlineResponse(
               : 'png';
       const filename = `image.${ext}`;
       const attachment: DiscordFileAttachment = { name: filename, data, contentType: ct };
-      await sendEmbedWithFiles(
-        delivery,
-        botToken,
-        channelId,
-        {
-          image: { url: `attachment://${filename}` },
-          color,
-          author,
-          footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }, latestContextUsage) },
-        },
-        [attachment],
-      );
+      const imgBuilder = new CorvidEmbed()
+        .setImage(`attachment://${filename}`)
+        .setColor(color)
+        .setAgent(authorIdentity)
+        .setModel(agentModel)
+        .setSession(sessionId);
+      if (projectName) imgBuilder.setProject(projectName);
+      if (latestContextUsage) imgBuilder.withContextUsage(latestContextUsage);
+      const { embed: imgEmbed } = imgBuilder.build();
+      await sendEmbedWithFiles(delivery, botToken, channelId, imgEmbed, [attachment]);
     } catch (err) {
       log.warn('Failed to send image to Discord', {
         imageUrl,
@@ -236,17 +234,10 @@ export function subscribeForAdaptiveInlineResponse(
         const now = Date.now();
         if (now - lastStatusTime >= STATUS_DEBOUNCE_MS && progressMessageId) {
           lastStatusTime = now;
-          editEmbed(delivery, botToken, channelId, progressMessageId, {
-            description: `\u23f3 ${statusText}`,
-            color: 0x5865f2,
-            author,
-            footer: {
-              text: buildFooterText(
-                { agentName, agentModel, sessionId, projectName, status: 'working...' },
-                latestContextUsage,
-              ),
-            },
-          }).catch((err) => {
+          const toolStatusBuilder = CorvidEmbed.toolStatus(statusText, footerCtx, authorIdentity);
+          if (latestContextUsage) toolStatusBuilder.withContextUsage(latestContextUsage);
+          const { embed: toolStatusEmbed } = toolStatusBuilder.build();
+          editEmbed(delivery, botToken, channelId, progressMessageId, toolStatusEmbed).catch((err) => {
             log.debug('Progress embed edit failed', {
               channelId,
               error: err instanceof Error ? err.message : String(err),
@@ -274,17 +265,10 @@ export function subscribeForAdaptiveInlineResponse(
         .then(() => {
           // Only mark progress embed as done if we upgraded to progress mode
           if (progressMode && progressMessageId) {
-            editEmbed(delivery, botToken, channelId, progressMessageId, {
-              description: '\u2705 Done',
-              color: 0x57f287,
-              author,
-              footer: {
-                text: buildFooterText(
-                  { agentName, agentModel, sessionId, projectName, status: 'done' },
-                  latestContextUsage,
-                ),
-              },
-            }).catch((err) => {
+            const doneBuilder = CorvidEmbed.done(footerCtx, authorIdentity);
+            if (latestContextUsage) doneBuilder.withContextUsage(latestContextUsage);
+            const { embed: doneEmbed } = doneBuilder.build();
+            editEmbed(delivery, botToken, channelId, progressMessageId, doneEmbed).catch((err) => {
               log.debug('Final progress embed edit failed', {
                 channelId,
                 error: err instanceof Error ? err.message : String(err),
@@ -294,24 +278,18 @@ export function subscribeForAdaptiveInlineResponse(
 
           // Offer "Continue in Thread" button so the user can move the conversation
           // out of the channel and into a dedicated thread (reduces channel spam).
-          sendEmbedWithButtons(
-            delivery,
-            botToken,
-            channelId,
-            {
-              description: 'Reply to continue here, or start a thread for a longer conversation.',
-              color: 0x95a5a6,
-              footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }, latestContextUsage) },
-            },
-            [
-              buildActionRow({
-                label: 'Continue in Thread',
-                customId: `continue_thread:${sessionId}`,
-                style: ButtonStyle.PRIMARY,
-                emoji: '🧵',
-              }),
-            ],
-          ).catch((err) => {
+          const continueBuilder = new CorvidEmbed()
+            .setDescription('Reply to continue here, or start a thread for a longer conversation.')
+            .setColor(0x95a5a6)
+            .setAgent(authorIdentity)
+            .setModel(agentModel)
+            .setSession(sessionId)
+            .withButtons(['continue_thread'])
+            .withButtonOverride('continue_thread', `continue_thread:${sessionId}`);
+          if (projectName) continueBuilder.setProject(projectName);
+          if (latestContextUsage) continueBuilder.withContextUsage(latestContextUsage);
+          const { embed: continueEmbed, components } = continueBuilder.build();
+          sendEmbedWithButtons(delivery, botToken, channelId, continueEmbed, components!).catch((err) => {
             log.debug('Continue-in-thread embed failed', {
               channelId,
               error: err instanceof Error ? err.message : String(err),
@@ -333,61 +311,18 @@ export function subscribeForAdaptiveInlineResponse(
       const errEvent = event as { error?: { message?: string; errorType?: string } };
       const errorType = errEvent.error?.errorType || 'unknown';
 
-      let title: string;
-      let description: string;
-      let errColor: number;
-      switch (errorType) {
-        case 'context_exhausted':
-          title = 'Context Limit Reached';
-          description = 'The conversation ran out of context space. Send a message to start a new session.';
-          errColor = 0xf0b232;
-          break;
-        case 'credits_exhausted':
-          title = 'Credits Exhausted';
-          description = 'Session paused — credits have been used up. Add credits to resume.';
-          errColor = 0xf0b232;
-          break;
-        case 'spawn_error':
-          title = 'Failed to Start';
-          description = 'The agent session could not be started. This may be a configuration issue.';
-          errColor = 0xff3355;
-          break;
-        default:
-          title = 'Session Error';
-          description = (errEvent.error?.message || 'An unexpected error occurred.').slice(0, 4096);
-          errColor = 0xff3355;
-          break;
-      }
-
       // If we have a progress embed, update it with the error; otherwise send a new one
+      const errBuilder = CorvidEmbed.error(errorType, footerCtx, authorIdentity, errEvent.error?.message);
+      if (latestContextUsage) errBuilder.withContextUsage(latestContextUsage);
+
       if (progressMode && progressMessageId) {
-        editEmbed(delivery, botToken, channelId, progressMessageId, {
-          title,
-          description,
-          color: errColor,
-          author,
-          footer: {
-            text: buildFooterText(
-              { agentName, agentModel, sessionId, projectName, status: errorType },
-              latestContextUsage,
-            ),
-          },
-        }).catch((err) => {
+        const { embed: errEmbed } = errBuilder.build();
+        editEmbed(delivery, botToken, channelId, progressMessageId, errEmbed).catch((err) => {
           log.debug('Error embed edit failed', { channelId, error: err instanceof Error ? err.message : String(err) });
         });
       } else {
-        sendEmbed(delivery, botToken, channelId, {
-          title,
-          description,
-          color: errColor,
-          author,
-          footer: {
-            text: buildFooterText(
-              { agentName, agentModel, sessionId, projectName, status: errorType },
-              latestContextUsage,
-            ),
-          },
-        }).catch((err) => {
+        const { embed: errEmbed } = errBuilder.build();
+        sendEmbed(delivery, botToken, channelId, errEmbed).catch((err) => {
           log.debug('Error embed send failed', { channelId, error: err instanceof Error ? err.message : String(err) });
         });
       }

--- a/server/discord/thread-response/embed-response.ts
+++ b/server/discord/thread-response/embed-response.ts
@@ -7,13 +7,12 @@ import type { ProcessManager } from '../../process/manager';
 import { extractContentImageUrls, extractContentText } from '../../process/types';
 import {
   agentColor,
-  buildActionRow,
-  buildAgentAuthor,
-  buildFooterText,
-  buildFooterWithStats,
   type ContextUsage,
   collapseCodeBlocks,
+  CorvidEmbed,
   type DiscordFileAttachment,
+  type EmbedAgentIdentity,
+  type FooterContext,
   editEmbed,
   hexColorToInt,
   sendEmbed,
@@ -23,8 +22,7 @@ import {
 } from '../embeds';
 import type { ThreadCallbackInfo } from '../thread-session-map';
 import { formatDuration, normalizeTimestamp } from '../thread-session-map';
-import { ButtonStyle } from '../types';
-import { sessionErrorEmbed, visibleEmbedParts } from './utils';
+import { visibleEmbedParts } from './utils';
 
 const log = createLogger('DiscordThreadManager');
 
@@ -69,7 +67,8 @@ export function subscribeForResponseWithEmbed(
   let latestContextUsage: ContextUsage | undefined;
 
   const color = hexColorToInt(displayColor) ?? agentColor(agentName);
-  const author = buildAgentAuthor({ agentName, displayIcon, avatarUrl });
+  const footerCtx: FooterContext = { agentName, agentModel, sessionId, projectName };
+  const authorIdentity: EmbedAgentIdentity = { agentName, displayIcon, avatarUrl };
 
   // Single progress message — created on first activity, edited in place for updates.
   // Eliminates message spam: instead of N status embeds, one embed is updated.
@@ -81,21 +80,11 @@ export function subscribeForResponseWithEmbed(
   });
 
   /** Post or upgrade the progress message. First call sends it, subsequent calls edit it. */
-  const updateProgressMessage = async (description: string, status: string, embedColor?: number) => {
+  const updateProgressEmbed = async (builder: CorvidEmbed) => {
     const t = getTurnInfo();
-    const embed = {
-      description,
-      color: embedColor ?? 0x95a5a6,
-      author,
-      footer: {
-        text: buildFooterText(
-          { agentName, agentModel, sessionId, projectName, status },
-          latestContextUsage,
-          t.active,
-          t.cumulative,
-        ),
-      },
-    };
+    if (latestContextUsage) builder.withContextUsage(latestContextUsage);
+    builder.withTurns(t.active, t.cumulative);
+    const { embed } = builder.build();
     if (progressMessageId) {
       await editEmbed(delivery, botToken, threadId, progressMessageId, embed);
     } else {
@@ -106,7 +95,7 @@ export function subscribeForResponseWithEmbed(
   // Acknowledgment: if no content arrives within ACK_DELAY_MS, send a progress embed
   const ackTimer = setTimeout(() => {
     if (!receivedAnyContent && !sentErrorMessage) {
-      updateProgressMessage('Received — working on it...', 'thinking').catch((err) => {
+      updateProgressEmbed(CorvidEmbed.progress(footerCtx, authorIdentity)).catch((err) => {
         log.debug('Ack embed failed', { threadId, error: err instanceof Error ? err.message : String(err) });
       });
     }
@@ -120,7 +109,7 @@ export function subscribeForResponseWithEmbed(
       return;
     }
     const elapsed = Math.round((Date.now() - startTime) / 1000);
-    updateProgressMessage(`Still working (${elapsed}s elapsed)...`, 'working...').catch((err) => {
+    updateProgressEmbed(CorvidEmbed.toolStatus(`Still working (${elapsed}s elapsed)...`, footerCtx, authorIdentity)).catch((err) => {
       log.debug('Progress embed failed', { threadId, error: err instanceof Error ? err.message : String(err) });
     });
   }, PROGRESS_INTERVAL_MS);
@@ -136,20 +125,20 @@ export function subscribeForResponseWithEmbed(
         // If we have an existing progress message, update it to show the crash.
         // Otherwise send a new embed.
         if (progressMessageId) {
+          // Build the crash embed without buttons for editing in-place
+          const crashNoButtonBuilder = new CorvidEmbed()
+            .setDescription('The agent session ended unexpectedly. Send a message to resume.')
+            .setColor(0xff3355)
+            .setAgent(authorIdentity)
+            .setStatus('crashed')
+            .setModel(agentModel)
+            .setSession(sessionId);
+          if (projectName) crashNoButtonBuilder.setProject(projectName);
+          if (latestContextUsage) crashNoButtonBuilder.withContextUsage(latestContextUsage);
           const ct = getTurnInfo();
-          editEmbed(delivery, botToken, threadId, progressMessageId, {
-            description: 'The agent session ended unexpectedly. Send a message to resume.',
-            color: 0xff3355,
-            author,
-            footer: {
-              text: buildFooterText(
-                { agentName, agentModel, sessionId, projectName, status: 'crashed' },
-                latestContextUsage,
-                ct.active,
-                ct.cumulative,
-              ),
-            },
-          }).catch((err) => {
+          crashNoButtonBuilder.withTurns(ct.active, ct.cumulative);
+          const { embed: crashEmbed } = crashNoButtonBuilder.build();
+          editEmbed(delivery, botToken, threadId, progressMessageId, crashEmbed).catch((err) => {
             log.warn('Failed to update progress embed with crash', {
               threadId,
               error: err instanceof Error ? err.message : String(err),
@@ -157,25 +146,11 @@ export function subscribeForResponseWithEmbed(
           });
         } else {
           const ct2 = getTurnInfo();
-          sendEmbedWithButtons(
-            delivery,
-            botToken,
-            threadId,
-            {
-              description: 'The agent session ended unexpectedly. Send a message to resume.',
-              color: 0xff3355,
-              author,
-              footer: {
-                text: buildFooterText(
-                  { agentName, agentModel, sessionId, projectName, status: 'crashed' },
-                  latestContextUsage,
-                  ct2.active,
-                  ct2.cumulative,
-                ),
-              },
-            },
-            [buildActionRow({ label: 'Resume', customId: 'resume_thread', style: ButtonStyle.SUCCESS, emoji: '🔄' })],
-          ).catch((err) => {
+          const crashBuilder = CorvidEmbed.crash(footerCtx, authorIdentity);
+          if (latestContextUsage) crashBuilder.withContextUsage(latestContextUsage);
+          crashBuilder.withTurns(ct2.active, ct2.cumulative);
+          const { embed: crashEmbed, components } = crashBuilder.build();
+          sendEmbedWithButtons(delivery, botToken, threadId, crashEmbed, components!).catch((err) => {
             log.warn('Failed to send crash embed', {
               threadId,
               error: err instanceof Error ? err.message : String(err),
@@ -196,10 +171,8 @@ export function subscribeForResponseWithEmbed(
     clearTyping();
     log.warn('Typing indicator safety timeout reached', { sessionId, threadId });
     if (!receivedAnyActivity) {
-      sendEmbed(delivery, botToken, threadId, {
-        description: 'The agent appears to be taking too long. It may still be working \u2014 send a message to check.',
-        color: 0xf0b232,
-      }).catch((err) => {
+      const { embed } = CorvidEmbed.timeout(footerCtx, authorIdentity).build();
+      sendEmbed(delivery, botToken, threadId, embed).catch((err) => {
         log.warn('Failed to send timeout embed', { threadId, error: err instanceof Error ? err.message : String(err) });
       });
     }
@@ -220,19 +193,17 @@ export function subscribeForResponseWithEmbed(
     const t = getTurnInfo();
     const parts = visibleEmbedParts(text);
     for (const part of parts) {
-      await sendEmbed(delivery, botToken, threadId, {
-        description: part,
-        color,
-        author,
-        footer: {
-          text: buildFooterText(
-            { agentName, agentModel, sessionId, projectName },
-            latestContextUsage,
-            t.active,
-            t.cumulative,
-          ),
-        },
-      });
+      const contentBuilder = new CorvidEmbed()
+        .setDescription(part)
+        .setColor(color)
+        .setAgent(authorIdentity)
+        .setModel(agentModel)
+        .setSession(sessionId)
+        .withTurns(t.active, t.cumulative);
+      if (latestContextUsage) contentBuilder.withContextUsage(latestContextUsage);
+      if (projectName) contentBuilder.setProject(projectName);
+      const { embed: contentEmbed } = contentBuilder.build();
+      await sendEmbed(delivery, botToken, threadId, contentEmbed);
     }
   };
 
@@ -257,25 +228,17 @@ export function subscribeForResponseWithEmbed(
       const filename = `image.${ext}`;
       const attachment: DiscordFileAttachment = { name: filename, data, contentType: ct };
       const imgT = getTurnInfo();
-      await sendEmbedWithFiles(
-        delivery,
-        botToken,
-        threadId,
-        {
-          image: { url: `attachment://${filename}` },
-          color,
-          author,
-          footer: {
-            text: buildFooterText(
-              { agentName, agentModel, sessionId, projectName },
-              latestContextUsage,
-              imgT.active,
-              imgT.cumulative,
-            ),
-          },
-        },
-        [attachment],
-      );
+      const imgBuilder = new CorvidEmbed()
+        .setImage(`attachment://${filename}`)
+        .setColor(color)
+        .setAgent(authorIdentity)
+        .setModel(agentModel)
+        .setSession(sessionId)
+        .withTurns(imgT.active, imgT.cumulative);
+      if (latestContextUsage) imgBuilder.withContextUsage(latestContextUsage);
+      if (projectName) imgBuilder.setProject(projectName);
+      const { embed: imgEmbed } = imgBuilder.build();
+      await sendEmbedWithFiles(delivery, botToken, threadId, imgEmbed, [attachment]);
     } catch (err) {
       log.warn('Failed to send image to Discord thread', {
         imageUrl,
@@ -328,7 +291,7 @@ export function subscribeForResponseWithEmbed(
         if (now - lastStatusTime >= STATUS_DEBOUNCE_MS) {
           lastStatusTime = now;
           // Edit the progress message in place instead of posting a new embed
-          updateProgressMessage(`⏳ ${statusText}`, 'working...').catch((err) => {
+          updateProgressEmbed(CorvidEmbed.toolStatus(statusText, footerCtx, authorIdentity)).catch((err) => {
             log.debug('Tool status embed edit failed', {
               threadId,
               error: err instanceof Error ? err.message : String(err),
@@ -359,19 +322,18 @@ export function subscribeForResponseWithEmbed(
       const warning = event as { level?: string; message?: string; usagePercent?: number };
       if (warning.level === 'critical') {
         const wt = getTurnInfo();
-        sendEmbed(delivery, botToken, threadId, {
-          description: `⚠️ ${warning.message || `Context usage at ${warning.usagePercent}%`}`,
-          color: 0xf0b232, // yellow/warning
-          author,
-          footer: {
-            text: buildFooterText(
-              { agentName, agentModel, sessionId, projectName, status: 'context warning' },
-              latestContextUsage,
-              wt.active,
-              wt.cumulative,
-            ),
-          },
-        }).catch((err) => {
+        const warnBuilder = new CorvidEmbed()
+          .setDescription(`⚠️ ${warning.message || `Context usage at ${warning.usagePercent}%`}`)
+          .setColor(0xf0b232)
+          .setAgent(authorIdentity)
+          .setModel(agentModel)
+          .setSession(sessionId)
+          .setStatus('context warning')
+          .withTurns(wt.active, wt.cumulative);
+        if (latestContextUsage) warnBuilder.withContextUsage(latestContextUsage);
+        if (projectName) warnBuilder.setProject(projectName);
+        const { embed: warnEmbed } = warnBuilder.build();
+        sendEmbed(delivery, botToken, threadId, warnEmbed).catch((err) => {
           log.debug('Context warning embed failed', {
             threadId,
             error: err instanceof Error ? err.message : String(err),
@@ -396,19 +358,11 @@ export function subscribeForResponseWithEmbed(
           const ttlMs = parseInt(process.env.KEEP_ALIVE_TTL_MS ?? String(15 * 60 * 1000), 10);
           const expiresAt = Math.floor((Date.now() + ttlMs) / 1000);
           const dt = getTurnInfo();
-          editEmbed(delivery, botToken, threadId, progressMessageId, {
-            description: `✅ Done · Expires <t:${expiresAt}:R>`,
-            color: 0x57f287,
-            author,
-            footer: {
-              text: buildFooterText(
-                { agentName, agentModel, sessionId, projectName, status: 'warm' },
-                latestContextUsage,
-                dt.active,
-                dt.cumulative,
-              ),
-            },
-          }).catch((err) => {
+          const warmBuilder = CorvidEmbed.warm(footerCtx, authorIdentity, expiresAt);
+          if (latestContextUsage) warmBuilder.withContextUsage(latestContextUsage);
+          warmBuilder.withTurns(dt.active, dt.cumulative);
+          const { embed: warmEmbed } = warmBuilder.build();
+          editEmbed(delivery, botToken, threadId, progressMessageId, warmEmbed).catch((err) => {
             log.debug('Progress warm edit failed', {
               threadId,
               error: err instanceof Error ? err.message : String(err),
@@ -429,19 +383,11 @@ export function subscribeForResponseWithEmbed(
       // Mark the progress message as done (if it exists) before sending the completion embed
       if (progressMessageId) {
         const dt = getTurnInfo();
-        editEmbed(delivery, botToken, threadId, progressMessageId, {
-          description: '✅ Done',
-          color: 0x57f287,
-          author,
-          footer: {
-            text: buildFooterText(
-              { agentName, agentModel, sessionId, projectName, status: 'done' },
-              latestContextUsage,
-              dt.active,
-              dt.cumulative,
-            ),
-          },
-        }).catch((err) => {
+        const doneBuilder = CorvidEmbed.done(footerCtx, authorIdentity);
+        if (latestContextUsage) doneBuilder.withContextUsage(latestContextUsage);
+        doneBuilder.withTurns(dt.active, dt.cumulative);
+        const { embed: doneEmbed } = doneBuilder.build();
+        editEmbed(delivery, botToken, threadId, progressMessageId, doneEmbed).catch((err) => {
           log.debug('Progress done edit failed', { threadId, error: err instanceof Error ? err.message : String(err) });
         });
       }
@@ -553,38 +499,17 @@ export function subscribeForResponseWithEmbed(
           });
         }
 
-        const footerCtx = { agentName, agentModel, sessionId, projectName, status: 'done' };
+        const completionCtx: FooterContext = { agentName, agentModel, sessionId, projectName, status: 'done' };
         const footerStats = { filesChanged: statsFiles, turns: statsTurns, tools: statsTools, commits: statsCommits };
         const statsCumulative = getSessionCumulativeTurns(db, sessionId);
 
-        // Build contextual buttons based on what the session actually did
-        const buttons: Array<{ label: string; customId: string; style?: number; emoji?: string }> = [];
+        const completionBuilder = CorvidEmbed.completion(completionCtx, authorIdentity)
+          .setFields(fields)
+          .withStats(footerStats, statsCumulative);
+        if (latestContextUsage) completionBuilder.withContextUsage(latestContextUsage);
+        const { embed: completionEmbed, components } = completionBuilder.build();
 
-        // "New Session" is the primary action — actually starts a new session in this thread
-        buttons.push({ label: 'New Session', customId: 'new_session', style: ButtonStyle.SUCCESS, emoji: '🔄' });
-
-        // If a PR was created, add a contextual "View PR" button (URL button not supported
-        // via component API, so we include the PR URL in the completion description instead)
-
-        // "Create Issue" — lets the user file a GitHub issue from the conversation
-        buttons.push({ label: 'Create Issue', customId: 'create_issue', style: ButtonStyle.PRIMARY, emoji: '📋' });
-
-        // Archive is secondary
-        buttons.push({ label: 'Archive', customId: 'archive_thread', style: ButtonStyle.SECONDARY, emoji: '📦' });
-
-        await sendEmbedWithButtons(
-          delivery,
-          botToken,
-          threadId,
-          {
-            description: 'Session complete. Send a message to continue the conversation.',
-            color: 0x57f287,
-            author,
-            ...(fields.length > 0 ? { fields } : {}),
-            footer: { text: buildFooterWithStats(footerCtx, footerStats, latestContextUsage, statsCumulative) },
-          },
-          [buildActionRow(...buttons)],
-        );
+        await sendEmbedWithButtons(delivery, botToken, threadId, completionEmbed, components!);
       })().catch((err) => {
         log.debug('Session complete embed failed', {
           threadId,
@@ -601,52 +526,24 @@ export function subscribeForResponseWithEmbed(
       const errEvent = event as { error?: { message?: string; errorType?: string; recoverable?: boolean } };
       const errorType = errEvent.error?.errorType || 'unknown';
 
-      // Differentiated messages per error type
-      const { title, description, color: errColor } = sessionErrorEmbed(errorType, errEvent.error?.message);
-
       // If we have a progress message, update it to show the error; otherwise send new
       const et = getTurnInfo();
+      const errBuilder = CorvidEmbed.error(errorType, footerCtx, authorIdentity, errEvent.error?.message);
+      if (latestContextUsage) errBuilder.withContextUsage(latestContextUsage);
+      errBuilder.withTurns(et.active, et.cumulative);
+
       if (progressMessageId) {
-        editEmbed(delivery, botToken, threadId, progressMessageId, {
-          title,
-          description,
-          color: errColor,
-          author,
-          footer: {
-            text: buildFooterText(
-              { agentName, agentModel, sessionId, projectName, status: errorType },
-              latestContextUsage,
-              et.active,
-              et.cumulative,
-            ),
-          },
-        }).catch((err) => {
+        const { embed: errEmbed } = errBuilder.build();
+        editEmbed(delivery, botToken, threadId, progressMessageId, errEmbed).catch((err) => {
           log.debug('Session error embed edit failed', {
             threadId,
             error: err instanceof Error ? err.message : String(err),
           });
         });
       } else {
-        sendEmbedWithButtons(
-          delivery,
-          botToken,
-          threadId,
-          {
-            title,
-            description,
-            color: errColor,
-            author,
-            footer: {
-              text: buildFooterText(
-                { agentName, agentModel, sessionId, projectName, status: errorType },
-                latestContextUsage,
-                et.active,
-                et.cumulative,
-              ),
-            },
-          },
-          [buildActionRow({ label: 'Resume', customId: 'resume_thread', style: ButtonStyle.SUCCESS, emoji: '🔄' })],
-        ).catch((err) => {
+        errBuilder.withButtons(['resume']);
+        const { embed: errEmbed, components } = errBuilder.build();
+        sendEmbedWithButtons(delivery, botToken, threadId, errEmbed, components!).catch((err) => {
           log.debug('Session error embed failed', {
             threadId,
             error: err instanceof Error ? err.message : String(err),
@@ -675,30 +572,14 @@ export function subscribeForResponseWithEmbed(
         if (cumTurns > 0) {
           fields.push({ name: 'Turns', value: String(cumTurns), inline: true });
         }
-        const buttons: Array<{ label: string; customId: string; style?: number; emoji?: string }> = [];
-        buttons.push({ label: 'New Session', customId: 'new_session', style: ButtonStyle.SUCCESS, emoji: '🔄' });
-        buttons.push({ label: 'Create Issue', customId: 'create_issue', style: ButtonStyle.PRIMARY, emoji: '📋' });
-        buttons.push({ label: 'Archive', customId: 'archive_thread', style: ButtonStyle.SECONDARY, emoji: '📦' });
-        sendEmbedWithButtons(
-          delivery,
-          botToken,
-          threadId,
-          {
-            description: 'Session complete. Send a message to continue the conversation.',
-            color: 0x57f287,
-            author,
-            ...(fields.length > 0 ? { fields } : {}),
-            footer: {
-              text: buildFooterText(
-                { agentName, agentModel, sessionId, projectName, status: 'done' },
-                latestContextUsage,
-                dt.active,
-                dt.cumulative,
-              ),
-            },
-          },
-          [buildActionRow(...buttons)],
-        ).catch((err) => {
+
+        const exitCtx: FooterContext = { agentName, agentModel, sessionId, projectName, status: 'done' };
+        const exitBuilder = CorvidEmbed.completion(exitCtx, authorIdentity)
+          .setFields(fields)
+          .withTurns(dt.active, dt.cumulative);
+        if (latestContextUsage) exitBuilder.withContextUsage(latestContextUsage);
+        const { embed: exitEmbed, components } = exitBuilder.build();
+        sendEmbedWithButtons(delivery, botToken, threadId, exitEmbed, components!).catch((err) => {
           log.debug('Keep-alive completion embed failed', {
             threadId,
             error: err instanceof Error ? err.message : String(err),

--- a/server/discord/thread-response/embed-response.ts
+++ b/server/discord/thread-response/embed-response.ts
@@ -355,7 +355,7 @@ export function subscribeForResponseWithEmbed(
       if (isKeepAlive) {
         // Keep-alive turn complete: show warm status with TTL, stay subscribed for future turns
         if (progressMessageId) {
-          const ttlMs = parseInt(process.env.KEEP_ALIVE_TTL_MS ?? String(15 * 60 * 1000), 10);
+          const ttlMs = parseInt(process.env.KEEP_ALIVE_TTL_MS ?? String(2 * 60 * 60 * 1000), 10);
           const expiresAt = Math.floor((Date.now() + ttlMs) / 1000);
           const dt = getTurnInfo();
           const warmBuilder = CorvidEmbed.warm(footerCtx, authorIdentity, expiresAt);

--- a/server/discord/thread-response/inline-response.ts
+++ b/server/discord/thread-response/inline-response.ts
@@ -5,10 +5,11 @@ import type { ProcessManager } from '../../process/manager';
 import { extractContentText } from '../../process/types';
 import {
   agentColor,
-  buildAgentAuthor,
-  buildFooterText,
+  CorvidEmbed,
   type ContextUsage,
   collapseCodeBlocks,
+  type EmbedAgentIdentity,
+  type FooterContext,
   hexColorToInt,
   sendEmbed,
   sendReplyEmbed,
@@ -46,16 +47,16 @@ export function subscribeForInlineResponse(
   let receivedAnyActivity = false; // tracks any activity (content OR tool use)
   let latestContextUsage: ContextUsage | undefined;
   const color = hexColorToInt(displayColor) ?? agentColor(agentName);
-  const author = buildAgentAuthor({ agentName, displayIcon, avatarUrl });
+  const footerCtx: FooterContext = { agentName, agentModel, sessionId, projectName };
+  const authorIdentity: EmbedAgentIdentity = { agentName, displayIcon, avatarUrl };
 
   // Acknowledgment: if no content arrives within ACK_DELAY_MS, send a brief status
   const ackTimer = setTimeout(() => {
     if (!receivedAnyContent) {
-      sendEmbed(delivery, botToken, channelId, {
-        description: 'Received — working on it...',
-        color: 0x95a5a6,
-        author,
-      }).catch((err) => {
+      const ackBuilder = CorvidEmbed.progress(footerCtx, authorIdentity);
+      if (latestContextUsage) ackBuilder.withContextUsage(latestContextUsage);
+      const { embed: ackEmbed } = ackBuilder.build();
+      sendEmbed(delivery, botToken, channelId, ackEmbed).catch((err) => {
         log.debug('Ack embed failed (inline)', { channelId, error: err instanceof Error ? err.message : String(err) });
       });
     }
@@ -68,10 +69,11 @@ export function subscribeForInlineResponse(
       clearTyping();
       log.warn('Process died while typing indicator active (inline)', { sessionId, channelId });
       if (!receivedAnyContent) {
-        sendEmbed(delivery, botToken, channelId, {
-          description: 'The agent session ended unexpectedly. Send a message to start a new session.',
-          color: 0xff3355,
-        }).catch((err) => {
+        const { embed: crashEmbed } = new CorvidEmbed()
+          .setDescription('The agent session ended unexpectedly. Send a message to start a new session.')
+          .setColor(0xff3355)
+          .build();
+        sendEmbed(delivery, botToken, channelId, crashEmbed).catch((err) => {
           log.warn('Failed to send crash embed', {
             channelId,
             error: err instanceof Error ? err.message : String(err),
@@ -93,10 +95,10 @@ export function subscribeForInlineResponse(
     clearInterval(typingInterval);
     log.warn('Typing indicator safety timeout reached (inline)', { sessionId, channelId });
     if (!receivedAnyActivity) {
-      sendEmbed(delivery, botToken, channelId, {
-        description: 'The agent appears to be taking too long. It may still be working \u2014 send a message to check.',
-        color: 0xf0b232,
-      }).catch((err) => {
+      const timeoutBuilder = CorvidEmbed.timeout(footerCtx, authorIdentity);
+      if (latestContextUsage) timeoutBuilder.withContextUsage(latestContextUsage);
+      const { embed: timeoutEmbed } = timeoutBuilder.build();
+      sendEmbed(delivery, botToken, channelId, timeoutEmbed).catch((err) => {
         log.warn('Failed to send timeout embed', {
           channelId,
           error: err instanceof Error ? err.message : String(err),
@@ -119,12 +121,15 @@ export function subscribeForInlineResponse(
     const parts = visibleEmbedParts(text);
     for (let i = 0; i < parts.length; i++) {
       let sentId: string | null = null;
-      const embedPayload = {
-        description: parts[i],
-        color,
-        author,
-        footer: { text: buildFooterText({ agentName, agentModel, sessionId, projectName }, latestContextUsage) },
-      };
+      const contentBuilder = new CorvidEmbed()
+        .setDescription(parts[i])
+        .setColor(color)
+        .setAgent(authorIdentity)
+        .setModel(agentModel)
+        .setSession(sessionId);
+      if (projectName) contentBuilder.setProject(projectName);
+      if (latestContextUsage) contentBuilder.withContextUsage(latestContextUsage);
+      const { embed: embedPayload } = contentBuilder.build();
       if (i === 0) {
         sentId = await sendReplyEmbed(delivery, botToken, channelId, replyToMessageId, embedPayload);
         // Fall back to non-reply if the referenced message no longer exists

--- a/server/discord/work-dispatch.ts
+++ b/server/discord/work-dispatch.ts
@@ -76,7 +76,7 @@ export async function handleWorkIntake(
 
     log.info('Work task created from Discord', { taskId: task.id, userId });
 
-    const { embed: queuedEmbed } = CorvidEmbed.workTaskQueued(task.id, description).build();
+    const { embed: queuedEmbed } = CorvidEmbed.workTaskQueued(task.id, description, task.status).build();
     await sendEmbed(ctx.delivery, ctx.config.botToken, channelId, queuedEmbed);
 
     ctx.workTaskService.onStatusChange(task.id, (updatedTask) => {

--- a/server/discord/work-dispatch.ts
+++ b/server/discord/work-dispatch.ts
@@ -8,7 +8,7 @@
 import type { WorkTask } from '../../shared/types/work-tasks';
 import { listAgents } from '../db/agents';
 import { createLogger } from '../lib/logger';
-import { sendDiscordMessage, sendEmbed, sendMessageWithEmbed } from './embeds';
+import { CorvidEmbed, EMBED_COLORS, sendDiscordMessage, sendEmbed, sendMessageWithEmbed } from './embeds';
 import type { MessageHandlerContext } from './message-router';
 
 const log = createLogger('DiscordWorkDispatch');
@@ -76,30 +76,18 @@ export async function handleWorkIntake(
 
     log.info('Work task created from Discord', { taskId: task.id, userId });
 
-    await sendEmbed(ctx.delivery, ctx.config.botToken, channelId, {
-      title: 'Task Queued',
-      description: `**${task.id}**\n\n${description.slice(0, 200)}${description.length > 200 ? '...' : ''}`,
-      color: 0x5865f2,
-      footer: { text: `Status: ${task.status}` },
-    });
+    const { embed: queuedEmbed } = CorvidEmbed.workTaskQueued(task.id, description).build();
+    await sendEmbed(ctx.delivery, ctx.config.botToken, channelId, queuedEmbed);
 
     ctx.workTaskService.onStatusChange(task.id, (updatedTask) => {
-      const statusMessages: Record<string, { desc: string; color: number }> = {
-        branching: { desc: '⚙️ Setting up workspace and creating branch...', color: 0x5865f2 },
-        running: {
-          desc: `🤖 Agent working${(updatedTask.iterationCount ?? 1) > 1 ? ` (iteration ${updatedTask.iterationCount})` : ''}...`,
-          color: 0x5865f2,
-        },
-        validating: { desc: '🔍 Validating changes...', color: 0xf0b232 },
-      };
-      const statusInfo = statusMessages[updatedTask.status];
-      if (statusInfo) {
-        sendEmbed(ctx.delivery, ctx.config.botToken, channelId, {
-          title: 'Task Update',
-          description: `**${updatedTask.id}**\n\n${statusInfo.desc}`,
-          color: statusInfo.color,
-          footer: { text: `Status: ${updatedTask.status}` },
-        }).catch((err) => {
+      const activeStatuses = new Set(['branching', 'running', 'validating']);
+      if (activeStatuses.has(updatedTask.status)) {
+        const { embed: statusEmbed } = CorvidEmbed.workTaskStatus(
+          updatedTask.id,
+          updatedTask.status,
+          updatedTask.iterationCount,
+        ).build();
+        sendEmbed(ctx.delivery, ctx.config.botToken, channelId, statusEmbed).catch((err) => {
           log.debug('Failed to send work task status embed', {
             taskId: updatedTask.id,
             status: updatedTask.status,
@@ -121,11 +109,12 @@ export async function handleWorkIntake(
     const message = err instanceof Error ? err.message : String(err);
     log.error('Failed to create work task from Discord', { error: message, userId });
 
-    await sendEmbed(ctx.delivery, ctx.config.botToken, channelId, {
-      title: 'Task Failed',
-      description: message.slice(0, 500),
-      color: 0xed4245,
-    });
+    const { embed: failEmbed } = new CorvidEmbed()
+      .setTitle('Task Failed')
+      .setDescription(message.slice(0, 500))
+      .setColor(EMBED_COLORS.error)
+      .build();
+    await sendEmbed(ctx.delivery, ctx.config.botToken, channelId, failEmbed);
   }
 }
 
@@ -151,39 +140,34 @@ export async function sendTaskResult(
     }
     fields.push({ name: 'Iterations', value: String(task.iterationCount), inline: true });
 
+    const { embed: completedEmbed } = CorvidEmbed.workTaskCompleted(task.id, task.description)
+      .setFields(fields)
+      .build();
     await sendMessageWithEmbed(
       ctx.delivery,
       ctx.config.botToken,
       channelId,
       mention ? `${mention}Your work task is done!` : undefined,
-      {
-        title: 'Task Completed',
-        description: task.description.slice(0, 300),
-        color: 0x57f287,
-        fields,
-        footer: { text: `Task: ${task.id}` },
-      },
+      completedEmbed,
     );
   } else if (task.status === 'failed') {
+    const errorFields: Array<{ name: string; value: string; inline?: boolean }> = [
+      ...((task.error ? [{ name: 'Error', value: task.error.slice(0, 1024), inline: false }] : []) as Array<{
+        name: string;
+        value: string;
+        inline?: boolean;
+      }>),
+      { name: 'Iterations', value: String(task.iterationCount), inline: true },
+    ];
+    const { embed: failedEmbed } = CorvidEmbed.workTaskFailed(task.id, task.description)
+      .setFields(errorFields)
+      .build();
     await sendMessageWithEmbed(
       ctx.delivery,
       ctx.config.botToken,
       channelId,
       mention ? `${mention}Your work task encountered an issue.` : undefined,
-      {
-        title: 'Task Failed',
-        description: task.description.slice(0, 300),
-        color: 0xed4245,
-        fields: [
-          ...((task.error ? [{ name: 'Error', value: task.error.slice(0, 1024), inline: false }] : []) as Array<{
-            name: string;
-            value: string;
-            inline?: boolean;
-          }>),
-          { name: 'Iterations', value: String(task.iterationCount), inline: true },
-        ],
-        footer: { text: `Task: ${task.id}` },
-      },
+      failedEmbed,
     );
   }
 }

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -70,7 +70,7 @@ const ZERO_TURN_CIRCUIT_BREAKER_THRESHOLD = 3;
 const AUTO_COMPACT_THRESHOLD = 90;
 
 /** Keep-alive TTL default in ms. Configurable via KEEP_ALIVE_TTL_MS env var. */
-const KEEP_ALIVE_TTL_MS = parseInt(process.env.KEEP_ALIVE_TTL_MS ?? String(15 * 60 * 1000), 10);
+const KEEP_ALIVE_TTL_MS = parseInt(process.env.KEEP_ALIVE_TTL_MS ?? String(2 * 60 * 60 * 1000), 10);
 
 /** Whether keep-alive is globally enabled. Opt-in via KEEP_ALIVE_ENABLED env var. */
 const KEEP_ALIVE_ENABLED = process.env.KEEP_ALIVE_ENABLED === 'true';

--- a/server/process/session-timer-manager.ts
+++ b/server/process/session-timer-manager.ts
@@ -36,7 +36,7 @@ export interface SessionTimerConfig {
   timeoutCheckIntervalMs: number;
   /** Max time (ms) to wait for the first event after process registration. Default: 90s. */
   startupTimeoutMs: number;
-  /** Keep-alive TTL for warm processes in ms. Default: 15 minutes. */
+  /** Keep-alive TTL for warm processes in ms. Default: 2 hours. */
   keepAliveTtlMs: number;
 }
 
@@ -45,7 +45,7 @@ const DEFAULT_CONFIG: SessionTimerConfig = {
   stablePeriodMs: 10 * 60 * 1000,
   timeoutCheckIntervalMs: 60_000,
   startupTimeoutMs: parseInt(process.env.STARTUP_TIMEOUT_MS ?? '90000', 10),
-  keepAliveTtlMs: parseInt(process.env.KEEP_ALIVE_TTL_MS ?? String(15 * 60 * 1000), 10),
+  keepAliveTtlMs: parseInt(process.env.KEEP_ALIVE_TTL_MS ?? String(2 * 60 * 60 * 1000), 10),
 };
 
 export class SessionTimerManager {

--- a/specs/discord/bridge.spec.md
+++ b/specs/discord/bridge.spec.md
@@ -227,6 +227,16 @@ Bidirectional Discord bridge using the raw Discord Gateway WebSocket API (v10). 
 | `sendEmbedWithFiles` | `(delivery, botToken, channelId, embed, files)` | `Promise<string \| null>` | Send an embed with file attachments via multipart/form-data |
 | `sendMessageWithFiles` | `(delivery, botToken, channelId, content, files)` | `Promise<string \| null>` | Send a text message with file attachments via multipart/form-data |
 
+### Re-exported from embed-builder.ts (via embeds.ts)
+
+| Export | Type | Description |
+|--------|------|-------------|
+| `CorvidEmbed` | `class` | Chainable builder for Discord embeds with auto-constructed footers, author blocks, and button rows. Includes static preset factories for common embed types. |
+| `EMBED_COLORS` | `const` | Canonical color palette: neutral, working, success, warning, error, errorAlt |
+| `EMBED_BUTTONS` | `const` | Button definitions: new_session, archive, create_issue, resume, continue_thread |
+| `EmbedAgentIdentity` | `interface` | Agent identity for building embed author blocks (agentName, displayIcon?, avatarUrl?) |
+| `EmbedButtonKey` | `type` | Union of valid button keys from EMBED_BUTTONS |
+
 ### Exported Functions (from message-router.ts)
 
 | Function | Parameters | Returns | Description |

--- a/specs/discord/thread-response.spec.md
+++ b/specs/discord/thread-response.spec.md
@@ -3,6 +3,7 @@ module: thread-response
 version: 1
 status: draft
 files:
+  - server/discord/embed-builder.ts
   - server/discord/thread-response/embed-response.ts
   - server/discord/thread-response/inline-response.ts
   - server/discord/thread-response/progress-response.ts
@@ -22,6 +23,18 @@ depends_on:
 Provides response subscription strategies for Discord conversations. Each strategy subscribes to agent process events and delivers responses to Discord channels/threads using different UX patterns (rich embeds, inline replies, edit-in-place progress, or adaptive). Also includes recovery logic for reconnecting subscriptions after server restart and shared utility functions.
 
 ## Public API
+
+### Exported Classes (embed-builder.ts)
+
+| Export | Type | Description |
+|--------|------|-------------|
+| `CorvidEmbed` | `class` | Chainable builder for Discord embeds with auto-constructed footers, author blocks, and button rows. Static preset factories: progress, toolStatus, warm, done, completion, crash, error, timeout, workTaskQueued, workTaskStatus, workTaskCompleted, workTaskFailed. |
+| `EMBED_COLORS` | `const` | Canonical color palette: neutral (0x95a5a6), working (0x5865f2), success (0x57f287), warning (0xf0b232), error (0xff3355), errorAlt (0xed4245) |
+| `EMBED_BUTTONS` | `const` | Button definitions: new_session, archive, create_issue, resume, continue_thread |
+| `EmbedAgentIdentity` | `interface` | Agent identity for building embed author blocks (agentName, displayIcon?, avatarUrl?) |
+| `EmbedButtonKey` | `type` | Union type of valid button keys from EMBED_BUTTONS |
+| `ButtonDef` | `interface` | Shape of a button definition (label, emoji, customId, style) |
+| `BuiltEmbed` | `interface` | Return type of CorvidEmbed.build() — { embed: DiscordEmbed, components?: DiscordActionRow[] } |
 
 ### Exported Functions (embed-response.ts)
 


### PR DESCRIPTION
## Summary

Closes #2250

- **New `CorvidEmbed` builder** (`server/discord/embed-builder.ts`) — chainable builder with canonical color palette (`EMBED_COLORS`), button registry (`EMBED_BUTTONS`), and 12 preset factories (progress, toolStatus, warm, done, completion, crash, error, timeout, workTaskQueued, workTaskStatus, workTaskCompleted, workTaskFailed)
- **Migrated all embed construction sites** to use the builder: `embed-response.ts`, `adaptive-response.ts`, `inline-response.ts`, `work-dispatch.ts` — eliminating ~400 lines of duplicated color/footer/button/author logic
- **Fixed keep-alive TTL default** from 15 minutes → 2 hours in 3 locations (`manager.ts`, `session-timer-manager.ts`, `embed-response.ts`)
- **97 new tests** covering all constants, builder methods, presets, and edge cases
- **Specs updated** for both `bridge.spec.md` (re-exports) and `thread-response.spec.md` (new file + exports)

## Stats

- 11 files changed, +1472 / -427 lines
- 10,728 tests pass (1 pre-existing AST WASM failure in worktree)
- 216 specs pass, 100% coverage
- TypeScript clean

## Test plan

- [x] Verify Discord thread responses show correct embeds (progress → done → completion)
- [x] Verify keep-alive TTL shows 2-hour countdown, not 15 minutes
- [x] Verify work task embeds (queued → running → completed/failed) render correctly
- [x] Verify crash/timeout/error embeds display proper colors and buttons
- [x] Run `fledge lanes run verify` — lint, typecheck, test, spec-check all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)