### PR TITLE
fix(discord): prevent race condition in thread message handling

### DIFF
--- a/server/__tests__/discord-bridge-threads.test.ts
+++ b/server/__tests__/discord-bridge-threads.test.ts
@@ -102,7 +102,7 @@ describe('DiscordBridge thread subscription dedup', () => {
       expect(pm.subscribe).toHaveBeenCalledTimes(1);
       expect(pm.unsubscribe).not.toHaveBeenCalled();
 
-      // Second message — should unsubscribe old callback then re-subscribe
+      // Second message — same session, should reuse existing callback (no re-subscribe)
       await (bridge as unknown as { handleMessage: (msg: unknown) => Promise<void> }).handleMessage({
         id: '200000000000000011',
         channel_id: '400000000000000001',
@@ -111,10 +111,10 @@ describe('DiscordBridge thread subscription dedup', () => {
         timestamp: new Date().toISOString(),
       });
 
-      // unsubscribe called once (for the first callback)
-      expect(pm.unsubscribe).toHaveBeenCalledTimes(1);
-      // subscribe called twice total (once per message)
-      expect(pm.subscribe).toHaveBeenCalledTimes(2);
+      // No unsubscribe — existing callback handles both messages
+      expect(pm.unsubscribe).not.toHaveBeenCalled();
+      // subscribe called once (first message only; second reuses the active callback)
+      expect(pm.subscribe).toHaveBeenCalledTimes(1);
     } finally {
       cleanup();
     }
@@ -183,10 +183,10 @@ describe('DiscordBridge thread subscription dedup', () => {
         timestamp: new Date().toISOString(),
       });
 
-      // After second message, callback should be replaced
+      // After second message, callback should be the SAME (same session = reuse, not replace)
       expect(tsm.threadCallbacks.has('500000000000000001')).toBe(true);
       const secondCallback = tsm.threadCallbacks.get('500000000000000001')!.callback;
-      expect(secondCallback).not.toBe(firstCallback);
+      expect(secondCallback).toBe(firstCallback);
     } finally {
       cleanup();
     }

--- a/server/discord/message-router.ts
+++ b/server/discord/message-router.ts
@@ -1163,19 +1163,26 @@ async function routeToThread(
     return;
   }
 
-  subscribeForResponseWithEmbed(
-    ctx.processManager,
-    ctx.delivery,
-    ctx.config.botToken,
-    ctx.db,
-    ctx.threadCallbacks,
-    sessionId,
-    threadId,
-    agentName,
-    agentModel,
-    projectName,
-    displayColor,
-    displayIcon,
-    avatarUrl,
-  );
+  // Only re-subscribe if no active callback exists for this thread+session.
+  // When a callback is already listening, re-subscribing causes a race condition:
+  // the replacement callback's result handler fires on the FIRST turn's completion
+  // and unsubscribes itself, dropping all subsequent turns' responses.
+  const existingCb = ctx.threadCallbacks.get(threadId);
+  if (!existingCb || existingCb.sessionId !== sessionId) {
+    subscribeForResponseWithEmbed(
+      ctx.processManager,
+      ctx.delivery,
+      ctx.config.botToken,
+      ctx.db,
+      ctx.threadCallbacks,
+      sessionId,
+      threadId,
+      agentName,
+      agentModel,
+      projectName,
+      displayColor,
+      displayIcon,
+      avatarUrl,
+    );
+  }
 }

--- a/server/discord/thread-response/embed-response.ts
+++ b/server/discord/thread-response/embed-response.ts
@@ -47,9 +47,10 @@ export function subscribeForResponseWithEmbed(
   displayIcon?: string | null,
   avatarUrl?: string | null,
 ): void {
-  // Unsubscribe the previous callback for this thread to prevent duplicates
+  // Dispose the previous callback's timers and unsubscribe to prevent zombie timers / duplicates
   const prev = threadCallbacks.get(threadId);
   if (prev) {
+    prev.dispose?.();
     processManager.unsubscribe(prev.sessionId, prev.callback);
   }
 
@@ -711,6 +712,15 @@ export function subscribeForResponseWithEmbed(
     }
   };
 
+  const dispose = () => {
+    clearTyping();
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+    flush();
+  };
+
   processManager.subscribe(sessionId, callback);
-  threadCallbacks.set(threadId, { sessionId, callback });
+  threadCallbacks.set(threadId, { sessionId, callback, dispose });
 }

--- a/server/discord/thread-session-map.ts
+++ b/server/discord/thread-session-map.ts
@@ -38,6 +38,8 @@ export interface ThreadSessionInfo {
 export interface ThreadCallbackInfo {
   sessionId: string;
   callback: EventCallback;
+  /** Clean up timers and buffered state when replacing this subscription. */
+  dispose?: () => void;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Fix race condition** where multiple messages arriving in the same Discord thread close together caused the event callback to be replaced mid-response, resulting in duplicate embeds for one user and complete silence for the other
- **Skip re-subscription** when an active callback already exists for the same thread+session — the existing callback handles events for both messages
- **Add `dispose()` cleanup** to properly tear down timers (typing indicators, ack embeds, flush debounce) and flush buffered content when a subscription IS legitimately replaced (different session, recovery)

## Root Cause

`routeToThread()` unconditionally called `subscribeForResponseWithEmbed()` for every incoming message. The second call unsubscribed the first callback and created a new one, orphaning the old callback's timers and leaving no listener for the first message's response.

## Files Changed

- `server/discord/message-router.ts` — Guard against redundant re-subscription
- `server/discord/thread-response/embed-response.ts` — Add `dispose()` for proper cleanup
- `server/discord/thread-session-map.ts` — Add `dispose` field to `ThreadCallbackInfo`
- `server/__tests__/discord-bridge-threads.test.ts` — Update tests to verify fix behavior

## Test plan

- [x] All 10,655 tests pass
- [x] TypeScript types clean
- [x] Biome lint clean
- [ ] Manual test: send messages from two users rapidly in the same thread, verify both get responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)