### PR TITLE
fix(discord): filter premature SDK context_usage readings in embed footer

### DIFF
--- a/server/__tests__/process-manager-compact.test.ts
+++ b/server/__tests__/process-manager-compact.test.ts
@@ -219,6 +219,8 @@ describe('auto-compact on context_usage event', () => {
       type: 'context_usage',
       session_id: sessionId,
       usagePercent: 92,
+      estimatedTokens: 184000,
+      contextWindow: 200000,
     } as unknown as ClaudeStreamEvent;
 
     (pm as any).handleEvent(sessionId, event);
@@ -238,6 +240,8 @@ describe('auto-compact on context_usage event', () => {
       type: 'context_usage',
       session_id: sessionId,
       usagePercent: 85,
+      estimatedTokens: 170000,
+      contextWindow: 200000,
     } as unknown as ClaudeStreamEvent;
 
     (pm as any).handleEvent(sessionId, event);
@@ -257,6 +261,8 @@ describe('auto-compact on context_usage event', () => {
       type: 'context_usage',
       session_id: sessionId,
       usagePercent: 75,
+      estimatedTokens: 150000,
+      contextWindow: 200000,
     } as unknown as ClaudeStreamEvent;
 
     (pm as any).handleEvent(sessionId, event);
@@ -277,6 +283,8 @@ describe('auto-compact on context_usage event', () => {
       type: 'context_usage',
       session_id: sessionId,
       usagePercent: 90,
+      estimatedTokens: 180000,
+      contextWindow: 200000,
     } as unknown as ClaudeStreamEvent;
 
     (pm as any).handleEvent(sessionId, event);

--- a/server/__tests__/process-manager-compact.test.ts
+++ b/server/__tests__/process-manager-compact.test.ts
@@ -218,6 +218,8 @@ describe('auto-compact on context_usage event', () => {
     const event = {
       type: 'context_usage',
       session_id: sessionId,
+      estimatedTokens: 92000,
+      contextWindow: 100000,
       usagePercent: 92,
       estimatedTokens: 184000,
       contextWindow: 200000,
@@ -239,6 +241,8 @@ describe('auto-compact on context_usage event', () => {
     const event = {
       type: 'context_usage',
       session_id: sessionId,
+      estimatedTokens: 85000,
+      contextWindow: 100000,
       usagePercent: 85,
       estimatedTokens: 170000,
       contextWindow: 200000,
@@ -260,6 +264,8 @@ describe('auto-compact on context_usage event', () => {
     const event = {
       type: 'context_usage',
       session_id: sessionId,
+      estimatedTokens: 75000,
+      contextWindow: 100000,
       usagePercent: 75,
       estimatedTokens: 150000,
       contextWindow: 200000,
@@ -282,6 +288,8 @@ describe('auto-compact on context_usage event', () => {
     const event = {
       type: 'context_usage',
       session_id: sessionId,
+      estimatedTokens: 90000,
+      contextWindow: 100000,
       usagePercent: 90,
       estimatedTokens: 180000,
       contextWindow: 200000,

--- a/server/__tests__/process-manager-compact.test.ts
+++ b/server/__tests__/process-manager-compact.test.ts
@@ -218,11 +218,9 @@ describe('auto-compact on context_usage event', () => {
     const event = {
       type: 'context_usage',
       session_id: sessionId,
-      estimatedTokens: 92000,
-      contextWindow: 100000,
-      usagePercent: 92,
       estimatedTokens: 184000,
       contextWindow: 200000,
+      usagePercent: 92,
     } as unknown as ClaudeStreamEvent;
 
     (pm as any).handleEvent(sessionId, event);
@@ -241,11 +239,9 @@ describe('auto-compact on context_usage event', () => {
     const event = {
       type: 'context_usage',
       session_id: sessionId,
-      estimatedTokens: 85000,
-      contextWindow: 100000,
-      usagePercent: 85,
       estimatedTokens: 170000,
       contextWindow: 200000,
+      usagePercent: 85,
     } as unknown as ClaudeStreamEvent;
 
     (pm as any).handleEvent(sessionId, event);
@@ -264,11 +260,9 @@ describe('auto-compact on context_usage event', () => {
     const event = {
       type: 'context_usage',
       session_id: sessionId,
-      estimatedTokens: 75000,
-      contextWindow: 100000,
-      usagePercent: 75,
       estimatedTokens: 150000,
       contextWindow: 200000,
+      usagePercent: 75,
     } as unknown as ClaudeStreamEvent;
 
     (pm as any).handleEvent(sessionId, event);
@@ -288,11 +282,9 @@ describe('auto-compact on context_usage event', () => {
     const event = {
       type: 'context_usage',
       session_id: sessionId,
-      estimatedTokens: 90000,
-      contextWindow: 100000,
-      usagePercent: 90,
       estimatedTokens: 180000,
       contextWindow: 200000,
+      usagePercent: 90,
     } as unknown as ClaudeStreamEvent;
 
     (pm as any).handleEvent(sessionId, event);

--- a/server/discord/thread-response/embed-response.ts
+++ b/server/discord/thread-response/embed-response.ts
@@ -369,16 +369,23 @@ export function subscribeForResponseWithEmbed(
 
       if (isKeepAlive) {
         // Keep-alive turn complete: show warm status with TTL, stay subscribed for future turns
+        const ttlMs = parseInt(process.env.KEEP_ALIVE_TTL_MS ?? String(2 * 60 * 60 * 1000), 10);
+        const expiresAt = Math.floor((Date.now() + ttlMs) / 1000);
+        const dt = getTurnInfo();
+        const warmBuilder = CorvidEmbed.warm(footerCtx, authorIdentity, expiresAt);
+        if (latestContextUsage) warmBuilder.withContextUsage(latestContextUsage);
+        warmBuilder.withTurns(dt.active, dt.cumulative);
+        const { embed: warmEmbed } = warmBuilder.build();
         if (progressMessageId) {
-          const ttlMs = parseInt(process.env.KEEP_ALIVE_TTL_MS ?? String(2 * 60 * 60 * 1000), 10);
-          const expiresAt = Math.floor((Date.now() + ttlMs) / 1000);
-          const dt = getTurnInfo();
-          const warmBuilder = CorvidEmbed.warm(footerCtx, authorIdentity, expiresAt);
-          if (latestContextUsage) warmBuilder.withContextUsage(latestContextUsage);
-          warmBuilder.withTurns(dt.active, dt.cumulative);
-          const { embed: warmEmbed } = warmBuilder.build();
           editEmbed(delivery, botToken, threadId, progressMessageId, warmEmbed).catch((err) => {
             log.debug('Progress warm edit failed', {
+              threadId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
+        } else {
+          sendEmbed(delivery, botToken, threadId, warmEmbed).catch((err) => {
+            log.debug('Warm embed send failed', {
               threadId,
               error: err instanceof Error ? err.message : String(err),
             });

--- a/server/discord/thread-response/embed-response.ts
+++ b/server/discord/thread-response/embed-response.ts
@@ -1,5 +1,5 @@
 import type { Database } from 'bun:sqlite';
-import { getSessionActiveDurationMs, getSessionCumulativeTurns, getSessionTurns } from '../../db/sessions';
+import { getSession, getSessionActiveDurationMs, getSessionCumulativeTurns, getSessionTurns } from '../../db/sessions';
 import type { DeliveryTracker } from '../../lib/delivery-tracker';
 import { createLogger } from '../../lib/logger';
 import type { EventCallback } from '../../process/interfaces';
@@ -8,12 +8,12 @@ import { extractContentImageUrls, extractContentText } from '../../process/types
 import {
   agentColor,
   type ContextUsage,
-  collapseCodeBlocks,
   CorvidEmbed,
+  collapseCodeBlocks,
   type DiscordFileAttachment,
   type EmbedAgentIdentity,
-  type FooterContext,
   editEmbed,
+  type FooterContext,
   hexColorToInt,
   sendEmbed,
   sendEmbedWithButtons,
@@ -66,6 +66,14 @@ export function subscribeForResponseWithEmbed(
   let sentErrorMessage = false; // dedup: prevent repeated error messages for same session
   const startTime = Date.now();
   let latestContextUsage: ContextUsage | undefined;
+  const existingSession = getSession(db, sessionId);
+  if (existingSession?.lastContextTokens && existingSession.lastContextWindow) {
+    latestContextUsage = {
+      estimatedTokens: existingSession.lastContextTokens,
+      contextWindow: existingSession.lastContextWindow,
+      usagePercent: Math.round((existingSession.lastContextTokens / existingSession.lastContextWindow) * 100),
+    };
+  }
 
   const color = hexColorToInt(displayColor) ?? agentColor(agentName);
   const footerCtx: FooterContext = { agentName, agentModel, sessionId, projectName };
@@ -110,7 +118,9 @@ export function subscribeForResponseWithEmbed(
       return;
     }
     const elapsed = Math.round((Date.now() - startTime) / 1000);
-    updateProgressEmbed(CorvidEmbed.toolStatus(`Still working (${elapsed}s elapsed)...`, footerCtx, authorIdentity)).catch((err) => {
+    updateProgressEmbed(
+      CorvidEmbed.toolStatus(`Still working (${elapsed}s elapsed)...`, footerCtx, authorIdentity),
+    ).catch((err) => {
       log.debug('Progress embed failed', { threadId, error: err instanceof Error ? err.message : String(err) });
     });
   }, PROGRESS_INTERVAL_MS);
@@ -311,11 +321,15 @@ export function subscribeForResponseWithEmbed(
     if (event.type === 'context_usage') {
       const usage = event as { estimatedTokens?: number; contextWindow?: number; usagePercent?: number };
       if (usage.estimatedTokens != null && usage.contextWindow != null && usage.usagePercent != null) {
-        latestContextUsage = {
-          estimatedTokens: usage.estimatedTokens,
-          contextWindow: usage.contextWindow,
-          usagePercent: usage.usagePercent,
-        };
+        // Skip premature SDK readings (e.g., 79 tokens before full context loads).
+        // Real sessions always exceed 1000 tokens from system prompt alone.
+        if (usage.estimatedTokens >= 1000) {
+          latestContextUsage = {
+            estimatedTokens: usage.estimatedTokens,
+            contextWindow: usage.contextWindow,
+            usagePercent: usage.usagePercent,
+          };
+        }
       }
     }
 

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -1911,7 +1911,7 @@ export class ProcessManager {
     // Track context usage and auto-compact at threshold
     if (event.type === 'context_usage' && meta) {
       const usage = event as { estimatedTokens?: number; contextWindow?: number; usagePercent?: number };
-      if (usage.usagePercent != null && usage.usagePercent > 0) {
+      if (usage.usagePercent != null && usage.usagePercent > 0 && (usage.estimatedTokens ?? 0) >= 1000) {
         meta.lastContextUsagePercent = usage.usagePercent;
         if (usage.estimatedTokens && usage.contextWindow) {
           updateSessionContextTokens(this.db, sessionId, usage.estimatedTokens, usage.contextWindow);


### PR DESCRIPTION
## Summary
- **Seed `latestContextUsage` from DB** on subscribe — embeds immediately show the last known good token value instead of nothing
- **Filter context_usage < 1000 tokens** — rejects premature SDK readings (e.g. 79 tokens) that arrive before the full conversation context is loaded. Real sessions always exceed 1000 tokens from system prompt alone.

Fixes the `⚪ 0% (79/200k)` flash on cold starts before the real `🟢 35% (70k/200k)` arrives.

## Test plan
- [x] Restart server, send message to warm session — footer should show correct tokens from first embed
- [x] Cold start a new session — should show DB-seeded value, then update to real value (no 0% flash)
- [x] Verify compaction still shows reduced token count (will always be >1000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)