### PR TITLE
feat(discord): keep-alive default + footer cleanup

### DIFF
--- a/server/__tests__/discord-embeds-validation.test.ts
+++ b/server/__tests__/discord-embeds-validation.test.ts
@@ -46,38 +46,38 @@ describe('assertInteractionToken', () => {
 });
 
 describe('buildFooterText', () => {
-  test('includes all context segments', () => {
+  test('includes model, session, and status (no agent name or project)', () => {
     const result = buildFooterText({
       agentName: 'Corvid',
-      agentModel: 'opus',
+      agentModel: 'claude-opus-4-6',
       projectName: 'my-project',
       sessionId: 'abcdef1234567890',
       status: 'running',
     });
-    expect(result).toBe('Corvid · opus · my-project · sid:abcdef12 · running');
+    expect(result).toBe('opus-4.6 · abcdef12 · running');
   });
 
-  test('returns agent name and model when no other context', () => {
-    const result = buildFooterText({ agentName: 'Corvid', agentModel: 'opus' });
-    expect(result).toBe('Corvid · opus');
+  test('returns shortened model when no other context', () => {
+    const result = buildFooterText({ agentName: 'Corvid', agentModel: 'claude-opus-4-6' });
+    expect(result).toBe('opus-4.6');
   });
 
-  test('includes projectName', () => {
+  test('omits projectName from footer', () => {
     const result = buildFooterText({
       agentName: 'Corvid',
       agentModel: 'opus',
       projectName: 'my-project',
     });
-    expect(result).toBe('Corvid · opus · my-project');
+    expect(result).toBe('opus');
   });
 
-  test('includes sessionId as truncated sid:', () => {
+  test('includes sessionId without sid: prefix', () => {
     const result = buildFooterText({
       agentName: 'Corvid',
       agentModel: 'opus',
       sessionId: 'abcdef1234567890',
     });
-    expect(result).toBe('Corvid · opus · sid:abcdef12');
+    expect(result).toBe('opus · abcdef12');
   });
 
   test('includes status', () => {
@@ -86,7 +86,7 @@ describe('buildFooterText', () => {
       agentModel: 'opus',
       status: 'completed',
     });
-    expect(result).toBe('Corvid · opus · completed');
+    expect(result).toBe('opus · completed');
   });
 
   test('works without agentModel', () => {
@@ -94,22 +94,32 @@ describe('buildFooterText', () => {
       agentName: 'Corvid',
       status: 'done',
     });
-    expect(result).toBe('Corvid · done');
+    expect(result).toBe('done');
+  });
+
+  test('shortens claude model names', () => {
+    expect(buildFooterText({ agentName: 'X', agentModel: 'claude-opus-4-6' })).toBe('opus-4.6');
+    expect(buildFooterText({ agentName: 'X', agentModel: 'claude-sonnet-4-6' })).toBe('sonnet-4.6');
+    expect(buildFooterText({ agentName: 'X', agentModel: 'claude-haiku-4-5' })).toBe('haiku-4.5');
+  });
+
+  test('passes through non-claude model names unchanged', () => {
+    expect(buildFooterText({ agentName: 'X', agentModel: 'gpt-4o' })).toBe('gpt-4o');
   });
 
   test('shows T:x(n) when cumulative turns exceed active turns', () => {
     const result = buildFooterText({ agentName: 'Corvid', agentModel: 'opus' }, undefined, 5, 23);
-    expect(result).toBe('Corvid · opus | T:5(23)');
+    expect(result).toBe('opus | T:5(23)');
   });
 
   test('shows T:x when cumulative equals active turns', () => {
     const result = buildFooterText({ agentName: 'Corvid', agentModel: 'opus' }, undefined, 5, 5);
-    expect(result).toBe('Corvid · opus | T:5');
+    expect(result).toBe('opus | T:5');
   });
 
   test('shows T:x when no cumulative turns provided', () => {
     const result = buildFooterText({ agentName: 'Corvid', agentModel: 'opus' }, undefined, 5);
-    expect(result).toBe('Corvid · opus | T:5');
+    expect(result).toBe('opus | T:5');
   });
 });
 
@@ -119,7 +129,7 @@ describe('buildFooterWithStats', () => {
       { agentName: 'Corvid', agentModel: 'opus', sessionId: 'abcdef1234567890', status: 'done' },
       { filesChanged: 5, turns: 12, commits: 3 },
     );
-    expect(result).toBe('Corvid · opus · sid:abcdef12 · done | 5 files · 12 turns · 3 commits');
+    expect(result).toBe('opus · abcdef12 · done | 5 files · 12 turns · 3 commits');
   });
 
   test('omits zero stats', () => {
@@ -127,7 +137,7 @@ describe('buildFooterWithStats', () => {
       { agentName: 'Corvid', agentModel: 'opus', status: 'done' },
       { filesChanged: 0, turns: 8, commits: 0 },
     );
-    expect(result).toBe('Corvid · opus · done | 8 turns');
+    expect(result).toBe('opus · done | 8 turns');
   });
 
   test('returns base footer when all stats are zero', () => {
@@ -135,12 +145,12 @@ describe('buildFooterWithStats', () => {
       { agentName: 'Corvid', agentModel: 'opus', status: 'done' },
       { filesChanged: 0, turns: 0, commits: 0 },
     );
-    expect(result).toBe('Corvid · opus · done');
+    expect(result).toBe('opus · done');
   });
 
   test('includes tools stat', () => {
     const result = buildFooterWithStats({ agentName: 'Corvid', status: 'done' }, { turns: 3, tools: 15 });
-    expect(result).toBe('Corvid · done | 3 turns · 15 tools');
+    expect(result).toBe('done | 3 turns · 15 tools');
   });
 
   test('shows cumulative turns in stats when greater', () => {
@@ -150,12 +160,12 @@ describe('buildFooterWithStats', () => {
       undefined,
       23,
     );
-    expect(result).toBe('Corvid · done | 5 turns (23 total) · 10 tools');
+    expect(result).toBe('done | 5 turns (23 total) · 10 tools');
   });
 
   test('omits cumulative when equal to active', () => {
     const result = buildFooterWithStats({ agentName: 'Corvid', status: 'done' }, { turns: 5, tools: 10 }, undefined, 5);
-    expect(result).toBe('Corvid · done | 5 turns · 10 tools');
+    expect(result).toBe('done | 5 turns · 10 tools');
   });
 });
 

--- a/server/__tests__/embed-builder.test.ts
+++ b/server/__tests__/embed-builder.test.ts
@@ -188,14 +188,14 @@ describe('CorvidEmbed builder — footer', () => {
     expect(embed.footer).toBeUndefined();
   });
 
-  test('footer includes agent name when setAgent is called', () => {
+  test('footer excludes agent name (shown in embed author instead)', () => {
     const { embed } = new CorvidEmbed()
       .setAgent({ agentName: 'Rook' })
       .build();
-    expect(embed.footer?.text).toContain('Rook');
+    expect(embed.footer?.text).toBe('');
   });
 
-  test('footer includes model when set via setModel', () => {
+  test('footer includes shortened model, session, and status', () => {
     const { embed } = new CorvidEmbed()
       .setAgent(AUTHOR)
       .setModel('claude-sonnet-4-6')
@@ -204,16 +204,16 @@ describe('CorvidEmbed builder — footer', () => {
       .setStatus('thinking')
       .build();
     const footer = embed.footer!.text;
-    expect(footer).toContain('Rook');
-    expect(footer).toContain('claude-sonnet-4-6');
-    expect(footer).toContain('sid:abcdef12');
-    expect(footer).toContain('corvid-agent');
+    expect(footer).toContain('sonnet-4.6');
+    expect(footer).toContain('abcdef12');
+    expect(footer).not.toContain('Rook');
+    expect(footer).not.toContain('corvid-agent');
     expect(footer).toContain('thinking');
   });
 
-  test('presets pass agentModel from FooterContext to footer', () => {
+  test('presets pass shortened agentModel from FooterContext to footer', () => {
     const { embed } = CorvidEmbed.progress(CTX, AUTHOR).build();
-    expect(embed.footer!.text).toContain('claude-sonnet-4-6');
+    expect(embed.footer!.text).toContain('sonnet-4.6');
   });
 
   test('withContextUsage adds usage to footer', () => {
@@ -380,9 +380,10 @@ describe('CorvidEmbed.progress()', () => {
     expect(embed.description).toContain('working on it');
   });
 
-  test('footer contains agent name', () => {
+  test('footer contains shortened model, not agent name', () => {
     const { embed } = CorvidEmbed.progress(CTX, AUTHOR).build();
-    expect(embed.footer?.text).toContain('Rook');
+    expect(embed.footer?.text).toContain('sonnet-4.6');
+    expect(embed.footer?.text).not.toContain('Rook');
   });
 
   test('footer status is thinking', () => {
@@ -531,9 +532,10 @@ describe('CorvidEmbed.error()', () => {
     expect(embed.description).toBe('Custom fallback message');
   });
 
-  test('footer contains agent name', () => {
+  test('footer contains shortened model, not agent name', () => {
     const { embed } = CorvidEmbed.error('timeout', CTX, AUTHOR).build();
-    expect(embed.footer?.text).toContain('Rook');
+    expect(embed.footer?.text).toContain('sonnet-4.6');
+    expect(embed.footer?.text).not.toContain('Rook');
   });
 });
 
@@ -725,7 +727,7 @@ describe('CorvidEmbed chaining', () => {
     expect(embed.description).toBe('✅ Done');
     expect(embed.color).toBe(EMBED_COLORS.success);
     expect(embed.author?.name).toBe('🐦 Rook');
-    expect(embed.footer?.text).toContain('Rook');
+    expect(embed.footer?.text).not.toContain('Rook');
     expect(embed.footer?.text).toContain('T:10');
     expect(components).toHaveLength(1);
     expect(components![0].components).toHaveLength(2);

--- a/server/discord/command-handlers/component-handlers.ts
+++ b/server/discord/command-handlers/component-handlers.ts
@@ -141,6 +141,7 @@ export async function handleComponentInteraction(
         initialPrompt: prevInfo?.topic ?? 'New session',
         source: 'discord' as SessionSource,
         workDir,
+        keepAlive: true,
       });
 
       const threadInfo: ThreadSessionInfo = {
@@ -226,6 +227,7 @@ export async function handleComponentInteraction(
         initialPrompt: 'Continued from channel mention',
         source: 'discord' as SessionSource,
         workDir: ctWorkDir,
+        keepAlive: true,
       });
 
       const ctThreadInfo: ThreadSessionInfo = {

--- a/server/discord/command-handlers/message-commands.ts
+++ b/server/discord/command-handlers/message-commands.ts
@@ -244,6 +244,7 @@ export async function handleMessageCommand(
     name: toolPolicy.sessionName,
     initialPrompt: message,
     source: 'discord' as SessionSource,
+    keepAlive: true,
   });
 
   const textWithContext = withAuthorContext(message, userId, username, channelId);

--- a/server/discord/command-handlers/session-commands.ts
+++ b/server/discord/command-handlers/session-commands.ts
@@ -145,6 +145,7 @@ export async function handleSessionCommand(
     initialPrompt: topic,
     source: 'discord' as SessionSource,
     workDir,
+    keepAlive: true,
   });
 
   const threadInfo = {

--- a/server/discord/embeds.ts
+++ b/server/discord/embeds.ts
@@ -194,9 +194,16 @@ function formatTokenCount(tokens: number): string {
   return String(tokens);
 }
 
+function shortenModelName(model: string): string {
+  const m = model.match(/^claude-(\w+)-(\d+)-(\d+)$/);
+  if (m) return `${m[1]}-${m[2]}.${m[3]}`;
+  return model;
+}
+
 /**
- * Build a detailed footer string with full session context.
- * Format: `AgentName · model · project · sid:XXXXXX · status | T:5(23) | 🟢 32% (64k/200k)`
+ * Build a compact footer string with session context.
+ * Format: `opus-4.6 · XXXXXXXX · status | T:5(23) | 🟢 32% (64k/200k)`
+ * Agent name is in the embed author; project name is in the thread title — both omitted.
  * When cumulativeTurns equals active turns, shows just `T:5`.
  * Segments are omitted when their value is not provided.
  */
@@ -206,15 +213,12 @@ export function buildFooterText(
   turns?: number,
   cumulativeTurns?: number,
 ): string {
-  const parts: string[] = [ctx.agentName];
+  const parts: string[] = [];
   if (ctx.agentModel) {
-    parts.push(ctx.agentModel);
-  }
-  if (ctx.projectName) {
-    parts.push(ctx.projectName);
+    parts.push(shortenModelName(ctx.agentModel));
   }
   if (ctx.sessionId) {
-    parts.push(`sid:${ctx.sessionId.slice(0, 8)}`);
+    parts.push(ctx.sessionId.slice(0, 8));
   }
   if (ctx.status) {
     parts.push(ctx.status);
@@ -236,7 +240,7 @@ export function buildFooterText(
 
 /**
  * Build a footer with session context AND run stats.
- * Format: `AgentName · model · sid:XXXXXX · status | 5 files · 12 turns (23 total) · 38 tools | 🟢 32% (64k/200k)`
+ * Format: `opus-4.6 · XXXXXXXX · status | 5 files · 12 turns (23 total) · 38 tools | 🟢 32% (64k/200k)`
  */
 export function buildFooterWithStats(
   ctx: FooterContext,

--- a/server/discord/message-router.ts
+++ b/server/discord/message-router.ts
@@ -574,6 +574,7 @@ async function handleMentionReply(
     initialPrompt: cleanText,
     source: 'discord' as SessionSource,
     workDir,
+    keepAlive: true,
   });
 
   const agentName = agent.name;
@@ -947,6 +948,7 @@ async function resumeExpiredThreadSession(
     initialPrompt: text,
     source: 'discord' as SessionSource,
     workDir,
+    keepAlive: true,
   });
 
   const threadInfo = {

--- a/server/discord/voice/voice-session.ts
+++ b/server/discord/voice/voice-session.ts
@@ -277,6 +277,7 @@ export class VoiceSessionRouter {
       initialPrompt: voicePrompt,
       source: 'discord' as SessionSource,
       workDir,
+      keepAlive: true,
     });
 
     this.processManager.startProcess(session, session.initialPrompt);

--- a/server/telegram/bridge.ts
+++ b/server/telegram/bridge.ts
@@ -371,6 +371,7 @@ export class TelegramBridge {
         name: `Telegram (user ${userId})`,
         initialPrompt: text,
         source,
+        keepAlive: true,
       });
 
       sessionId = session.id;


### PR DESCRIPTION
## Summary
- **Keep-alive on by default** for Discord (all 6 session creation paths) and Telegram sessions. Councils, work tasks, and A2A sessions are unchanged — they still default to `keepAlive: false`.
- **Footer cleanup**: drop agent name (already in embed author), drop project name (visible in thread title), remove `sid:` prefix, shorten model names (`claude-opus-4-6` → `opus-4.6`).

Before: `CorvidAgent · claude-opus-4-6 · corvid-agent · sid:475169fc | T:6(53) | 🟢 39% (77k/200k)`
After: `opus-4.6 · 475169fc | T:6(53) | 🟢 39% (77k/200k)`

## Test plan
- [ ] Verify Discord session starts with keep-alive enabled (check `keep_alive = 1` in DB)
- [ ] Verify warm turn works (send message, wait, send another — should be fast)
- [ ] Verify footer shows shortened format in progress/completion/error embeds
- [ ] Verify council sessions still start without keep-alive
- [ ] Run embed test suites (143 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)