### PR TITLE
feat(algochat): keep-alive warm-turn support for AlgoChat bridge

### DIFF
--- a/server/__tests__/algochat-subscription-manager.test.ts
+++ b/server/__tests__/algochat-subscription-manager.test.ts
@@ -1271,3 +1271,95 @@ describe('mixed subscriptions', () => {
     expect(sm.hasLocalSubscription(SESSION_ID_2)).toBe(false);
   });
 });
+
+// ── keep-alive warm-turn support ─────────────────────────────────────────
+
+describe('subscribeForResponse (keepAlive=true)', () => {
+  test('sends response immediately on result (warm turn), stays subscribed', async () => {
+    sm.subscribeForResponse(SESSION_ID, PARTICIPANT, true);
+
+    pm._emit(SESSION_ID, contentBlockStart('text'));
+    pm._emit(SESSION_ID, contentBlockDelta('Turn 1 response'));
+    pm._emit(SESSION_ID, contentBlockStop());
+    pm._emit(SESSION_ID, resultEvent());
+
+    await Bun.sleep(10);
+
+    // Response sent immediately at turn end, not waiting for session_exited
+    const warmResponse = rf._responses.find((r) => r.content === 'Turn 1 response');
+    expect(warmResponse).toBeDefined();
+    expect(warmResponse!.participant).toBe(PARTICIPANT);
+
+    // Still subscribed — session is warm
+    expect(sm.hasChainSubscription(SESSION_ID)).toBe(true);
+  });
+
+  test('delivers each turn independently in multi-turn warm session', async () => {
+    sm.subscribeForResponse(SESSION_ID, PARTICIPANT, true);
+
+    // Turn 1
+    pm._emit(SESSION_ID, contentBlockStart('text'));
+    pm._emit(SESSION_ID, contentBlockDelta('First response'));
+    pm._emit(SESSION_ID, contentBlockStop());
+    pm._emit(SESSION_ID, resultEvent());
+    await Bun.sleep(10);
+
+    // Turn 2 — new subscription replaces callback
+    sm.subscribeForResponse(SESSION_ID, PARTICIPANT, true);
+    pm._emit(SESSION_ID, contentBlockStart('text'));
+    pm._emit(SESSION_ID, contentBlockDelta('Second response'));
+    pm._emit(SESSION_ID, contentBlockStop());
+    pm._emit(SESSION_ID, resultEvent());
+    await Bun.sleep(10);
+
+    const nonStatus = rf._responses.filter((r) => !r.content.startsWith('[Status]'));
+    expect(nonStatus.length).toBe(2);
+    expect(nonStatus[0].content).toBe('First response');
+    expect(nonStatus[1].content).toBe('Second response');
+  });
+
+  test('replaces existing callback on re-subscribe for warm turn', () => {
+    sm.subscribeForResponse(SESSION_ID, PARTICIPANT, true);
+    const subscribeCallsBefore = (pm.subscribe as ReturnType<typeof mock>).mock.calls.length;
+
+    sm.subscribeForResponse(SESSION_ID, PARTICIPANT, true);
+    const subscribeCallsAfter = (pm.subscribe as ReturnType<typeof mock>).mock.calls.length;
+
+    // Old callback was unsubscribed and new one registered
+    expect((pm.unsubscribe as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+    expect(subscribeCallsAfter).toBe(subscribeCallsBefore + 1);
+  });
+
+  test('session_exited cleans up without double-sending', async () => {
+    sm.subscribeForResponse(SESSION_ID, PARTICIPANT, true);
+
+    pm._emit(SESSION_ID, contentBlockStart('text'));
+    pm._emit(SESSION_ID, contentBlockDelta('Last response'));
+    pm._emit(SESSION_ID, contentBlockStop());
+    pm._emit(SESSION_ID, resultEvent());
+    await Bun.sleep(10);
+
+    // Turn response already sent — session_exited should not send it again
+    const responsesBeforeExit = rf._responses.filter((r) => !r.content.startsWith('[Status]')).length;
+
+    pm._emit(SESSION_ID, sessionExitedEvent());
+    await Bun.sleep(10);
+
+    const responsesAfterExit = rf._responses.filter((r) => !r.content.startsWith('[Status]')).length;
+    expect(responsesAfterExit).toBe(responsesBeforeExit); // No additional send
+
+    // Unsubscribed after exit
+    expect(sm.hasChainSubscription(SESSION_ID)).toBe(false);
+  });
+
+  test('non-keep-alive dedup still returns early (no callback replacement)', () => {
+    sm.subscribeForResponse(SESSION_ID, PARTICIPANT, false);
+    const subscribeCallsBefore = (pm.subscribe as ReturnType<typeof mock>).mock.calls.length;
+
+    sm.subscribeForResponse(SESSION_ID, PARTICIPANT, false);
+
+    // No replacement — returned early
+    expect((pm.unsubscribe as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+    expect((pm.subscribe as ReturnType<typeof mock>).mock.calls.length).toBe(subscribeCallsBefore);
+  });
+});

--- a/server/algochat/message-router.ts
+++ b/server/algochat/message-router.ts
@@ -658,7 +658,7 @@ export class MessageRouter {
 
         conversation = createConversation(this.db, participant, agentId, session.id);
 
-        this.subscriptionManager.subscribeForResponse(session.id, participant);
+        this.subscriptionManager.subscribeForResponse(session.id, participant, session.keepAlive);
 
         // Handle session start failure
         try {
@@ -682,14 +682,18 @@ export class MessageRouter {
       } else {
         if (conversation.sessionId) {
           // Always subscribe so the reply gets sent back on-chain
-          this.subscriptionManager.subscribeForResponse(conversation.sessionId, participant);
+          const { getSession } = await import('../db/sessions');
+          const existingSession = getSession(this.db, conversation.sessionId);
+          this.subscriptionManager.subscribeForResponse(
+            conversation.sessionId,
+            participant,
+            existingSession?.keepAlive ?? false,
+          );
 
           const sent = this.processManager.sendMessage(conversation.sessionId, agentContent);
           if (!sent) {
-            const { getSession } = await import('../db/sessions');
-            const session = getSession(this.db, conversation.sessionId);
-            if (session) {
-              this.processManager.resumeProcess(session, agentContent);
+            if (existingSession) {
+              this.processManager.resumeProcess(existingSession, agentContent);
             }
           }
         } else {
@@ -714,7 +718,7 @@ export class MessageRouter {
               updateConversationSession(this.db, conversation.id, session.id);
               conversation.sessionId = session.id;
 
-              this.subscriptionManager.subscribeForResponse(session.id, participant);
+              this.subscriptionManager.subscribeForResponse(session.id, participant, session.keepAlive);
               try {
                 this.processManager.startProcess(session, agentContent);
                 // Record inbound AlgoChat message as a short-term observation

--- a/server/algochat/subscription-manager.ts
+++ b/server/algochat/subscription-manager.ts
@@ -15,6 +15,7 @@
  */
 
 import { createLogger } from '../lib/logger';
+import type { EventCallback } from '../process/interfaces';
 import type { ProcessManager } from '../process/manager';
 import type { ClaudeStreamEvent } from '../process/types';
 import { extractContentText } from '../process/types';
@@ -65,8 +66,8 @@ export class SubscriptionManager {
   private processManager: ProcessManager;
   private responseFormatter: ResponseFormatter;
 
-  /** Active on-chain subscriptions (sessionId set). */
-  private chainSubscriptions: Set<string> = new Set();
+  /** Active on-chain subscription callbacks keyed by sessionId. */
+  private chainCallbacks: Map<string, EventCallback> = new Map();
   /** Local subscription callbacks keyed by sessionId. */
   private localSubscriptions: Map<string, (sid: string, event: ClaudeStreamEvent) => void> = new Map();
   /** Local send functions keyed by sessionId (updatable for WS reconnects). */
@@ -94,7 +95,7 @@ export class SubscriptionManager {
    * Check whether an on-chain subscription exists for a session.
    */
   hasChainSubscription(sessionId: string): boolean {
-    return this.chainSubscriptions.has(sessionId);
+    return this.chainCallbacks.has(sessionId);
   }
 
   /**
@@ -133,10 +134,15 @@ export class SubscriptionManager {
    * @param sessionId - The session to subscribe to
    * @param participant - The on-chain participant address to send responses to
    */
-  subscribeForResponse(sessionId: string, participant: string): void {
-    // Avoid duplicate subscriptions when multiple messages arrive for the same session
-    if (this.chainSubscriptions.has(sessionId)) return;
-    this.chainSubscriptions.add(sessionId);
+  subscribeForResponse(sessionId: string, participant: string, keepAlive = false): void {
+    // Dedup: for keep-alive sessions, replace the existing callback so the new
+    // turn's response is routed to the correct participant context.
+    const existing = this.chainCallbacks.get(sessionId);
+    if (existing) {
+      if (!keepAlive) return; // non-keep-alive: skip duplicate
+      this.processManager.unsubscribe(sessionId, existing);
+      this.chainCallbacks.delete(sessionId);
+    }
 
     // We only send the LAST text block from the last turn. Earlier text
     // blocks are intermediate explanations (tool call reasoning, etc.)
@@ -164,7 +170,7 @@ export class SubscriptionManager {
 
       stopProgressTimer();
       this.processManager.unsubscribe(sessionId, callback);
-      this.chainSubscriptions.delete(sessionId);
+      this.chainCallbacks.delete(sessionId);
       this.clearSubscriptionTimer(sessionId);
 
       // Prefer streamed text block > last turn response > full assistant text
@@ -517,8 +523,29 @@ export class SubscriptionManager {
         } else if (lastAssistantText.trim()) {
           lastTurnResponse = lastAssistantText;
         }
-        lastTextBlock = '';
-        lastAssistantText = '';
+
+        if (keepAlive) {
+          // Warm turn: send this turn's response immediately and reset for the next turn.
+          // The process stays alive; session_exited fires only when the keep-alive TTL expires.
+          const turnText = lastTurnResponse.trim();
+          if (turnText) {
+            this.responseFormatter.sendResponse(participant, turnText).catch((err: unknown) => {
+              log.warn('Failed to send warm-turn AlgoChat response', {
+                participant,
+                sessionId,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            });
+          }
+          lastTextBlock = '';
+          lastAssistantText = '';
+          lastTurnResponse = '';
+          agentQueryCount = 0;
+          statusEmitted = false;
+        } else {
+          lastTextBlock = '';
+          lastAssistantText = '';
+        }
         resetTimer(); // Turn completed — reset timeout
       }
 
@@ -531,6 +558,7 @@ export class SubscriptionManager {
       }
     };
 
+    this.chainCallbacks.set(sessionId, callback);
     this.processManager.subscribe(sessionId, callback);
     resetTimer();
   }
@@ -702,7 +730,10 @@ export class SubscriptionManager {
     }
     this.subscriptionTimers.clear();
     this.subscriptionTimeoutCallbacks.clear();
-    this.chainSubscriptions.clear();
+    for (const [sid, cb] of this.chainCallbacks.entries()) {
+      this.processManager.unsubscribe(sid, cb);
+    }
+    this.chainCallbacks.clear();
     this.localSubscriptions.clear();
     this.localSendFns.clear();
     this.localEventFns.clear();


### PR DESCRIPTION
## Summary

Phase 3 of the Session Keep-Alive epic (#2222): adds warm-turn support to the AlgoChat bridge so sessions with `keep_alive=1` send per-turn responses on-chain immediately instead of waiting for `session_exited`.

### The Problem

Before this PR, `subscribeForResponse` accumulated text across turns and only sent the final consolidated response when the session fully exited (`session_exited` event). With keep-alive enabled, that event doesn't fire for up to 15 minutes after the last turn — the on-chain participant would receive no response until the keep-alive TTL expired.

### Changes

**`server/algochat/subscription-manager.ts`**
- Replace `chainSubscriptions: Set<string>` with `chainCallbacks: Map<string, EventCallback>` for proper per-callback lifecycle tracking
- `subscribeForResponse` now accepts a `keepAlive` parameter (default `false`)
- On `result` with `keepAlive=true`: send the turn's response immediately and reset per-turn state (`lastTurnResponse`, `agentQueryCount`, `statusEmitted`), stay subscribed for the next turn
- On `session_exited`: unsubscribe and clean up without double-sending (for warm sessions, `lastTurnResponse` is already reset each turn)
- For warm sessions, re-subscribe on new messages replaces the existing callback (unsubscribe old, subscribe new) instead of returning early
- `cleanup()` now properly unsubscribes all active callbacks before clearing the map

**`server/algochat/message-router.ts`**
- Pass `session.keepAlive` to all three `subscribeForResponse` call sites
- Consolidate the `getSession` call at the follow-up message site (eliminates a duplicate DB query)

**`server/__tests__/algochat-subscription-manager.test.ts`**
- 5 new tests: warm-turn immediate delivery, multi-turn delivery with correct per-turn isolation, callback replacement on re-subscribe, `session_exited` no double-send, non-keep-alive dedup backward compat

### Verification

- TypeScript: ✅ clean
- Lint: ✅ clean
- Tests: ✅ 10,767 pass, 0 fail (88 AlgoChat subscription-manager tests, 82 message-router tests)
- Specs: ✅ all pass, 100% file + LOC coverage

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` — clean
- [x] `bun test server/__tests__/algochat-subscription-manager.test.ts` — 88/88 pass (5 new)
- [x] `bun test server/__tests__/algochat-message-router.test.ts` — 82/82 pass
- [x] `bun test` — 10,767 pass, 0 fail
- [x] `bun run spec:check` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)