### PR TITLE
feat(discord): improve @mention reliability — new session per mention, 5m TTL, lighter context

### DIFF
--- a/server/__tests__/discord-bridge-core.test.ts
+++ b/server/__tests__/discord-bridge-core.test.ts
@@ -37,6 +37,7 @@ function createMockProcessManager() {
     resumeProcess: mock(() => {}),
     stopProcess: mock(() => {}),
     isRunning: mock(() => true),
+    setKeepAliveTtl: mock(() => {}),
   } as unknown as import('../process/manager').ProcessManager;
 }
 

--- a/server/__tests__/discord-bridge-mentions.test.ts
+++ b/server/__tests__/discord-bridge-mentions.test.ts
@@ -36,6 +36,7 @@ function createMockProcessManager() {
     resumeProcess: mock(() => {}),
     stopProcess: mock(() => {}),
     isRunning: mock(() => true),
+    setKeepAliveTtl: mock(() => {}),
   } as unknown as import('../process/manager').ProcessManager;
 }
 

--- a/server/__tests__/discord-bridge-onboarding.test.ts
+++ b/server/__tests__/discord-bridge-onboarding.test.ts
@@ -35,6 +35,7 @@ function createMockProcessManager() {
     resumeProcess: mock(() => {}),
     stopProcess: mock(() => {}),
     isRunning: mock(() => true),
+    setKeepAliveTtl: mock(() => {}),
   } as unknown as import('../process/manager').ProcessManager;
 }
 

--- a/server/__tests__/discord-bridge-threads.test.ts
+++ b/server/__tests__/discord-bridge-threads.test.ts
@@ -35,6 +35,7 @@ function createMockProcessManager() {
     resumeProcess: mock(() => {}),
     stopProcess: mock(() => {}),
     isRunning: mock(() => true),
+    setKeepAliveTtl: mock(() => {}),
   } as unknown as import('../process/manager').ProcessManager;
 }
 

--- a/server/__tests__/discord-bridge-work-intake.test.ts
+++ b/server/__tests__/discord-bridge-work-intake.test.ts
@@ -35,6 +35,7 @@ function createMockProcessManager() {
     resumeProcess: mock(() => {}),
     stopProcess: mock(() => {}),
     isRunning: mock(() => true),
+    setKeepAliveTtl: mock(() => {}),
   } as unknown as import('../process/manager').ProcessManager;
 }
 

--- a/server/__tests__/discord-public-mode.test.ts
+++ b/server/__tests__/discord-public-mode.test.ts
@@ -31,6 +31,7 @@ function createMockProcessManager() {
     resumeProcess: mock(() => {}),
     stopProcess: mock(() => {}),
     isRunning: mock(() => true),
+    setKeepAliveTtl: mock(() => {}),
   } as unknown as import('../process/manager').ProcessManager;
 }
 

--- a/server/__tests__/discord-ux-overhaul.test.ts
+++ b/server/__tests__/discord-ux-overhaul.test.ts
@@ -44,6 +44,7 @@ function createMockProcessManager() {
     resumeProcess: mock(() => {}),
     stopProcess: mock(() => {}),
     isRunning: mock(() => true),
+    setKeepAliveTtl: mock(() => {}),
   } as unknown as ProcessManager;
 }
 

--- a/server/discord/embeds.ts
+++ b/server/discord/embeds.ts
@@ -159,6 +159,8 @@ export interface FooterContext {
   sessionId?: string;
   projectName?: string;
   status?: string;
+  /** Session type label shown in footer (e.g. 'mention · 5m'). */
+  sessionType?: string;
 }
 
 /** Stats that can be appended to the footer on completion embeds. */
@@ -214,6 +216,9 @@ export function buildFooterText(
   cumulativeTurns?: number,
 ): string {
   const parts: string[] = [];
+  if (ctx.sessionType) {
+    parts.push(ctx.sessionType);
+  }
   if (ctx.agentModel) {
     parts.push(shortenModelName(ctx.agentModel));
   }

--- a/server/discord/message-router.ts
+++ b/server/discord/message-router.ts
@@ -13,7 +13,6 @@ import { getChannelProjectId, setChannelProjectId } from '../db/discord-channel-
 import { updateDiscordConfig } from '../db/discord-config';
 import {
   getChannelMessageHistory,
-  getLatestMentionSessionByChannel,
   getMentionSession,
   saveMentionSession,
   updateMentionSessionActivity,
@@ -61,6 +60,9 @@ const log = createLogger('DiscordMessageHandler');
 
 /** Maximum number of bot message→session mappings to keep for mention-reply context. */
 const MAX_MENTION_SESSIONS = 500;
+
+/** Keep-alive TTL for mention sessions — shorter than thread sessions since mentions are quick interactions. */
+const MENTION_KEEP_ALIVE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 /** Cooldown for permission-denial replies: only notify a user once per window. */
 const PERM_DENY_COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes
@@ -399,35 +401,7 @@ export async function handleMessage(ctx: MessageHandlerContext, data: DiscordMes
       );
       return;
     }
-    // If we can't find the session by bot message ID, fall through to channel fallback below
-  }
-
-  // Channel-based fallback: if a user sends a message in a channel with a recent
-  // mention session (within 60 min), resume that session even without a reply reference.
-  // This handles the common case where users type follow-ups without using Discord's reply.
-  if (!isReplyToBot || !data.message_reference?.message_id) {
-    const channelSession = getLatestMentionSessionByChannel(ctx.db, channelId);
-    if (channelSession) {
-      log.info('Channel-based mention session fallback', {
-        channelId,
-        sessionId: channelSession.sessionId,
-        userId,
-      });
-      await handleMentionReplyResume(
-        ctx,
-        channelId,
-        userId,
-        data.id,
-        text,
-        channelSession,
-        permLevel,
-        data.mentions,
-        data.author.id,
-        data.author.username,
-        data.attachments,
-      );
-      return;
-    }
+    // Reply references a bot message we don't have a session for — fall through to new session
   }
 
   // In public mode, BASIC-tier users who @mention the bot should use /message
@@ -625,7 +599,8 @@ async function handleMentionReply(
     attachments,
   );
   const promptWithContext = previousContext ? `${previousContext}\n\n${textWithUrls}` : textWithUrls;
-  ctx.processManager.startProcess(session, promptWithContext);
+  ctx.processManager.startProcess(session, promptWithContext, { skipSkillPrompt: true });
+  ctx.processManager.setKeepAliveTtl(session.id, MENTION_KEEP_ALIVE_TTL_MS);
 
   // Record inbound Discord message as a short-term observation for context retention
   recordObservation(ctx.db, {
@@ -727,6 +702,13 @@ async function handleMentionReplyResume(
   });
   const sent = ctx.processManager.sendMessage(sessionId, contextualContent);
   if (!sent) {
+    // Session expired — notify user that context may be summarized
+    sendEmbed(ctx.delivery, ctx.config.botToken, channelId, {
+      description: 'Resuming from earlier — context may be summarized.',
+      color: 0x95a5a6,
+      footer: { text: 'mention session resumed' },
+    }).catch(() => {});
+
     // resumeProcess only accepts strings — include attachment URLs so images aren't lost
     const resumeText =
       typeof contextualContent === 'string'
@@ -737,6 +719,7 @@ async function handleMentionReplyResume(
     const channelContext = buildChannelContext(ctx.db, channelId);
     const resumeTextWithContext = channelContext ? `${channelContext}\n\n${resumeText}` : resumeText;
     ctx.processManager.resumeProcess(session, resumeTextWithContext);
+    ctx.processManager.setKeepAliveTtl(sessionId, MENTION_KEEP_ALIVE_TTL_MS);
 
     // If resumeProcess failed (e.g. death loop reset, spawn error), fall back to a new session
     if (!ctx.processManager.isRunning(sessionId)) {

--- a/server/discord/thread-response/adaptive-response.ts
+++ b/server/discord/thread-response/adaptive-response.ts
@@ -54,7 +54,7 @@ export function subscribeForAdaptiveInlineResponse(
   const TYPING_TIMEOUT_MS = 4 * 60 * 1000;
   let receivedAnyActivity = false;
   const color = hexColorToInt(displayColor) ?? agentColor(agentName);
-  const footerCtx: FooterContext = { agentName, agentModel, sessionId, projectName };
+  const footerCtx: FooterContext = { agentName, agentModel, sessionId, projectName, sessionType: 'mention · 5m' };
   const authorIdentity: EmbedAgentIdentity = { agentName, displayIcon, avatarUrl };
 
   // Progress embed state — only created when tool use is detected

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -172,6 +172,8 @@ interface SessionMeta {
   lastContextUsagePercent?: number;
   /** Cached channel/thread ID for observation scoping (resolved lazily on first message). */
   channelId?: string | null;
+  /** Per-session keep-alive TTL override in ms (e.g. shorter TTL for mention sessions). */
+  keepAliveTtlMs?: number;
 }
 
 export class ProcessManager {
@@ -182,6 +184,8 @@ export class ProcessManager {
   private processes: Map<string, SdkProcess> = new Map();
   private readonly eventBus = new SessionEventBus();
   private sessionMeta: Map<string, SessionMeta> = new Map();
+  /** Per-session keep-alive TTL overrides (e.g. shorter TTL for mention sessions). */
+  private keepAliveTtlOverrides: Map<string, number> = new Map();
   private ephemeralDirs: Map<string, ResolvedDir> = new Map();
   /** Guard against concurrent resume/start for the same session. */
   private startingSession: Set<string> = new Set();
@@ -279,6 +283,11 @@ export class ProcessManager {
     this.pluginRegistry = registry;
   }
 
+  /** Set a per-session keep-alive TTL override (e.g. 5m for mention sessions vs 2h default). */
+  setKeepAliveTtl(sessionId: string, ttlMs: number): void {
+    this.keepAliveTtlOverrides.set(sessionId, ttlMs);
+  }
+
   /** Build an McpToolContext for a given agent, or null if MCP services aren't available. */
   private buildMcpContext(
     agentId: string,
@@ -334,6 +343,10 @@ export class ProcessManager {
       conversationOnly?: boolean;
       toolAllowList?: string[];
       mcpToolAllowList?: string[];
+      /** Per-session keep-alive TTL override in ms (e.g. 5m for mention sessions). */
+      keepAliveTtlMs?: number;
+      /** Skip skill bundle prompt loading for lightweight sessions (e.g. mention sessions). */
+      skipSkillPrompt?: boolean;
     },
   ): void {
     if (this.startingSession.has(session.id)) {
@@ -509,6 +522,7 @@ export class ProcessManager {
         options?.conversationOnly,
         options?.toolAllowList,
         options?.mcpToolAllowList,
+        options?.skipSkillPrompt,
       );
     } else {
       this.startSdkProcessWrapped(
@@ -522,6 +536,7 @@ export class ProcessManager {
         options?.conversationOnly,
         options?.toolAllowList,
         options?.mcpToolAllowList,
+        options?.skipSkillPrompt,
       );
     }
   }
@@ -543,6 +558,7 @@ export class ProcessManager {
       conversationOnly?: boolean;
       toolAllowList?: string[];
       mcpToolAllowList?: string[];
+      skipSkillPrompt?: boolean;
     },
   ): Promise<void> {
     const resolved = await resolveProjectDir(project);
@@ -591,6 +607,7 @@ export class ProcessManager {
         options?.conversationOnly,
         options?.toolAllowList,
         options?.mcpToolAllowList,
+        options?.skipSkillPrompt,
       );
     }
   }
@@ -606,10 +623,14 @@ export class ProcessManager {
     conversationOnly?: boolean,
     toolAllowList?: string[],
     mcpToolAllowList?: string[],
+    skipSkillPrompt?: boolean,
   ): void {
     const effectiveProject = session.workDir ? { ...project, workingDir: session.workDir } : project;
 
     const config = resolveSessionConfig(this.db, agent, session.agentId, session.projectId);
+    if (skipSkillPrompt) {
+      config.skillPrompt = undefined;
+    }
 
     // Conversation-only sessions (or empty toolAllowList) get NO tools — pure text conversation.
     // When toolAllowList has items, it's a restricted session (e.g. buddy review).
@@ -1576,6 +1597,7 @@ export class ProcessManager {
     this.approvalManager.cancelSession(sessionId);
     this.ownerQuestionManager.cancelSession(sessionId);
     this.sessionMeta.delete(sessionId);
+    this.keepAliveTtlOverrides.delete(sessionId);
   }
 
   /**
@@ -1710,6 +1732,7 @@ export class ProcessManager {
 
     this.eventBus.clearAllSessionSubscribers();
     this.sessionMeta.clear();
+    this.keepAliveTtlOverrides.clear();
   }
 
   private handleApiOutage(sessionId: string): void {
@@ -2138,7 +2161,8 @@ export class ProcessManager {
     accumulateActiveDuration(this.db, sessionId);
 
     // Start keep-alive TTL — process will be killed if no new message arrives
-    this.timerManager.startKeepAliveTtl(sessionId, KEEP_ALIVE_TTL_MS);
+    const effectiveTtl = this.keepAliveTtlOverrides.get(sessionId) ?? KEEP_ALIVE_TTL_MS;
+    this.timerManager.startKeepAliveTtl(sessionId, effectiveTtl);
 
     // Clear the normal inactivity timeout — warm processes use keep-alive TTL instead
     this.timerManager.clearSessionTimeout(sessionId);

--- a/server/process/session-exit-handler.ts
+++ b/server/process/session-exit-handler.ts
@@ -288,12 +288,46 @@ export function persistConversationSummary(db: Database, sessionId: string): voi
 }
 
 /**
+ * Check if a worktree has uncommitted changes or unpushed commits.
+ */
+async function isWorktreeDirty(workDir: string): Promise<boolean> {
+  try {
+    const statusProc = Bun.spawn(['git', 'status', '--porcelain'], {
+      cwd: workDir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const statusOutput = await new Response(statusProc.stdout).text();
+    await statusProc.exited;
+    if (statusOutput.trim().length > 0) return true;
+
+    const logProc = Bun.spawn(['git', 'log', '--oneline', '@{upstream}..HEAD'], {
+      cwd: workDir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const logOutput = await new Response(logProc.stdout).text();
+    await logProc.exited;
+    return logOutput.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Clean up worktrees created for chat sessions (not work tasks).
  * Chat worktree directories contain `/chat-` in the path.
  * Also cleans up ephemeral project directories.
  * Fire-and-forget — errors are logged but do not block session cleanup.
+ *
+ * For mention sessions, checks for uncommitted work before cleanup:
+ * - Clean worktrees are removed immediately
+ * - Dirty worktrees are preserved (caller notified via return value)
  */
-export function cleanupChatWorktree(deps: Pick<ExitHandlerDeps, 'db' | 'ephemeralDirs'>, sessionId: string): void {
+export async function cleanupChatWorktree(
+  deps: Pick<ExitHandlerDeps, 'db' | 'ephemeralDirs'>,
+  sessionId: string,
+): Promise<'cleaned' | 'dirty' | 'skipped'> {
   // Clean up ephemeral project directories
   const ephemeral = deps.ephemeralDirs.get(sessionId);
   if (ephemeral) {
@@ -309,10 +343,22 @@ export function cleanupChatWorktree(deps: Pick<ExitHandlerDeps, 'db' | 'ephemera
 
   // Clean up chat worktrees
   const session = getSession(deps.db, sessionId);
-  if (!session?.workDir?.includes('/chat-')) return;
+  if (!session?.workDir?.includes('/chat-')) return 'skipped';
 
   const project = session.projectId ? getProject(deps.db, session.projectId) : null;
-  if (!project?.workingDir) return;
+  if (!project?.workingDir) return 'skipped';
+
+  const isMentionSession = session.name?.startsWith('Discord mention:');
+  if (isMentionSession) {
+    const dirty = await isWorktreeDirty(session.workDir);
+    if (dirty) {
+      log.info('Mention session worktree has uncommitted changes — preserving', {
+        sessionId,
+        workDir: session.workDir,
+      });
+      return 'dirty';
+    }
+  }
 
   removeWorktree(project.workingDir, session.workDir, { cleanBranch: true }).catch((err) => {
     log.warn('Failed to clean up chat worktree', {
@@ -321,4 +367,5 @@ export function cleanupChatWorktree(deps: Pick<ExitHandlerDeps, 'db' | 'ephemera
       error: err instanceof Error ? err.message : String(err),
     });
   });
+  return 'cleaned';
 }


### PR DESCRIPTION
## Summary

Overhauls Discord @mention behavior for reliability and resource efficiency, based on discussion with Kyn.

### Core behavior changes (#2260, #2261)
- **Every @mention creates a fresh session** — removed the 60-min channel-based fallback that could accidentally resume old conversations
- **Reply chains are the only continuation path** — if you reply to the bot's message, it resumes that session. Otherwise, new session every time. No guessing.

### Performance & resource improvements (#2262, #2263, #2264)
- **5-minute keep-alive TTL** for mention sessions (vs 2h for thread sessions) — matches the ephemeral nature of quick @mention interactions
- **Skip skill bundle prompt loading** for mention sessions — reduces token usage since mentions are quick questions, not deep work
- **Conditional worktree cleanup** on TTL expiry — clean worktrees are removed immediately, dirty ones with uncommitted work are preserved

### UX polish (#2265)
- **"mention · 5m" label** in embed footers so users can distinguish mention sessions from thread sessions at a glance
- **"Resuming from earlier — context may be summarized"** notice when replying to an expired mention session

## Files changed
- `server/discord/message-router.ts` — core routing changes, TTL, skipSkillPrompt
- `server/process/manager.ts` — per-session keepAlive TTL override
- `server/process/session-exit-handler.ts` — conditional worktree cleanup for mentions
- `server/discord/embeds.ts` — sessionType in footer
- `server/discord/thread-response/adaptive-response.ts` — mention footer label
- 7 test files — updated mock process managers

## Test plan
- [x] 529 Discord tests pass (0 failures across 32 files)
- [x] Biome lint clean on all modified files
- [x] Manual test: @mention creates new session each time
- [x] Manual test: reply to bot message resumes session
- [x] Manual test: session expires after 5m idle
- [x] Manual test: embed footer shows "mention · 5m"

Closes #2260, closes #2261, closes #2262, closes #2263, closes #2264, closes #2265

🤖 Generated with [Claude Code](https://claude.com/claude-code)