### PR TITLE
fix(discord): show mention · 5m label in embed footers

### DIFF
--- a/server/discord/embed-builder.ts
+++ b/server/discord/embed-builder.ts
@@ -133,6 +133,7 @@ export class CorvidEmbed {
   private _sessionId?: string;
   private _projectName?: string;
   private _status?: string;
+  private _sessionType?: string;
 
   // Footer
   private _footerOverride?: string;
@@ -186,6 +187,11 @@ export class CorvidEmbed {
 
   setStatus(status: string): this {
     this._status = status;
+    return this;
+  }
+
+  setSessionType(sessionType: string): this {
+    this._sessionType = sessionType;
     return this;
   }
 
@@ -289,6 +295,7 @@ export class CorvidEmbed {
         ...(this._sessionId ? { sessionId: this._sessionId } : {}),
         ...(this._projectName ? { projectName: this._projectName } : {}),
         ...(this._status ? { status: this._status } : {}),
+        ...(this._sessionType ? { sessionType: this._sessionType } : {}),
       };
 
       const footerText = this._stats

--- a/server/discord/thread-response/adaptive-response.ts
+++ b/server/discord/thread-response/adaptive-response.ts
@@ -127,6 +127,7 @@ export function subscribeForAdaptiveInlineResponse(
         .setAgent(authorIdentity)
         .setModel(agentModel)
         .setSession(sessionId);
+      if (footerCtx.sessionType) contentBuilder.setSessionType(footerCtx.sessionType);
       if (projectName) contentBuilder.setProject(projectName);
       if (latestContextUsage) contentBuilder.withContextUsage(latestContextUsage);
       const { embed: embedPayload } = contentBuilder.build();
@@ -191,6 +192,7 @@ export function subscribeForAdaptiveInlineResponse(
         .setAgent(authorIdentity)
         .setModel(agentModel)
         .setSession(sessionId);
+      if (footerCtx.sessionType) imgBuilder.setSessionType(footerCtx.sessionType);
       if (projectName) imgBuilder.setProject(projectName);
       if (latestContextUsage) imgBuilder.withContextUsage(latestContextUsage);
       const { embed: imgEmbed } = imgBuilder.build();
@@ -286,6 +288,7 @@ export function subscribeForAdaptiveInlineResponse(
             .setSession(sessionId)
             .withButtons(['continue_thread'])
             .withButtonOverride('continue_thread', `continue_thread:${sessionId}`);
+          if (footerCtx.sessionType) continueBuilder.setSessionType(footerCtx.sessionType);
           if (projectName) continueBuilder.setProject(projectName);
           if (latestContextUsage) continueBuilder.withContextUsage(latestContextUsage);
           const { embed: continueEmbed, components } = continueBuilder.build();


### PR DESCRIPTION
## Summary
- Added `setSessionType()` to `CorvidEmbed` builder so content embeds can include the session type in their footer
- Wired `footerCtx.sessionType` through all three embed paths in `adaptive-response.ts`: content (flush), continuation prompt, and image attachments
- Previously, `sessionType: 'mention · 5m'` was set in the footer context but only used by progress/tool-status/done embeds (via static factory methods) — content embeds built with `.setModel()/.setSession()` had no way to include it

## Before
`opus-4.6 · 552b8a56 | ⚪ 6% (12k/200k)`

## After
`mention · 5m · opus-4.6 · 552b8a56 | ⚪ 6% (12k/200k)`

## Test plan
- [x] TypeScript compiles clean
- [x] 556/556 Discord tests pass
- [x] @mention bot in a channel → footer shows "mention · 5m" prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)