### PR TITLE
feat(github): add human collaborator attribution to PRs, issues, and commits

### DIFF
--- a/server/__tests__/github-tool-handlers.test.ts
+++ b/server/__tests__/github-tool-handlers.test.ts
@@ -85,7 +85,9 @@ const {
   handleGitHubFollowUser,
 } = await import('../mcp/tool-handlers');
 
-const { friendlyModelName, formatAgentSignature, formatCoAuthoredBy } = await import('../mcp/tool-handlers/github');
+const { friendlyModelName, formatAgentSignature, formatCoAuthoredBy, formatHumanCoAuthoredBy } = await import(
+  '../mcp/tool-handlers/github'
+);
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -958,5 +960,53 @@ describe('formatCoAuthoredBy (#1576)', () => {
 
   test('returns empty string for undefined agent', () => {
     expect(formatCoAuthoredBy(undefined)).toBe('');
+  });
+});
+
+// ── formatHumanCoAuthoredBy ─────────────────────────────────────────────
+
+describe('formatHumanCoAuthoredBy', () => {
+  test('formats with GitHub noreply email when username is present', () => {
+    expect(formatHumanCoAuthoredBy({ displayName: 'Leif', githubUsername: 'kyntrin' })).toBe(
+      'Co-Authored-By: Leif <kyntrin@users.noreply.github.com>',
+    );
+  });
+
+  test('formats with display name only when no GitHub username', () => {
+    expect(formatHumanCoAuthoredBy({ displayName: 'Leif' })).toBe('Co-Authored-By: Leif');
+  });
+});
+
+// ── formatAgentSignature with collaborators ──────────────────────────────
+
+describe('formatAgentSignature with collaborators', () => {
+  test('appends collaborator with GitHub username as @mention', () => {
+    const sig = formatAgentSignature({ name: 'Rook', model: 'claude-opus-4-6' }, undefined, [
+      { displayName: 'Leif', githubUsername: 'kyntrin' },
+    ]);
+    expect(sig).toContain('Requested by: @kyntrin');
+  });
+
+  test('appends collaborator display name when no GitHub username', () => {
+    const sig = formatAgentSignature({ name: 'Rook', model: 'claude-opus-4-6' }, undefined, [{ displayName: 'Leif' }]);
+    expect(sig).toContain('Requested by: Leif');
+  });
+
+  test('appends multiple collaborators comma-separated', () => {
+    const sig = formatAgentSignature({ name: 'Rook', model: 'claude-opus-4-6' }, undefined, [
+      { displayName: 'Leif', githubUsername: 'kyntrin' },
+      { displayName: 'Tofu' },
+    ]);
+    expect(sig).toContain('Requested by: @kyntrin, Tofu');
+  });
+
+  test('omits collaborator line when collaborators array is empty', () => {
+    const sig = formatAgentSignature({ name: 'Rook', model: 'claude-opus-4-6' }, undefined, []);
+    expect(sig).not.toContain('Requested by');
+  });
+
+  test('omits collaborator line when collaborators is undefined', () => {
+    const sig = formatAgentSignature({ name: 'Rook', model: 'claude-opus-4-6' });
+    expect(sig).not.toContain('Requested by');
   });
 });

--- a/server/mcp/sdk-tools.ts
+++ b/server/mcp/sdk-tools.ts
@@ -678,6 +678,10 @@ export function createCorvidMcpServer(ctx: McpToolContext, pluginTools?: ReturnT
         body: z.string().describe('PR description/body'),
         head: z.string().describe('Source branch name'),
         base: z.string().optional().describe('Target branch name (default "main")'),
+        requested_by: z
+          .string()
+          .optional()
+          .describe('GitHub username(s) or Discord ID(s) of the human collaborator(s), comma-separated'),
       },
       async (args) => handleGitHubCreatePr(ctx, args),
     ),
@@ -700,6 +704,10 @@ export function createCorvidMcpServer(ctx: McpToolContext, pluginTools?: ReturnT
         title: z.string().describe('Issue title'),
         body: z.string().describe('Issue description/body'),
         labels: z.array(z.string()).optional().describe('Labels to apply to the issue'),
+        requested_by: z
+          .string()
+          .optional()
+          .describe('GitHub username(s) or Discord ID(s) of the human collaborator(s), comma-separated'),
       },
       async (args) => handleGitHubCreateIssue(ctx, args),
     ),

--- a/server/mcp/tool-handlers/github.ts
+++ b/server/mcp/tool-handlers/github.ts
@@ -1,5 +1,6 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { getAgent } from '../../db/agents';
+import { type ContactPlatform, findContactByPlatformId } from '../../db/contacts';
 import { assertRepoAllowed } from '../../github/off-limits';
 import * as github from '../../github/operations';
 import { checkInternPrGuard } from '../../work/intern-guard';
@@ -10,6 +11,29 @@ import {
 } from '../scheduler-tool-gating';
 import type { McpToolContext } from './types';
 import { errorResult, textResult } from './types';
+
+export interface HumanCollaborator {
+  displayName: string;
+  githubUsername?: string;
+}
+
+export function resolveCollaborator(
+  db: import('bun:sqlite').Database,
+  platform: ContactPlatform,
+  platformId: string,
+): HumanCollaborator | null {
+  const contact = findContactByPlatformId(db, '', platform, platformId);
+  if (!contact) return null;
+  const githubLink = contact.links?.find((l) => l.platform === 'github');
+  return { displayName: contact.displayName, githubUsername: githubLink?.platformId };
+}
+
+export function formatHumanCoAuthoredBy(collaborator: HumanCollaborator): string {
+  if (collaborator.githubUsername) {
+    return `Co-Authored-By: ${collaborator.displayName} <${collaborator.githubUsername}@users.noreply.github.com>`;
+  }
+  return `Co-Authored-By: ${collaborator.displayName}`;
+}
 
 /** Map a raw model ID to a human-friendly name for GitHub signatures. */
 export function friendlyModelName(model: string): string {
@@ -31,12 +55,18 @@ export function friendlyModelName(model: string): string {
 export function formatAgentSignature(
   agent: { name: string; model: string } | null | undefined,
   taskId?: string,
+  collaborators?: HumanCollaborator[],
 ): string {
   if (!agent) return '';
   const modelDisplay = friendlyModelName(agent.model);
   const parts = [`Agent: ${agent.name}`, `Model: ${modelDisplay}`];
   if (taskId) parts.push(`Task: ${taskId}`);
-  return `\n\n---\n\u{1F916} ${parts.join(' | ')}`;
+  let sig = `\n\n---\n\u{1F916} ${parts.join(' | ')}`;
+  if (collaborators?.length) {
+    const names = collaborators.map((c) => (c.githubUsername ? `@${c.githubUsername}` : c.displayName));
+    sig += `\n\u{1F464} Requested by: ${names.join(', ')}`;
+  }
+  return sig;
 }
 
 /** Format a Co-Authored-By trailer for git commits (#1576). */
@@ -47,10 +77,10 @@ export function formatCoAuthoredBy(agent: { name: string; model: string } | null
 }
 
 /** Build an agent identity signature footer by looking up the agent from the DB. */
-export function buildAgentSignature(ctx: McpToolContext): string {
+export function buildAgentSignature(ctx: McpToolContext, collaborators?: HumanCollaborator[]): string {
   try {
     const agent = getAgent(ctx.db, ctx.agentId);
-    return formatAgentSignature(agent);
+    return formatAgentSignature(agent, undefined, collaborators);
   } catch {
     return '';
   }
@@ -67,6 +97,34 @@ function enforceSchedulerGuards(ctx: McpToolContext, toolName: string, repo: str
     if (err) return errorResult(err);
   }
   return null;
+}
+
+/**
+ * Resolve a `requested_by` string into collaborator info.
+ * Accepts a GitHub username (with or without @), a Discord ID, or a display name.
+ */
+function resolveRequestedBy(ctx: McpToolContext, requestedBy?: string): HumanCollaborator[] | undefined {
+  if (!requestedBy) return undefined;
+  const names = requestedBy
+    .split(',')
+    .map((n) => n.trim())
+    .filter(Boolean);
+  const collaborators: HumanCollaborator[] = [];
+  for (const name of names) {
+    const cleaned = name.startsWith('@') ? name.slice(1) : name;
+    const byGithub = resolveCollaborator(ctx.db, 'github', cleaned);
+    if (byGithub) {
+      collaborators.push(byGithub);
+      continue;
+    }
+    const byDiscord = resolveCollaborator(ctx.db, 'discord', cleaned);
+    if (byDiscord) {
+      collaborators.push(byDiscord);
+      continue;
+    }
+    collaborators.push({ displayName: cleaned, githubUsername: cleaned });
+  }
+  return collaborators.length > 0 ? collaborators : undefined;
 }
 
 export async function handleGitHubStarRepo(_ctx: McpToolContext, args: { repo: string }): Promise<CallToolResult> {
@@ -127,7 +185,7 @@ export async function handleGitHubListPrs(
 
 export async function handleGitHubCreatePr(
   ctx: McpToolContext,
-  args: { repo: string; title: string; body: string; head: string; base?: string },
+  args: { repo: string; title: string; body: string; head: string; base?: string; requested_by?: string },
 ): Promise<CallToolResult> {
   try {
     assertRepoAllowed(args.repo);
@@ -145,7 +203,8 @@ export async function handleGitHubCreatePr(
     } catch {
       // Fail open: if the agent lookup fails, allow the operation to proceed.
     }
-    const bodyWithSig = args.body + buildAgentSignature(ctx);
+    const collaborators = resolveRequestedBy(ctx, args.requested_by);
+    const bodyWithSig = args.body + buildAgentSignature(ctx, collaborators);
     const result = await github.createPr(args.repo, args.title, bodyWithSig, args.head, args.base ?? 'main');
     if (!result.ok) return errorResult(result.error ?? 'Failed to create PR');
     return textResult(`PR created: ${result.prUrl ?? 'success'}`);
@@ -177,7 +236,7 @@ export async function handleGitHubReviewPr(
 
 export async function handleGitHubCreateIssue(
   ctx: McpToolContext,
-  args: { repo: string; title: string; body: string; labels?: string[] },
+  args: { repo: string; title: string; body: string; labels?: string[]; requested_by?: string },
 ): Promise<CallToolResult> {
   try {
     assertRepoAllowed(args.repo);
@@ -191,7 +250,8 @@ export async function handleGitHubCreateIssue(
         effectiveLabels.push(SCHEDULER_ESCALATION_LABEL);
       }
     }
-    const bodyWithSig = args.body + buildAgentSignature(ctx);
+    const collaborators = resolveRequestedBy(ctx, args.requested_by);
+    const bodyWithSig = args.body + buildAgentSignature(ctx, collaborators);
     const result = await github.createIssue(args.repo, args.title, bodyWithSig, effectiveLabels);
     if (!result.ok) return errorResult(result.error ?? 'Failed to create issue');
     return textResult(`Issue created: ${result.issueUrl ?? 'success'}`);

--- a/server/work/session-lifecycle.ts
+++ b/server/work/session-lifecycle.ts
@@ -6,7 +6,13 @@ import { createSession } from '../db/sessions';
 import { clearWorktreeDir, getWorkTask, updateWorkTaskStatus } from '../db/work-tasks';
 import { createLogger } from '../lib/logger';
 import { removeWorktree } from '../lib/worktree';
-import { formatAgentSignature, formatCoAuthoredBy } from '../mcp/tool-handlers/github';
+import {
+  formatAgentSignature,
+  formatCoAuthoredBy,
+  formatHumanCoAuthoredBy,
+  type HumanCollaborator,
+  resolveCollaborator,
+} from '../mcp/tool-handlers/github';
 import type { ProcessManager } from '../process/manager';
 import { checkInternPrGuard } from './intern-guard';
 import { runValidation } from './validation';
@@ -211,6 +217,9 @@ export async function createPrFallback(db: Database, taskId: string, sessionOutp
   const agent = task.agentId ? getAgent(db, task.agentId) : null;
   const coAuthor = formatCoAuthoredBy(agent);
 
+  // Resolve human collaborator from requester info
+  const collaborators = resolveCollaboratorsFromTask(db, task.requesterInfo);
+
   try {
     // Ensure origin remote exists — projects with persistent strategy may lack it (#1829)
     const hasOrigin = await ensureOriginRemote(db, task.projectId, cwd);
@@ -226,8 +235,11 @@ export async function createPrFallback(db: Database, taskId: string, sessionOutp
       // There are uncommitted changes — commit them
       const addProc = Bun.spawn(['git', 'add', '-A'], { cwd, stdout: 'pipe', stderr: 'pipe' });
       await addProc.exited;
-      const commitMsg = coAuthor
-        ? `Work task: ${task.description.slice(0, 60)}\n\n${coAuthor}`
+      const trailers = [coAuthor];
+      for (const c of collaborators) trailers.push(formatHumanCoAuthoredBy(c));
+      const trailerStr = trailers.filter(Boolean).join('\n');
+      const commitMsg = trailerStr
+        ? `Work task: ${task.description.slice(0, 60)}\n\n${trailerStr}`
         : `Work task: ${task.description.slice(0, 60)}`;
       const commitProc = Bun.spawn(['git', 'commit', '-m', commitMsg], { cwd, stdout: 'pipe', stderr: 'pipe' });
       await commitProc.exited;
@@ -251,7 +263,7 @@ export async function createPrFallback(db: Database, taskId: string, sessionOutp
     // Create PR via gh CLI
     const title = `[Agent] ${task.description.slice(0, 60)}`;
     const baseBody = `Automated work task.\n\n**Description:** ${task.description}\n\n**Summary:** ${sanitizeSessionSummary(sessionOutput, 300)}`;
-    const body = baseBody + formatAgentSignature(agent, taskId);
+    const body = baseBody + formatAgentSignature(agent, taskId, collaborators.length > 0 ? collaborators : undefined);
     log.info('Fallback: creating PR', { taskId, branch: task.branchName });
 
     const prProc = Bun.spawn(['gh', 'pr', 'create', '--title', title, '--body', body, '--head', task.branchName], {
@@ -317,6 +329,19 @@ export async function cleanupWorktree(db: Database, taskId: string): Promise<voi
 
   await removeWorktree(project.workingDir, task.worktreeDir);
   clearWorktreeDir(db, taskId);
+}
+
+function resolveCollaboratorsFromTask(db: Database, requesterInfo: Record<string, unknown>): HumanCollaborator[] {
+  const collaborators: HumanCollaborator[] = [];
+  if (typeof requesterInfo.discordUserId === 'string') {
+    const c = resolveCollaborator(db, 'discord', requesterInfo.discordUserId);
+    if (c) collaborators.push(c);
+  }
+  if (typeof requesterInfo.algochatAddress === 'string') {
+    const c = resolveCollaborator(db, 'algochat', requesterInfo.algochatAddress);
+    if (c) collaborators.push(c);
+  }
+  return collaborators;
 }
 
 /**

--- a/specs/mcp/tools/tool-handlers.spec.md
+++ b/specs/mcp/tools/tool-handlers.spec.md
@@ -74,9 +74,12 @@ Implements every `corvid_*` MCP tool handler. Each exported function takes an `M
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
 | `friendlyModelName` | `(model: string)` | `string` | Map a raw model ID (e.g. `claude-opus-4-6`) to a human-friendly name (e.g. `Opus 4.6`) |
-| `formatAgentSignature` | `(agent: { name, model } \| null \| undefined)` | `string` | Format an identity footer from an agent object; returns empty string for null/undefined |
+| `formatAgentSignature` | `(agent: { name, model } \| null \| undefined, taskId?, collaborators?)` | `string` | Format an identity footer from an agent object with optional human collaborator attribution; returns empty string for null/undefined |
 | `formatCoAuthoredBy` | `(agent: { name, model } \| null \| undefined)` | `string` | Format a Co-Authored-By git trailer from an agent object; returns empty string for null/undefined |
-| `buildAgentSignature` | `(ctx: McpToolContext)` | `string` | Look up agent from DB and build identity footer; returns empty string on failure |
+| `formatHumanCoAuthoredBy` | `(collaborator: HumanCollaborator)` | `string` | Format a Co-Authored-By git trailer for a human collaborator, using their GitHub noreply email if available |
+| `buildAgentSignature` | `(ctx: McpToolContext, collaborators?)` | `string` | Look up agent from DB and build identity footer with optional human collaborator attribution; returns empty string on failure |
+| `resolveCollaborator` | `(db: Database, platform: ContactPlatform, platformId: string)` | `HumanCollaborator \| null` | Look up a human collaborator from the contacts DB by platform ID, resolving their GitHub username if linked |
+| `HumanCollaborator` | interface | `{ displayName, githubUsername? }` | Represents a human collaborator for attribution in PRs, issues, and commits |
 
 ### Exported Functions
 
@@ -156,7 +159,7 @@ Implements every `corvid_*` MCP tool handler. Each exported function takes an `M
 6. **All handlers return `CallToolResult`**: Every handler returns `{ content: [{ type: 'text', text }] }` via `textResult()` or `errorResult()` helpers
 7. **Service availability checks**: Handlers check for optional services (e.g. `ctx.workTaskService`, `ctx.schedulerService`) before use and return error results if missing
 8. **Status emission**: Long-running handlers call `ctx.emitStatus?.()` to provide progress updates to the UI
-9. **Agent identity signature**: GitHub write operations (`handleGitHubCreatePr`, `handleGitHubCreateIssue`, `handleGitHubCommentOnPr`, `handleGitHubReviewPr`) append an agent identity footer to the body via `buildAgentSignature()`. If the agent cannot be resolved, no signature is appended (fail-open)
+9. **Agent identity signature**: GitHub write operations (`handleGitHubCreatePr`, `handleGitHubCreateIssue`, `handleGitHubCommentOnPr`, `handleGitHubReviewPr`) append an agent identity footer to the body via `buildAgentSignature()`. If the agent cannot be resolved, no signature is appended (fail-open). PR and issue creation tools accept an optional `requested_by` parameter to attribute human collaborators — resolved via the contacts DB and displayed as `Requested by: @username` in the footer
 
 ## Behavioral Examples
 


### PR DESCRIPTION
## Summary

- PRs and issues now show **"Requested by: @username"** in the agent signature footer when a human collaborator is specified
- Work task fallback commits include a **Co-Authored-By** trailer for the human who requested the work
- New `requested_by` parameter on `corvid_github_create_pr` and `corvid_github_create_issue` MCP tools — accepts GitHub usernames or Discord IDs (comma-separated for multiple)
- Work tasks auto-resolve the human collaborator from `requesterInfo.discordUserId` via the contacts DB

### How it works

`requested_by` → contacts DB lookup (GitHub → Discord → fallback to raw name) → `HumanCollaborator { displayName, githubUsername }` → appended to PR footer and commit trailers.

## Test plan

- [x] TypeScript compiles clean
- [x] Lint passes (biome)
- [x] 28/28 work task lifecycle + PR tests pass
- [x] 216/216 specs pass, 0 warnings
- [x] CI

---
🤖 Agent: CorvidAgent | Model: Opus 4.6
👤 Requested by: @kyntrin