### PR TITLE
feat(github): standardized PR body template (#2272)

### DIFF
--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -43,7 +43,7 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Unit tests | 4,242 test files |
 | E2E tests | 360 across 33 Playwright specs |
 | Security tests | 232 dedicated |
-| Module specs | 217 .spec.md files |
+| Module specs | 218 .spec.md files |
 | Test:code ratio | 1.14x (more test than production) |
 | Dependencies | 17 direct |
 | Version | 0.51.0 |

--- a/server/github/pr-body.ts
+++ b/server/github/pr-body.ts
@@ -1,0 +1,41 @@
+export interface PrBodyOptions {
+  /** 1-3 bullet points describing what changed and why */
+  summary: string[];
+  /** Bulleted list of specific changes */
+  changes?: string[];
+  /** Verification checklist items */
+  testPlan?: string[];
+}
+
+/**
+ * Format a standardized PR body with Summary, Changes, and Test Plan sections.
+ * The agent signature footer (🤖 / 👤 lines) is appended separately by the MCP handler
+ * via formatAgentSignature().
+ *
+ * Template (#2272):
+ *   ## Summary
+ *   - bullet...
+ *
+ *   ## Changes
+ *   - change...
+ *
+ *   ## Test Plan
+ *   - [ ] step...
+ */
+export function formatPrBody(opts: PrBodyOptions): string {
+  const sections: string[] = [];
+
+  if (opts.summary.length > 0) {
+    sections.push(`## Summary\n${opts.summary.map((s) => `- ${s}`).join('\n')}`);
+  }
+
+  if (opts.changes && opts.changes.length > 0) {
+    sections.push(`## Changes\n${opts.changes.map((c) => `- ${c}`).join('\n')}`);
+  }
+
+  if (opts.testPlan && opts.testPlan.length > 0) {
+    sections.push(`## Test Plan\n${opts.testPlan.map((t) => `- [ ] ${t}`).join('\n')}`);
+  }
+
+  return sections.join('\n\n');
+}

--- a/server/work/session-lifecycle.ts
+++ b/server/work/session-lifecycle.ts
@@ -4,6 +4,7 @@ import { recordAudit } from '../db/audit';
 import { getProject } from '../db/projects';
 import { createSession } from '../db/sessions';
 import { clearWorktreeDir, getWorkTask, updateWorkTaskStatus } from '../db/work-tasks';
+import { formatPrBody } from '../github/pr-body';
 import { createLogger } from '../lib/logger';
 import { removeWorktree } from '../lib/worktree';
 import {
@@ -262,7 +263,12 @@ export async function createPrFallback(db: Database, taskId: string, sessionOutp
 
     // Create PR via gh CLI
     const title = `[Agent] ${task.description.slice(0, 60)}`;
-    const baseBody = `Automated work task.\n\n**Description:** ${task.description}\n\n**Summary:** ${sanitizeSessionSummary(sessionOutput, 300)}`;
+    const sessionSummary = sanitizeSessionSummary(sessionOutput, 300);
+    const baseBody = formatPrBody({
+      summary: [task.description],
+      changes: sessionSummary ? [sessionSummary] : undefined,
+      testPlan: ['Review automated changes', 'Verify CI passes'],
+    });
     const body = baseBody + formatAgentSignature(agent, taskId, collaborators.length > 0 ? collaborators : undefined);
     log.info('Fallback: creating PR', { taskId, branch: task.branchName });
 

--- a/specs/github/github.spec.md
+++ b/specs/github/github.spec.md
@@ -5,6 +5,7 @@ status: draft
 files:
   - server/github/off-limits.ts
   - server/github/operations.ts
+  - server/github/pr-body.ts
 db_tables: []
 depends_on:
   - specs/lib/infra/infra.spec.md
@@ -26,6 +27,16 @@ Provides GitHub operations via the `gh` CLI (stars, forks, PRs, issues, reviews,
 | `isRepoOffLimits` | `repo: string` | `boolean` | Returns true if the repo is on the off-limits blocklist |
 | `assertRepoAllowed` | `repo: string` | `void` | Throws if the repo is off-limits; call before any write operation |
 | `_resetCache` | (none) | `void` | Resets the in-memory blocklist cache (for testing) |
+
+#### pr-body.ts
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `formatPrBody` | `opts: PrBodyOptions` | `string` | Formats a standardized PR body with Summary, Changes, and Test Plan sections |
+
+| Type | Description |
+|------|-------------|
+| `PrBodyOptions` | Interface with fields: summary (string[]), changes? (string[]), testPlan? (string[]) |
 
 #### operations.ts
 
@@ -119,6 +130,7 @@ Provides GitHub operations via the `gh` CLI (stars, forks, PRs, issues, reviews,
 | `server/webhooks/service` | `isGitHubConfigured` and GitHub operations for webhook-triggered actions |
 | `server/scheduler/service` | GitHub operations for scheduled tasks (review PRs, star repos, etc.) |
 | `server/work/service` | `createPr`, `assertRepoAllowed` for work task PR creation |
+| `server/work/session-lifecycle` | `formatPrBody` for standardized PR body formatting in fallback PR creation |
 
 ## Change Log
 

--- a/specs/server/github/pr-body/pr-body.spec.md
+++ b/specs/server/github/pr-body/pr-body.spec.md
@@ -1,0 +1,55 @@
+---
+module: pr-body
+version: 1
+status: active
+files:
+  - server/github/pr-body.ts
+db_tables: []
+depends_on: []
+tracks: [2272]
+---
+
+# PR Body Template
+
+## Purpose
+
+Standardized PR body formatting for work task pull requests. Provides a consistent template with Summary, Changes, and Test Plan sections.
+
+## Public API
+
+### Exported Types
+
+| Type | Kind | Description |
+|------|------|-------------|
+| `PrBodyOptions` | interface | Options for `formatPrBody` — `summary` (required), `changes` and `testPlan` (optional) |
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `formatPrBody` | `(opts: PrBodyOptions)` | `string` | Formats a PR body with Summary, Changes, and Test Plan sections |
+
+## Invariants
+
+- `formatPrBody` MUST include a `## Summary` section when `summary` array is non-empty
+- `formatPrBody` MUST omit `## Changes` section when `changes` is undefined or empty
+- `formatPrBody` MUST omit `## Test Plan` section when `testPlan` is undefined or empty
+- Test plan items MUST render as unchecked checkboxes (`- [ ]`)
+- The agent signature footer is NOT included by `formatPrBody` — it is appended separately by the caller
+
+## Behavioral Examples
+
+- `formatPrBody({ summary: ['Added login'] })` produces `## Summary\n- Added login`
+- `formatPrBody({ summary: ['Fix'], changes: ['Updated X'], testPlan: ['Verify Y'] })` produces all three sections separated by blank lines
+
+## Error Cases
+
+No runtime errors — `formatPrBody` is a pure formatter. Empty `summary` array produces an empty string.
+
+## Dependencies
+
+None. Pure utility with no imports.
+
+## Change Log
+
+- v1: Initial spec for #2272

--- a/specs/server/github/pr-body/requirements.md
+++ b/specs/server/github/pr-body/requirements.md
@@ -1,0 +1,27 @@
+---
+spec: pr-body.spec.md
+---
+
+## User Stories
+
+- As a work task system, I want a standardized PR body template so that all agent-created PRs have consistent formatting
+- As a code reviewer, I want PRs to have Summary, Changes, and Test Plan sections so that I can quickly understand what changed and how to verify it
+
+## Acceptance Criteria
+
+- `formatPrBody` with a non-empty `summary` array produces a `## Summary` section with bulleted items
+- `formatPrBody` with a non-empty `changes` array produces a `## Changes` section with bulleted items
+- `formatPrBody` with a non-empty `testPlan` array produces a `## Test Plan` section with unchecked checkbox items (`- [ ]`)
+- Empty or undefined optional sections are omitted entirely (no empty headings)
+- Sections are separated by double newlines
+- The function does not include an agent signature footer — callers append that separately
+
+## Constraints
+
+- Pure formatting utility — no side effects, no imports
+- Summary is required; changes and testPlan are optional
+
+## Out of Scope
+
+- Agent signature footer formatting (handled by `formatAgentSignature` in tool-handlers)
+- PR creation or GitHub API interaction


### PR DESCRIPTION
## Summary
- Add `formatPrBody()` utility that structures PR descriptions into `## Summary` / `## Changes` / `## Test Plan` sections
- Update work task fallback PRs (`createPrFallback`) to use the standardized template
- Preserve existing agent signature footer (🤖 / 👤 lines) from `formatAgentSignature()`

## Changes
- `server/github/pr-body.ts` — new file with `formatPrBody(opts: PrBodyOptions): string`
- `server/work/session-lifecycle.ts` — `createPrFallback()` now uses `formatPrBody()` instead of ad-hoc body construction
- `specs/server/github/pr-body/pr-body.spec.md` — spec for new module (100% file coverage)

## Test Plan
- [x] Work task fallback PRs render with `## Summary`, `## Changes`, `## Test Plan` sections
- [x] Agent signature footer still appears below the sections
- [x] `formatPrBody` with only `summary` omits empty sections
- [x] Typecheck and lint pass (`bun x tsc --noEmit --skipLibCheck`, `bun run lint`)
- [x] Spec check passes (`bun run spec:check`)

## Governance Gate: Changes Required in `server/mcp/tool-handlers/github.ts`

`server/mcp/tool-handlers/github.ts` is **Layer 1 (Structural)** governance-protected and was not modified. Full MCP integration (issue #2272 acceptance criterion: agents calling `corvid_github_create_pr` use the template) requires the following changes to be approved and merged separately:

### Needed change in `handleGitHubCreatePr` (lines 186–215)

**1. Update tool input schema** (in `sdk-tools.ts`) to accept structured fields:
```typescript
summary: z.array(z.string()).optional().describe("Bullet points for ## Summary section"),
changes: z.array(z.string()).optional().describe("Bullet points for ## Changes section"),
testPlan: z.array(z.string()).optional().describe("Checklist items for ## Test Plan section"),
body: z.string().optional().describe("Raw body — used when structured fields are not provided"),
```

**2. Update handler args type** and construct body:
```typescript
args: {
  repo: string; title: string;
  body?: string;
  summary?: string[]; changes?: string[]; testPlan?: string[];
  head: string; base?: string; requested_by?: string;
}

// In handler:
import { formatPrBody } from '../../github/pr-body';

const rawBody = (args.summary?.length)
  ? formatPrBody({ summary: args.summary, changes: args.changes, testPlan: args.testPlan })
  : (args.body ?? '');
const bodyWithSig = rawBody + buildAgentSignature(ctx, collaborators);
```

This is backwards-compatible: callers passing raw `body` continue to work; callers passing structured fields get the standardized template.

---
🤖 Agent: Jackdaw | Model: Sonnet 4.6