### PR TITLE
fix(github): prevent numeric Discord IDs from becoming GitHub usernames

### DIFF
--- a/server/__tests__/github-tool-handlers.test.ts
+++ b/server/__tests__/github-tool-handlers.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { addPlatformLink, createContact } from '../db/contacts';
+import { runMigrations } from '../db/schema';
 import type { McpToolContext } from '../mcp/tool-handlers';
 
 // ── Mock the github/operations module before importing handlers ──────────
@@ -85,9 +88,14 @@ const {
   handleGitHubFollowUser,
 } = await import('../mcp/tool-handlers');
 
-const { friendlyModelName, formatAgentSignature, formatCoAuthoredBy, formatHumanCoAuthoredBy } = await import(
-  '../mcp/tool-handlers/github'
-);
+const {
+  friendlyModelName,
+  formatAgentSignature,
+  formatCoAuthoredBy,
+  formatHumanCoAuthoredBy,
+  resolveCollaborator,
+  resolveRequestedBy,
+} = await import('../mcp/tool-handlers/github');
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -1008,5 +1016,106 @@ describe('formatAgentSignature with collaborators', () => {
   test('omits collaborator line when collaborators is undefined', () => {
     const sig = formatAgentSignature({ name: 'Rook', model: 'claude-opus-4-6' });
     expect(sig).not.toContain('Requested by');
+  });
+});
+
+// ── resolveCollaborator ──────────────────────────────────────────────────
+
+describe('resolveCollaborator', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+  });
+
+  afterEach(() => db.close());
+
+  test('returns null when contact not found', () => {
+    expect(resolveCollaborator(db, 'discord', '999')).toBeNull();
+  });
+
+  test('returns displayName and githubUsername when GitHub link exists', () => {
+    const contact = createContact(db, '', 'Leif');
+    addPlatformLink(db, '', contact.id, 'discord', '181969874455756800');
+    addPlatformLink(db, '', contact.id, 'github', 'kyntrin');
+
+    const result = resolveCollaborator(db, 'discord', '181969874455756800');
+    expect(result).toEqual({ displayName: 'Leif', githubUsername: 'kyntrin' });
+  });
+
+  test('returns displayName without githubUsername when no GitHub link', () => {
+    const contact = createContact(db, '', 'Leif');
+    addPlatformLink(db, '', contact.id, 'discord', '181969874455756800');
+
+    const result = resolveCollaborator(db, 'discord', '181969874455756800');
+    expect(result).toEqual({ displayName: 'Leif', githubUsername: undefined });
+  });
+});
+
+// ── resolveRequestedBy ───────────────────────────────────────────────────
+
+describe('resolveRequestedBy', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    runMigrations(db);
+  });
+
+  afterEach(() => db.close());
+
+  function makeDbCtx(): McpToolContext {
+    return makeCtx({ db });
+  }
+
+  test('returns undefined when requestedBy is not provided', () => {
+    expect(resolveRequestedBy(makeDbCtx())).toBeUndefined();
+  });
+
+  test('returns undefined for empty string', () => {
+    expect(resolveRequestedBy(makeDbCtx(), '')).toBeUndefined();
+  });
+
+  test('numeric-only Discord ID falls back without githubUsername', () => {
+    const result = resolveRequestedBy(makeDbCtx(), '181969874455756800');
+    expect(result).toEqual([{ displayName: '181969874455756800', githubUsername: undefined }]);
+  });
+
+  test('@username fallback sets githubUsername', () => {
+    const result = resolveRequestedBy(makeDbCtx(), '@kyntrin');
+    expect(result).toEqual([{ displayName: 'kyntrin', githubUsername: 'kyntrin' }]);
+  });
+
+  test('plain username fallback sets githubUsername', () => {
+    const result = resolveRequestedBy(makeDbCtx(), 'kyntrin');
+    expect(result).toEqual([{ displayName: 'kyntrin', githubUsername: 'kyntrin' }]);
+  });
+
+  test('resolves contact by Discord ID when in contacts DB', () => {
+    const contact = createContact(db, '', 'Leif');
+    addPlatformLink(db, '', contact.id, 'discord', '181969874455756800');
+    addPlatformLink(db, '', contact.id, 'github', 'kyntrin');
+
+    const result = resolveRequestedBy(makeDbCtx(), '181969874455756800');
+    expect(result).toEqual([{ displayName: 'Leif', githubUsername: 'kyntrin' }]);
+  });
+
+  test('resolves contact by GitHub username when in contacts DB', () => {
+    const contact = createContact(db, '', 'Leif');
+    addPlatformLink(db, '', contact.id, 'github', 'kyntrin');
+
+    const result = resolveRequestedBy(makeDbCtx(), '@kyntrin');
+    expect(result).toEqual([{ displayName: 'Leif', githubUsername: 'kyntrin' }]);
+  });
+
+  test('handles comma-separated list with mixed types', () => {
+    const result = resolveRequestedBy(makeDbCtx(), '@kyntrin, 181969874455756800');
+    expect(result).toEqual([
+      { displayName: 'kyntrin', githubUsername: 'kyntrin' },
+      { displayName: '181969874455756800', githubUsername: undefined },
+    ]);
   });
 });

--- a/server/mcp/tool-handlers/github.ts
+++ b/server/mcp/tool-handlers/github.ts
@@ -103,7 +103,7 @@ function enforceSchedulerGuards(ctx: McpToolContext, toolName: string, repo: str
  * Resolve a `requested_by` string into collaborator info.
  * Accepts a GitHub username (with or without @), a Discord ID, or a display name.
  */
-function resolveRequestedBy(ctx: McpToolContext, requestedBy?: string): HumanCollaborator[] | undefined {
+export function resolveRequestedBy(ctx: McpToolContext, requestedBy?: string): HumanCollaborator[] | undefined {
   if (!requestedBy) return undefined;
   const names = requestedBy
     .split(',')
@@ -122,7 +122,9 @@ function resolveRequestedBy(ctx: McpToolContext, requestedBy?: string): HumanCol
       collaborators.push(byDiscord);
       continue;
     }
-    collaborators.push({ displayName: cleaned, githubUsername: cleaned });
+    // Numeric-only strings are platform IDs (e.g. Discord snowflakes) — not valid GitHub usernames.
+    const githubUsername = /^\d+$/.test(cleaned) ? undefined : cleaned;
+    collaborators.push({ displayName: cleaned, githubUsername });
   }
   return collaborators.length > 0 ? collaborators : undefined;
 }

--- a/specs/mcp/tools/tool-handlers.spec.md
+++ b/specs/mcp/tools/tool-handlers.spec.md
@@ -79,6 +79,7 @@ Implements every `corvid_*` MCP tool handler. Each exported function takes an `M
 | `formatHumanCoAuthoredBy` | `(collaborator: HumanCollaborator)` | `string` | Format a Co-Authored-By git trailer for a human collaborator, using their GitHub noreply email if available |
 | `buildAgentSignature` | `(ctx: McpToolContext, collaborators?)` | `string` | Look up agent from DB and build identity footer with optional human collaborator attribution; returns empty string on failure |
 | `resolveCollaborator` | `(db: Database, platform: ContactPlatform, platformId: string)` | `HumanCollaborator \| null` | Look up a human collaborator from the contacts DB by platform ID, resolving their GitHub username if linked |
+| `resolveRequestedBy` | `(ctx: McpToolContext, requestedBy?: string)` | `HumanCollaborator[] \| undefined` | Resolve a comma-separated `requested_by` string into collaborators; tries GitHub then Discord contact lookup, falls back to treating the name as a GitHub username (numeric-only values get no `githubUsername`) |
 | `HumanCollaborator` | interface | `{ displayName, githubUsername? }` | Represents a human collaborator for attribution in PRs, issues, and commits |
 
 ### Exported Functions


### PR DESCRIPTION
## Summary

- Fixed a bug in `resolveRequestedBy` where numeric-only strings (Discord snowflake IDs like `181969874455756800`) were set as `githubUsername` when not found in the contacts DB, producing invalid `@181969874455756800` mentions in PR bodies
- Exported `resolveRequestedBy` for direct testability
- Added 10 new tests covering `resolveCollaborator` and `resolveRequestedBy`, including the numeric-ID fallback path and contact-DB lookups
- Updated `tool-handlers.spec.md` to document `resolveRequestedBy` in the public API

## Root cause

The fallback in `resolveRequestedBy` unconditionally set `githubUsername: cleaned` for any unresolved name. A Discord snowflake ID passed via `requested_by` that isn't in the contacts DB would become a GitHub `@mention` of a numeric string — an invalid GitHub username.

## Fix

```typescript
// Before:
collaborators.push({ displayName: cleaned, githubUsername: cleaned });

// After:
const githubUsername = /^\d+$/.test(cleaned) ? undefined : cleaned;
collaborators.push({ displayName: cleaned, githubUsername });
```

## Test plan

- [x] `bun test server/__tests__/github-tool-handlers.test.ts` — 95 pass, 0 fail
- [x] `bunx tsc --noEmit --skipLibCheck` — clean
- [x] `bun run spec:check` — all specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)