### PR TITLE
fix(discord): show project name in embed footer

### DIFF
--- a/server/__tests__/discord-embeds-validation.test.ts
+++ b/server/__tests__/discord-embeds-validation.test.ts
@@ -46,7 +46,7 @@ describe('assertInteractionToken', () => {
 });
 
 describe('buildFooterText', () => {
-  test('includes model, session, and status (no agent name or project)', () => {
+  test('includes project, model, session, and status (no agent name)', () => {
     const result = buildFooterText({
       agentName: 'Corvid',
       agentModel: 'claude-opus-4-6',
@@ -54,7 +54,7 @@ describe('buildFooterText', () => {
       sessionId: 'abcdef1234567890',
       status: 'running',
     });
-    expect(result).toBe('opus-4.6 · abcdef12 · running');
+    expect(result).toBe('my-project · opus-4.6 · abcdef12 · running');
   });
 
   test('returns shortened model when no other context', () => {
@@ -62,13 +62,13 @@ describe('buildFooterText', () => {
     expect(result).toBe('opus-4.6');
   });
 
-  test('omits projectName from footer', () => {
+  test('includes projectName in footer', () => {
     const result = buildFooterText({
       agentName: 'Corvid',
       agentModel: 'opus',
       projectName: 'my-project',
     });
-    expect(result).toBe('opus');
+    expect(result).toBe('my-project · opus');
   });
 
   test('includes sessionId without sid: prefix', () => {

--- a/server/__tests__/embed-builder.test.ts
+++ b/server/__tests__/embed-builder.test.ts
@@ -6,14 +6,9 @@
  * blocks, all preset factory methods, and edge cases.
  */
 import { describe, expect, test } from 'bun:test';
-import {
-  CorvidEmbed,
-  EMBED_BUTTONS,
-  EMBED_COLORS,
-  type EmbedAgentIdentity,
-} from '../discord/embed-builder';
-import { ButtonStyle } from '../discord/types';
+import { CorvidEmbed, EMBED_BUTTONS, EMBED_COLORS, type EmbedAgentIdentity } from '../discord/embed-builder';
 import type { FooterContext } from '../discord/embeds';
+import { ButtonStyle } from '../discord/types';
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -148,10 +143,7 @@ describe('CorvidEmbed builder — basic fields', () => {
       { name: 'A', value: '1' },
       { name: 'B', value: '2', inline: true },
     ];
-    const { embed } = new CorvidEmbed()
-      .addField('Old', 'field')
-      .setFields(fields)
-      .build();
+    const { embed } = new CorvidEmbed().addField('Old', 'field').setFields(fields).build();
     expect(embed.fields).toHaveLength(2);
     expect(embed.fields![0].name).toBe('A');
   });
@@ -189,9 +181,7 @@ describe('CorvidEmbed builder — footer', () => {
   });
 
   test('footer excludes agent name (shown in embed author instead)', () => {
-    const { embed } = new CorvidEmbed()
-      .setAgent({ agentName: 'Rook' })
-      .build();
+    const { embed } = new CorvidEmbed().setAgent({ agentName: 'Rook' }).build();
     expect(embed.footer?.text).toBe('');
   });
 
@@ -207,7 +197,7 @@ describe('CorvidEmbed builder — footer', () => {
     expect(footer).toContain('sonnet-4.6');
     expect(footer).toContain('abcdef12');
     expect(footer).not.toContain('Rook');
-    expect(footer).not.toContain('corvid-agent');
+    expect(footer).toContain('corvid-agent');
     expect(footer).toContain('thinking');
   });
 
@@ -228,18 +218,12 @@ describe('CorvidEmbed builder — footer', () => {
   });
 
   test('withTurns adds turn counter to footer', () => {
-    const { embed } = new CorvidEmbed()
-      .setAgent({ agentName: 'Rook' })
-      .withTurns(5)
-      .build();
+    const { embed } = new CorvidEmbed().setAgent({ agentName: 'Rook' }).withTurns(5).build();
     expect(embed.footer!.text).toContain('T:5');
   });
 
   test('withTurns with cumulativeTurns shows T:x(n) format', () => {
-    const { embed } = new CorvidEmbed()
-      .setAgent({ agentName: 'Rook' })
-      .withTurns(5, 23)
-      .build();
+    const { embed } = new CorvidEmbed().setAgent({ agentName: 'Rook' }).withTurns(5, 23).build();
     expect(embed.footer!.text).toContain('T:5(23)');
   });
 
@@ -256,10 +240,7 @@ describe('CorvidEmbed builder — footer', () => {
   });
 
   test('withStats with cumulativeTurns shows cumulative in footer', () => {
-    const { embed } = new CorvidEmbed()
-      .setAgent({ agentName: 'Rook' })
-      .withStats({ turns: 5, tools: 10 }, 23)
-      .build();
+    const { embed } = new CorvidEmbed().setAgent({ agentName: 'Rook' }).withStats({ turns: 5, tools: 10 }, 23).build();
     const footer = embed.footer!.text;
     expect(footer).toContain('5 turns (23 total)');
   });
@@ -288,9 +269,7 @@ describe('CorvidEmbed builder — author', () => {
   });
 
   test('agent without displayIcon does not prepend emoji to name', () => {
-    const { embed } = new CorvidEmbed()
-      .setAgent({ agentName: 'Rook' })
-      .build();
+    const { embed } = new CorvidEmbed().setAgent({ agentName: 'Rook' }).build();
     expect(embed.author?.name).toBe('Rook');
   });
 
@@ -313,17 +292,13 @@ describe('CorvidEmbed builder — author', () => {
 
 describe('CorvidEmbed builder — buttons', () => {
   test('withButtons produces action row components', () => {
-    const { components } = new CorvidEmbed()
-      .withButtons(['new_session', 'archive'])
-      .build();
+    const { components } = new CorvidEmbed().withButtons(['new_session', 'archive']).build();
     expect(components).toHaveLength(1);
     expect(components![0].components).toHaveLength(2);
   });
 
   test('button labels match EMBED_BUTTONS definitions', () => {
-    const { components } = new CorvidEmbed()
-      .withButtons(['new_session', 'create_issue', 'archive'])
-      .build();
+    const { components } = new CorvidEmbed().withButtons(['new_session', 'create_issue', 'archive']).build();
     const labels = components![0].components.map((b) => b.label);
     expect(labels).toContain('New Session');
     expect(labels).toContain('Create Issue');
@@ -331,9 +306,7 @@ describe('CorvidEmbed builder — buttons', () => {
   });
 
   test('button customIds match EMBED_BUTTONS definitions', () => {
-    const { components } = new CorvidEmbed()
-      .withButtons(['resume'])
-      .build();
+    const { components } = new CorvidEmbed().withButtons(['resume']).build();
     expect(components![0].components[0].custom_id).toBe('resume_thread');
   });
 
@@ -360,9 +333,7 @@ describe('CorvidEmbed builder — buttons', () => {
   });
 
   test('button emoji is set on action row component', () => {
-    const { components } = new CorvidEmbed()
-      .withButtons(['archive'])
-      .build();
+    const { components } = new CorvidEmbed().withButtons(['archive']).build();
     expect(components![0].components[0].emoji?.name).toBe('📦');
   });
 });

--- a/server/__tests__/embed-builder.test.ts
+++ b/server/__tests__/embed-builder.test.ts
@@ -185,7 +185,7 @@ describe('CorvidEmbed builder — footer', () => {
     expect(embed.footer?.text).toBe('');
   });
 
-  test('footer includes shortened model, session, and status', () => {
+  test('footer includes project, shortened model, session, and status', () => {
     const { embed } = new CorvidEmbed()
       .setAgent(AUTHOR)
       .setModel('claude-sonnet-4-6')
@@ -194,6 +194,7 @@ describe('CorvidEmbed builder — footer', () => {
       .setStatus('thinking')
       .build();
     const footer = embed.footer!.text;
+    expect(footer).toContain('corvid-agent');
     expect(footer).toContain('sonnet-4.6');
     expect(footer).toContain('abcdef12');
     expect(footer).not.toContain('Rook');

--- a/server/discord/embed-builder.ts
+++ b/server/discord/embed-builder.ts
@@ -346,10 +346,7 @@ export class CorvidEmbed {
    * Used for live tool execution status updates.
    */
   static toolStatus(message: string, ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
-    const b = new CorvidEmbed()
-      .setDescription(`⏳ ${message}`)
-      .setColor(EMBED_COLORS.neutral)
-      .setStatus('working...');
+    const b = new CorvidEmbed().setDescription(`⏳ ${message}`).setColor(EMBED_COLORS.neutral).setStatus('working...');
     return CorvidEmbed.applyContext(b, ctx, author);
   }
 
@@ -369,10 +366,7 @@ export class CorvidEmbed {
    * Used when editing the progress embed after a result arrives.
    */
   static done(ctx: FooterContext, author: EmbedAgentIdentity): CorvidEmbed {
-    const b = new CorvidEmbed()
-      .setDescription('✅ Done')
-      .setColor(EMBED_COLORS.success)
-      .setStatus('done');
+    const b = new CorvidEmbed().setDescription('✅ Done').setColor(EMBED_COLORS.success).setStatus('done');
     return CorvidEmbed.applyContext(b, ctx, author);
   }
 
@@ -407,13 +401,14 @@ export class CorvidEmbed {
    * Maps known error types (context_exhausted, credits_exhausted, timeout, crash,
    * spawn_error) to user-facing titles, descriptions, and colors.
    */
-  static error(errorType: string, ctx: FooterContext, author: EmbedAgentIdentity, fallbackMessage?: string): CorvidEmbed {
+  static error(
+    errorType: string,
+    ctx: FooterContext,
+    author: EmbedAgentIdentity,
+    fallbackMessage?: string,
+  ): CorvidEmbed {
     const { title, description, color } = sessionErrorEmbed(errorType, fallbackMessage);
-    const b = new CorvidEmbed()
-      .setTitle(title)
-      .setDescription(description)
-      .setColor(color)
-      .setStatus(errorType);
+    const b = new CorvidEmbed().setTitle(title).setDescription(description).setColor(color).setStatus(errorType);
     return CorvidEmbed.applyContext(b, ctx, author);
   }
 

--- a/server/discord/embeds.ts
+++ b/server/discord/embeds.ts
@@ -757,5 +757,4 @@ export {
   type EmbedAgentIdentity,
   type EmbedButtonKey,
 } from './embed-builder';
-/** Re-export splitEmbedDescription and collapseCodeBlocks for use by other modules. */
 export { collapseCodeBlocks, splitEmbedDescription } from './message-formatter';

--- a/server/discord/embeds.ts
+++ b/server/discord/embeds.ts
@@ -204,8 +204,8 @@ function shortenModelName(model: string): string {
 
 /**
  * Build a compact footer string with session context.
- * Format: `opus-4.6 · XXXXXXXX · status | T:5(23) | 🟢 32% (64k/200k)`
- * Agent name is in the embed author; project name is in the thread title — both omitted.
+ * Format: `corvid-agent · opus-4.6 · XXXXXXXX · status | T:5(23) | 🟢 32% (64k/200k)`
+ * Agent name is in the embed author; project name is included first when present.
  * When cumulativeTurns equals active turns, shows just `T:5`.
  * Segments are omitted when their value is not provided.
  */
@@ -216,6 +216,9 @@ export function buildFooterText(
   cumulativeTurns?: number,
 ): string {
   const parts: string[] = [];
+  if (ctx.projectName) {
+    parts.push(ctx.projectName);
+  }
   if (ctx.sessionType) {
     parts.push(ctx.sessionType);
   }
@@ -747,7 +750,12 @@ export async function sendMessageWithFiles(
   }
 }
 
+export {
+  CorvidEmbed,
+  EMBED_BUTTONS,
+  EMBED_COLORS,
+  type EmbedAgentIdentity,
+  type EmbedButtonKey,
+} from './embed-builder';
 /** Re-export splitEmbedDescription and collapseCodeBlocks for use by other modules. */
 export { collapseCodeBlocks, splitEmbedDescription } from './message-formatter';
-
-export { CorvidEmbed, EMBED_BUTTONS, EMBED_COLORS, type EmbedAgentIdentity, type EmbedButtonKey } from './embed-builder';

--- a/server/discord/thread-response/adaptive-response.ts
+++ b/server/discord/thread-response/adaptive-response.ts
@@ -5,8 +5,8 @@ import type { ProcessManager } from '../../process/manager';
 import { extractContentImageUrls, extractContentText } from '../../process/types';
 import {
   agentColor,
-  CorvidEmbed,
   type ContextUsage,
+  CorvidEmbed,
   collapseCodeBlocks,
   type DiscordFileAttachment,
   type EmbedAgentIdentity,
@@ -94,9 +94,7 @@ export function subscribeForAdaptiveInlineResponse(
     log.warn('Typing indicator safety timeout reached (adaptive)', { sessionId, channelId });
     if (!receivedAnyActivity) {
       const { embed: timeoutEmbed } = new CorvidEmbed()
-        .setDescription(
-          'The agent appears to be taking too long. It may still be working — send a message to check.',
-        )
+        .setDescription('The agent appears to be taking too long. It may still be working — send a message to check.')
         .setColor(0xf0b232)
         .build();
       sendEmbed(delivery, botToken, channelId, timeoutEmbed).catch((err) => {
@@ -282,7 +280,9 @@ export function subscribeForAdaptiveInlineResponse(
           // out of the channel and into a dedicated thread (reduces channel spam).
           const expiresAtUnix = Math.floor(Date.now() / 1000) + 5 * 60;
           const continueBuilder = new CorvidEmbed()
-            .setDescription(`Reply to continue here, or start a thread for a longer conversation. Expires <t:${expiresAtUnix}:R>.`)
+            .setDescription(
+              `Reply to continue here, or start a thread for a longer conversation. Expires <t:${expiresAtUnix}:R>.`,
+            )
             .setColor(0x95a5a6)
             .setAgent(authorIdentity)
             .setModel(agentModel)

--- a/server/discord/thread-response/inline-response.ts
+++ b/server/discord/thread-response/inline-response.ts
@@ -5,8 +5,8 @@ import type { ProcessManager } from '../../process/manager';
 import { extractContentText } from '../../process/types';
 import {
   agentColor,
-  CorvidEmbed,
   type ContextUsage,
+  CorvidEmbed,
   collapseCodeBlocks,
   type EmbedAgentIdentity,
   type FooterContext,

--- a/server/discord/work-dispatch.ts
+++ b/server/discord/work-dispatch.ts
@@ -159,9 +159,7 @@ export async function sendTaskResult(
       }>),
       { name: 'Iterations', value: String(task.iterationCount), inline: true },
     ];
-    const { embed: failedEmbed } = CorvidEmbed.workTaskFailed(task.id, task.description)
-      .setFields(errorFields)
-      .build();
+    const { embed: failedEmbed } = CorvidEmbed.workTaskFailed(task.id, task.description).setFields(errorFields).build();
     await sendMessageWithEmbed(
       ctx.delivery,
       ctx.config.botToken,


### PR DESCRIPTION
## Summary

- `buildFooterText()` had `projectName` in `FooterContext` but never used it — the comment said it was "in the thread title"
- Added project name as the first `·`-separated segment in the embed footer
- Footer now reads: `corvid-agent · sonnet-4.6 · XXXXXXXX · status | T:5 | 🟢 32%`

## Test Plan

- [x] Send a `/message` in Discord with a project selected — confirm project name appears in embed footer
- [x] Send without a project — confirm footer renders correctly (segment omitted gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)