### PR TITLE
fix(work): detect all uncommitted changes and verify commits before PR fallback

### DIFF
--- a/server/work/session-lifecycle.ts
+++ b/server/work/session-lifecycle.ts
@@ -229,11 +229,13 @@ export async function createPrFallback(db: Database, taskId: string, sessionOutp
       return null;
     }
 
-    // Ensure all changes are committed (agent may have left unstaged changes)
-    const statusProc = Bun.spawn(['git', 'diff', '--quiet'], { cwd, stdout: 'pipe', stderr: 'pipe' });
+    // Ensure all changes are committed (agent may have left unstaged/untracked changes)
+    // Use `git status --porcelain` which detects ALL pending changes:
+    // untracked files, staged changes, and unstaged modifications.
+    const statusProc = Bun.spawn(['git', 'status', '--porcelain'], { cwd, stdout: 'pipe', stderr: 'pipe' });
+    const statusOutput = await new Response(statusProc.stdout).text();
     await statusProc.exited;
-    if ((await statusProc.exited) !== 0) {
-      // There are uncommitted changes — commit them
+    if (statusOutput.trim().length > 0) {
       const addProc = Bun.spawn(['git', 'add', '-A'], { cwd, stdout: 'pipe', stderr: 'pipe' });
       await addProc.exited;
       const trailers = [coAuthor];
@@ -244,6 +246,19 @@ export async function createPrFallback(db: Database, taskId: string, sessionOutp
         : `Work task: ${task.description.slice(0, 60)}`;
       const commitProc = Bun.spawn(['git', 'commit', '-m', commitMsg], { cwd, stdout: 'pipe', stderr: 'pipe' });
       await commitProc.exited;
+    }
+
+    // Verify the branch has commits to push (avoid empty PRs)
+    const logProc = Bun.spawn(['git', 'log', '--oneline', 'HEAD', '--not', '--remotes=origin'], {
+      cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const logOutput = await new Response(logProc.stdout).text();
+    await logProc.exited;
+    if (logOutput.trim().length === 0) {
+      log.warn('Fallback: branch has no commits ahead of remote — nothing to push', { taskId });
+      return null;
     }
 
     // Push the branch

--- a/specs/work/session-lifecycle.spec.md
+++ b/specs/work/session-lifecycle.spec.md
@@ -77,7 +77,7 @@ Handles the post-session lifecycle for work tasks: validates output, iterates on
 - **Given** a completed session with no PR URL in the output
 - **When** `createPrFallback` is called
 - **Then** it ensures an `origin` remote exists (adding one from the project's `gitUrl` if missing)
-- **And** commits any unstaged changes, pushes the branch, and runs `gh pr create`
+- **And** commits any uncommitted changes (untracked, staged, or modified), pushes the branch, and runs `gh pr create`
 - **And** returns the PR URL on success or `null` on failure
 
 ### Scenario: Fallback PR creation with missing origin remote
@@ -96,6 +96,7 @@ Handles the post-session lifecycle for work tasks: validates output, iterates on
 | PR URL not in output and fallback fails | Task marked `failed` with descriptive error |
 | `createPrFallback` with no branch or worktree | Returns `null` immediately |
 | No origin remote and no project `gitUrl` | Logs warning, returns `null` |
+| Branch has no commits ahead of remote | Logs warning, returns `null` (avoids empty PRs) |
 | Git push fails during fallback | Logs warning, returns `null` |
 | `gh pr create` fails during fallback | Logs warning, returns `null` |
 
@@ -124,6 +125,7 @@ Handles the post-session lifecycle for work tasks: validates output, iterates on
 
 | Date | Author | Change |
 |------|--------|--------|
+| 2026-05-05 | corvid-agent | Fix fallback PR creation: use `git status --porcelain` (not `git diff --quiet`) to detect all uncommitted changes; add commits-ahead check before push (#2282) |
 | 2026-05-01 | corvid-agent | Mark tasks `escalation_needed` at iteration cap instead of `failed`; notify with actionable instructions (#2209) |
 | 2026-04-28 | corvid-agent | Add `notifyOwner` to `SessionLifecycleContext`; notify on iteration-cap failure (#2165) |
 | 2026-03-23 | corvid-agent | Initial spec — extracted from work-task-service.spec.md |


### PR DESCRIPTION
## Summary

- Replace `git diff --quiet` with `git status --porcelain` in `createPrFallback` to detect **all** types of uncommitted changes (untracked files, staged changes, modifications) — not just unstaged modifications to tracked files
- Add a commits-ahead check before pushing: if the branch has no commits beyond what origin already has, return `null` early with a clear warning instead of pushing an empty branch and having `gh pr create` fail cryptically

## Root Cause

`git diff --quiet` only checks the working tree against the index for tracked files. When an agent creates new files without staging them, or stages changes without committing, `git diff --quiet` exits 0 (no diff) and the fallback skips the commit step. The subsequent push succeeds but `gh pr create` fails because the branch is identical to main.

## Test plan

- [x] TypeScript type check passes
- [x] Biome lint passes (0 issues)
- [x] All 33 work task tests pass (lifecycle, PR, ensure-origin)
- [x] Spec validation passes (217/217 specs)

Fixes #2282