### PR TITLE
spec(bridge): add module spec for bridge endpoint

### DIFF
--- a/specs/bridge/bridge.spec.md
+++ b/specs/bridge/bridge.spec.md
@@ -1,0 +1,207 @@
+---
+module: bridge
+version: 1
+status: stable
+files:
+  - shared/bridge-protocol.ts
+  - server/bridge/types.ts
+  - server/bridge/service.ts
+  - server/bridge/service.test.ts
+  - server/mcp/tool-handlers/bridge.ts
+  - server/routes/bridge.ts
+db_tables: []
+depends_on:
+  - server/lib/logger.ts
+  - server/middleware/guards.ts
+  - server/mcp/sdk-tools.ts
+---
+
+# Bridge
+
+## Purpose
+
+Provides a secure WebSocket tunnel so developers can connect their local machines to a running corvid-agent instance. An agent can then perform file reads, file writes, directory listings, and command execution on the developer's machine without opening inbound ports — the connection is always outbound from the developer's machine.
+
+The bridge is intended for the `fledge-plugin-bridge` Kotlin plugin but can be used by any client that implements the protocol.
+
+## Public API
+
+### Exported Types
+
+#### `shared/bridge-protocol.ts`
+
+| Type | Description |
+|------|-------------|
+| `BridgeAuthMessage` | First message from client: `{ type, token, projectId, capabilities, label? }` |
+| `BridgeCapabilities` | `{ read: boolean, write: boolean, exec: boolean }` — operation permission flags |
+| `BridgeRequest` | Agent-to-client request: `{ id, type, path?, content?, command?, cwd? }` |
+| `BridgeResponse` | Client-to-server reply: `{ id, type, success, data?, error? }` |
+| `BridgeSessionInfo` | Serializable session view for HTTP/MCP endpoints |
+
+#### `server/bridge/types.ts`
+
+| Type | Description |
+|------|-------------|
+| `BridgeSession` | Internal session: includes WebSocket ref, pending request map, timestamps |
+| `BridgeWsData` | WebSocket connection metadata: `{ type: 'bridge', sessionId, authenticated, authTimeoutTimer? }` |
+
+### Exported Classes
+
+| Class | Description |
+|-------|-------------|
+| `BridgeService` | Core session registry and request router (see methods below) |
+
+### Exported Functions
+
+| Function | Module | Parameters | Returns | Description |
+|----------|--------|-----------|---------|-------------|
+| `handleDevBridgeRoutes` | `server/routes/bridge.ts` | `(req, url, db, ctx, bridgeService)` | `Response \| null` | HTTP route handler for `/api/bridge/sessions` endpoints |
+| `handleBridgeListSessions` | `server/mcp/tool-handlers/bridge.ts` | `(ctx, args)` | `Promise<ToolResult>` | MCP handler for `corvid_bridge_sessions` |
+| `handleBridgeRequest` | `server/mcp/tool-handlers/bridge.ts` | `(ctx, args)` | `Promise<ToolResult>` | MCP handler for `corvid_bridge_request` |
+
+### Exported Constants
+
+| Constant | Module | Value | Description |
+|----------|--------|-------|-------------|
+| `MAX_PATH_LENGTH` | `server/bridge/service.ts` | 4096 | Max characters in a path argument |
+| `MAX_CONTENT_LENGTH` | `server/bridge/service.ts` | 10 485 760 | Max bytes in file write content |
+| `MAX_COMMAND_LENGTH` | `server/bridge/service.ts` | 8192 | Max characters in an exec command |
+| `RATE_LIMIT_WINDOW_MS` | `server/bridge/service.ts` | 60 000 | Rate limit window (ms) |
+| `RATE_LIMIT_MAX_REQUESTS` | `server/bridge/service.ts` | 120 | Max requests per session per window |
+| `IDLE_SESSION_TIMEOUT_MS` | `server/bridge/service.ts` | 1 800 000 | Idle session reap threshold (ms) |
+| `IDLE_REAP_INTERVAL_MS` | `server/bridge/service.ts` | 60 000 | How often idle sessions are checked (ms) |
+
+### BridgeService Methods
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `listSessions` | `()` | `BridgeSessionInfo[]` | Returns all active sessions (serializable) |
+| `getSession` | `(sessionId: string)` | `BridgeSession \| undefined` | Internal session lookup |
+| `registerSession` | `(sessionId, label, projectId, caps, ws)` | `void` | Called on successful auth handshake |
+| `removeSession` | `(sessionId: string)` | `void` | Removes session and rejects all pending requests |
+| `sendRequest` | `(sessionId, request, timeoutMs?)` | `Promise<BridgeResponse>` | Validates and forwards request to client |
+| `handleResponse` | `(sessionId, response)` | `void` | Resolves pending promise when client replies |
+| `intersectCapabilities` | `(clientCaps: BridgeCapabilities)` | `BridgeCapabilities` | Caps client requests to server-configured maximums |
+| `dispose` | `()` | `void` | Clears timers and removes all sessions |
+
+### HTTP Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/bridge/sessions` | List all active bridge sessions |
+| `GET` | `/api/bridge/sessions/:id` | Get a single session by ID (404 if not found) |
+
+### WebSocket Endpoint
+
+| Path | Description |
+|------|-------------|
+| `/api/bridge/ws` | Bridge client connection point; requires auth handshake as first message |
+
+### MCP Tools (registered when `bridgeService` is available)
+
+| Tool | Description |
+|------|-------------|
+| `corvid_bridge_sessions` | List active bridge sessions |
+| `corvid_bridge_request` | Send a request through a named bridge session |
+
+## Invariants
+
+1. The first message on any bridge WebSocket connection MUST be a valid `auth` message. Non-auth first messages cause immediate close with code 1008.
+2. Client capabilities are always intersected with server-configured maximums (`BRIDGE_ALLOW_*` env vars). A client can never gain more capability than the server allows.
+3. Every `BridgeRequest` sent to a client MUST have a matching pending `Promise` entry. Responses that reference unknown IDs are silently dropped.
+4. A pending request that receives no response within `timeoutMs` (default 30 000 ms) is rejected with a timeout error and removed from the pending map.
+5. Sessions idle for longer than `IDLE_SESSION_TIMEOUT_MS` (30 min) are reaped: the WebSocket is closed with code 4003 and the session is removed.
+6. Path arguments MUST NOT contain `..` after POSIX normalization (path traversal prevention).
+7. Path and `cwd` arguments MUST NOT contain null bytes.
+8. `exec` command arguments MUST NOT contain shell metacharacters (`;`, `|`, `&`, `` ` ``, `$()`, `{}`, `[]`, `<>`, `!`, newlines, backslash).
+9. `exec` command arguments MUST NOT match the `DANGEROUS_COMMANDS` pattern (e.g., `rm -rf`, `mkfs`, `shutdown`).
+10. Each session is independently rate-limited: max `RATE_LIMIT_MAX_REQUESTS` (120) requests per `RATE_LIMIT_WINDOW_MS` (60 s).
+11. `read` capability is enabled by default; `write` and `exec` are opt-in via `BRIDGE_ALLOW_WRITE=true` / `BRIDGE_ALLOW_EXEC=true`.
+
+## Behavioral Examples
+
+### Scenario: Successful auth and file read
+
+- **Given** a developer connects to `/api/bridge/ws` and sends `{ type: "auth", token: "<api-key>", projectId: "proj-1", capabilities: { read: true, write: false, exec: false }, label: "My MacBook" }`
+- **When** the server validates the token
+- **Then** the server replies `{ type: "auth_ok", sessionId: "<uuid>" }`, registers the session, and the session appears in `GET /api/bridge/sessions`
+
+### Scenario: Agent reads a remote file
+
+- **Given** a session `sess-abc` with `read: true` is registered
+- **When** an agent calls `corvid_bridge_request` with `session_id: "sess-abc"`, `request_type: "file.read"`, `path: "/home/dev/project/src/index.ts"`
+- **Then** the server sends a `BridgeRequest` JSON frame to the client WebSocket; the client processes it and replies with `{ id: "...", type: "file.read", success: true, data: "<file contents>" }`; the agent receives the file contents as text
+
+### Scenario: Auth failure — wrong token
+
+- **Given** the server has an API key configured
+- **When** a client sends `{ type: "auth", token: "wrong-key", ... }`
+- **Then** the server sends `{ error: "Invalid token" }` and closes the connection with code 4001
+
+### Scenario: Path traversal blocked
+
+- **Given** a bridge session with `read: true`
+- **When** an agent sends a `file.read` request with `path: "../../etc/passwd"`
+- **Then** `sendRequest()` rejects with `"Path traversal detected"` before sending anything to the client
+
+### Scenario: Idle session reaped
+
+- **Given** a session has been idle for more than 30 minutes
+- **When** the reap interval fires (every 60 s)
+- **Then** the session WebSocket is closed with code 4003 ("Idle timeout") and the session is removed
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Non-auth first message | Send `{ error: "First message must be auth" }`, close code 1008 |
+| Wrong API token | Send `{ error: "Invalid token" }`, close code 4001 |
+| Auth timeout (no first message within ~10 s) | Close code 4001, "Authentication timeout" |
+| Session not found for `sendRequest` | Reject with `"Bridge session not found"` |
+| Missing capability for request type | Reject with `"Missing capability: '<cap>' is required for <type>"` |
+| Path traversal in `path` or `cwd` | Reject with `"Path traversal detected"` |
+| Null byte in path | Reject with `"Path contains null bytes"` |
+| Shell metacharacter in command | Reject with `"Command contains disallowed shell metacharacters"` |
+| Dangerous command pattern | Reject with `"Command matches blocked pattern"` |
+| Path exceeds MAX_PATH_LENGTH (4096) | Reject with `"Path exceeds maximum length of 4096 characters"` |
+| Content exceeds MAX_CONTENT_LENGTH (10 MB) | Reject with `"Content exceeds maximum size of..."` |
+| Command exceeds MAX_COMMAND_LENGTH (8192) | Reject with `"Command exceeds maximum length of 8192 characters"` |
+| Rate limit exceeded (120 req/60 s) | Reject with `"Rate limit exceeded"` |
+| Request timeout | Reject with `"Request timeout after <N>ms"` |
+| Bridge service unavailable (HTTP/MCP) | 503 response / `errorResult('Bridge service not available')` |
+| Bridge session not found (HTTP) | 404 `{ error: "Session not found" }` |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| `server/lib/logger.ts` | `createLogger('BridgeService')` |
+| `server/middleware/guards.ts` | `timingSafeEqual` for token comparison |
+| `server/mcp/sdk-tools.ts` | Tool registration hook |
+| `server/lib/response.ts` | `json()` helper in HTTP routes |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| `server/index.ts` | Instantiates `BridgeService`, wires WebSocket upgrade for `/api/bridge/ws`, passes to WS handler and route handler |
+| `server/ws/handler.ts` | Calls `handleBridgeMessage`, `removeSession` on close |
+| `server/routes/bridge.ts` | `listSessions()`, `getSession()` |
+| `server/mcp/tool-handlers/bridge.ts` | `listSessions()`, `sendRequest()` |
+| `server/process/mcp-service-container.ts` | Provides `bridgeService` to MCP tool context |
+
+## Configuration
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `BRIDGE_ALLOW_READ` | `true` | Allow file read and list operations. Set to `'false'` to disable. |
+| `BRIDGE_ALLOW_WRITE` | `false` | Allow file write operations. Set to `'true'` to enable. |
+| `BRIDGE_ALLOW_EXEC` | `false` | Allow command execution. Set to `'true'` to enable. |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-06 | Jackdaw | Initial spec — documents bridge module added in PR #2287 |

--- a/specs/bridge/context.md
+++ b/specs/bridge/context.md
@@ -1,0 +1,27 @@
+# Bridge — Context
+
+## Why this module exists
+
+Agents run inside a server process with no direct access to a developer's local filesystem or shell. The bridge module solves this by allowing a developer to run the `fledge-plugin-bridge` Kotlin plugin locally, which connects outbound to corvid-agent. Once connected, agents can read files, write files, list directories, and execute commands on the developer's machine — all without the developer needing to open any inbound ports.
+
+## Design decisions
+
+**Outbound-only connection**: The developer's machine always initiates the connection, making the bridge work behind NAT and firewalls.
+
+**Capability intersection**: The server defines maximum allowed capabilities via env vars (`BRIDGE_ALLOW_*`). Clients can request a subset but cannot exceed the server ceiling. This means `BRIDGE_ALLOW_EXEC=false` is an absolute safety net regardless of what the client requests.
+
+**Read enabled by default**: File reads are the most common and least dangerous operation. Setting `BRIDGE_ALLOW_READ=false` allows fully restricting even reads.
+
+**Reject-on-validation**: All path traversal, null byte, shell metacharacter, and dangerous-command checks happen on the server before any message is sent to the client. The client is never asked to enforce safety.
+
+**Rate limiting is per-session**: Independent sessions are independently limited (120 req/60 s each), so one misbehaving agent cannot starve others.
+
+**Idle reaping**: Sessions idle for 30+ minutes are closed automatically to prevent resource leaks from abandoned connections.
+
+## Security model
+
+The bridge is guarded by the same API key used for HTTP/WS auth. Token comparison uses `timingSafeEqual` to prevent timing attacks. Authentication must complete within a short timeout window (configurable in `handler.ts`) to prevent half-open connections from consuming resources.
+
+## Relationship to `fledge-plugin-bridge`
+
+The Kotlin plugin (`CorvidLabs/fledge-plugin-bridge`) implements the client side of this protocol. The plugin reads/writes/executes locally and relays results back. This spec defines the server contract the plugin must satisfy.

--- a/specs/bridge/requirements.md
+++ b/specs/bridge/requirements.md
@@ -1,0 +1,52 @@
+---
+spec: bridge.spec.md
+---
+
+## Product Requirements
+
+- Developers can connect their local machine to a running corvid-agent instance over a secure WebSocket, enabling agents to perform file and command operations on the developer's machine without opening inbound ports.
+- The bridge connection is always outbound from the developer's machine, making it work transparently behind NAT, firewalls, and corporate proxies.
+- Capabilities are negotiated per-session and capped by server configuration, so operators can enable or disable read, write, and exec access independently.
+- Agents can list all active bridge sessions and route requests to specific sessions by ID using MCP tools.
+
+## User Stories
+
+- As a developer, I want to connect my local machine to corvid-agent via `fledge-plugin-bridge` so that agents can read and modify files in my local workspace
+- As an agent, I want to call `corvid_bridge_sessions` to see which developer machines are connected so I can route file requests to the correct session
+- As an agent, I want to call `corvid_bridge_request` with a `file.read` request so I can read a file from a connected developer's machine
+- As an operator, I want to set `BRIDGE_ALLOW_EXEC=false` so that bridge sessions are restricted to file operations only, preventing agents from running arbitrary commands on developer machines
+- As a platform administrator, I want idle sessions automatically reaped after 30 minutes so that abandoned connections don't consume server resources
+
+## Acceptance Criteria
+
+- A client that connects to `/api/bridge/ws` and sends a valid `auth` message receives `{ type: "auth_ok", sessionId: "..." }` and appears in `GET /api/bridge/sessions`
+- A client with the wrong token receives `{ error: "Invalid token" }` and is disconnected with close code 4001
+- A client that does not send an auth message within the auth timeout window is disconnected with close code 4001
+- `BridgeService.sendRequest()` resolves with the `BridgeResponse` when the client replies within the timeout
+- `BridgeService.sendRequest()` rejects with a timeout error when no response arrives within `timeoutMs`
+- Path arguments containing `..` (after POSIX normalization) are rejected before the request reaches the client
+- Path arguments containing null bytes are rejected before the request reaches the client
+- `exec` commands containing shell metacharacters are rejected before the request reaches the client
+- `exec` commands matching the `DANGEROUS_COMMANDS` pattern are rejected before the request reaches the client
+- Capability mismatches (e.g., `file.write` on a read-only session) are rejected before the request reaches the client
+- Rate limiting enforces a maximum of 120 requests per session per 60-second window
+- Sessions idle for more than 30 minutes are closed with code 4003 and removed
+- `BRIDGE_ALLOW_READ=false` prevents all `file.read` and `file.list` operations regardless of client-requested capabilities
+- `BRIDGE_ALLOW_WRITE=true` enables `file.write` operations; default is disabled
+- `BRIDGE_ALLOW_EXEC=true` enables `exec` operations; default is disabled
+
+## Constraints
+
+- The bridge WebSocket endpoint (`/api/bridge/ws`) requires the same API key used for all other corvid-agent auth
+- Bridge session IDs are server-generated UUIDs — the client cannot choose its own session ID
+- Content payloads for file writes are capped at 10 MB; paths at 4096 characters; commands at 8192 characters
+- The bridge has no persistent storage — sessions are in-memory only and lost on server restart
+- `exec` commands are passed as argument arrays or simple strings; shell interpretation (pipes, redirects, chaining) is explicitly blocked
+
+## Out of Scope
+
+- Implementing the client-side bridge (that is handled by `fledge-plugin-bridge`)
+- File streaming for large binary files
+- Bidirectional streaming or real-time log tailing
+- Bridge session persistence across server restarts
+- Project-level scoping of bridge sessions (currently any authenticated agent can use any bridge session)

--- a/specs/bridge/tasks.md
+++ b/specs/bridge/tasks.md
@@ -1,0 +1,14 @@
+# Bridge — Tasks
+
+## Completed
+
+- [x] Initial implementation — BridgeService, HTTP routes, WebSocket upgrade, MCP tools (PR #2287)
+- [x] Module spec written (this spec)
+
+## Potential future work
+
+- [ ] Bridge session disconnect endpoint (`DELETE /api/bridge/sessions/:id`) for manual eviction
+- [ ] Dashboard UI panel showing active bridge sessions
+- [ ] Project-scoped session isolation (agents can only use sessions matching their project)
+- [ ] Configurable auth timeout (currently hardcoded in `handler.ts`)
+- [ ] Structured exec output (stdout/stderr/exit-code as separate fields rather than concatenated string)


### PR DESCRIPTION
## Summary

- Adds `specs/bridge/bridge.spec.md` — full module spec for the bridge endpoint added in PR #2287
- Adds `specs/bridge/requirements.md` — product requirements, user stories, acceptance criteria, and constraints
- Adds `specs/bridge/context.md` — design rationale and security model notes
- Adds `specs/bridge/tasks.md` — completed work log and future improvement ideas

## Coverage

- **18/18 exports documented** across `shared/bridge-protocol.ts`, `server/bridge/types.ts`, `server/bridge/service.ts`, `server/routes/bridge.ts`, and `server/mcp/tool-handlers/bridge.ts`
- All spec invariants, error cases, behavioral examples, configuration, and dependency relationships documented
- 219/219 specs pass, 0 warnings, 100% file and LOC coverage

## Test plan

- [x] `bun run spec:check -- --force` — 219 specs: 219 passed, 0 warnings, 0 failed
- [x] File and LOC coverage: 589/589 (100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)