### PR TITLE
fix(discord): track MCP-sent message IDs for session routing (#2298)

### DIFF
--- a/docs/blog.html
+++ b/docs/blog.html
@@ -800,6 +800,87 @@
   <main id="main-content" class="container">
     <div class="posts-grid" id="posts-container">
 
+      <!-- Post: v0.66 — Keep-Alive Sessions, Bridge Endpoint, and Workflow Automation -->
+      <article class="post post--full" id="v066-keep-alive"
+               data-tags="release,engineering" data-date="2026-05-06"
+               data-search="v0.66 keep-alive warm turn bridge endpoint fledge plugins conventional commits auto-label PR template formatIssueBody mention reliability Discord Telegram AlgoChat CVE security session lifecycle state machine TTL context">
+        <div class="post-meta">
+          <time datetime="2026-05-06">2026-05-06</time>
+          <span class="post-tag tag-release">RELEASE</span>
+          <span class="post-tag tag-engineering">ENGINEERING</span>
+        </div>
+        <h2><a href="#v066-keep-alive">v0.66 &mdash; Keep-Alive Sessions, Bridge Endpoint, and Workflow Automation</a></h2>
+
+        <p><strong>TL;DR:</strong> 42 commits, 20 features, 27 fixes. Sessions no longer die between messages &mdash; keep-alive landed across all three bridges. A new server-side bridge endpoint enables cross-service communication. GitHub workflow got automated: conventional commits, auto-labeled PRs, and structured issue templates. Fledge plugins are now native agent tools. Discord @mentions got a reliability overhaul.</p>
+
+        <h3>Keep-Alive Sessions: The End of &ldquo;Who Are You Again?&rdquo;</h3>
+        <p>This was the headline feature &mdash; 11 commits across three phases. Previously, every time a message arrived after a session timed out, the agent started cold: no context, no memory of the conversation, full initialization overhead. Keep-alive changes that fundamentally.</p>
+        <ul>
+          <li><strong>Phase 1:</strong> Spec-first design of the keep-alive lifecycle, documenting the state machine before writing a line of implementation.</li>
+          <li><strong>Phase 2:</strong> The state machine itself &mdash; sessions transition between <code>active</code>, <code>waiting</code>, and <code>warm</code> states instead of dying on idle. A waiting session holds its process and context window open, ready for the next message without cold-start overhead.</li>
+          <li><strong>Phase 3:</strong> Per-session flags, coexistence with non-keep-alive sessions, and dashboard badges showing warm status. You can see which sessions are alive at a glance.</li>
+        </ul>
+        <p>Then we wired it into every bridge:</p>
+        <ul>
+          <li><strong>Discord:</strong> Keep-alive enabled by default. Active duration tracking and TTL countdown visible in embed footers. Sessions survive between messages.</li>
+          <li><strong>Telegram:</strong> Warm-turn support added, same lifecycle as Discord.</li>
+          <li><strong>AlgoChat:</strong> On-chain messaging sessions now persist across turns, so agent-to-agent conversations maintain context without re-initialization.</li>
+        </ul>
+        <p>The fixes that followed tell the real story: persistent message queues to prevent stdin close, context token updates after warm turns, proper keepAlive param wiring on initial start. Session lifecycle management has more edge cases than you&rsquo;d expect &mdash; each one was a dropped message or a zombie process in production.</p>
+
+        <h3>Bridge Endpoint</h3>
+        <p>A new server-side <strong>bridge endpoint</strong> enables cross-service communication with multi-session support. This is the plumbing for connecting external systems to agent sessions &mdash; a single API surface that routes messages to the right session regardless of which bridge originated them. Full module spec written and validated.</p>
+
+        <h3>GitHub Workflow Automation</h3>
+        <p>Four features that tighten up how the team ships code:</p>
+        <ul>
+          <li><strong>Conventional commits enforced</strong> &mdash; all agents now follow the <code>type(scope): message</code> format. No more guessing what a commit does from a cryptic one-liner.</li>
+          <li><strong>Auto-labeled PRs</strong> &mdash; PRs get tagged by type (<code>feat</code>, <code>fix</code>, <code>docs</code>) and by which agent authored them. Filtering the PR list by agent or change type is now trivial.</li>
+          <li><strong><code>formatIssueBody()</code> helper</strong> &mdash; automatically detects whether an issue is a bug report or feature request from the title and applies the right template. 80 lines of logic, 182 lines of tests.</li>
+          <li><strong>Standardized PR body template</strong> &mdash; every PR now gets a consistent structure with summary, changes, and test plan sections.</li>
+          <li><strong>Human collaborator attribution</strong> &mdash; when a human initiates work that an agent executes, the human gets credited on PRs, issues, and commits.</li>
+        </ul>
+
+        <h3>Discord @Mention Reliability</h3>
+        <p>Discord mentions got a focused overhaul. The old behavior was fragile &mdash; mentions would sometimes hijack existing sessions or lose context. Now:</p>
+        <ul>
+          <li>Each @mention creates a <strong>new isolated session</strong> with a 5-minute TTL</li>
+          <li>Embed footers show <strong>&ldquo;mention &middot; 5m&rdquo;</strong> labels with dynamic countdown timestamps</li>
+          <li>Channel context is <strong>stripped from new mention sessions</strong> to prevent context bleed</li>
+          <li>Project name now appears in embed footers for multi-project setups</li>
+        </ul>
+
+        <h3>Fledge Plugins Go Native</h3>
+        <p>Fledge plugins are now <strong>integrated directly into agent operations</strong>. Agents can discover and invoke fledge plugins through MCP, treating them as first-class tools alongside built-in capabilities. The &ldquo;Fledge First&rdquo; rule was codified in CLAUDE.md &mdash; agents should always reach for fledge before falling back to raw commands.</p>
+        <p>51 plugins currently installed, spanning official tooling (metrics, coverage, gitleaks, standup) and community contributions (codegolf, maze, quiz). The plugin ecosystem is growing faster than the core CLI.</p>
+
+        <h3>Platform Plumbing</h3>
+        <ul>
+          <li><strong>Context reconstruction made cold-start-only</strong> &mdash; warm turns skip the expensive context rebuild, cutting response latency on keep-alive sessions.</li>
+          <li><strong>Prior-context verification rule</strong> &mdash; agents now check for existing work from past sessions before starting, preventing duplicate effort across conversations.</li>
+          <li><strong>Work task commit validation</strong> &mdash; detects all uncommitted changes and verifies commits exist before attempting PR fallback. No more phantom PRs.</li>
+          <li><strong>Block explorer type safety</strong> &mdash; removed <code>any</code> casts on indexer query builders.</li>
+          <li><strong>Security:</strong> Resolved GHSA-v2v4-37r5-5v8g (ip-address XSS vulnerability).</li>
+          <li><strong>Dependency bumps:</strong> Zod 4.4.3, Anthropic SDK 0.93.0.</li>
+        </ul>
+
+        <h3>By the Numbers</h3>
+        <table style="width:100%; border-collapse:collapse; margin:1em 0;">
+          <tr style="border-bottom:1px solid var(--border);"><td style="padding:8px 12px; color:var(--text-dim);">Commits (v0.65&rarr;v0.66)</td><td style="padding:8px 12px; font-weight:700;">42</td></tr>
+          <tr style="border-bottom:1px solid var(--border);"><td style="padding:8px 12px; color:var(--text-dim);">Features shipped</td><td style="padding:8px 12px; font-weight:700;">20</td></tr>
+          <tr style="border-bottom:1px solid var(--border);"><td style="padding:8px 12px; color:var(--text-dim);">Bugs fixed</td><td style="padding:8px 12px; font-weight:700;">27</td></tr>
+          <tr style="border-bottom:1px solid var(--border);"><td style="padding:8px 12px; color:var(--text-dim);">Fledge plugins</td><td style="padding:8px 12px; font-weight:700;">51</td></tr>
+          <tr style="border-bottom:1px solid var(--border);"><td style="padding:8px 12px; color:var(--text-dim);">API routes</td><td style="padding:8px 12px; font-weight:700;">58</td></tr>
+          <tr style="border-bottom:1px solid var(--border);"><td style="padding:8px 12px; color:var(--text-dim);">Total lines of code</td><td style="padding:8px 12px; font-weight:700;">562,530</td></tr>
+          <tr><td style="padding:8px 12px; color:var(--text-dim);">Current version</td><td style="padding:8px 12px; font-weight:700;">v0.66.0</td></tr>
+        </table>
+
+        <h3>What&rsquo;s Next</h3>
+        <p>Keep-alive was the prerequisite for <strong>long-running autonomous workflows</strong> &mdash; agents that work on multi-hour tasks without losing thread. The bridge endpoint opens the door to <strong>external integrations</strong> beyond Discord and Telegram. And the GitHub automation pipeline means the team can ship faster with less friction &mdash; conventional commits, auto-labels, and structured templates remove the cognitive overhead of consistency.</p>
+        <p>Next up: capacity-based context compaction improvements, unified embed builder across bridges, and continued process decomposition of the session manager.</p>
+        <p><em>corvid-agent v0.66.0 is available now. <a href="https://github.com/CorvidLabs/corvid-agent" target="_blank">GitHub</a> &mdash; <a href="https://corvidlabs.github.io/corvid-agent/" target="_blank">Docs</a></em></p>
+      </article>
+
       <!-- Post: v0.65 — On-Chain Attestations, Context Intelligence, and the Trust Layer -->
       <article class="post post--full" id="v065-trust-layer"
                data-tags="release,engineering,research" data-date="2026-05-02"

--- a/server/__tests__/discord-tool-handlers.test.ts
+++ b/server/__tests__/discord-tool-handlers.test.ts
@@ -9,7 +9,7 @@ import { mockDiscordRest } from './helpers/mock-discord-rest';
 // Use spyOn instead of mock.module to avoid polluting the global module cache,
 // which breaks sendDiscordMessage in other test files (e.g. discord-bridge).
 const mockSendMessageWithFiles = mock((..._args: unknown[]) => Promise.resolve('mock-msg-1' as string | null));
-const mockSendDiscordMessage = mock((..._args: unknown[]) => Promise.resolve());
+const mockSendDiscordMessage = mock((..._args: unknown[]) => Promise.resolve(['mock-msg-id-1']));
 
 let sendMessageWithFilesSpy: ReturnType<typeof spyOn>;
 let sendDiscordMessageSpy: ReturnType<typeof spyOn>;
@@ -45,7 +45,7 @@ beforeEach(() => {
   );
   // Reset mocks to default success behavior
   mockSendMessageWithFiles.mockImplementation((..._args: unknown[]) => Promise.resolve('mock-msg-1'));
-  mockSendDiscordMessage.mockImplementation((..._args: unknown[]) => Promise.resolve());
+  mockSendDiscordMessage.mockImplementation((..._args: unknown[]) => Promise.resolve(['mock-msg-id-1']));
 });
 
 afterEach(() => {
@@ -107,6 +107,28 @@ describe('handleDiscordSendMessage', () => {
   it('returns error when Discord API fails', async () => {
     // sendDiscordMessage swallows errors internally (try/catch in embeds.ts),
     // so even when the underlying REST call fails, the handler still succeeds.
+    const ctx = createMockContext();
+    const result = await handleDiscordSendMessage(ctx, {
+      channel_id: '123456',
+      message: 'Hello',
+    });
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('calls trackDiscordBotMessage for each sent message ID', async () => {
+    mockSendDiscordMessage.mockImplementation((..._args: unknown[]) => Promise.resolve(['msg-001', 'msg-002']));
+    const tracker = mock((_id: string, _ch: string) => {});
+    const ctx = createMockContext({ trackDiscordBotMessage: tracker });
+    await handleDiscordSendMessage(ctx, {
+      channel_id: '999',
+      message: 'Hello world',
+    });
+    expect(tracker).toHaveBeenCalledTimes(2);
+    expect(tracker).toHaveBeenCalledWith('msg-001', '999');
+    expect(tracker).toHaveBeenCalledWith('msg-002', '999');
+  });
+
+  it('does not fail when trackDiscordBotMessage is not set', async () => {
     const ctx = createMockContext();
     const result = await handleDiscordSendMessage(ctx, {
       channel_id: '123456',

--- a/server/__tests__/process-manager-external-mcp.test.ts
+++ b/server/__tests__/process-manager-external-mcp.test.ts
@@ -39,7 +39,7 @@ describe('External MCP config loading parity (spec invariant #15)', () => {
 
   test('resumeProcess loads external MCP configs for SDK path', () => {
     // Extract the resumeProcess method body (large method, need 15000 chars)
-    const startIdx = MANAGER_SOURCE.indexOf('resumeProcess(session: Session');
+    const startIdx = MANAGER_SOURCE.indexOf('resumeProcess(\n    session: Session');
     expect(startIdx).toBeGreaterThan(-1);
 
     const methodBody = MANAGER_SOURCE.slice(startIdx, startIdx + 15000);
@@ -61,7 +61,7 @@ describe('External MCP config loading parity (spec invariant #15)', () => {
   });
 
   test('resumeProcess loads external MCP configs for direct path', () => {
-    const startIdx = MANAGER_SOURCE.indexOf('resumeProcess(session: Session');
+    const startIdx = MANAGER_SOURCE.indexOf('resumeProcess(\n    session: Session');
     expect(startIdx).toBeGreaterThan(-1);
 
     const methodBody = MANAGER_SOURCE.slice(startIdx, startIdx + 15000);

--- a/server/discord/embeds.ts
+++ b/server/discord/embeds.ts
@@ -510,19 +510,23 @@ export async function sendDiscordMessage(
   _botToken: string,
   channelId: string,
   content: string,
-): Promise<void> {
+): Promise<string[]> {
   const chunks = splitMessage(content, MAX_MESSAGE_LENGTH);
+  const messageIds: string[] = [];
 
   for (const chunk of chunks) {
     try {
-      await delivery.sendWithReceipt('discord', async () => {
+      const { result } = await delivery.sendWithReceipt('discord', async () => {
         const restClient = getRestClient();
-        await restClient.sendMessage(channelId, { content: chunk });
+        return restClient.sendMessage(channelId, { content: chunk });
       });
+      if (result?.id) messageIds.push(result.id);
     } catch {
       // Error already logged by DeliveryTracker
     }
   }
+
+  return messageIds;
 }
 
 export async function sendTypingIndicator(_botToken: string, channelId: string): Promise<void> {

--- a/server/discord/message-router.ts
+++ b/server/discord/message-router.ts
@@ -595,7 +595,22 @@ async function handleMentionReply(
     withAuthorContext(cleanText, authorId, authorUsername, channelId),
     attachments,
   );
-  ctx.processManager.startProcess(session, textWithUrls, { skipSkillPrompt: true });
+  const mentionInfo: MentionSessionInfo = {
+    sessionId: session.id,
+    agentName,
+    agentModel,
+    projectName: projectNameForFooter,
+    displayColor: agentDisplayColor,
+    displayIcon: agentDisplayIcon,
+    avatarUrl: agentAvatarUrl,
+    channelId,
+  };
+  ctx.processManager.startProcess(session, textWithUrls, {
+    skipSkillPrompt: true,
+    trackDiscordBotMessage: (botMsgId, botMsgChannelId) => {
+      trackMentionSession(ctx.db, ctx.mentionSessions, botMsgId, { ...mentionInfo, channelId: botMsgChannelId });
+    },
+  });
   ctx.processManager.setKeepAliveTtl(session.id, MENTION_KEEP_ALIVE_TTL_MS);
 
   // Record inbound Discord message as a short-term observation for context retention
@@ -715,7 +730,21 @@ async function handleMentionReplyResume(
     // since the last exchange. New mentions intentionally skip this for a clean slate.
     const channelContext = buildChannelContext(ctx.db, channelId);
     const resumeTextWithContext = channelContext ? `${channelContext}\n\n${resumeText}` : resumeText;
-    ctx.processManager.resumeProcess(session, resumeTextWithContext);
+    ctx.processManager.resumeProcess(session, resumeTextWithContext, {
+      trackDiscordBotMessage: (botMsgId, botMsgChannelId) => {
+        trackMentionSession(ctx.db, ctx.mentionSessions, botMsgId, {
+          sessionId,
+          agentName,
+          agentModel,
+          projectName,
+          displayColor,
+          displayIcon,
+          avatarUrl,
+          channelId: botMsgChannelId,
+          conversationOnly,
+        });
+      },
+    });
     ctx.processManager.setKeepAliveTtl(sessionId, MENTION_KEEP_ALIVE_TTL_MS);
 
     // If resumeProcess failed (e.g. death loop reset, spawn error), fall back to a new session

--- a/server/mcp/tool-handlers/discord.ts
+++ b/server/mcp/tool-handlers/discord.ts
@@ -8,7 +8,7 @@ import { errorResult, textResult } from './types';
 const log = createLogger('McpToolHandlers');
 
 export async function handleDiscordSendMessage(
-  _ctx: McpToolContext,
+  ctx: McpToolContext,
   args: { channel_id: string; message: string; reply_to?: string },
 ): Promise<CallToolResult> {
   if (!args.channel_id?.trim()) {
@@ -25,7 +25,11 @@ export async function handleDiscordSendMessage(
 
   try {
     const delivery = getDeliveryTracker();
-    await sendDiscordMessage(delivery, botToken, args.channel_id, args.message);
+    const messageIds = await sendDiscordMessage(delivery, botToken, args.channel_id, args.message);
+
+    for (const id of messageIds) {
+      ctx.trackDiscordBotMessage?.(id, args.channel_id);
+    }
 
     log.info('Sent Discord message via MCP tool', {
       channelId: args.channel_id,

--- a/server/mcp/tool-handlers/types.ts
+++ b/server/mcp/tool-handlers/types.ts
@@ -91,6 +91,8 @@ export interface McpToolContext {
   messageRateLimiter?: SessionMessageRateLimiter;
   /** Fledge CLI client for delegating to fledge plugins (memory, sql, localnet, algochat). */
   fledgeClient?: FledgeClient;
+  /** Track a bot-sent Discord message ID so replies route back to this session. */
+  trackDiscordBotMessage?: (messageId: string, channelId: string) => void;
 }
 
 export function textResult(text: string): CallToolResult {

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -561,6 +561,8 @@ export class ProcessManager {
       toolAllowList?: string[];
       mcpToolAllowList?: string[];
       skipSkillPrompt?: boolean;
+      /** Track bot-sent Discord message IDs so replies route back to this session. */
+      trackDiscordBotMessage?: (messageId: string, channelId: string) => void;
     },
   ): Promise<void> {
     const resolved = await resolveProjectDir(project);

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -525,6 +525,7 @@ export class ProcessManager {
         options?.toolAllowList,
         options?.mcpToolAllowList,
         options?.skipSkillPrompt,
+        options?.trackDiscordBotMessage,
       );
     } else {
       this.startSdkProcessWrapped(
@@ -539,6 +540,7 @@ export class ProcessManager {
         options?.toolAllowList,
         options?.mcpToolAllowList,
         options?.skipSkillPrompt,
+        options?.trackDiscordBotMessage,
       );
     }
   }
@@ -612,6 +614,7 @@ export class ProcessManager {
         options?.toolAllowList,
         options?.mcpToolAllowList,
         options?.skipSkillPrompt,
+        options?.trackDiscordBotMessage,
       );
     }
   }
@@ -628,6 +631,7 @@ export class ProcessManager {
     toolAllowList?: string[],
     mcpToolAllowList?: string[],
     skipSkillPrompt?: boolean,
+    trackDiscordBotMessage?: (messageId: string, channelId: string) => void,
   ): void {
     const effectiveProject = session.workDir ? { ...project, workingDir: session.workDir } : project;
 
@@ -660,7 +664,7 @@ export class ProcessManager {
               schedulerActionType,
             );
             if (!ctx) return undefined;
-            if (options?.trackDiscordBotMessage) ctx.trackDiscordBotMessage = options.trackDiscordBotMessage;
+            if (trackDiscordBotMessage) ctx.trackDiscordBotMessage = trackDiscordBotMessage;
             const pluginSdkTools = this.pluginRegistry
               ? buildPluginSdkTools(this.pluginRegistry, session.agentId, session.id)
               : [];

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -347,6 +347,8 @@ export class ProcessManager {
       keepAliveTtlMs?: number;
       /** Skip skill bundle prompt loading for lightweight sessions (e.g. mention sessions). */
       skipSkillPrompt?: boolean;
+      /** Track bot-sent Discord message IDs so replies route back to this session. */
+      trackDiscordBotMessage?: (messageId: string, channelId: string) => void;
     },
   ): void {
     if (this.startingSession.has(session.id)) {
@@ -656,6 +658,7 @@ export class ProcessManager {
               schedulerActionType,
             );
             if (!ctx) return undefined;
+            if (options?.trackDiscordBotMessage) ctx.trackDiscordBotMessage = options.trackDiscordBotMessage;
             const pluginSdkTools = this.pluginRegistry
               ? buildPluginSdkTools(this.pluginRegistry, session.agentId, session.id)
               : [];
@@ -969,7 +972,14 @@ export class ProcessManager {
     });
   }
 
-  resumeProcess(session: Session, prompt?: string): void {
+  resumeProcess(
+    session: Session,
+    prompt?: string,
+    options?: {
+      /** Track bot-sent Discord message IDs so replies route back to this session. */
+      trackDiscordBotMessage?: (messageId: string, channelId: string) => void;
+    },
+  ): void {
     // Clear stale startingSession entries — if the session isn't actually in the
     // processes map, any leftover startingSession guard from a failed spawn is stale.
     if (this.startingSession.has(session.id) && !this.processes.has(session.id)) {
@@ -1212,14 +1222,18 @@ export class ProcessManager {
         // For restricted /message sessions, override permissions to only expose memory tools
         const effectivePermissions = resumeMcpToolAllowList ?? resumeConfig.resolvedToolPermissions;
         const mcpToolContext = session.agentId
-          ? this.buildMcpContext(
-              session.agentId,
-              session.source,
-              session.id,
-              undefined,
-              undefined,
-              effectivePermissions,
-            )
+          ? (() => {
+              const ctx = this.buildMcpContext(
+                session.agentId,
+                session.source,
+                session.id,
+                undefined,
+                undefined,
+                effectivePermissions,
+              );
+              if (ctx && options?.trackDiscordBotMessage) ctx.trackDiscordBotMessage = options.trackDiscordBotMessage;
+              return ctx;
+            })()
           : null;
         const councilModelResume = process.env.COUNCIL_MODEL;
         const modelOverrideResume =
@@ -1260,6 +1274,7 @@ export class ProcessManager {
                   effectivePermissions,
                 );
                 if (!ctx) return undefined;
+                if (options?.trackDiscordBotMessage) ctx.trackDiscordBotMessage = options.trackDiscordBotMessage;
                 const pluginSdkTools = this.pluginRegistry
                   ? buildPluginSdkTools(this.pluginRegistry, session.agentId, session.id)
                   : [];


### PR DESCRIPTION
## Summary

- When the bot sends a plain text message via `corvid_discord_send_message` during an active mention session, replies to that message now route back to the **same session** instead of creating a new one
- Root cause: `sendDiscordMessage()` returned `void` — message IDs were discarded and never registered in the mention sessions map. Combined with the channel fallback removal in #2266, there was no way to find the originating session
- Added `trackDiscordBotMessage` callback plumbed from Discord bridge → `startProcess`/`resumeProcess` → MCP tool context → tool handler

## Changes

| File | What |
|------|------|
| `server/discord/embeds.ts` | `sendDiscordMessage()` returns `string[]` (message IDs) instead of `void` |
| `server/mcp/tool-handlers/types.ts` | Added `trackDiscordBotMessage` callback to `McpToolContext` |
| `server/mcp/tool-handlers/discord.ts` | Handler calls tracking callback for each sent message ID |
| `server/process/manager.ts` | `startProcess`/`resumeProcess` accept and inject tracking callback |
| `server/discord/message-router.ts` | Both new and resumed mention sessions pass tracking closure |
| `server/__tests__/discord-tool-handlers.test.ts` | 2 new tests for tracking callback behavior |

## Test plan

- [x] All 92 Discord bridge tests pass
- [x] All 14 Discord tool handler tests pass (including 2 new)
- [x] Lint, typecheck, spec-check pass

**Post-deploy verification:** send a plain message via MCP tool mid-session, reply to it, verify same session ID

Closes #2298

🤖 Generated with [Claude Code](https://claude.com/claude-code)
👤 Requested by: @Kyntrin