### PR TITLE
feat(algochat): add localnet PSK bridge for dual-network operation

### DIFF
--- a/docs/blog.html
+++ b/docs/blog.html
@@ -800,6 +800,87 @@
   <main id="main-content" class="container">
     <div class="posts-grid" id="posts-container">
 
+      <!-- Post: v0.66 — Keep-Alive Sessions, Bridge Endpoint, and Workflow Automation -->
+      <article class="post post--full" id="v066-keep-alive"
+               data-tags="release,engineering" data-date="2026-05-06"
+               data-search="v0.66 keep-alive warm turn bridge endpoint fledge plugins conventional commits auto-label PR template formatIssueBody mention reliability Discord Telegram AlgoChat CVE security session lifecycle state machine TTL context">
+        <div class="post-meta">
+          <time datetime="2026-05-06">2026-05-06</time>
+          <span class="post-tag tag-release">RELEASE</span>
+          <span class="post-tag tag-engineering">ENGINEERING</span>
+        </div>
+        <h2><a href="#v066-keep-alive">v0.66 &mdash; Keep-Alive Sessions, Bridge Endpoint, and Workflow Automation</a></h2>
+
+        <p><strong>TL;DR:</strong> 42 commits, 20 features, 27 fixes. Sessions no longer die between messages &mdash; keep-alive landed across all three bridges. A new server-side bridge endpoint enables cross-service communication. GitHub workflow got automated: conventional commits, auto-labeled PRs, and structured issue templates. Fledge plugins are now native agent tools. Discord @mentions got a reliability overhaul.</p>
+
+        <h3>Keep-Alive Sessions: The End of &ldquo;Who Are You Again?&rdquo;</h3>
+        <p>This was the headline feature &mdash; 11 commits across three phases. Previously, every time a message arrived after a session timed out, the agent started cold: no context, no memory of the conversation, full initialization overhead. Keep-alive changes that fundamentally.</p>
+        <ul>
+          <li><strong>Phase 1:</strong> Spec-first design of the keep-alive lifecycle, documenting the state machine before writing a line of implementation.</li>
+          <li><strong>Phase 2:</strong> The state machine itself &mdash; sessions transition between <code>active</code>, <code>waiting</code>, and <code>warm</code> states instead of dying on idle. A waiting session holds its process and context window open, ready for the next message without cold-start overhead.</li>
+          <li><strong>Phase 3:</strong> Per-session flags, coexistence with non-keep-alive sessions, and dashboard badges showing warm status. You can see which sessions are alive at a glance.</li>
+        </ul>
+        <p>Then we wired it into every bridge:</p>
+        <ul>
+          <li><strong>Discord:</strong> Keep-alive enabled by default. Active duration tracking and TTL countdown visible in embed footers. Sessions survive between messages.</li>
+          <li><strong>Telegram:</strong> Warm-turn support added, same lifecycle as Discord.</li>
+          <li><strong>AlgoChat:</strong> On-chain messaging sessions now persist across turns, so agent-to-agent conversations maintain context without re-initialization.</li>
+        </ul>
+        <p>The fixes that followed tell the real story: persistent message queues to prevent stdin close, context token updates after warm turns, proper keepAlive param wiring on initial start. Session lifecycle management has more edge cases than you&rsquo;d expect &mdash; each one was a dropped message or a zombie process in production.</p>
+
+        <h3>Bridge Endpoint</h3>
+        <p>A new server-side <strong>bridge endpoint</strong> enables cross-service communication with multi-session support. This is the plumbing for connecting external systems to agent sessions &mdash; a single API surface that routes messages to the right session regardless of which bridge originated them. Full module spec written and validated.</p>
+
+        <h3>GitHub Workflow Automation</h3>
+        <p>Four features that tighten up how the team ships code:</p>
+        <ul>
+          <li><strong>Conventional commits enforced</strong> &mdash; all agents now follow the <code>type(scope): message</code> format. No more guessing what a commit does from a cryptic one-liner.</li>
+          <li><strong>Auto-labeled PRs</strong> &mdash; PRs get tagged by type (<code>feat</code>, <code>fix</code>, <code>docs</code>) and by which agent authored them. Filtering the PR list by agent or change type is now trivial.</li>
+          <li><strong><code>formatIssueBody()</code> helper</strong> &mdash; automatically detects whether an issue is a bug report or feature request from the title and applies the right template. 80 lines of logic, 182 lines of tests.</li>
+          <li><strong>Standardized PR body template</strong> &mdash; every PR now gets a consistent structure with summary, changes, and test plan sections.</li>
+          <li><strong>Human collaborator attribution</strong> &mdash; when a human initiates work that an agent executes, the human gets credited on PRs, issues, and commits.</li>
+        </ul>
+
+        <h3>Discord @Mention Reliability</h3>
+        <p>Discord mentions got a focused overhaul. The old behavior was fragile &mdash; mentions would sometimes hijack existing sessions or lose context. Now:</p>
+        <ul>
+          <li>Each @mention creates a <strong>new isolated session</strong> with a 5-minute TTL</li>
+          <li>Embed footers show <strong>&ldquo;mention &middot; 5m&rdquo;</strong> labels with dynamic countdown timestamps</li>
+          <li>Channel context is <strong>stripped from new mention sessions</strong> to prevent context bleed</li>
+          <li>Project name now appears in embed footers for multi-project setups</li>
+        </ul>
+
+        <h3>Fledge Plugins Go Native</h3>
+        <p>Fledge plugins are now <strong>integrated directly into agent operations</strong>. Agents can discover and invoke fledge plugins through MCP, treating them as first-class tools alongside built-in capabilities. The &ldquo;Fledge First&rdquo; rule was codified in CLAUDE.md &mdash; agents should always reach for fledge before falling back to raw commands.</p>
+        <p>51 plugins currently installed, spanning official tooling (metrics, coverage, gitleaks, standup) and community contributions (codegolf, maze, quiz). The plugin ecosystem is growing faster than the core CLI.</p>
+
+        <h3>Platform Plumbing</h3>
+        <ul>
+          <li><strong>Context reconstruction made cold-start-only</strong> &mdash; warm turns skip the expensive context rebuild, cutting response latency on keep-alive sessions.</li>
+          <li><strong>Prior-context verification rule</strong> &mdash; agents now check for existing work from past sessions before starting, preventing duplicate effort across conversations.</li>
+          <li><strong>Work task commit validation</strong> &mdash; detects all uncommitted changes and verifies commits exist before attempting PR fallback. No more phantom PRs.</li>
+          <li><strong>Block explorer type safety</strong> &mdash; removed <code>any</code> casts on indexer query builders.</li>
+          <li><strong>Security:</strong> Resolved GHSA-v2v4-37r5-5v8g (ip-address XSS vulnerability).</li>
+          <li><strong>Dependency bumps:</strong> Zod 4.4.3, Anthropic SDK 0.93.0.</li>
+        </ul>
+
+        <h3>By the Numbers</h3>
+        <table style="width:100%; border-collapse:collapse; margin:1em 0;">
+          <tr style="border-bottom:1px solid var(--border);"><td style="padding:8px 12px; color:var(--text-dim);">Commits (v0.65&rarr;v0.66)</td><td style="padding:8px 12px; font-weight:700;">42</td></tr>
+          <tr style="border-bottom:1px solid var(--border);"><td style="padding:8px 12px; color:var(--text-dim);">Features shipped</td><td style="padding:8px 12px; font-weight:700;">20</td></tr>
+          <tr style="border-bottom:1px solid var(--border);"><td style="padding:8px 12px; color:var(--text-dim);">Bugs fixed</td><td style="padding:8px 12px; font-weight:700;">27</td></tr>
+          <tr style="border-bottom:1px solid var(--border);"><td style="padding:8px 12px; color:var(--text-dim);">Fledge plugins</td><td style="padding:8px 12px; font-weight:700;">51</td></tr>
+          <tr style="border-bottom:1px solid var(--border);"><td style="padding:8px 12px; color:var(--text-dim);">API routes</td><td style="padding:8px 12px; font-weight:700;">58</td></tr>
+          <tr style="border-bottom:1px solid var(--border);"><td style="padding:8px 12px; color:var(--text-dim);">Total lines of code</td><td style="padding:8px 12px; font-weight:700;">562,530</td></tr>
+          <tr><td style="padding:8px 12px; color:var(--text-dim);">Current version</td><td style="padding:8px 12px; font-weight:700;">v0.66.0</td></tr>
+        </table>
+
+        <h3>What&rsquo;s Next</h3>
+        <p>Keep-alive was the prerequisite for <strong>long-running autonomous workflows</strong> &mdash; agents that work on multi-hour tasks without losing thread. The bridge endpoint opens the door to <strong>external integrations</strong> beyond Discord and Telegram. And the GitHub automation pipeline means the team can ship faster with less friction &mdash; conventional commits, auto-labels, and structured templates remove the cognitive overhead of consistency.</p>
+        <p>Next up: capacity-based context compaction improvements, unified embed builder across bridges, and continued process decomposition of the session manager.</p>
+        <p><em>corvid-agent v0.66.0 is available now. <a href="https://github.com/CorvidLabs/corvid-agent" target="_blank">GitHub</a> &mdash; <a href="https://corvidlabs.github.io/corvid-agent/" target="_blank">Docs</a></em></p>
+      </article>
+
       <!-- Post: v0.65 — On-Chain Attestations, Context Intelligence, and the Trust Layer -->
       <article class="post post--full" id="v065-trust-layer"
                data-tags="release,engineering,research" data-date="2026-05-02"

--- a/server/__tests__/algochat-bridge-localnet-psk.test.ts
+++ b/server/__tests__/algochat-bridge-localnet-psk.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for AlgoChatBridge.addLocalnetPSKBridge — dual-network PSK bridge.
+ *
+ * Uses minimal mocks for AlgoChatService and ProcessManager since the bridge
+ * constructor and addLocalnetPSKBridge only store references and wire callbacks.
+ */
+
+import { Database } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { AlgoChatBridge } from '../algochat/bridge';
+import type { AlgoChatConfig } from '../algochat/config';
+import type { AlgoChatService } from '../algochat/service';
+import { runMigrations } from '../db/schema';
+import type { ProcessManager } from '../process/manager';
+
+function createMockService(): AlgoChatService {
+  return {
+    syncManager: {
+      on: () => {},
+      start: () => {},
+      stop: () => {},
+    },
+    chatAccount: {},
+    algorandService: {},
+    algodClient: {},
+    indexerClient: null,
+  } as unknown as AlgoChatService;
+}
+
+function createMockProcessManager(): ProcessManager {
+  return {
+    setOwnerCheck: () => {},
+    extendTimeout: () => false,
+    subscribeAll: () => {},
+    unsubscribeAll: () => {},
+  } as unknown as ProcessManager;
+}
+
+function createTestConfig(overrides?: Partial<AlgoChatConfig>): AlgoChatConfig {
+  return {
+    mnemonic: null,
+    network: 'testnet' as const,
+    agentNetwork: 'localnet' as const,
+    syncInterval: 30000,
+    defaultAgentId: null,
+    enabled: true,
+    pskContact: null,
+    ownerAddresses: new Set<string>(),
+    ...overrides,
+  };
+}
+
+let db: Database;
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  runMigrations(db);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe('AlgoChatBridge.addLocalnetPSKBridge', () => {
+  test('constructs bridge and adds localnet PSK bridge without error', () => {
+    const service = createMockService();
+    const processManager = createMockProcessManager();
+    const config = createTestConfig();
+
+    const bridge = new AlgoChatBridge(db, processManager, config, service);
+
+    const localnetService = createMockService();
+    const localnetConfig = createTestConfig({ network: 'localnet' as const });
+
+    expect(() => bridge.addLocalnetPSKBridge(localnetService, localnetConfig)).not.toThrow();
+  });
+
+  test('start includes localnet managers when bridge is configured', () => {
+    const service = createMockService();
+    const processManager = createMockProcessManager();
+    const config = createTestConfig();
+
+    const bridge = new AlgoChatBridge(db, processManager, config, service);
+
+    const localnetService = createMockService();
+    const localnetConfig = createTestConfig({ network: 'localnet' as const });
+    bridge.addLocalnetPSKBridge(localnetService, localnetConfig);
+
+    expect(() => bridge.start()).not.toThrow();
+    bridge.stop();
+  });
+
+  test('stop cleans up localnet managers when bridge is configured', () => {
+    const service = createMockService();
+    const processManager = createMockProcessManager();
+    const config = createTestConfig();
+
+    const bridge = new AlgoChatBridge(db, processManager, config, service);
+
+    const localnetService = createMockService();
+    const localnetConfig = createTestConfig({ network: 'localnet' as const });
+    bridge.addLocalnetPSKBridge(localnetService, localnetConfig);
+
+    bridge.start();
+    expect(() => bridge.stop()).not.toThrow();
+  });
+
+  test('start and stop work without localnet bridge', () => {
+    const service = createMockService();
+    const processManager = createMockProcessManager();
+    const config = createTestConfig();
+
+    const bridge = new AlgoChatBridge(db, processManager, config, service);
+
+    expect(() => bridge.start()).not.toThrow();
+    expect(() => bridge.stop()).not.toThrow();
+  });
+
+  test('localnet PSK contacts from DB are loaded during bridge setup', () => {
+    const service = createMockService();
+    const processManager = createMockProcessManager();
+    const config = createTestConfig();
+
+    const bridge = new AlgoChatBridge(db, processManager, config, service);
+
+    // Insert a localnet PSK contact before adding bridge
+    const psk = crypto.getRandomValues(new Uint8Array(32));
+    db.prepare(`
+      INSERT INTO psk_contacts (id, nickname, network, initial_psk, active, created_at, updated_at)
+      VALUES (?, ?, ?, ?, 1, datetime('now'), datetime('now'))
+    `).run('merlin-test', 'Merlin', 'localnet', psk);
+
+    const localnetService = createMockService();
+    const localnetConfig = createTestConfig({ network: 'localnet' as const });
+
+    // Should not throw even with contacts in the DB
+    expect(() => bridge.addLocalnetPSKBridge(localnetService, localnetConfig)).not.toThrow();
+  });
+});

--- a/server/algochat/bridge.ts
+++ b/server/algochat/bridge.ts
@@ -72,6 +72,10 @@ export class AlgoChatBridge implements ChannelAdapter {
   private discoveryPoller: PSKDiscoveryPoller;
   private messageRouter: MessageRouter;
 
+  // Localnet PSK bridge (for dual-network operation)
+  private localnetContactManager: PSKContactManager | null = null;
+  private localnetDiscoveryPoller: PSKDiscoveryPoller | null = null;
+
   // Optional dependencies (for getter access)
   private agentWalletService: AgentWalletService | null = null;
 
@@ -178,6 +182,49 @@ export class AlgoChatBridge implements ChannelAdapter {
     this.commandHandler.setAgentMessenger(messenger);
   }
 
+  // ── Localnet PSK bridge (dual-network support) ────────────────────
+
+  /**
+   * Add a secondary PSK bridge on localnet so that agents communicating
+   * on localnet (e.g. Merlin, Starling) can reach us even when the
+   * primary messaging network is testnet/mainnet.
+   */
+  addLocalnetPSKBridge(localnetService: AlgoChatService, localnetConfig: AlgoChatConfig): void {
+    this.localnetContactManager = new PSKContactManager(this.db, localnetConfig, localnetService);
+    this.localnetDiscoveryPoller = new PSKDiscoveryPoller(
+      this.db,
+      localnetConfig,
+      localnetService,
+      this.localnetContactManager,
+    );
+
+    // Wire PSK message callback to the same message router
+    this.localnetContactManager.setOnPskMessage((msg) => {
+      this.messageRouter.handleIncomingMessage(msg.sender, msg.content, msg.confirmedRound, msg.amount).catch((err) => {
+        log.error('Error handling localnet PSK message', { error: err instanceof Error ? err.message : String(err) });
+      });
+    });
+
+    // Wire discovery poller first-message callback
+    this.localnetDiscoveryPoller.setOnFirstMessage((sender, text, round, amount) => {
+      this.messageRouter.handleIncomingMessage(sender, text, round, amount).catch((err) => {
+        log.error('Error handling discovered localnet PSK message', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    });
+
+    // Load existing localnet PSK contacts from DB
+    this.localnetContactManager.setupPSKManagers();
+
+    // Update the PSK manager lookup to check both networks
+    this.responseFormatter.setPskManagerLookup((address) => {
+      return this.contactManager.lookupPskManager(address) ?? this.localnetContactManager?.lookupPskManager(address) ?? null;
+    });
+
+    log.info('Localnet PSK bridge added for dual-network operation');
+  }
+
   // ── Public API ───────────────────────────────────────────────────────
 
   async sendApprovalRequest(participant: string, request: ApprovalRequestWire): Promise<void> {
@@ -190,6 +237,13 @@ export class AlgoChatBridge implements ChannelAdapter {
     this.contactManager.startMatched(this.config.syncInterval);
     this.discoveryPoller.start();
     this.discoveryService.startDiscoveryPolling();
+
+    // Start localnet PSK bridge if configured
+    if (this.localnetContactManager && this.localnetDiscoveryPoller) {
+      this.localnetContactManager.startMatched(this.config.syncInterval);
+      this.localnetDiscoveryPoller.start();
+    }
+
     log.info('Started listening for messages');
   }
 
@@ -200,6 +254,11 @@ export class AlgoChatBridge implements ChannelAdapter {
     this.discoveryService.cleanup();
     this.messageRouter.cleanupSessionNotifications();
     this.subscriptionManager.cleanup();
+
+    // Stop localnet PSK bridge
+    if (this.localnetContactManager) this.localnetContactManager.stopAll();
+    if (this.localnetDiscoveryPoller) this.localnetDiscoveryPoller.stop();
+
     log.info('Stopped');
   }
 

--- a/server/algochat/init.ts
+++ b/server/algochat/init.ts
@@ -138,6 +138,12 @@ export async function initAlgoChat(deps: AlgoChatInitDeps): Promise<void> {
 
   algochatState.bridge = new AlgoChatBridge(db, processManager, algochatConfig, service);
 
+  // Add localnet PSK bridge when agent network differs from messaging network
+  // so that agents communicating on localnet can reach us via PSK
+  if (algochatConfig.agentNetwork !== algochatConfig.network && agentService !== service) {
+    algochatState.bridge.addLocalnetPSKBridge(agentService, agentNetworkConfig);
+  }
+
   // Scan for plaintext key configuration issues (#924)
   const plaintextWarnings = detectPlaintextKeyConfig(agentNetworkConfig.network);
   if (plaintextWarnings.length > 0 && agentNetworkConfig.network === 'mainnet') {

--- a/specs/algochat/bridge.spec.md
+++ b/specs/algochat/bridge.spec.md
@@ -74,6 +74,7 @@ Central orchestrator for the AlgoChat on-chain messaging system. Bridges Algoran
 | `setOwnerQuestionManager` | `(manager: OwnerQuestionManager)` | `void` | Late-inject owner question manager |
 | `setWorkTaskService` | `(service: WorkTaskService)` | `void` | Late-inject work task service (wraps in a `WorkCommandRouter` for the command handler) |
 | `setAgentMessenger` | `(messenger: AgentMessenger)` | `void` | Late-inject agent messenger |
+| `addLocalnetPSKBridge` | `(service: AlgoChatService, config: AlgoChatConfig)` | `void` | Add secondary PSK bridge on localnet for dual-network PSK contact discovery and messaging |
 | `sendApprovalRequest` | `(participant: string, request: ApprovalRequestWire)` | `Promise<void>` | Send a tool approval request to a participant via on-chain message |
 | `start` | `()` | `void` | Start all PSK managers, sync polling, and discovery polling |
 | `stop` | `()` | `void` | Stop all PSK managers, polling timers, and session subscriptions |
@@ -112,6 +113,7 @@ Central orchestrator for the AlgoChat on-chain messaging system. Bridges Algoran
 13. **Per-agent conversation access control**: Conversations can be routed to private agents. Non-owner access is checked against the per-agent conversation mode; denied requests fail silently without response
 14. **Session isolation**: AlgoChat-sourced sessions create isolated git worktrees for safe code execution
 15. **Session notification forwarding**: Approval requests, session errors, and session exits from AlgoChat-sourced sessions are forwarded as on-chain messages to the participant
+16. **Dual-network PSK bridge**: When `agentNetwork !== network`, a secondary PSKContactManager and PSKDiscoveryPoller are created on the localnet service. This allows agents communicating on localnet to reach us via PSK even when the primary messaging network is testnet/mainnet. Both managers share the same MessageRouter and ResponseFormatter lookup
 
 ## Behavioral Examples
 
@@ -190,3 +192,4 @@ Central orchestrator for the AlgoChat on-chain messaging system. Bridges Algoran
 |------|--------|--------|
 | 2026-02-19 | corvid-agent | Initial spec |
 | 2026-04-14 | corvid-agent | Update service count (4→7), fix method signatures, update dedup invariant, add invariants 11-15, add missing methods, add worktree error case (#2018) |
+| 2026-05-09 | corvid-agent | Add dual-network PSK bridge: `addLocalnetPSKBridge` method, invariant 16 (merlin#48) |


### PR DESCRIPTION
## Summary

- Adds `addLocalnetPSKBridge()` method to `AlgoChatBridge` that creates a secondary PSKContactManager + PSKDiscoveryPoller on localnet
- When `agentNetwork !== network` (e.g. testnet messaging, localnet agents), `init.ts` now calls this method so that PSK contacts on localnet are loaded, polled, and their messages routed through the same MessageRouter
- Response routing also checks the localnet PSK manager, so replies go back on the correct network
- Updated bridge spec with new method, invariant 16, and changelog entry

Closes CorvidLabs/merlin#48

## Test plan

- [x] Start corvid-agent with `ALGORAND_NETWORK=testnet` and `AGENT_NETWORK=localnet`
- [x] Verify logs show "Localnet PSK bridge added for dual-network operation"
- [x] Verify localnet PSK contacts (e.g. "merlin") are loaded by the secondary manager
- [x] Send a PSK-encrypted message from Merlin on localnet — verify it's received and routed
- [x] Verify response goes back on localnet (not testnet)
- [x] Start with matching networks (both localnet) — verify no secondary bridge is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)