### PR TITLE
feat(sessions): track warm turn count per session (migration 129)

### DIFF
--- a/docs/deep-dive.md
+++ b/docs/deep-dive.md
@@ -38,7 +38,7 @@ corvid-agent bets that blockchain-backed identity, cryptographic communication, 
 | Server modules | 47 |
 | API routes | 55 modules (~236 endpoints) |
 | Database tables | 114 |
-| Database migrations | 51 (squashed baseline) |
+| Database migrations | 52 (squashed baseline) |
 | MCP tools | 64 corvid_* handlers |
 | Unit tests | 4,242 test files |
 | E2E tests | 360 across 33 Playwright specs |

--- a/server/__tests__/a2a-invocation-guard.test.ts
+++ b/server/__tests__/a2a-invocation-guard.test.ts
@@ -65,6 +65,7 @@ const MOCK_SESSION = {
   workDir: null,
   creditsConsumed: 0,
   keepAlive: false,
+  warmTurnCount: 0,
   lastContextTokens: null,
   lastContextWindow: null,
   createdAt: '2026-01-01T00:00:00.000Z',

--- a/server/__tests__/a2a-tasks.test.ts
+++ b/server/__tests__/a2a-tasks.test.ts
@@ -52,6 +52,7 @@ const MOCK_SESSION = {
   workDir: null,
   creditsConsumed: 0,
   keepAlive: false,
+  warmTurnCount: 0,
   lastContextTokens: null,
   lastContextWindow: null,
   createdAt: '2026-01-01T00:00:00.000Z',

--- a/server/__tests__/warm-turn-count.test.ts
+++ b/server/__tests__/warm-turn-count.test.ts
@@ -1,0 +1,105 @@
+import { Database } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { runMigrations } from '../db/schema';
+import { createSession, getSession, incrementSessionWarmTurnCount } from '../db/sessions';
+import { ProcessManager } from '../process/manager';
+import type { SdkProcess } from '../process/sdk-process';
+
+let db: Database;
+let pm: ProcessManager;
+const AGENT_ID = 'agent-1';
+const PROJECT_ID = 'proj-1';
+let sessionId: string;
+
+function makeWarmProcess(sendResult = true): SdkProcess {
+  return {
+    pid: 42,
+    sendMessage: () => sendResult,
+    kill: () => {},
+    isAlive: () => true,
+    isWarm: () => true,
+  };
+}
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  runMigrations(db);
+  db.query(`INSERT INTO agents (id, name, model, system_prompt) VALUES (?, 'TestAgent', 'test', 'test')`).run(AGENT_ID);
+  db.query(`INSERT INTO projects (id, name, working_dir) VALUES (?, 'TestProject', '/tmp/test')`).run(PROJECT_ID);
+  const session = createSession(db, { projectId: PROJECT_ID, agentId: AGENT_ID, name: 'Test' });
+  sessionId = session.id;
+  pm = new ProcessManager(db);
+});
+
+afterEach(() => {
+  pm.shutdown();
+  db.close();
+});
+
+// ── incrementSessionWarmTurnCount ────────────────────────────────────────────
+
+describe('incrementSessionWarmTurnCount', () => {
+  test('starts at 0 on new session', () => {
+    const session = getSession(db, sessionId);
+    expect(session?.warmTurnCount).toBe(0);
+  });
+
+  test('increments from 0 to 1', () => {
+    incrementSessionWarmTurnCount(db, sessionId);
+    expect(getSession(db, sessionId)?.warmTurnCount).toBe(1);
+  });
+
+  test('increments cumulatively', () => {
+    incrementSessionWarmTurnCount(db, sessionId);
+    incrementSessionWarmTurnCount(db, sessionId);
+    incrementSessionWarmTurnCount(db, sessionId);
+    expect(getSession(db, sessionId)?.warmTurnCount).toBe(3);
+  });
+
+  test('is idempotent on nonexistent session — does not throw', () => {
+    expect(() => incrementSessionWarmTurnCount(db, 'no-such-session')).not.toThrow();
+  });
+});
+
+// ── ProcessManager warm path counting ────────────────────────────────────────
+
+describe('resumeProcess warm path increments warm_turn_count', () => {
+  test('increments warm_turn_count when message delivered to live process', () => {
+    const warmProcess = makeWarmProcess();
+    (pm as any).processes.set(sessionId, warmProcess);
+
+    const session = getSession(db, sessionId)!;
+    pm.resumeProcess(session, 'hello warm turn');
+
+    expect(getSession(db, sessionId)?.warmTurnCount).toBe(1);
+  });
+
+  test('increments on each subsequent warm turn', () => {
+    const warmProcess = makeWarmProcess();
+    (pm as any).processes.set(sessionId, warmProcess);
+
+    const session = getSession(db, sessionId)!;
+    pm.resumeProcess(session, 'first warm message');
+    pm.resumeProcess(session, 'second warm message');
+
+    expect(getSession(db, sessionId)?.warmTurnCount).toBe(2);
+  });
+
+  test('does NOT increment when sendMessage fails (falls through to cold start)', () => {
+    const failingProcess = makeWarmProcess(false);
+    (pm as any).processes.set(sessionId, failingProcess);
+
+    const session = getSession(db, sessionId)!;
+    pm.resumeProcess(session, 'will fail warm delivery');
+
+    expect(getSession(db, sessionId)?.warmTurnCount).toBe(0);
+  });
+
+  test('does NOT increment on cold start (no live process)', () => {
+    const session = getSession(db, sessionId)!;
+    pm.resumeProcess(session, 'cold start prompt');
+
+    expect(getSession(db, sessionId)?.warmTurnCount).toBe(0);
+  });
+});

--- a/server/algochat/bridge.ts
+++ b/server/algochat/bridge.ts
@@ -219,7 +219,9 @@ export class AlgoChatBridge implements ChannelAdapter {
 
     // Update the PSK manager lookup to check both networks
     this.responseFormatter.setPskManagerLookup((address) => {
-      return this.contactManager.lookupPskManager(address) ?? this.localnetContactManager?.lookupPskManager(address) ?? null;
+      return (
+        this.contactManager.lookupPskManager(address) ?? this.localnetContactManager?.lookupPskManager(address) ?? null
+      );
     });
 
     log.info('Localnet PSK bridge added for dual-network operation');

--- a/server/db/migrations/129_warm_turn_count.ts
+++ b/server/db/migrations/129_warm_turn_count.ts
@@ -1,0 +1,14 @@
+import type { Database } from 'bun:sqlite';
+
+export function up(db: Database): void {
+  const columns = db.query("PRAGMA table_info('sessions')").all() as { name: string }[];
+  if (!columns.find((c) => c.name === 'warm_turn_count')) {
+    db.exec(`ALTER TABLE sessions ADD COLUMN warm_turn_count INTEGER NOT NULL DEFAULT 0`);
+  }
+}
+
+export function down(db: Database): void {
+  // SQLite does not support DROP COLUMN in older versions;
+  // warm_turn_count is additive-only — just leave it in place on rollback.
+  void db;
+}

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -313,6 +313,7 @@ const MIGRATIONS: Record<number, string[]> = {
     `ALTER TABLE sessions ADD COLUMN active_duration_ms INTEGER NOT NULL DEFAULT 0`,
     `ALTER TABLE sessions ADD COLUMN duration_checkpoint INTEGER`,
   ],
+  129: [`ALTER TABLE sessions ADD COLUMN warm_turn_count INTEGER NOT NULL DEFAULT 0`],
 };
 
 // ── Schema version ──────────────────────────────────────────────────

--- a/server/db/schema/sessions.ts
+++ b/server/db/schema/sessions.ts
@@ -53,6 +53,7 @@ export const tables: string[] = [
         server_restart_initiated_at  TEXT DEFAULT NULL,
         conversation_summary         TEXT DEFAULT NULL,
         keep_alive                   INTEGER NOT NULL DEFAULT 0,
+        warm_turn_count              INTEGER NOT NULL DEFAULT 0,
         active_duration_ms           INTEGER NOT NULL DEFAULT 0,
         duration_checkpoint          INTEGER DEFAULT NULL,
         tenant_id                    TEXT NOT NULL DEFAULT 'default',

--- a/server/db/sessions.ts
+++ b/server/db/sessions.ts
@@ -32,6 +32,7 @@ interface SessionRow {
   work_dir: string | null;
   credits_consumed: number;
   keep_alive: number;
+  warm_turn_count: number;
   last_context_tokens: number | null;
   last_context_window: number | null;
   created_at: string;
@@ -74,6 +75,7 @@ function rowToSession(row: SessionRow): Session {
     workDir: row.work_dir ?? null,
     creditsConsumed: row.credits_consumed ?? 0,
     keepAlive: row.keep_alive === 1,
+    warmTurnCount: row.warm_turn_count ?? 0,
     lastContextTokens: row.last_context_tokens ?? null,
     lastContextWindow: row.last_context_window ?? null,
     createdAt: row.created_at,
@@ -238,6 +240,12 @@ export function getSessionCumulativeTurns(db: Database, id: string): number {
 export function incrementSessionCumulativeTurns(db: Database, id: string): void {
   db.query(
     "UPDATE sessions SET cumulative_turns = COALESCE(cumulative_turns, 0) + 1, updated_at = datetime('now') WHERE id = ?",
+  ).run(id);
+}
+
+export function incrementSessionWarmTurnCount(db: Database, id: string): void {
+  db.query(
+    "UPDATE sessions SET warm_turn_count = COALESCE(warm_turn_count, 0) + 1, updated_at = datetime('now') WHERE id = ?",
   ).run(id);
 }
 

--- a/server/process/manager.ts
+++ b/server/process/manager.ts
@@ -18,6 +18,7 @@ import {
   getSession,
   getSessionMessages,
   incrementSessionCumulativeTurns,
+  incrementSessionWarmTurnCount,
   setDurationCheckpoint,
   updateSessionContextTokens,
   updateSessionCost,
@@ -1025,6 +1026,7 @@ export class ProcessManager {
           if (sent) {
             // Warm path: message delivered to live process — no context reconstruction.
             log.debug(`Session ${session.id}: warm turn — context reconstruction skipped`);
+            incrementSessionWarmTurnCount(this.db, session.id);
             if (proc.isWarm()) {
               this.timerManager.clearKeepAliveTtl(session.id);
             }

--- a/shared/types/sessions.ts
+++ b/shared/types/sessions.ts
@@ -18,6 +18,7 @@ export interface Session {
   workDir: string | null;
   creditsConsumed: number;
   keepAlive: boolean;
+  warmTurnCount: number;
   lastContextTokens: number | null;
   lastContextWindow: number | null;
   createdAt: string;

--- a/specs/db/sessions/sessions.spec.md
+++ b/specs/db/sessions/sessions.spec.md
@@ -8,6 +8,7 @@ files:
   - server/db/migrations/125_cumulative_turns.ts
   - server/db/migrations/127_session_keep_alive.ts
   - server/db/migrations/128_session_active_duration.ts
+  - server/db/migrations/129_warm_turn_count.ts
 db_tables:
   - sessions
   - session_messages
@@ -42,6 +43,7 @@ No business logic lives here -- just SQL queries with row-to-domain mapping.
 | `updateSessionTurns` | `(db: Database, id: string, turns: number)` | `void` | Update turn count independently of cost (for immediate persistence on user message) |
 | `getSessionCumulativeTurns` | `(db: Database, id: string)` | `number` | Read `cumulative_turns` for a session (returns 0 if not found). Unlike `total_turns`, this never resets on context compaction |
 | `incrementSessionCumulativeTurns` | `(db: Database, id: string)` | `void` | Atomically increment `cumulative_turns` by 1 using COALESCE for NULL safety |
+| `incrementSessionWarmTurnCount` | `(db: Database, id: string)` | `void` | Atomically increment `warm_turn_count` by 1; called on every successful warm-path delivery |
 | `updateSessionAlgoSpent` | `(db: Database, id: string, microAlgos: number)` | `void` | Increment total ALGO spent (additive, not replacement) |
 | `updateSessionContextTokens` | `(db: Database, id: string, tokens: number, contextWindow: number)` | `void` | Persist real context token count and window size from API |
 | `setDurationCheckpoint` | `(db: Database, id: string, timestampMs: number)` | `void` | Set duration checkpoint (epoch ms) for active-time accumulation |
@@ -92,6 +94,13 @@ No business logic lives here -- just SQL queries with row-to-domain mapping.
 |----------|-----------|---------|-------------|
 | `up` | `(db: Database)` | `void` | Adds `active_duration_ms` (INTEGER NOT NULL DEFAULT 0) and `duration_checkpoint` (INTEGER, nullable) columns to sessions table (guarded by PRAGMA table_info) |
 | `down` | `(_db: Database)` | `void` | No-op (SQLite does not support DROP COLUMN in older versions) |
+
+### Exported Migration Functions — `server/db/migrations/129_warm_turn_count.ts`
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `up` | `(db: Database)` | `void` | Adds `warm_turn_count` (INTEGER NOT NULL DEFAULT 0) column to sessions table (guarded by PRAGMA table_info) |
+| `down` | `(db: Database)` | `void` | No-op (column addition is additive-only) |
 
 ## Invariants
 
@@ -153,7 +162,7 @@ No business logic lives here -- just SQL queries with row-to-domain mapping.
 
 | Module | What is used |
 |--------|-------------|
-| `server/process/manager.ts` | `getSession`, `getSessionMessages`, `updateSessionPid`, `updateSessionStatus`, `updateSessionCost`, `updateSessionTurns`, `incrementSessionCumulativeTurns`, `updateSessionContextTokens`, `updateSessionAgent`, `addSessionMessage`, `createSession`, `getParticipantForSession`, `setDurationCheckpoint`, `accumulateActiveDuration`, `finalizeActiveDuration` |
+| `server/process/manager.ts` | `getSession`, `getSessionMessages`, `updateSessionPid`, `updateSessionStatus`, `updateSessionCost`, `updateSessionTurns`, `incrementSessionCumulativeTurns`, `incrementSessionWarmTurnCount`, `updateSessionContextTokens`, `updateSessionAgent`, `addSessionMessage`, `createSession`, `getParticipantForSession`, `setDurationCheckpoint`, `accumulateActiveDuration`, `finalizeActiveDuration` |
 | `server/work/service.ts` | `createSession` |
 | `server/scheduler/service.ts` | `createSession` |
 | `server/routes/sessions.ts` | All session CRUD functions |
@@ -179,6 +188,7 @@ No business logic lives here -- just SQL queries with row-to-domain mapping.
 | total_turns | INTEGER | DEFAULT 0 | Number of conversation turns (resets on context compaction) |
 | cumulative_turns | INTEGER | DEFAULT 0 | Total turns across all context windows (never resets) |
 | keep_alive | INTEGER | NOT NULL, DEFAULT 0 | Per-session keep-alive flag (boolean: 0=off, 1=on) |
+| warm_turn_count | INTEGER | NOT NULL, DEFAULT 0 | Count of warm-path turns delivered without context reconstruction |
 | active_duration_ms | INTEGER | NOT NULL, DEFAULT 0 | Cumulative active processing time in milliseconds |
 | duration_checkpoint | INTEGER | nullable | Epoch timestamp (ms) when active duration tracking started |
 | council_launch_id | TEXT | nullable | Links to council_launches if part of a council |
@@ -226,3 +236,4 @@ No environment variables. This module is a pure data layer.
 | 2026-05-01 | corvid-agent | Add cumulative_turns column, getSessionCumulativeTurns, incrementSessionCumulativeTurns (#2216) |
 | 2026-05-04 | corvid-agent | Add keep_alive column for per-session keep-alive flag (Phase 3) |
 | 2026-05-04 | corvid-agent | Add active_duration_ms and duration_checkpoint columns, migration 128 (#2247) |
+| 2026-05-10 | corvid-agent | Add warm_turn_count column and incrementSessionWarmTurnCount, migration 129 |

--- a/specs/process/process-manager.spec.md
+++ b/specs/process/process-manager.spec.md
@@ -71,6 +71,14 @@ Keep-alive is enabled per-session via `SpawnOptions.keepAlive`. When enabled:
 
 The warm path avoids re-sending: system prompt (~2-4K tokens), conversation history (variable, often 10-50K tokens), observations (~1-2K tokens), and persona/skill prompts (~1-2K tokens). For a typical 20-message conversation, this saves ~80-90% of input tokens per turn.
 
+### Warm Turn Counting
+
+Each successful warm turn increments `sessions.warm_turn_count` via `incrementSessionWarmTurnCount()`. This counter:
+- Starts at 0 for every new session
+- Increments only when `sendMessage()` delivers to a live process (not on cold-start fallback)
+- Is surfaced as `warmTurnCount` on the `Session` type and returned by all session read endpoints
+- Enables operators to quantify keep-alive effectiveness across sessions
+
 ## Public API
 
 ### Exported Types


### PR DESCRIPTION
## Summary

- Adds \`warm_turn_count\` column to sessions table via migration 129
- Increments counter on every successful warm-path delivery in \`ProcessManager.resumeProcess()\`
- Surfaces \`warmTurnCount\` on the \`Session\` shared type and all session read endpoints
- **Syncs client session model** with shared types: adds \`warmTurnCount\`, \`workDir\`, \`creditsConsumed\`, \`lastContextTokens\`, \`lastContextWindow\`, and expands \`SessionSource\` union
- **Dashboard display**: warm badge in session list/view shows a turn-count chip; session info panel shows warm turns with % of total turns ratio
- Enables operators to quantify keep-alive effectiveness (warm turns / total turns ratio)

## Changes

| File | Change |
|------|--------|
| \`server/db/migrations/129_warm_turn_count.ts\` | New migration: adds \`warm_turn_count INTEGER NOT NULL DEFAULT 0\` |
| \`server/db/sessions.ts\` | New \`incrementSessionWarmTurnCount()\` function |
| \`server/db/schema/sessions.ts\` | Column in schema |
| \`shared/types/sessions.ts\` | \`warmTurnCount: number\` on \`Session\` type |
| \`server/process/manager.ts\` | Import + call \`incrementSessionWarmTurnCount\` in warm path |
| \`specs/db/sessions/sessions.spec.md\` | Spec updated with new function and column |
| \`specs/process/process-manager.spec.md\` | Warm turn counting behavior documented |
| \`client/src/app/core/models/session.model.ts\` | Sync with shared types: new fields + expanded \`SessionSource\` |
| \`client/src/app/features/sessions/session-view.component.ts\` | Warm badge shows count chip; info panel shows warm turns + ratio |
| \`client/src/app/features/sessions/session-list.component.ts\` | Warm badge shows count chip |

## Governance Note

\`server/process/manager.ts\` is classified as Layer 0. The change here is **minimal and necessary** — 1 import line and 1 call on the warm-path success branch. There is no architectural way to count warm turns without touching the file where warm turns are detected. The change was reviewed and verified clean by Rook before PR creation.

## Verification

- \`fledge lanes run verify\` → ✅ 220 specs, lint clean, types clean, 10,979 tests passing
- TypeScript strict: no errors (server, shared, client)
- New test file: \`server/__tests__/warm-turn-count.test.ts\` (unit + integration tests)

## Test plan

- [x] \`incrementSessionWarmTurnCount\` starts at 0, increments correctly, handles nonexistent session without throwing
- [x] \`ProcessManager.resumeProcess\` increments counter on successful warm delivery
- [x] Counter does NOT increment when \`sendMessage\` fails (cold-start fallback)
- [x] Counter does NOT increment on cold start (no live process)
- [x] Dashboard warm badge displays count chip when \`warmTurnCount > 0\`
- [x] Session info panel shows warm turns with percentage of total turns