### PR TITLE
style: fix biome formatting in ws handler and algochat bridge

### DIFF
--- a/server/algochat/bridge.ts
+++ b/server/algochat/bridge.ts
@@ -219,7 +219,9 @@ export class AlgoChatBridge implements ChannelAdapter {
 
     // Update the PSK manager lookup to check both networks
     this.responseFormatter.setPskManagerLookup((address) => {
-      return this.contactManager.lookupPskManager(address) ?? this.localnetContactManager?.lookupPskManager(address) ?? null;
+      return (
+        this.contactManager.lookupPskManager(address) ?? this.localnetContactManager?.lookupPskManager(address) ?? null
+      );
     });
 
     log.info('Localnet PSK bridge added for dual-network operation');

--- a/server/ws/handler.ts
+++ b/server/ws/handler.ts
@@ -157,7 +157,11 @@ export function createWebSocketHandler(
       const label = typeof msg.label === 'string' ? msg.label.slice(0, MAX_LABEL_LENGTH) : 'unnamed';
       const projectId = typeof msg.projectId === 'string' ? msg.projectId.slice(0, MAX_LABEL_LENGTH) : '';
 
-      const clientCaps = (msg.capabilities as BridgeCapabilities | undefined) ?? { read: true, write: false, exec: false };
+      const clientCaps = (msg.capabilities as BridgeCapabilities | undefined) ?? {
+        read: true,
+        write: false,
+        exec: false,
+      };
       const effectiveCaps = service.intersectCapabilities(clientCaps);
 
       data.authenticated = true;


### PR DESCRIPTION
## Summary

Two lines that exceeded Biome's line length limit, introduced in recent PRs, were flagging as format errors:

- `server/ws/handler.ts`: expand inline `clientCaps` default object to multi-line (added in #2316)
- `server/algochat/bridge.ts`: wrap the chained `??` return expression in parentheses (added in #2309)

Both are pure formatting — no logic change.

## Test plan

- [x] `fledge lanes run check` — lint and typecheck clean
- [x] No behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)