### PR TITLE
fix(discord): replace any casts in embeds and rest-client with typed narrowing

### DIFF
--- a/server/__tests__/discord-rest-client.test.ts
+++ b/server/__tests__/discord-rest-client.test.ts
@@ -353,7 +353,8 @@ describe('DiscordRestClient methods', () => {
       expect(calls).toHaveLength(1);
       expect(calls[0].method).toBe('get');
       expect(calls[0].route).toContain('guild-1');
-      expect(calls[0].route).toContain('with_counts=true');
+      const opts = calls[0].options as { query?: URLSearchParams } | undefined;
+      expect(opts?.query?.get('with_counts')).toBe('true');
     });
 
     test('throws on API error', async () => {

--- a/server/algochat/bridge.ts
+++ b/server/algochat/bridge.ts
@@ -219,7 +219,9 @@ export class AlgoChatBridge implements ChannelAdapter {
 
     // Update the PSK manager lookup to check both networks
     this.responseFormatter.setPskManagerLookup((address) => {
-      return this.contactManager.lookupPskManager(address) ?? this.localnetContactManager?.lookupPskManager(address) ?? null;
+      return (
+        this.contactManager.lookupPskManager(address) ?? this.localnetContactManager?.lookupPskManager(address) ?? null
+      );
     });
 
     log.info('Localnet PSK bridge added for dual-network operation');

--- a/server/discord/embeds.ts
+++ b/server/discord/embeds.ts
@@ -6,7 +6,7 @@
  * REST client (rest-client.ts), which handles rate limiting automatically.
  */
 
-import { MessageFlags, type RepliableInteraction } from 'discord.js';
+import { type APIEmbed, MessageFlags, type RepliableInteraction } from 'discord.js';
 import type { DeliveryTracker } from '../lib/delivery-tracker';
 import { createLogger } from '../lib/logger';
 import { splitMessage } from './message-formatter';
@@ -296,8 +296,10 @@ export async function respondToInteractionEmbed(
   ephemeral = false,
 ): Promise<void> {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await interaction.reply({ embeds: [embed as any], ...(ephemeral && { flags: MessageFlags.Ephemeral }) });
+    await interaction.reply({
+      embeds: [embed as unknown as APIEmbed],
+      ...(ephemeral && { flags: MessageFlags.Ephemeral }),
+    });
   } catch (error) {
     log.error('Failed to respond to Discord interaction with embed', {
       error: error instanceof Error ? error.message : String(error),
@@ -311,8 +313,10 @@ export async function respondToInteractionEmbeds(
   ephemeral = false,
 ): Promise<void> {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await interaction.reply({ embeds: embeds as any[], ...(ephemeral && { flags: MessageFlags.Ephemeral }) });
+    await interaction.reply({
+      embeds: embeds as unknown[] as APIEmbed[],
+      ...(ephemeral && { flags: MessageFlags.Ephemeral }),
+    });
   } catch (error) {
     log.error('Failed to respond to Discord interaction with embeds', {
       error: error instanceof Error ? error.message : String(error),
@@ -345,8 +349,7 @@ export async function editDeferredResponse(
   try {
     const body: Record<string, unknown> = {};
     if (content) body.content = content.slice(0, MAX_MESSAGE_LENGTH);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (embeds) body.embeds = embeds as any[];
+    if (embeds) body.embeds = embeds as unknown[] as APIEmbed[];
     await interaction.editReply(body);
   } catch (error) {
     log.error('Failed to edit deferred response', {

--- a/server/discord/rest-client.ts
+++ b/server/discord/rest-client.ts
@@ -272,8 +272,7 @@ export class DiscordRestClient {
     try {
       let result: unknown;
       if (withCounts) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        result = await (this.rest.get as any)(`/guilds/${guildId}?with_counts=true`);
+        result = await this.rest.get(Routes.guild(guildId), { query: new URLSearchParams({ with_counts: 'true' }) });
       } else {
         result = await this.rest.get(Routes.guild(guildId));
       }

--- a/server/ws/handler.ts
+++ b/server/ws/handler.ts
@@ -157,7 +157,11 @@ export function createWebSocketHandler(
       const label = typeof msg.label === 'string' ? msg.label.slice(0, MAX_LABEL_LENGTH) : 'unnamed';
       const projectId = typeof msg.projectId === 'string' ? msg.projectId.slice(0, MAX_LABEL_LENGTH) : '';
 
-      const clientCaps = (msg.capabilities as BridgeCapabilities | undefined) ?? { read: true, write: false, exec: false };
+      const clientCaps = (msg.capabilities as BridgeCapabilities | undefined) ?? {
+        read: true,
+        write: false,
+        exec: false,
+      };
       const effectiveCaps = service.intersectCapabilities(clientCaps);
 
       data.authenticated = true;


### PR DESCRIPTION
## Summary

Eliminates the last `any` casts in production Discord integration code:

- **`server/discord/embeds.ts`**: `embed as any` and `embeds as any[]` in `interaction.reply()` calls are replaced with `as unknown as APIEmbed` double-casts, importing `APIEmbed` from `discord.js`. The type mismatch exists because our internal `DiscordEmbed` interface is structurally compatible with Discord.js's `APIEmbed` but not declared as extending it.
- **`server/discord/rest-client.ts`**: `(this.rest.get as any)` used to append `?with_counts=true` as a raw string is replaced with the proper `{ query: new URLSearchParams(...) }` options object from the discord.js REST API.
- **`server/algochat/bridge.ts`, `server/ws/handler.ts`**: Two biome line-length formatting fixes that carry over from `origin/main` after PR #2316 merged.

After this PR, the only remaining `any` in production code is `handler: (...args: any[]) => void` in the ambient declaration file `ts-algochat.d.ts`, which is an intentional variadic event handler.

## Test plan

- [x] `fledge lanes run check` — lint and typecheck clean
- [x] `bun test server/__tests__/discord-bridge-core.test.ts` — 10/10 pass
- [x] No behavioral change — only type safety improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)