### PR TITLE
feat(bridge): add DELETE /api/bridge/sessions/:id endpoint

### DIFF
--- a/server/routes/bridge.test.ts
+++ b/server/routes/bridge.test.ts
@@ -74,4 +74,28 @@ describe('bridge routes', () => {
     expect(body.capabilities.write).toBe(true);
     expect(body.capabilities.exec).toBe(false);
   });
+
+  test('DELETE /api/bridge/sessions/:id returns 404 for unknown', async () => {
+    const req = new Request('http://localhost/api/bridge/sessions/nonexistent', { method: 'DELETE' });
+    const url = new URL(req.url);
+    const res = await handleDevBridgeRoutes(req, url, null as any, context, service);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(404);
+    const body = await res!.json();
+    expect(body.error).toBe('Session not found');
+  });
+
+  test('DELETE /api/bridge/sessions/:id removes session and returns 204', async () => {
+    const svc = new BridgeService();
+    const mockWs = { send: () => {}, close: () => {} } as any;
+    svc.registerSession('del1', 'test-laptop', 'proj-1', { read: true, write: false, exec: false }, mockWs);
+    expect(svc.getSession('del1')).not.toBeNull();
+
+    const req = new Request('http://localhost/api/bridge/sessions/del1', { method: 'DELETE' });
+    const url = new URL(req.url);
+    const res = await handleDevBridgeRoutes(req, url, null as any, context, svc);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(204);
+    expect(svc.getSession('del1')).toBeUndefined();
+  });
 });

--- a/server/routes/bridge.ts
+++ b/server/routes/bridge.ts
@@ -32,6 +32,14 @@ export async function handleDevBridgeRoutes(
     });
   }
 
+  if (sessionMatch && req.method === 'DELETE') {
+    const sessionId = sessionMatch[1];
+    const session = bridgeService.getSession(sessionId);
+    if (!session) return json({ error: 'Session not found' }, 404);
+    bridgeService.removeSession(sessionId);
+    return new Response(null, { status: 204 });
+  }
+
   const requestMatch = url.pathname.match(/^\/api\/bridge\/sessions\/([^/]+)\/request$/);
   if (requestMatch && req.method === 'POST') {
     const sessionId = requestMatch[1];

--- a/specs/bridge/bridge.spec.md
+++ b/specs/bridge/bridge.spec.md
@@ -90,6 +90,7 @@ The bridge is intended for the `fledge-plugin-bridge` Kotlin plugin but can be u
 |--------|------|-------------|
 | `GET` | `/api/bridge/sessions` | List all active bridge sessions |
 | `GET` | `/api/bridge/sessions/:id` | Get a single session by ID (404 if not found) |
+| `DELETE` | `/api/bridge/sessions/:id` | Evict a bridge session by ID. Returns 204 on success, 404 if not found. Closes the WebSocket and rejects all pending requests. |
 
 ### WebSocket Endpoint
 
@@ -150,6 +151,17 @@ The bridge is intended for the `fledge-plugin-bridge` Kotlin plugin but can be u
 - **When** the reap interval fires (every 60 s)
 - **Then** the session WebSocket is closed with code 4003 ("Idle timeout") and the session is removed
 
+### Scenario: DELETE /api/bridge/sessions/:id — session exists
+
+- **Given** an authenticated session with ID `abc123`
+- **When** `DELETE /api/bridge/sessions/abc123` is called
+- **Then** the session is removed, WS is closed, and response is 204 No Content
+
+### Scenario: DELETE /api/bridge/sessions/:id — session not found
+
+- **When** `DELETE /api/bridge/sessions/unknown` is called
+- **Then** response is 404 `{ error: "Session not found" }`
+
 ## Error Cases
 
 | Condition | Behavior |
@@ -204,4 +216,5 @@ The bridge is intended for the `fledge-plugin-bridge` Kotlin plugin but can be u
 
 | Date | Author | Change |
 |------|--------|--------|
+| 2026-05-12 | Jackdaw | Added DELETE /api/bridge/sessions/:id for manual session eviction |
 | 2026-05-06 | Jackdaw | Initial spec — documents bridge module added in PR #2287 |

--- a/specs/bridge/tasks.md
+++ b/specs/bridge/tasks.md
@@ -4,10 +4,10 @@
 
 - [x] Initial implementation — BridgeService, HTTP routes, WebSocket upgrade, MCP tools (PR #2287)
 - [x] Module spec written (this spec)
+- [x] Bridge session disconnect endpoint (`DELETE /api/bridge/sessions/:id`) for manual eviction
 
 ## Potential future work
 
-- [ ] Bridge session disconnect endpoint (`DELETE /api/bridge/sessions/:id`) for manual eviction
 - [ ] Dashboard UI panel showing active bridge sessions
 - [ ] Project-scoped session isolation (agents can only use sessions matching their project)
 - [ ] Configurable auth timeout (currently hardcoded in `handler.ts`)


### PR DESCRIPTION
## Summary

Adds a DELETE HTTP endpoint for manual bridge session eviction. Operators can now force-close a session, closing its WebSocket connection and rejecting all pending requests.

## Changes

- Added DELETE handler in `server/routes/bridge.ts` that validates session exists
- Returns 204 No Content on success, 404 if session not found
- Reuses existing `sessionMatch` regex variable for consistent path matching
- Updated `specs/bridge/bridge.spec.md` with endpoint documentation and behavioral scenarios
- Marked task as complete in `specs/bridge/tasks.md`

## Verification

- ✅ All lint checks passed
- ✅ All type checks passed
- ✅ All tests passed
- ✅ All spec checks passed (220/220 specs)
- ✅ No DB migrations needed (sessions are in-memory)
- ✅ No new types needed (uses existing BridgeService method)

## Implementation Details

The DELETE handler:
1. Validates the session exists via `getSession(sessionId)`
2. Returns 404 if not found (same pattern as GET)
3. Calls `removeSession(sessionId)` to close the WebSocket and reject pending requests
4. Returns 204 No Content with empty body on success