### PR TITLE
feat(sessions): enforce credit balance guard on session creation for paid deployments

### DIFF
--- a/server/__tests__/discord-ux-overhaul.test.ts
+++ b/server/__tests__/discord-ux-overhaul.test.ts
@@ -22,6 +22,35 @@ import type { ThreadCallbackInfo } from '../discord/thread-session-map';
 import { DeliveryTracker } from '../lib/delivery-tracker';
 import type { ProcessManager } from '../process/manager';
 
+// ─── Discord call types ───────────────────────────────────────────────────────
+
+interface DiscordEmbed {
+  description?: string;
+  color?: number;
+  title?: string;
+  footer?: { text?: string };
+  fields?: Array<{ name: string; value: string }>;
+}
+
+interface DiscordButton {
+  label?: string;
+  custom_id?: string;
+}
+
+interface DiscordCallData {
+  embeds?: DiscordEmbed[];
+  components?: Array<{ components?: DiscordButton[] }>;
+  content?: string;
+  [key: string]: unknown;
+}
+
+type DiscordCall = {
+  method: 'respond' | 'editDeferred' | 'send' | 'edit' | 'sendFiles';
+  data: DiscordCallData;
+};
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
 // Valid Discord snowflake IDs for testing
 const THREAD_ID = '400000000000000001';
 const MSG_ID = '500000000000000001';
@@ -50,32 +79,32 @@ function createMockProcessManager() {
 
 /** Install a mock rest client that returns valid snowflake IDs */
 function installSnowflakeMock(): {
-  calls: unknown[];
+  calls: DiscordCall[];
   cleanup: () => void;
-  waitForCall: (predicate: (c: any) => boolean, timeoutMs?: number) => Promise<unknown>;
+  waitForCall: (predicate: (c: DiscordCall) => boolean, timeoutMs?: number) => Promise<DiscordCall>;
 } {
-  const calls: unknown[] = [];
-  const listeners: Array<(entry: unknown) => void> = [];
-  const pushCall = (entry: unknown) => {
+  const calls: DiscordCall[] = [];
+  const listeners: Array<(entry: DiscordCall) => void> = [];
+  const pushCall = (entry: DiscordCall) => {
     calls.push(entry);
     for (const fn of listeners) fn(entry);
   };
   const mockClient: Partial<DiscordRestClient> = {
     respondToInteraction: async (_id, _token, data) => {
-      pushCall({ method: 'respond', data });
+      pushCall({ method: 'respond', data: data as DiscordCallData });
       return {} as never;
     },
     deferInteraction: async () => {},
     editDeferredResponse: async (_appId, _token, data) => {
-      pushCall({ method: 'editDeferred', data });
+      pushCall({ method: 'editDeferred', data: data as DiscordCallData });
       return {} as never;
     },
     sendMessage: async (_channelId, data) => {
-      pushCall({ method: 'send', data });
+      pushCall({ method: 'send', data: data as DiscordCallData });
       return { id: MSG_ID } as never;
     },
     editMessage: async (_channelId, _messageId, data) => {
-      pushCall({ method: 'edit', data });
+      pushCall({ method: 'edit', data: data as DiscordCallData });
       return { id: MSG_ID } as never;
     },
     deleteMessage: async () => {},
@@ -83,14 +112,14 @@ function installSnowflakeMock(): {
     removeReaction: async () => {},
     sendTypingIndicator: async () => {},
     sendMessageWithFiles: async (_channelId, data) => {
-      pushCall({ method: 'sendFiles', data });
+      pushCall({ method: 'sendFiles', data: data as DiscordCallData });
       return { id: MSG_ID } as never;
     },
   };
   _setRestClientForTesting(mockClient as DiscordRestClient);
 
   /** Wait for a call matching the predicate (checks existing calls first, then listens for new ones). */
-  const waitForCall = (predicate: (c: any) => boolean, timeoutMs = 10_000): Promise<unknown> => {
+  const waitForCall = (predicate: (c: DiscordCall) => boolean, timeoutMs = 10_000): Promise<DiscordCall> => {
     const existing = calls.find(predicate);
     if (existing) return Promise.resolve(existing);
     return new Promise((resolve, reject) => {
@@ -99,7 +128,7 @@ function installSnowflakeMock(): {
         if (idx >= 0) listeners.splice(idx, 1);
         reject(new Error(`waitForCall timed out after ${timeoutMs}ms`));
       }, timeoutMs);
-      const handler = (entry: unknown) => {
+      const handler = (entry: DiscordCall) => {
         if (predicate(entry)) {
           clearTimeout(timer);
           const idx = listeners.indexOf(handler);
@@ -160,7 +189,7 @@ describe('embed-response streaming edits', () => {
       callback('session-1', { type: 'tool_status', statusMessage: 'Running tests...' });
       await new Promise((r) => setTimeout(r, 100));
 
-      const sendCalls = calls.filter((c: any) => c.method === 'send');
+      const sendCalls = calls.filter((c: DiscordCall) => c.method === 'send');
       expect(sendCalls.length).toBeGreaterThanOrEqual(1);
 
       // Wait for debounce (3s)
@@ -170,7 +199,7 @@ describe('embed-response streaming edits', () => {
       callback('session-1', { type: 'tool_status', statusMessage: 'Compiling...' });
       await new Promise((r) => setTimeout(r, 100));
 
-      const editCalls = calls.filter((c: any) => c.method === 'edit');
+      const editCalls = calls.filter((c: DiscordCall) => c.method === 'edit');
       expect(editCalls.length).toBeGreaterThanOrEqual(1);
     } finally {
       const cb = pendingSubscribers[0]?.callback;
@@ -187,27 +216,27 @@ describe('embed-response streaming edits', () => {
 
     // Use a promise-based approach instead of polling to avoid CI timing flakiness.
     // The mock sendMessage resolves a promise when a call with button components arrives.
-    let resolveButtons: (call: unknown) => void;
-    const buttonsPromise = new Promise<unknown>((resolve) => {
+    let resolveButtons: (call: DiscordCall) => void;
+    const buttonsPromise = new Promise<DiscordCall>((resolve) => {
       resolveButtons = resolve;
     });
 
-    const calls: unknown[] = [];
+    const calls: DiscordCall[] = [];
     const mockClient: Partial<DiscordRestClient> = {
       respondToInteraction: async (_id, _token, data) => {
-        calls.push({ method: 'respond', data });
+        calls.push({ method: 'respond', data: data as DiscordCallData });
         return {} as never;
       },
       deferInteraction: async () => {},
       editDeferredResponse: async (_appId, _token, data) => {
-        calls.push({ method: 'editDeferred', data });
+        calls.push({ method: 'editDeferred', data: data as DiscordCallData });
         return {} as never;
       },
       sendMessage: async (_channelId, data) => {
-        const entry = { method: 'send', data };
+        const entry: DiscordCall = { method: 'send', data: data as DiscordCallData };
         calls.push(entry);
         // Resolve the promise when we see buttons
-        if ((data as any)?.components?.[0]?.components?.length > 0) {
+        if ((entry.data.components?.[0]?.components?.length ?? 0) > 0) {
           resolveButtons(entry);
         }
         return { id: MSG_ID } as never;
@@ -257,8 +286,8 @@ describe('embed-response streaming edits', () => {
 
       expect(embedWithButtons).toBeDefined();
       if (embedWithButtons) {
-        const actionRow = (embedWithButtons as any).data.components[0];
-        const buttonLabels = actionRow.components.map((b: any) => b.label);
+        const actionRow = embedWithButtons.data.components?.[0];
+        const buttonLabels = actionRow?.components?.map((b) => b.label) ?? [];
         expect(buttonLabels).toContain('New Session');
         expect(buttonLabels).toContain('Create Issue');
         expect(buttonLabels).toContain('Archive');
@@ -300,7 +329,7 @@ describe('embed-response streaming edits', () => {
       await new Promise((r) => setTimeout(r, 500));
 
       // Should have an edit with ✅ Done
-      const doneEdit = calls.find((c: any) => c.method === 'edit' && c.data?.embeds?.[0]?.description === '✅ Done');
+      const doneEdit = calls.find((c: DiscordCall) => c.method === 'edit' && c.data?.embeds?.[0]?.description === '✅ Done');
       expect(doneEdit).toBeDefined();
     } finally {
       cleanup();
@@ -388,7 +417,7 @@ describe('embed-response streaming edits', () => {
       await new Promise((r) => setTimeout(r, 200));
 
       // Should send a warning embed with yellow color
-      const warningEmbed = calls.find((c: any) => c.method === 'send' && c.data?.embeds?.[0]?.color === 0xf0b232);
+      const warningEmbed = calls.find((c: DiscordCall) => c.method === 'send' && c.data?.embeds?.[0]?.color === 0xf0b232);
       expect(warningEmbed).toBeDefined();
     } finally {
       const cb = pendingSubscribers.find((s) => s.sessionId === 'session-ctx')?.callback;
@@ -470,7 +499,7 @@ describe('embed-response streaming edits', () => {
 
       // Wait for crash edit event-driven (typing interval fires at 8s, then async chain completes)
       const crashEdit = await waitForCall(
-        (c: any) => c.method === 'edit' && c.data?.embeds?.[0]?.description?.includes('ended unexpectedly'),
+        (c: DiscordCall) => c.method === 'edit' && (c.data?.embeds?.[0]?.description?.includes('ended unexpectedly') ?? false),
         12000,
       );
       expect(crashEdit).toBeDefined();
@@ -504,26 +533,26 @@ describe('embed-response streaming edits', () => {
     const delivery = new DeliveryTracker();
     const threadCallbacks = new Map<string, ThreadCallbackInfo>();
 
-    let resolveButtons: (call: unknown) => void;
-    const buttonsPromise = new Promise<unknown>((resolve) => {
+    let resolveButtons: (call: DiscordCall) => void;
+    const buttonsPromise = new Promise<DiscordCall>((resolve) => {
       resolveButtons = resolve;
     });
 
-    const calls: unknown[] = [];
+    const calls: DiscordCall[] = [];
     const mockClient: Partial<DiscordRestClient> = {
       respondToInteraction: async () => ({}) as never,
       deferInteraction: async () => {},
       editDeferredResponse: async () => ({}) as never,
       sendMessage: async (_channelId, data) => {
-        const entry = { method: 'send', data };
+        const entry: DiscordCall = { method: 'send', data: data as DiscordCallData };
         calls.push(entry);
-        if ((data as any)?.components?.[0]?.components?.length > 0) {
+        if ((entry.data.components?.[0]?.components?.length ?? 0) > 0) {
           resolveButtons(entry);
         }
         return { id: MSG_ID } as never;
       },
       editMessage: async (_channelId, _messageId, data) => {
-        calls.push({ method: 'edit', data });
+        calls.push({ method: 'edit', data: data as DiscordCallData });
         return { id: MSG_ID } as never;
       },
       deleteMessage: async () => {},
@@ -531,7 +560,7 @@ describe('embed-response streaming edits', () => {
       removeReaction: async () => {},
       sendTypingIndicator: async () => {},
       sendMessageWithFiles: async (_channelId, data) => {
-        calls.push({ method: 'sendFiles', data });
+        calls.push({ method: 'sendFiles', data: data as DiscordCallData });
         return { id: MSG_ID } as never;
       },
     };
@@ -564,9 +593,9 @@ describe('embed-response streaming edits', () => {
 
       expect(embedWithButtons).toBeDefined();
       if (embedWithButtons) {
-        const embed = (embedWithButtons as any).data.embeds[0];
+        const embed = embedWithButtons.data.embeds?.[0];
         // Should have stats fields
-        const fieldNames = (embed.fields || []).map((f: any) => f.name);
+        const fieldNames = (embed?.fields ?? []).map((f) => f.name);
         expect(fieldNames).toContain('Duration');
         expect(fieldNames).toContain('Turns');
         expect(fieldNames).toContain('Tool Calls');
@@ -602,7 +631,7 @@ describe('embed-response streaming edits', () => {
 
       // Should have sent an ack embed
       const ackEmbed = calls.find(
-        (c: any) => c.method === 'send' && c.data?.embeds?.[0]?.description?.includes('working on it'),
+        (c: DiscordCall) => c.method === 'send' && (c.data?.embeds?.[0]?.description?.includes('working on it') ?? false),
       );
       expect(ackEmbed).toBeDefined();
     } finally {
@@ -647,7 +676,7 @@ describe('embed-response streaming edits', () => {
       await new Promise((r) => setTimeout(r, 200));
 
       // Should have an edit for the error
-      const errorEdit = calls.find((c: any) => c.method === 'edit' && c.data?.embeds?.[0]?.color !== undefined);
+      const errorEdit = calls.find((c: DiscordCall) => c.method === 'edit' && c.data?.embeds?.[0]?.color !== undefined);
       expect(errorEdit).toBeDefined();
     } finally {
       const cb = pendingSubscribers.find((s) => s.sessionId === 'session-5')?.callback;
@@ -663,32 +692,32 @@ describe('adaptive-response Continue in Thread button', () => {
     const pm = createMockProcessManager();
     const delivery = new DeliveryTracker();
 
-    let resolveButtons: (call: unknown) => void;
-    const buttonsPromise = new Promise<unknown>((resolve) => {
+    let resolveButtons: (call: DiscordCall) => void;
+    const buttonsPromise = new Promise<DiscordCall>((resolve) => {
       resolveButtons = resolve;
     });
 
-    const calls: unknown[] = [];
+    const calls: DiscordCall[] = [];
     const mockClient: Partial<DiscordRestClient> = {
       respondToInteraction: async (_id, _token, data) => {
-        calls.push({ method: 'respond', data });
+        calls.push({ method: 'respond', data: data as DiscordCallData });
         return {} as never;
       },
       deferInteraction: async () => {},
       editDeferredResponse: async (_appId, _token, data) => {
-        calls.push({ method: 'editDeferred', data });
+        calls.push({ method: 'editDeferred', data: data as DiscordCallData });
         return {} as never;
       },
       sendMessage: async (_channelId, data) => {
-        const entry = { method: 'send', data };
+        const entry: DiscordCall = { method: 'send', data: data as DiscordCallData };
         calls.push(entry);
-        if ((data as any)?.components?.[0]?.components?.some((b: any) => b.custom_id?.startsWith('continue_thread'))) {
+        if (entry.data.components?.[0]?.components?.some((b) => b.custom_id?.startsWith('continue_thread'))) {
           resolveButtons(entry);
         }
         return { id: MSG_ID } as never;
       },
       editMessage: async (_channelId, _messageId, data) => {
-        calls.push({ method: 'edit', data });
+        calls.push({ method: 'edit', data: data as DiscordCallData });
         return {} as never;
       },
       deleteMessage: async () => {},
@@ -696,7 +725,7 @@ describe('adaptive-response Continue in Thread button', () => {
       removeReaction: async () => {},
       sendTypingIndicator: async () => {},
       sendMessageWithFiles: async (_channelId, data) => {
-        calls.push({ method: 'sendFiles', data });
+        calls.push({ method: 'sendFiles', data: data as DiscordCallData });
         return { id: MSG_ID } as never;
       },
     };
@@ -729,8 +758,8 @@ describe('adaptive-response Continue in Thread button', () => {
 
       expect(embedWithButtons).toBeDefined();
       if (embedWithButtons) {
-        const actionRow = (embedWithButtons as any).data.components[0];
-        const buttonIds = actionRow.components.map((b: any) => b.custom_id);
+        const actionRow = embedWithButtons.data.components?.[0];
+        const buttonIds = actionRow?.components?.map((b) => b.custom_id) ?? [];
         expect(buttonIds[0]).toMatch(/^continue_thread:/);
       }
     } finally {
@@ -769,7 +798,7 @@ describe('adaptive-response Continue in Thread button', () => {
 
       // Should send a new embed (not edit)
       const errorEmbed = calls.find(
-        (c: any) => c.method === 'send' && c.data?.embeds?.[0]?.title === 'Credits Exhausted',
+        (c: DiscordCall) => c.method === 'send' && c.data?.embeds?.[0]?.title === 'Credits Exhausted',
       );
       expect(errorEmbed).toBeDefined();
     } finally {
@@ -928,7 +957,7 @@ describe('progress-response real-time context usage', () => {
       );
 
       // Wait for the initial progress embed to be sent
-      await waitForCall((c: any) => c.method === 'send');
+      await waitForCall((c: DiscordCall) => c.method === 'send');
       const callback = pendingSubscribers.find((s) => s.sessionId === 'session-ctx-1')!.callback;
 
       // Wait past debounce so context_usage update isn't throttled
@@ -945,7 +974,7 @@ describe('progress-response real-time context usage', () => {
 
       // Should have edited the progress embed with usage in the footer
       const editWithUsage = calls.find(
-        (c: any) => c.method === 'edit' && c.data?.embeds?.[0]?.footer?.text?.includes('25%'),
+        (c: DiscordCall) => c.method === 'edit' && (c.data?.embeds?.[0]?.footer?.text?.includes('25%') ?? false),
       );
       expect(editWithUsage).toBeDefined();
     } finally {
@@ -973,7 +1002,7 @@ describe('progress-response real-time context usage', () => {
         'test-model',
       );
 
-      await waitForCall((c: any) => c.method === 'send');
+      await waitForCall((c: DiscordCall) => c.method === 'send');
       const callback = pendingSubscribers.find((s) => s.sessionId === 'session-ctx-2')!.callback;
 
       // Send a tool_status to set the description
@@ -993,10 +1022,10 @@ describe('progress-response real-time context usage', () => {
       await new Promise((r) => setTimeout(r, 200));
 
       // Find the edit triggered by context_usage (after the tool_status edit)
-      const edits = calls.filter((c: any) => c.method === 'edit');
-      const lastEdit = edits[edits.length - 1] as any;
-      expect(lastEdit.data.embeds[0].description).toContain('Reading file...');
-      expect(lastEdit.data.embeds[0].footer.text).toContain('45%');
+      const edits = calls.filter((c: DiscordCall) => c.method === 'edit');
+      const lastEdit = edits[edits.length - 1];
+      expect(lastEdit?.data.embeds?.[0]?.description).toContain('Reading file...');
+      expect(lastEdit?.data.embeds?.[0]?.footer?.text).toContain('45%');
     } finally {
       const cb = pendingSubscribers.find((s) => s.sessionId === 'session-ctx-2')?.callback;
       if (cb) cb('session-ctx-2', { type: 'result', result: '' });
@@ -1022,14 +1051,14 @@ describe('progress-response real-time context usage', () => {
         'test-model',
       );
 
-      await waitForCall((c: any) => c.method === 'send');
+      await waitForCall((c: DiscordCall) => c.method === 'send');
       const callback = pendingSubscribers.find((s) => s.sessionId === 'session-ctx-3')!.callback;
 
       // Wait past initial debounce
       await new Promise((r) => setTimeout(r, 3200));
 
       // Record baseline edit count before sending rapid events
-      const editsBefore = calls.filter((c: any) => c.method === 'edit').length;
+      const editsBefore = calls.filter((c: DiscordCall) => c.method === 'edit').length;
 
       // Rapidly send multiple context_usage events
       for (let i = 0; i < 5; i++) {
@@ -1043,7 +1072,7 @@ describe('progress-response real-time context usage', () => {
       await new Promise((r) => setTimeout(r, 200));
 
       // Only 1 new edit should have been made (debounced), not 5
-      const editsAfterSend = calls.filter((c: any) => c.method === 'edit').length;
+      const editsAfterSend = calls.filter((c: DiscordCall) => c.method === 'edit').length;
       expect(editsAfterSend - editsBefore).toBe(1);
     } finally {
       const cb = pendingSubscribers.find((s) => s.sessionId === 'session-ctx-3')?.callback;
@@ -1070,7 +1099,7 @@ describe('progress-response real-time context usage', () => {
         'test-model',
       );
 
-      await waitForCall((c: any) => c.method === 'send');
+      await waitForCall((c: DiscordCall) => c.method === 'send');
       const callback = pendingSubscribers.find((s) => s.sessionId === 'session-ctx-4')!.callback;
 
       callback('session-ctx-4', {
@@ -1081,7 +1110,7 @@ describe('progress-response real-time context usage', () => {
       await new Promise((r) => setTimeout(r, 200));
 
       // Should send a new warning embed with yellow color
-      const warningEmbed = calls.find((c: any) => c.method === 'send' && c.data?.embeds?.[0]?.color === 0xf0b232);
+      const warningEmbed = calls.find((c: DiscordCall) => c.method === 'send' && c.data?.embeds?.[0]?.color === 0xf0b232);
       expect(warningEmbed).toBeDefined();
     } finally {
       const cb = pendingSubscribers.find((s) => s.sessionId === 'session-ctx-4')?.callback;
@@ -1108,7 +1137,7 @@ describe('progress-response real-time context usage', () => {
         'test-model',
       );
 
-      await waitForCall((c: any) => c.method === 'send');
+      await waitForCall((c: DiscordCall) => c.method === 'send');
       const callback = pendingSubscribers.find((s) => s.sessionId === 'session-ctx-5')!.callback;
 
       callback('session-ctx-5', {
@@ -1119,7 +1148,7 @@ describe('progress-response real-time context usage', () => {
       await new Promise((r) => setTimeout(r, 200));
 
       // No warning embed should be sent (only critical level triggers it)
-      const warningEmbed = calls.find((c: any) => c.method === 'send' && c.data?.embeds?.[0]?.color === 0xf0b232);
+      const warningEmbed = calls.find((c: DiscordCall) => c.method === 'send' && c.data?.embeds?.[0]?.color === 0xf0b232);
       expect(warningEmbed).toBeUndefined();
     } finally {
       const cb = pendingSubscribers.find((s) => s.sessionId === 'session-ctx-5')?.callback;
@@ -1146,7 +1175,7 @@ describe('progress-response real-time context usage', () => {
         'test-model',
       );
 
-      await waitForCall((c: any) => c.method === 'send');
+      await waitForCall((c: DiscordCall) => c.method === 'send');
       // Let the .then() callback set progressMessageId
       await new Promise((r) => setTimeout(r, 50));
       const callback = pendingSubscribers.find((s) => s.sessionId === 'session-ctx-6')!.callback;
@@ -1165,10 +1194,10 @@ describe('progress-response real-time context usage', () => {
 
       // The "Done" edit should include context usage
       const doneEdit = calls.find(
-        (c: any) =>
+        (c: DiscordCall) =>
           c.method === 'edit' &&
           c.data?.embeds?.[0]?.description === '✅ Done' &&
-          c.data?.embeds?.[0]?.footer?.text?.includes('75%'),
+          (c.data?.embeds?.[0]?.footer?.text?.includes('75%') ?? false),
       );
       expect(doneEdit).toBeDefined();
     } finally {

--- a/server/__tests__/routes-sessions.test.ts
+++ b/server/__tests__/routes-sessions.test.ts
@@ -1,7 +1,9 @@
 import { Database } from 'bun:sqlite';
 import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test';
+import { grantCredits } from '../db/credits';
 import { runMigrations } from '../db/schema';
 import { insertSessionMetrics } from '../db/session-metrics';
+import type { AuthConfig } from '../middleware/auth';
 import type { ProcessManager } from '../process/manager';
 import { handleSessionRoutes } from '../routes/sessions';
 import type { WorkTaskService } from '../work/service';
@@ -601,6 +603,64 @@ describe('Session Routes', () => {
       expect(res!.status).toBe(201);
       const data = await res!.json();
       expect(data.complexityWarning).toBeUndefined();
+    });
+  });
+
+  describe('POST /api/sessions — payment gating', () => {
+    // Valid Algorand address format: 58 uppercase base32 chars [A-Z2-7]
+    const WALLET_EMPTY = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    const WALLET_FUNDED = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+    const WALLET_NO_CHECK = 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+
+    const remoteConfig: AuthConfig = { apiKey: 'test-key', allowedOrigins: [], bindHost: '0.0.0.0' };
+    const localhostConfig: AuthConfig = { apiKey: null, allowedOrigins: [], bindHost: '127.0.0.1' };
+
+    it('returns 402 when wallet has zero credits on a non-localhost deployment', async () => {
+      const pm = createMockPM();
+      const context = { walletAddress: WALLET_EMPTY, tenantId: 'default', authenticated: false };
+      const { req, url } = fakeReq('POST', '/api/sessions', { projectId, name: 'Gated' });
+      const res = await handleSessionRoutes(req, url, db, pm, context, null, remoteConfig);
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(402);
+      const data = await res!.json();
+      expect(data.error).toBe('Insufficient credits');
+      expect(data.available).toBe(0);
+    });
+
+    it('allows session creation on localhost even with zero credits', async () => {
+      const pm = createMockPM();
+      const context = { walletAddress: WALLET_EMPTY, tenantId: 'default', authenticated: false };
+      const { req, url } = fakeReq('POST', '/api/sessions', { projectId, name: 'Local' });
+      const res = await handleSessionRoutes(req, url, db, pm, context, null, localhostConfig);
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(201);
+    });
+
+    it('allows session creation when no wallet address is in context', async () => {
+      const pm = createMockPM();
+      const { req, url } = fakeReq('POST', '/api/sessions', { projectId, name: 'No Wallet' });
+      const res = await handleSessionRoutes(req, url, db, pm, undefined, null, remoteConfig);
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(201);
+    });
+
+    it('allows session creation when wallet has positive credits on non-localhost', async () => {
+      grantCredits(db, WALLET_FUNDED, 50, 'test-grant');
+      const pm = createMockPM();
+      const context = { walletAddress: WALLET_FUNDED, tenantId: 'default', authenticated: false };
+      const { req, url } = fakeReq('POST', '/api/sessions', { projectId, name: 'Funded' });
+      const res = await handleSessionRoutes(req, url, db, pm, context, null, remoteConfig);
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(201);
+    });
+
+    it('skips credit check when authConfig is not provided', async () => {
+      const pm = createMockPM();
+      const context = { walletAddress: WALLET_NO_CHECK, tenantId: 'default', authenticated: false };
+      const { req, url } = fakeReq('POST', '/api/sessions', { projectId, name: 'No Config' });
+      const res = await handleSessionRoutes(req, url, db, pm, context, null, null);
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(201);
     });
   });
 });

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -466,7 +466,15 @@ async function handleRoutes(
   const settingsResponse = await handleSettingsRoutes(req, url, db, context, getAuthConfig());
   if (settingsResponse) return settingsResponse;
 
-  const sessionResponse = await handleSessionRoutes(req, url, db, processManager, context, workTaskService);
+  const sessionResponse = await handleSessionRoutes(
+    req,
+    url,
+    db,
+    processManager,
+    context,
+    workTaskService,
+    getAuthConfig(),
+  );
   if (sessionResponse) return sessionResponse;
 
   const councilResponse = handleCouncilRoutes(req, url, db, processManager, agentMessenger, context, reputationScorer);

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -1,6 +1,7 @@
 import type { Database } from 'bun:sqlite';
 import { getAgent } from '../db/agents';
 import { recordAudit } from '../db/audit';
+import { getBalance } from '../db/credits';
 import { getSessionMetrics } from '../db/session-metrics';
 import {
   addSessionMessage,
@@ -22,6 +23,7 @@ import {
   UpdateSessionSchema,
   ValidationError,
 } from '../lib/validation';
+import type { AuthConfig } from '../middleware/auth';
 import type { RequestContext } from '../middleware/guards';
 import { tenantRoleGuard } from '../middleware/guards';
 import { getClientIp } from '../middleware/rate-limit';
@@ -37,6 +39,7 @@ export async function handleSessionRoutes(
   processManager: ProcessManager,
   context?: RequestContext,
   workTaskService?: WorkTaskService | null,
+  authConfig?: AuthConfig | null,
 ): Promise<Response | null> {
   const path = url.pathname;
   const method = req.method;
@@ -53,7 +56,7 @@ export async function handleSessionRoutes(
       const denied = tenantRoleGuard('operator', 'owner')(req, url, context);
       if (denied) return denied;
     }
-    return handleCreate(req, db, processManager, tenantId);
+    return handleCreate(req, db, processManager, tenantId, context?.walletAddress, authConfig);
   }
 
   const match = path.match(/^\/api\/sessions\/([^/]+)(\/(.+))?$/);
@@ -137,8 +140,21 @@ async function handleCreate(
   db: Database,
   processManager: ProcessManager,
   tenantId: string = 'default',
+  walletAddress?: string,
+  authConfig?: AuthConfig | null,
 ): Promise<Response> {
   try {
+    if (walletAddress && authConfig) {
+      const isLocalhost =
+        authConfig.bindHost === '127.0.0.1' || authConfig.bindHost === 'localhost' || authConfig.bindHost === '::1';
+      if (!isLocalhost) {
+        const balance = getBalance(db, walletAddress);
+        if (balance.available <= 0) {
+          return json({ error: 'Insufficient credits', available: balance.available }, 402);
+        }
+      }
+    }
+
     const data = await parseBodyOrThrow(req, CreateSessionSchema);
     if (data.initialPrompt) {
       const injectionDenied = checkInjection(db, data.initialPrompt, 'session_create', req);

--- a/specs/billing/tasks.md
+++ b/specs/billing/tasks.md
@@ -4,7 +4,7 @@ spec: billing.spec.md
 
 ## Active Tasks
 
-- [ ] v1.0.0-rc security and payment gating: enforce credit balance checks before session start on non-localhost deployments (#1689)
+- [x] v1.0.0-rc security and payment gating: enforce credit balance checks before session start on non-localhost deployments (#1689)
 - [ ] Add billing dashboard view: current-period usage breakdown, credit balance, and cost projection (#1623)
 - [ ] USDC deposit confirmation flow: notify operators via AlgoChat when a USDC transfer is detected and converted to credits
 - [ ] Add Stripe webhook replay protection integration test covering the 300-second window

--- a/specs/middleware/auth.spec.md
+++ b/specs/middleware/auth.spec.md
@@ -52,6 +52,7 @@ HTTP and WebSocket authentication, CORS handling, and startup security validatio
 7. **CORS origin reflection with Vary**: When `allowedOrigins` is configured, the request origin is reflected if it matches the allowlist; `Vary: Origin` is set when the reflected origin is not `*`
 8. **Disallowed origin**: When `allowedOrigins` is set and the request origin is not in the list, `Access-Control-Allow-Origin` is set to empty string (browser blocks the response)
 9. **CORS secure default on public deployments**: When `allowedOrigins` is empty and `bindHost` is not localhost, cross-origin requests (those with an `Origin` header) receive `Access-Control-Allow-Origin: ''` (browser blocks). Non-browser requests (no `Origin` header) receive `Access-Control-Allow-Origin: *`.
+10. **Payment gate on session creation**: When `AuthConfig` is passed to `handleSessionRoutes` and `bindHost` is non-localhost, any session creation request carrying a wallet address in the request context is checked for a positive available credit balance. Requests with `available <= 0` are rejected with HTTP 402. Localhost deployments and requests without a wallet address are never gated.
 
 ## Behavioral Examples
 

--- a/specs/middleware/tasks.md
+++ b/specs/middleware/tasks.md
@@ -5,7 +5,7 @@ spec: auth.spec.md
 ## Active Tasks
 
 - [ ] Secure remote access: implement mutual TLS or token-scoped API keys for non-localhost deployments (#1549)
-- [ ] v1.0.0-rc payment gating: add credit balance middleware guard for session creation on paid deployments (#1689)
+- [x] v1.0.0-rc payment gating: add credit balance middleware guard for session creation on paid deployments (#1689)
 - [ ] Add 2FA (TOTP) support for admin endpoints — currently auth is single-factor API key only (#430 adjacent)
 - [ ] Expose API key rotation status and expiry in the Security settings panel
 


### PR DESCRIPTION
## Summary

- Adds a credit balance check to `POST /api/sessions` for non-localhost (paid) deployments
- When a request carries a wallet address (`?wallet=<addr>`) and the deployment is non-localhost (`bindHost !== 127.0.0.1/localhost/::1`), a zero-or-negative available balance returns **HTTP 402** with `{ error: 'Insufficient credits', available: 0 }`
- Localhost deployments and requests without a wallet address are never gated — developer and owner flows are unaffected
- Implements the long-standing v1.0.0 mainnet roadmap task tracked in `specs/middleware/tasks.md` and `specs/billing/tasks.md` (#1689)

## Changes

- `server/routes/sessions.ts` — accept optional `AuthConfig`, check balance in `handleCreate` before parsing body
- `server/routes/index.ts` — pass `getAuthConfig()` to `handleSessionRoutes`
- `server/__tests__/routes-sessions.test.ts` — 5 new payment-gating tests
- `specs/middleware/auth.spec.md` — added invariant #10 documenting the payment gate
- `specs/middleware/tasks.md` + `specs/billing/tasks.md` — marked task complete

## Test plan

- [x] `bun x tsc --noEmit --skipLibCheck` — 0 errors
- [x] `bun run lint` — 0 new errors (pre-existing discord-ux-overhaul format issue on branch)
- [x] `bun test server/__tests__/routes-sessions.test.ts` — 40/40 pass (5 new)
- [x] `bun test` — 10978/10978 pass
- [x] `fledge run spec-check --force` — 220/220 specs pass

🤖 Agent: Jackdaw | Model: claude-sonnet-4-6