### PR TITLE
CI: standardize Actions (paths + concurrency + runners)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,6 +17,10 @@ on:
     - cron: "0 7 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -10,6 +10,10 @@ on:
       - "package.json"
   workflow_dispatch:
 
+concurrency:
+  group: stats-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/task-check.yml
+++ b/.github/workflows/task-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
 
+concurrency:
+  group: task-check-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 


### PR DESCRIPTION
## Summary
Standardizes branch-CI workflows for this PUBLIC bun-ts repo, mirroring the CorvidLabs/merlin CI standard.

- **ci.yml**: add `concurrency: { group: ci-${{ github.ref }}, cancel-in-progress: true }` so redundant push/PR runs cancel. Existing `paths-ignore` scoping and GitHub-hosted runners (ubuntu/macos/windows-latest) left intact — `paths-ignore` is preserved rather than converted to an explicit `paths:` set because the push trigger also carries `tags: ["v*"]` for releases, and a positive `paths:` filter would risk filtering out release-tag pushes.
- **security.yml**: add concurrency group (kept its security-scoped `pull_request` paths and weekly schedule).
- **stats.yml**: add concurrency group (kept its existing `paths:` set).
- **task-check.yml**: add concurrency group. No `paths:` added — it validates the PR description task list, not code, so it must run on every PR regardless of changed files.

### Not changed (correct as-is)
- Runners: all 12 workflows already use GitHub-hosted runners — correct for a PUBLIC repo (no self-hosted to convert).
- `pages.yml`: already has site-scoped `paths:` (docs/**) + a `pages` concurrency group.
- `e2e.yml` (dispatch), `codeql.yml` (schedule/dispatch), `docker-publish.yml` / `release.yml` (tag-push/dispatch), `heartbeat.yml` / `branch-protection.yml` (schedule/dispatch), `dependabot-lockfile.yml` (automation): not branch CI, so no `paths:` added per the standard.

Mirrors the CorvidLabs/merlin CI standard.

## Test Plan
- [x] All changed workflows parse with `yaml.safe_load`
- [x] `actionlint` clean on changed files (only a pre-existing SC2129 style note in untouched ci.yml code)