### PR TITLE
Fix: update README version badge to 0.66.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.63.1-4a90d9" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.66.0-4a90d9" alt="Version">
   <a href="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml"><img src="https://github.com/CorvidLabs/corvid-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/github/license/CorvidLabs/corvid-agent" alt="License">
   <a href="https://codecov.io/gh/CorvidLabs/corvid-agent"><img src="https://codecov.io/gh/CorvidLabs/corvid-agent/graph/badge.svg" alt="Coverage"></a>


### PR DESCRIPTION
Problem: README version badge reads version-0.63.1, but the latest published release is v0.66.0.

Fix: Update the badge URL to https://img.shields.io/badge/version-0.66.0-4a90d9 (or switch to a dynamic github/v/release/CorvidLabs/corvid-agent badge to avoid future drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)